### PR TITLE
Add test sweepers

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,6 +13,10 @@ test: fmtcheck
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
+sweep:
+	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
+	go test ./tfe -v -timeout 60m -sweep=prod
+
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 15m
 
@@ -56,5 +60,5 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test sweep
 

--- a/tfe/tfe_sweeper_test.go
+++ b/tfe/tfe_sweeper_test.go
@@ -29,21 +29,21 @@ func getOrgSweeper(name string) *resource.Sweeper {
 
 			client, err := getClient(hostname, token, insecure)
 			if err != nil {
-				return err
+				return fmt.Errorf("Error getting client: %s",err)
 			}
 
 			ctx := context.TODO()
 			orgList, err := client.Organizations.List(ctx, tfe.OrganizationListOptions{})
 			if err != nil {
-				return err
+				return fmt.Errorf("Error listing organizations: %s",err)
 			}
 			for _, org := range orgList.Items {
 				log.Printf("[DEBUG] Testing if org %s starts with tst-terraform or named terraform-updated", org.Name)
-				if strings.HasPrefix(org.Name, "tst-terraform") || org.Name == "terraform-updated" {
+				if strings.HasPrefix(org.Name, "tst-terraform") {
 					log.Printf("[DEBUG] deleting org %s", org.Name)
 					err = client.Organizations.Delete(ctx, org.Name)
 					if err != nil {
-						return err
+						return fmt.Errorf("Error deleting organization %q %s",org.Name, err)
 					}
 				}
 			}

--- a/tfe/tfe_sweeper_test.go
+++ b/tfe/tfe_sweeper_test.go
@@ -1,0 +1,59 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-tfe"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func getOrgSweeper(name string) *resource.Sweeper {
+	return &resource.Sweeper{
+		Name: name,
+		F: func(ununsed string) error {
+			if os.Getenv("TFE_HOSTNAME") == "" && (os.Getenv("TFE_TOKEN") == "") {
+				return fmt.Errorf("must provide environment variables TFE_HOSTNAME and TFE_TOKEN")
+			}
+			hostname := os.Getenv("TFE_HOSTNAME")
+			token := os.Getenv("TFE_TOKEN")
+			insecure := os.Getenv("TFE_INSECURE") != ""
+
+			client, err := getClient(hostname, token, insecure)
+			if err != nil {
+				return err
+			}
+
+			ctx := context.TODO()
+			orgList, err := client.Organizations.List(ctx, tfe.OrganizationListOptions{})
+			if err != nil {
+				return err
+			}
+			for _, org := range orgList.Items {
+				log.Printf("[DEBUG] Testing if org %s starts with tst-terraform or named terraform-updated", org.Name)
+				if strings.HasPrefix(org.Name, "tst-terraform") || org.Name == "terraform-updated" {
+					log.Printf("[DEBUG] deleting org %s", org.Name)
+					err = client.Organizations.Delete(ctx, org.Name)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// Sweepers usually go along with the tests. In TF[CE]'s case everything depends on the organization,
+// which means that if we delete it then all the other entities will  be deleted automatically.
+func init() {
+	resource.AddTestSweepers("org_sweeper", getOrgSweeper("org_sweeper"))
+}


### PR DESCRIPTION
## Description

Sweepers are used to cleanup after failed tests.
Because of the way data are modeled in the TF platform everything
depends on the organization. This means that in order to cleanup we
just need to delete the test organization and the rest of the
resources will be deleted automatically.


