### PR TITLE
Randomize org name

### DIFF
--- a/tfe/data_source_oauth_client_test.go
+++ b/tfe/data_source_oauth_client_test.go
@@ -2,18 +2,21 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccTFEOAuthClientDataSource_basic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOAuthClientDataSourceConfig(),
+				Config: testAccTFEOAuthClientDataSourceConfig(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"tfe_oauth_client.test", "api_url",
@@ -30,10 +33,10 @@ func TestAccTFEOAuthClientDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccTFEOAuthClientDataSourceConfig() string {
+func testAccTFEOAuthClientDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 	resource "tfe_organization" "foobar" {
-		name  = "tst-terraform"
+		name  = "tst-terraform-%d"
 		email = "admin@company.com"
 	  }
 	  
@@ -48,5 +51,5 @@ func testAccTFEOAuthClientDataSourceConfig() string {
 	  data "tfe_oauth_client" "client" {
 		  oauth_client_id = "${tfe_oauth_client.test.id}"
 	  }
-	`, GITHUB_TOKEN)
+	`, rInt, GITHUB_TOKEN)
 }

--- a/tfe/data_source_organization_membership_test.go
+++ b/tfe/data_source_organization_membership_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccTFEOrganizationMembershipDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -22,7 +23,7 @@ func TestAccTFEOrganizationMembershipDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_organization_membership.foobar", "email", "example@hashicorp.com"),
 					resource.TestCheckResourceAttr(
-						"data.tfe_organization_membership.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"data.tfe_organization_membership.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_organization_membership.foobar", "user_id"),
 				),
 			},

--- a/tfe/data_source_ssh_key_test.go
+++ b/tfe/data_source_ssh_key_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccTFESSHKeyDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -22,7 +23,7 @@ func TestAccTFESSHKeyDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_ssh_key.foobar", "name", fmt.Sprintf("ssh-key-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_ssh_key.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"data.tfe_ssh_key.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_ssh_key.foobar", "id"),
 				),
 			},

--- a/tfe/data_source_team_test.go
+++ b/tfe/data_source_team_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccTFETeamDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -22,7 +23,7 @@ func TestAccTFETeamDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_team.foobar", "name", fmt.Sprintf("team-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_team.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"data.tfe_team.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_team.foobar", "id"),
 				),
 			},

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccTFEWorkspaceIDsDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -26,7 +27,7 @@ func TestAccTFEWorkspaceIDsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.1", fmt.Sprintf("workspace-bar-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"data.tfe_workspace_ids.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "full_names.%", "2"),
 					resource.TestCheckResourceAttr(
@@ -66,6 +67,7 @@ func TestAccTFEWorkspaceIDsDataSource_basic(t *testing.T) {
 
 func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -80,7 +82,7 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.0", "*"),
 					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"data.tfe_workspace_ids.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "full_names.%", "3"),
 					resource.TestCheckResourceAttr(

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -23,7 +24,7 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "name", fmt.Sprintf("workspace-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_workspace.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"data.tfe_workspace.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "auto_apply", "true"),
 					resource.TestCheckResourceAttr(

--- a/tfe/resource_tfe_notification_configuration_test.go
+++ b/tfe/resource_tfe_notification_configuration_test.go
@@ -2,9 +2,11 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -13,6 +15,7 @@ import (
 
 func TestAccTFENotificationConfiguration_basic(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,7 +23,7 @@ func TestAccTFENotificationConfiguration_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_basic,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -43,6 +46,7 @@ func TestAccTFENotificationConfiguration_basic(t *testing.T) {
 
 func TestAccTFENotificationConfiguration_basicWorkspaceID(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,7 +54,7 @@ func TestAccTFENotificationConfiguration_basicWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_basicWorkspaceID,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basicWorkspaceID, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -73,6 +77,7 @@ func TestAccTFENotificationConfiguration_basicWorkspaceID(t *testing.T) {
 
 func TestAccTFENotificationConfiguration_emailUserIDs(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -80,7 +85,7 @@ func TestAccTFENotificationConfiguration_emailUserIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_emailUserIDs,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_emailUserIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -103,6 +108,7 @@ func TestAccTFENotificationConfiguration_emailUserIDs(t *testing.T) {
 
 func TestAccTFENotificationConfiguration_update(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -110,7 +116,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_basic,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -128,7 +134,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFENotificationConfiguration_update,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_update, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -155,6 +161,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 
 func TestAccTFENotificationConfiguration_updateWorkspaceID(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -162,7 +169,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_basicWorkspaceID,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basicWorkspaceID, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -180,7 +187,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceID(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFENotificationConfiguration_updateWorkspaceID,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_updateWorkspaceID, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -207,6 +214,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceID(t *testing.T) {
 
 func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -214,7 +222,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_basic,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -232,7 +240,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(
 				),
 			},
 			{
-				Config: testAccTFENotificationConfiguration_basicWorkspaceID,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basicWorkspaceID, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -250,7 +258,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(
 				),
 			},
 			{
-				Config: testAccTFENotificationConfiguration_updateWorkspaceID,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_updateWorkspaceID, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -277,6 +285,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(
 
 func TestAccTFENotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -284,7 +293,7 @@ func TestAccTFENotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_emailUserIDs,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_emailUserIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -302,7 +311,7 @@ func TestAccTFENotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFENotificationConfiguration_updateEmailUserIDs,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_updateEmailUserIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -326,16 +335,18 @@ func TestAccTFENotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 }
 
 func TestAccTFENotificationConfiguration_validateSchemaAttributesEmail(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFENotificationConfiguration_emailWithURL,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_emailWithURL, rInt),
 				ExpectError: regexp.MustCompile(`^.*URL cannot be set with destination type of email`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_emailWithToken,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_emailWithToken, rInt),
 				ExpectError: regexp.MustCompile(`^.*Token cannot be set with destination type of email`),
 			},
 		},
@@ -343,20 +354,22 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesEmail(t *testin
 }
 
 func TestAccTFENotificationConfiguration_validateSchemaAttributesGeneric(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFENotificationConfiguration_genericWithEmailAddresses,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithEmailAddresses, rInt),
 				ExpectError: regexp.MustCompile(`^.*Email addresses cannot be set with destination type of generic`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_genericWithEmailUserIDs,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithEmailUserIDs, rInt),
 				ExpectError: regexp.MustCompile(`^.*Email user IDs cannot be set with destination type of generic`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_genericWithoutURL,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithoutURL, rInt),
 				ExpectError: regexp.MustCompile(`^.*URL is required with destination type of generic`),
 			},
 		},
@@ -364,24 +377,26 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesGeneric(t *test
 }
 
 func TestAccTFENotificationConfiguration_validateSchemaAttributesSlack(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFENotificationConfiguration_slackWithEmailAddresses,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithEmailAddresses, rInt),
 				ExpectError: regexp.MustCompile(`^.*Email addresses cannot be set with destination type of slack`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_slackWithEmailUserIDs,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithEmailUserIDs, rInt),
 				ExpectError: regexp.MustCompile(`^.*Email user IDs cannot be set with destination type of slack`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_slackWithToken,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithToken, rInt),
 				ExpectError: regexp.MustCompile(`^.*Token cannot be set with destination type of slack`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_slackWithoutURL,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithoutURL, rInt),
 				ExpectError: regexp.MustCompile(`^.*URL is required with destination type of slack`),
 			},
 		},
@@ -390,6 +405,7 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesSlack(t *testin
 
 func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -397,7 +413,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail(t *
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_emailUserIDs,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_emailUserIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -415,11 +431,11 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail(t *
 				),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_emailWithURL,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_emailWithURL, rInt),
 				ExpectError: regexp.MustCompile(`^.*URL cannot be set with destination type of email`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_emailWithToken,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_emailWithToken, rInt),
 				ExpectError: regexp.MustCompile(`^.*Token cannot be set with destination type of email`),
 			},
 		},
@@ -428,6 +444,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail(t *
 
 func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -435,7 +452,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_basic,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -453,15 +470,15 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t
 				),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_genericWithEmailAddresses,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithEmailAddresses, rInt),
 				ExpectError: regexp.MustCompile(`^.*Email addresses cannot be set with destination type of generic`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_genericWithEmailUserIDs,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithEmailUserIDs, rInt),
 				ExpectError: regexp.MustCompile(`^.*Email user IDs cannot be set with destination type of generic`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_genericWithoutURL,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithoutURL, rInt),
 				ExpectError: regexp.MustCompile(`^.*URL is required with destination type of generic`),
 			},
 		},
@@ -470,6 +487,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t
 
 func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -477,7 +495,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_slack,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_slack, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -495,19 +513,19 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *
 				),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_slackWithEmailAddresses,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithEmailAddresses, rInt),
 				ExpectError: regexp.MustCompile(`^.*Email addresses cannot be set with destination type of slack`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_slackWithEmailUserIDs,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithEmailUserIDs, rInt),
 				ExpectError: regexp.MustCompile(`^.*Email user IDs cannot be set with destination type of slack`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_slackWithToken,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithToken, rInt),
 				ExpectError: regexp.MustCompile(`^.*Token cannot be set with destination type of slack`),
 			},
 			{
-				Config:      testAccTFENotificationConfiguration_slackWithoutURL,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithoutURL, rInt),
 				ExpectError: regexp.MustCompile(`^.*URL is required with destination type of slack`),
 			},
 		},
@@ -516,6 +534,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *
 
 func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -523,7 +542,7 @@ func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_duplicateTriggers,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_duplicateTriggers, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -545,13 +564,15 @@ func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 }
 
 func TestAccTFENotificationConfiguration_noWorkspaceID(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFENotificationConfiguration_noWorkspaceID,
+				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_noWorkspaceID, rInt),
 				ExpectError: regexp.MustCompile(`One of workspace_id or workspace_external_id must be set`),
 			},
 		},
@@ -559,13 +580,15 @@ func TestAccTFENotificationConfiguration_noWorkspaceID(t *testing.T) {
 }
 
 func TestAccTFENotificationConfigurationImport_basic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_update,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_update, rInt),
 			},
 
 			{
@@ -579,13 +602,15 @@ func TestAccTFENotificationConfigurationImport_basic(t *testing.T) {
 }
 
 func TestAccTFENotificationConfigurationImport_emailUserIDs(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_updateEmailUserIDs,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_updateEmailUserIDs, rInt),
 			},
 
 			{
@@ -599,13 +624,15 @@ func TestAccTFENotificationConfigurationImport_emailUserIDs(t *testing.T) {
 }
 
 func TestAccTFENotificationConfigurationImport_emptyEmailUserIDs(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENotificationConfiguration_emailUserIDs,
+				Config: fmt.Sprintf(testAccTFENotificationConfiguration_emailUserIDs, rInt),
 			},
 
 			{
@@ -831,9 +858,9 @@ func testAccCheckTFENotificationConfigurationDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFENotificationConfiguration_basic = `
+var testAccTFENotificationConfiguration_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -851,7 +878,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_emailUserIDs = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -873,7 +900,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_slack = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -891,7 +918,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_basicWorkspaceID = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -909,7 +936,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_update = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -930,7 +957,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_updateWorkspaceID = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -951,7 +978,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_updateEmailUserIDs = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -976,7 +1003,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_emailWithURL = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -994,7 +1021,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_emailWithToken = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1012,7 +1039,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_genericWithEmailAddresses = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1030,7 +1057,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_genericWithEmailUserIDs = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1053,7 +1080,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_genericWithoutURL = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1070,7 +1097,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_slackWithEmailAddresses = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1088,7 +1115,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_slackWithEmailUserIDs = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1111,7 +1138,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_slackWithToken = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1130,7 +1157,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_slackWithoutURL = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1147,7 +1174,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_duplicateTriggers = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1166,7 +1193,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_noWorkspaceID = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_notification_configuration_test.go
+++ b/tfe/resource_tfe_notification_configuration_test.go
@@ -23,7 +23,7 @@ func TestAccTFENotificationConfiguration_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basic, rInt),
+				Config: testAccTFENotificationConfiguration_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -54,7 +54,7 @@ func TestAccTFENotificationConfiguration_basicWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basicWorkspaceID, rInt),
+				Config: testAccTFENotificationConfiguration_basicWorkspaceID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -85,7 +85,7 @@ func TestAccTFENotificationConfiguration_emailUserIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_emailUserIDs, rInt),
+				Config: testAccTFENotificationConfiguration_emailUserIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -116,7 +116,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basic, rInt),
+				Config: testAccTFENotificationConfiguration_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -134,7 +134,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_update, rInt),
+				Config: testAccTFENotificationConfiguration_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -169,7 +169,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basicWorkspaceID, rInt),
+				Config: testAccTFENotificationConfiguration_basicWorkspaceID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -187,7 +187,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceID(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_updateWorkspaceID, rInt),
+				Config: testAccTFENotificationConfiguration_updateWorkspaceID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -222,7 +222,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basic, rInt),
+				Config: testAccTFENotificationConfiguration_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -240,7 +240,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basicWorkspaceID, rInt),
+				Config: testAccTFENotificationConfiguration_basicWorkspaceID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -258,7 +258,7 @@ func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_updateWorkspaceID, rInt),
+				Config: testAccTFENotificationConfiguration_updateWorkspaceID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -293,7 +293,7 @@ func TestAccTFENotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_emailUserIDs, rInt),
+				Config: testAccTFENotificationConfiguration_emailUserIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -311,7 +311,7 @@ func TestAccTFENotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_updateEmailUserIDs, rInt),
+				Config: testAccTFENotificationConfiguration_updateEmailUserIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -342,11 +342,11 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesEmail(t *testin
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_emailWithURL, rInt),
+				Config:      testAccTFENotificationConfiguration_emailWithURL(rInt),
 				ExpectError: regexp.MustCompile(`^.*URL cannot be set with destination type of email`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_emailWithToken, rInt),
+				Config:      testAccTFENotificationConfiguration_emailWithToken(rInt),
 				ExpectError: regexp.MustCompile(`^.*Token cannot be set with destination type of email`),
 			},
 		},
@@ -361,15 +361,15 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesGeneric(t *test
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithEmailAddresses, rInt),
+				Config:      testAccTFENotificationConfiguration_genericWithEmailAddresses(rInt),
 				ExpectError: regexp.MustCompile(`^.*Email addresses cannot be set with destination type of generic`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithEmailUserIDs, rInt),
+				Config:      testAccTFENotificationConfiguration_genericWithEmailUserIDs(rInt),
 				ExpectError: regexp.MustCompile(`^.*Email user IDs cannot be set with destination type of generic`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithoutURL, rInt),
+				Config:      testAccTFENotificationConfiguration_genericWithoutURL(rInt),
 				ExpectError: regexp.MustCompile(`^.*URL is required with destination type of generic`),
 			},
 		},
@@ -384,19 +384,19 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesSlack(t *testin
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithEmailAddresses, rInt),
+				Config:      testAccTFENotificationConfiguration_slackWithEmailAddresses(rInt),
 				ExpectError: regexp.MustCompile(`^.*Email addresses cannot be set with destination type of slack`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithEmailUserIDs, rInt),
+				Config:      testAccTFENotificationConfiguration_slackWithEmailUserIDs(rInt),
 				ExpectError: regexp.MustCompile(`^.*Email user IDs cannot be set with destination type of slack`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithToken, rInt),
+				Config:      testAccTFENotificationConfiguration_slackWithToken(rInt),
 				ExpectError: regexp.MustCompile(`^.*Token cannot be set with destination type of slack`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithoutURL, rInt),
+				Config:      testAccTFENotificationConfiguration_slackWithoutURL(rInt),
 				ExpectError: regexp.MustCompile(`^.*URL is required with destination type of slack`),
 			},
 		},
@@ -413,7 +413,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail(t *
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_emailUserIDs, rInt),
+				Config: testAccTFENotificationConfiguration_emailUserIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -431,11 +431,11 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail(t *
 				),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_emailWithURL, rInt),
+				Config:      testAccTFENotificationConfiguration_emailWithURL(rInt),
 				ExpectError: regexp.MustCompile(`^.*URL cannot be set with destination type of email`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_emailWithToken, rInt),
+				Config:      testAccTFENotificationConfiguration_emailWithToken(rInt),
 				ExpectError: regexp.MustCompile(`^.*Token cannot be set with destination type of email`),
 			},
 		},
@@ -452,7 +452,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_basic, rInt),
+				Config: testAccTFENotificationConfiguration_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -470,15 +470,15 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t
 				),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithEmailAddresses, rInt),
+				Config:      testAccTFENotificationConfiguration_genericWithEmailAddresses(rInt),
 				ExpectError: regexp.MustCompile(`^.*Email addresses cannot be set with destination type of generic`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithEmailUserIDs, rInt),
+				Config:      testAccTFENotificationConfiguration_genericWithEmailUserIDs(rInt),
 				ExpectError: regexp.MustCompile(`^.*Email user IDs cannot be set with destination type of generic`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_genericWithoutURL, rInt),
+				Config:      testAccTFENotificationConfiguration_genericWithoutURL(rInt),
 				ExpectError: regexp.MustCompile(`^.*URL is required with destination type of generic`),
 			},
 		},
@@ -495,7 +495,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_slack, rInt),
+				Config: testAccTFENotificationConfiguration_slack(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -513,19 +513,19 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *
 				),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithEmailAddresses, rInt),
+				Config:      testAccTFENotificationConfiguration_slackWithEmailAddresses(rInt),
 				ExpectError: regexp.MustCompile(`^.*Email addresses cannot be set with destination type of slack`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithEmailUserIDs, rInt),
+				Config:      testAccTFENotificationConfiguration_slackWithEmailUserIDs(rInt),
 				ExpectError: regexp.MustCompile(`^.*Email user IDs cannot be set with destination type of slack`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithToken, rInt),
+				Config:      testAccTFENotificationConfiguration_slackWithToken(rInt),
 				ExpectError: regexp.MustCompile(`^.*Token cannot be set with destination type of slack`),
 			},
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_slackWithoutURL, rInt),
+				Config:      testAccTFENotificationConfiguration_slackWithoutURL(rInt),
 				ExpectError: regexp.MustCompile(`^.*URL is required with destination type of slack`),
 			},
 		},
@@ -542,7 +542,7 @@ func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_duplicateTriggers, rInt),
+				Config: testAccTFENotificationConfiguration_duplicateTriggers(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -572,7 +572,7 @@ func TestAccTFENotificationConfiguration_noWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccTFENotificationConfiguration_noWorkspaceID, rInt),
+				Config:      testAccTFENotificationConfiguration_noWorkspaceID(rInt),
 				ExpectError: regexp.MustCompile(`One of workspace_id or workspace_external_id must be set`),
 			},
 		},
@@ -588,7 +588,7 @@ func TestAccTFENotificationConfigurationImport_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_update, rInt),
+				Config: testAccTFENotificationConfiguration_update(rInt),
 			},
 
 			{
@@ -610,7 +610,7 @@ func TestAccTFENotificationConfigurationImport_emailUserIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_updateEmailUserIDs, rInt),
+				Config: testAccTFENotificationConfiguration_updateEmailUserIDs(rInt),
 			},
 
 			{
@@ -632,7 +632,7 @@ func TestAccTFENotificationConfigurationImport_emptyEmailUserIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFENotificationConfiguration_emailUserIDs, rInt),
+				Config: testAccTFENotificationConfiguration_emailUserIDs(rInt),
 			},
 
 			{
@@ -858,7 +858,8 @@ func testAccCheckTFENotificationConfigurationDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccTFENotificationConfiguration_basic = `
+func testAccTFENotificationConfiguration_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -874,9 +875,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type      = "generic"
   url                   = "http://example.com"
   workspace_external_id = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_emailUserIDs = `
+func testAccTFENotificationConfiguration_emailUserIDs(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -896,9 +899,11 @@ resource "tfe_notification_configuration" "foobar" {
   name             = "notification_email"
   destination_type = "email"
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_slack = `
+func testAccTFENotificationConfiguration_slack(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -914,9 +919,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type      = "slack"
   url                   = "http://example.com"
   workspace_external_id = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_basicWorkspaceID = `
+func testAccTFENotificationConfiguration_basicWorkspaceID(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -932,9 +939,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type      = "generic"
   url                   = "http://example.com"
   workspace_id          = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_update = `
+func testAccTFENotificationConfiguration_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -953,9 +962,11 @@ resource "tfe_notification_configuration" "foobar" {
   triggers              = ["run:created", "run:needs_attention"]
   url                   = "http://example.com/?update=true"
   workspace_external_id = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_updateWorkspaceID = `
+func testAccTFENotificationConfiguration_updateWorkspaceID(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -974,10 +985,11 @@ resource "tfe_notification_configuration" "foobar" {
   triggers              = ["run:created", "run:needs_attention"]
   url                   = "http://example.com/?update=true"
   workspace_id          = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_updateEmailUserIDs = `
-resource "tfe_organization" "foobar" {
+func testAccTFENotificationConfiguration_updateEmailUserIDs(rInt int) string {
+	return fmt.Sprintf(`resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
@@ -999,9 +1011,11 @@ resource "tfe_notification_configuration" "foobar" {
   enabled          = true
   triggers         = ["run:created", "run:needs_attention"]
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_emailWithURL = `
+func testAccTFENotificationConfiguration_emailWithURL(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1017,9 +1031,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type = "email"
   url              = "http://example.com"
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_emailWithToken = `
+func testAccTFENotificationConfiguration_emailWithToken(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1035,9 +1051,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type = "email"
   token            = "1234567890"
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_genericWithEmailAddresses = `
+func testAccTFENotificationConfiguration_genericWithEmailAddresses(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1053,9 +1071,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type = "generic"
   email_addresses  = ["test@example.com", "test2@example.com"]
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_genericWithEmailUserIDs = `
+func testAccTFENotificationConfiguration_genericWithEmailUserIDs(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1076,9 +1096,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type = "generic"
   email_user_ids   = ["${tfe_organization_membership.foobar.id}"]
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_genericWithoutURL = `
+func testAccTFENotificationConfiguration_genericWithoutURL(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1093,9 +1115,11 @@ resource "tfe_notification_configuration" "foobar" {
   name             = "notification_generic_without_url"
   destination_type = "generic"
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_slackWithEmailAddresses = `
+func testAccTFENotificationConfiguration_slackWithEmailAddresses(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1111,9 +1135,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type = "slack"
   email_addresses  = ["test@example.com", "test2@example.com"]
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_slackWithEmailUserIDs = `
+func testAccTFENotificationConfiguration_slackWithEmailUserIDs(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1134,9 +1160,11 @@ resource "tfe_notification_configuration" "foobar" {
   destination_type = "slack"
   email_user_ids   = ["${tfe_organization_membership.foobar.id}"]
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_slackWithToken = `
+func testAccTFENotificationConfiguration_slackWithToken(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1153,9 +1181,11 @@ resource "tfe_notification_configuration" "foobar" {
   token            = "1234567890"
   url              = "http://example.com"
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_slackWithoutURL = `
+func testAccTFENotificationConfiguration_slackWithoutURL(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1170,9 +1200,11 @@ resource "tfe_notification_configuration" "foobar" {
   name             = "notification_slack_without_url"
   destination_type = "slack"
   workspace_id     = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_duplicateTriggers = `
+func testAccTFENotificationConfiguration_duplicateTriggers(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1189,9 +1221,11 @@ resource "tfe_notification_configuration" "foobar" {
   triggers              = ["run:created", "run:created", "run:created"]
   url                   = "http://example.com"
   workspace_external_id = tfe_workspace.foobar.id
-}`
+}`, rInt)
+}
 
-const testAccTFENotificationConfiguration_noWorkspaceID = `
+func testAccTFENotificationConfiguration_noWorkspaceID(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1206,4 +1240,5 @@ resource "tfe_notification_configuration" "foobar" {
   name                  = "notification_basic"
   destination_type      = "generic"
   url                   = "http://example.com"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_oauth_client_test.go
+++ b/tfe/resource_tfe_oauth_client_test.go
@@ -2,15 +2,17 @@ package tfe
 
 import (
 	"fmt"
-	"testing"
-
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"math/rand"
+	"testing"
+	"time"
 )
 
 func TestAccTFEOAuthClient_basic(t *testing.T) {
 	oc := &tfe.OAuthClient{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -23,7 +25,7 @@ func TestAccTFEOAuthClient_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOAuthClient_basic,
+				Config: getTestAccTFEOAuthClientBasic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOAuthClientExists("tfe_oauth_client.foobar", oc),
 					testAccCheckTFEOAuthClientAttributes(oc),
@@ -108,9 +110,10 @@ func testAccCheckTFEOAuthClientDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccTFEOAuthClient_basic = fmt.Sprintf(`
+func getTestAccTFEOAuthClientBasic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -120,4 +123,5 @@ resource "tfe_oauth_client" "foobar" {
   http_url         = "https://github.com"
   oauth_token      = "%s"
   service_provider = "github"
-}`, GITHUB_TOKEN)
+}`, rInt, GITHUB_TOKEN)
+}

--- a/tfe/resource_tfe_oauth_client_test.go
+++ b/tfe/resource_tfe_oauth_client_test.go
@@ -25,7 +25,7 @@ func TestAccTFEOAuthClient_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getTestAccTFEOAuthClientBasic(rInt),
+				Config: testAccTFEOAuthClient_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOAuthClientExists("tfe_oauth_client.foobar", oc),
 					testAccCheckTFEOAuthClientAttributes(oc),
@@ -110,7 +110,7 @@ func testAccCheckTFEOAuthClientDestroy(s *terraform.State) error {
 	return nil
 }
 
-func getTestAccTFEOAuthClientBasic(rInt int) string {
+func testAccTFEOAuthClient_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"

--- a/tfe/resource_tfe_organization_membership_test.go
+++ b/tfe/resource_tfe_organization_membership_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccTFEOrganizationMembership_basic(t *testing.T) {
 	mem := &tfe.OrganizationMembership{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,15 +22,15 @@ func TestAccTFEOrganizationMembership_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganizationMembership_basic, rInt),
+				Config: testAccTFEOrganizationMembership_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationMembershipExists(
 						"tfe_organization_membership.foobar", mem),
-					testAccCheckTFEOrganizationMembershipAttributes(mem, fmt.Sprintf("tst-terraform-%d", rInt)),
+					testAccCheckTFEOrganizationMembershipAttributes(mem, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_organization_membership.foobar", "email", "example@hashicorp.com"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_membership.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"tfe_organization_membership.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("tfe_organization_membership.foobar", "user_id"),
 				),
 			},
@@ -46,7 +47,7 @@ func TestAccTFEOrganizationMembershipImport(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganizationMembership_basic, rInt),
+				Config: testAccTFEOrganizationMembership_basic(rInt),
 			},
 			{
 				ResourceName:      "tfe_organization_membership.foobar",
@@ -128,7 +129,8 @@ func testAccCheckTFEOrganizationMembershipDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFEOrganizationMembership_basic = `
+func testAccTFEOrganizationMembership_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -137,4 +139,5 @@ resource "tfe_organization" "foobar" {
 resource "tfe_organization_membership" "foobar" {
   email        = "example@hashicorp.com"
   organization = "${tfe_organization.foobar.id}"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccTFEOrganization_basic(t *testing.T) {
 	org := &tfe.Organization{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,13 +22,13 @@ func TestAccTFEOrganization_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganization_basic, rInt),
+				Config: testAccTFEOrganization_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
-					testAccCheckTFEOrganizationAttributes(org, fmt.Sprintf("tst-terraform-%d", rInt)),
+					testAccCheckTFEOrganizationAttributes(org, orgName),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"tfe_organization.foobar", "name", orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
@@ -42,6 +43,7 @@ func TestAccTFEOrganization_update(t *testing.T) {
 	org := &tfe.Organization{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	rInt1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -49,13 +51,13 @@ func TestAccTFEOrganization_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganization_basic, rInt),
+				Config: testAccTFEOrganization_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
-					testAccCheckTFEOrganizationAttributes(org, fmt.Sprintf("tst-terraform-%d", rInt)),
+					testAccCheckTFEOrganizationAttributes(org, orgName),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"tfe_organization.foobar", "name", orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
@@ -64,7 +66,7 @@ func TestAccTFEOrganization_update(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEOrganization_update, rInt1),
+				Config: testAccTFEOrganization_update(rInt1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
@@ -96,7 +98,7 @@ func TestAccTFEOrganization_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganization_basic, rInt),
+				Config: testAccTFEOrganization_basic(rInt),
 			},
 
 			{
@@ -208,17 +210,21 @@ func testAccCheckTFEOrganizationDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFEOrganization_basic = `
+func testAccTFEOrganization_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
-}`
+}`, rInt)
+}
 
-const testAccTFEOrganization_update = `
+func testAccTFEOrganization_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name                     = "tst-terraform-%d"
   email                    = "admin-updated@company.com"
   session_timeout_minutes  = 3600
   session_remember_minutes = 3600
   owners_team_saml_role_id = "owners"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccTFEOrganizationToken_basic(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,12 +23,12 @@ func TestAccTFEOrganizationToken_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganizationToken_basic, rInt),
+				Config: testAccTFEOrganizationToken_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"tfe_organization_token.foobar", "organization", orgName),
 				),
 			},
 		},
@@ -37,6 +38,7 @@ func TestAccTFEOrganizationToken_basic(t *testing.T) {
 func TestAccTFEOrganizationToken_existsWithoutForce(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,17 +46,17 @@ func TestAccTFEOrganizationToken_existsWithoutForce(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganizationToken_basic, rInt),
+				Config: testAccTFEOrganizationToken_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"tfe_organization_token.foobar", "organization", orgName),
 				),
 			},
 
 			{
-				Config:      fmt.Sprintf(testAccTFEOrganizationToken_existsWithoutForce, rInt),
+				Config:      testAccTFEOrganizationToken_existsWithoutForce(rInt),
 				ExpectError: regexp.MustCompile(`token already exists`),
 			},
 		},
@@ -64,6 +66,7 @@ func TestAccTFEOrganizationToken_existsWithoutForce(t *testing.T) {
 func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -71,22 +74,22 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganizationToken_basic, rInt),
+				Config: testAccTFEOrganizationToken_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"tfe_organization_token.foobar", "organization", orgName),
 				),
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEOrganizationToken_existsWithForce, rInt),
+				Config: testAccTFEOrganizationToken_existsWithForce(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.regenerated", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.regenerated", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"tfe_organization_token.regenerated", "organization", orgName),
 				),
 			},
 		},
@@ -102,7 +105,7 @@ func TestAccTFEOrganizationToken_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEOrganizationToken_basic, rInt),
+				Config: testAccTFEOrganizationToken_basic(rInt),
 			},
 
 			{
@@ -165,7 +168,8 @@ func testAccCheckTFEOrganizationTokenDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFEOrganizationToken_basic = `
+func testAccTFEOrganizationToken_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -173,9 +177,11 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_organization_token" "foobar" {
   organization = "${tfe_organization.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFEOrganizationToken_existsWithoutForce = `
+func testAccTFEOrganizationToken_existsWithoutForce(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -187,9 +193,11 @@ resource "tfe_organization_token" "foobar" {
 
 resource "tfe_organization_token" "error" {
   organization = "${tfe_organization.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFEOrganizationToken_existsWithForce = `
+func testAccTFEOrganizationToken_existsWithForce(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -202,4 +210,5 @@ resource "tfe_organization_token" "foobar" {
 resource "tfe_organization_token" "regenerated" {
   organization     = "${tfe_organization.foobar.id}"
   force_regenerate = true
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -2,8 +2,10 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"regexp"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -12,6 +14,7 @@ import (
 
 func TestAccTFEOrganizationToken_basic(t *testing.T) {
 	token := &tfe.OrganizationToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,12 +22,12 @@ func TestAccTFEOrganizationToken_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganizationToken_basic,
+				Config: fmt.Sprintf(testAccTFEOrganizationToken_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", "tst-terraform"),
+						"tfe_organization_token.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 				),
 			},
 		},
@@ -33,6 +36,7 @@ func TestAccTFEOrganizationToken_basic(t *testing.T) {
 
 func TestAccTFEOrganizationToken_existsWithoutForce(t *testing.T) {
 	token := &tfe.OrganizationToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,17 +44,17 @@ func TestAccTFEOrganizationToken_existsWithoutForce(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganizationToken_basic,
+				Config: fmt.Sprintf(testAccTFEOrganizationToken_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", "tst-terraform"),
+						"tfe_organization_token.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 				),
 			},
 
 			{
-				Config:      testAccTFEOrganizationToken_existsWithoutForce,
+				Config:      fmt.Sprintf(testAccTFEOrganizationToken_existsWithoutForce, rInt),
 				ExpectError: regexp.MustCompile(`token already exists`),
 			},
 		},
@@ -59,6 +63,7 @@ func TestAccTFEOrganizationToken_existsWithoutForce(t *testing.T) {
 
 func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 	token := &tfe.OrganizationToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -66,22 +71,22 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganizationToken_basic,
+				Config: fmt.Sprintf(testAccTFEOrganizationToken_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", "tst-terraform"),
+						"tfe_organization_token.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 				),
 			},
 
 			{
-				Config: testAccTFEOrganizationToken_existsWithForce,
+				Config: fmt.Sprintf(testAccTFEOrganizationToken_existsWithForce, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.regenerated", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.regenerated", "organization", "tst-terraform"),
+						"tfe_organization_token.regenerated", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 				),
 			},
 		},
@@ -89,13 +94,15 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 }
 
 func TestAccTFEOrganizationToken_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganizationToken_basic,
+				Config: fmt.Sprintf(testAccTFEOrganizationToken_basic, rInt),
 			},
 
 			{
@@ -160,7 +167,7 @@ func testAccCheckTFEOrganizationTokenDestroy(s *terraform.State) error {
 
 const testAccTFEOrganizationToken_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -170,7 +177,7 @@ resource "tfe_organization_token" "foobar" {
 
 const testAccTFEOrganizationToken_existsWithoutForce = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -184,7 +191,7 @@ resource "tfe_organization_token" "error" {
 
 const testAccTFEOrganizationToken_existsWithForce = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_policy_set_parameter_test.go
+++ b/tfe/resource_tfe_policy_set_parameter_test.go
@@ -21,7 +21,7 @@ func TestAccTFEPolicySetParameter_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySetParameter_basic, rInt),
+				Config: testAccTFEPolicySetParameter_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -48,7 +48,7 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySetParameter_basic, rInt),
+				Config: testAccTFEPolicySetParameter_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -63,7 +63,7 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySetParameter_update, rInt),
+				Config: testAccTFEPolicySetParameter_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -89,7 +89,7 @@ func TestAccTFEPolicySetParameter_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySetParameter_basic, rInt),
+				Config: testAccTFEPolicySetParameter_basic(rInt),
 			},
 
 			{
@@ -192,7 +192,8 @@ func testAccCheckTFEPolicySetParameterDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFEPolicySetParameter_basic = `
+func testAccTFEPolicySetParameter_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -207,9 +208,11 @@ resource "tfe_policy_set_parameter" "foobar" {
   key          = "key_test"
   value        = "value_test"
   policy_set_id = "${tfe_policy_set.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFEPolicySetParameter_update = `
+func testAccTFEPolicySetParameter_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -225,4 +228,5 @@ resource "tfe_policy_set_parameter" "foobar" {
   value        = "value_updated"
   sensitive    = true
   policy_set_id = "${tfe_policy_set.foobar.id}"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_policy_set_parameter_test.go
+++ b/tfe/resource_tfe_policy_set_parameter_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,6 +13,7 @@ import (
 
 func TestAccTFEPolicySetParameter_basic(t *testing.T) {
 	parameter := &tfe.PolicySetParameter{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +21,7 @@ func TestAccTFEPolicySetParameter_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySetParameter_basic,
+				Config: fmt.Sprintf(testAccTFEPolicySetParameter_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -37,6 +40,7 @@ func TestAccTFEPolicySetParameter_basic(t *testing.T) {
 
 func TestAccTFEPolicySetParameter_update(t *testing.T) {
 	parameter := &tfe.PolicySetParameter{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,7 +48,7 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySetParameter_basic,
+				Config: fmt.Sprintf(testAccTFEPolicySetParameter_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -59,7 +63,7 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySetParameter_update,
+				Config: fmt.Sprintf(testAccTFEPolicySetParameter_update, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -77,13 +81,15 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 }
 
 func TestAccTFEPolicySetParameter_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySetParameter_basic,
+				Config: fmt.Sprintf(testAccTFEPolicySetParameter_basic, rInt),
 			},
 
 			{
@@ -188,7 +194,7 @@ func testAccCheckTFEPolicySetParameterDestroy(s *terraform.State) error {
 
 const testAccTFEPolicySetParameter_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -205,7 +211,7 @@ resource "tfe_policy_set_parameter" "foobar" {
 
 const testAccTFEPolicySetParameter_update = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -2,16 +2,18 @@ package tfe
 
 import (
 	"fmt"
-	"regexp"
-	"testing"
-
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"math/rand"
+	"regexp"
+	"testing"
+	"time"
 )
 
 func TestAccTFEPolicySet_basic(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,7 +21,7 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_basic,
+				Config: fmt.Sprintf(testAccTFEPolicySet_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -39,6 +41,8 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 
 func TestAccTFEPolicySet_update(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -46,7 +50,7 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_basic,
+				Config: fmt.Sprintf(testAccTFEPolicySet_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -62,10 +66,10 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_populated,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -82,6 +86,8 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 
 func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -89,7 +95,7 @@ func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_basic,
+				Config: fmt.Sprintf(testAccTFEPolicySet_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -104,10 +110,10 @@ func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEPolicySet_populated,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -119,10 +125,10 @@ func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -139,6 +145,7 @@ func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
 
 func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -146,7 +153,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_basic,
+				Config: fmt.Sprintf(testAccTFEPolicySet_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -161,7 +168,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEPolicySet_empty,
+				Config: fmt.Sprintf(testAccTFEPolicySet_empty, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -181,6 +188,8 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 
 func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -188,10 +197,10 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populated,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -204,10 +213,10 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_updatePopulated,
+				Config: fmt.Sprintf(testAccTFEPolicySet_updatePopulated, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulatedUpdated(policySet),
+					testAccCheckTFEPolicySetPopulatedUpdated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated-updated"),
 					resource.TestCheckResourceAttr(
@@ -224,6 +233,8 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 
 func TestAccTFEPolicySet_updatePopulatedWorkspaceIDs(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -231,10 +242,10 @@ func TestAccTFEPolicySet_updatePopulatedWorkspaceIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -247,10 +258,10 @@ func TestAccTFEPolicySet_updatePopulatedWorkspaceIDs(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_updatePopulatedWorkspaceIDs,
+				Config: fmt.Sprintf(testAccTFEPolicySet_updatePopulatedWorkspaceIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulatedUpdated(policySet),
+					testAccCheckTFEPolicySetPopulatedUpdated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated-updated"),
 					resource.TestCheckResourceAttr(
@@ -267,6 +278,8 @@ func TestAccTFEPolicySet_updatePopulatedWorkspaceIDs(t *testing.T) {
 
 func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -274,10 +287,10 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populated,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -290,7 +303,7 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_global,
+				Config: fmt.Sprintf(testAccTFEPolicySet_global, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -308,6 +321,8 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 
 func TestAccTFEPolicySet_updateWorkspaceIDsToGlobal(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -315,10 +330,10 @@ func TestAccTFEPolicySet_updateWorkspaceIDsToGlobal(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -331,7 +346,7 @@ func TestAccTFEPolicySet_updateWorkspaceIDsToGlobal(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_global,
+				Config: fmt.Sprintf(testAccTFEPolicySet_global, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -349,6 +364,8 @@ func TestAccTFEPolicySet_updateWorkspaceIDsToGlobal(t *testing.T) {
 
 func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -356,7 +373,7 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_global,
+				Config: fmt.Sprintf(testAccTFEPolicySet_global, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -370,10 +387,10 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_populated,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -390,6 +407,8 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 
 func TestAccTFEPolicySet_updateGlobalToWorkspaceIDs(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -397,7 +416,7 @@ func TestAccTFEPolicySet_updateGlobalToWorkspaceIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_global,
+				Config: fmt.Sprintf(testAccTFEPolicySet_global, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -411,10 +430,10 @@ func TestAccTFEPolicySet_updateGlobalToWorkspaceIDs(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet),
+					testAccCheckTFEPolicySetPopulated(policySet, orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -431,6 +450,7 @@ func TestAccTFEPolicySet_updateGlobalToWorkspaceIDs(t *testing.T) {
 
 func TestAccTFEPolicySet_vcs(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -452,7 +472,7 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_vcs,
+				Config: getTestAccTFEPolicySetVCS(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -478,6 +498,7 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 
 func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 	policySet := &tfe.PolicySet{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -499,7 +520,7 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_vcs,
+				Config: getTestAccTFEPolicySetVCS(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -520,7 +541,7 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEPolicySet_updateVCSBranch,
+				Config: getTestAccTFEPolicySetUpdateVCSBranch(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -545,13 +566,15 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_invalidName(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFEPolicySet_invalidName,
+				Config:      fmt.Sprintf(testAccTFEPolicySet_invalidName, rInt),
 				ExpectError: regexp.MustCompile(`can only include letters, numbers, -, and _.`),
 			},
 		},
@@ -559,13 +582,15 @@ func TestAccTFEPolicySet_invalidName(t *testing.T) {
 }
 
 func TestAccTFEPolicySetImport(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs,
+				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
 			},
 
 			{
@@ -623,7 +648,7 @@ func testAccCheckTFEPolicySetAttributes(policySet *tfe.PolicySet) resource.TestC
 	}
 }
 
-func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet) resource.TestCheckFunc {
+func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		tfeClient := testAccProvider.Meta().(*tfe.Client)
 
@@ -650,7 +675,7 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet) resource.TestCh
 		}
 
 		workspaceID := policySet.Workspaces[0].ID
-		workspace, _ := tfeClient.Workspaces.Read(ctx, "tst-terraform", "workspace-foo")
+		workspace, _ := tfeClient.Workspaces.Read(ctx, orgName, "workspace-foo")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
 		}
@@ -659,7 +684,7 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet) resource.TestCh
 	}
 }
 
-func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet) resource.TestCheckFunc {
+func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		tfeClient := testAccProvider.Meta().(*tfe.Client)
 
@@ -686,7 +711,7 @@ func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet) resource
 		}
 
 		workspaceID := policySet.Workspaces[0].ID
-		workspace, _ := tfeClient.Workspaces.Read(ctx, "tst-terraform", "workspace-bar")
+		workspace, _ := tfeClient.Workspaces.Read(ctx, orgName, "workspace-bar")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
 		}
@@ -749,7 +774,7 @@ func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
 
 const testAccTFEPolicySet_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -768,7 +793,7 @@ resource "tfe_policy_set" "foobar" {
 
 const testAccTFEPolicySet_empty = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
  resource "tfe_policy_set" "foobar" {
@@ -779,7 +804,7 @@ resource "tfe_organization" "foobar" {
 
 const testAccTFEPolicySet_populated = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -803,7 +828,7 @@ resource "tfe_policy_set" "foobar" {
 
 const testAccTFEPolicySet_populatedWorkspaceIDs = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -827,7 +852,7 @@ resource "tfe_policy_set" "foobar" {
 
 const testAccTFEPolicySet_updatePopulated = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -862,7 +887,7 @@ resource "tfe_policy_set" "foobar" {
 
 const testAccTFEPolicySet_updatePopulatedWorkspaceIDs = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -897,7 +922,7 @@ resource "tfe_policy_set" "foobar" {
 
 const testAccTFEPolicySet_global = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -919,9 +944,10 @@ resource "tfe_policy_set" "foobar" {
   policy_ids   = ["${tfe_sentinel_policy.foo.id}"]
 }`
 
-var testAccTFEPolicySet_vcs = fmt.Sprintf(`
+func getTestAccTFEPolicySetVCS(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -946,15 +972,17 @@ resource "tfe_policy_set" "foobar" {
 
   policies_path = "%s"
 }
-`,
-	GITHUB_TOKEN,
-	GITHUB_POLICY_SET_IDENTIFIER,
-	GITHUB_POLICY_SET_PATH,
-)
+`, rInt,
+		GITHUB_TOKEN,
+		GITHUB_POLICY_SET_IDENTIFIER,
+		GITHUB_POLICY_SET_PATH,
+	)
+}
 
-var testAccTFEPolicySet_updateVCSBranch = fmt.Sprintf(`
+func getTestAccTFEPolicySetUpdateVCSBranch(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -979,16 +1007,17 @@ resource "tfe_policy_set" "foobar" {
 
   policies_path = "%s"
 }
-`,
-	GITHUB_TOKEN,
-	GITHUB_POLICY_SET_IDENTIFIER,
-	GITHUB_POLICY_SET_BRANCH,
-	GITHUB_POLICY_SET_PATH,
-)
+`, rInt,
+		GITHUB_TOKEN,
+		GITHUB_POLICY_SET_IDENTIFIER,
+		GITHUB_POLICY_SET_BRANCH,
+		GITHUB_POLICY_SET_PATH,
+	)
+}
 
 const testAccTFEPolicySet_invalidName = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -21,7 +21,7 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_basic, rInt),
+				Config: testAccTFEPolicySet_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -50,7 +50,7 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_basic, rInt),
+				Config: testAccTFEPolicySet_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -66,7 +66,7 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
+				Config: testAccTFEPolicySet_populated(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -95,7 +95,7 @@ func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_basic, rInt),
+				Config: testAccTFEPolicySet_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -110,7 +110,7 @@ func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
+				Config: testAccTFEPolicySet_populated(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -125,7 +125,7 @@ func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
+				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -153,7 +153,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_basic, rInt),
+				Config: testAccTFEPolicySet_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -168,7 +168,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_empty, rInt),
+				Config: testAccTFEPolicySet_empty(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -197,7 +197,7 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
+				Config: testAccTFEPolicySet_populated(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -213,7 +213,7 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_updatePopulated, rInt),
+				Config: testAccTFEPolicySet_updatePopulated(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulatedUpdated(policySet, orgName),
@@ -242,7 +242,7 @@ func TestAccTFEPolicySet_updatePopulatedWorkspaceIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
+				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -258,7 +258,7 @@ func TestAccTFEPolicySet_updatePopulatedWorkspaceIDs(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_updatePopulatedWorkspaceIDs, rInt),
+				Config: testAccTFEPolicySet_updatePopulatedWorkspaceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulatedUpdated(policySet, orgName),
@@ -287,7 +287,7 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
+				Config: testAccTFEPolicySet_populated(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -303,7 +303,7 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_global, rInt),
+				Config: testAccTFEPolicySet_global(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -330,7 +330,7 @@ func TestAccTFEPolicySet_updateWorkspaceIDsToGlobal(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
+				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -346,7 +346,7 @@ func TestAccTFEPolicySet_updateWorkspaceIDsToGlobal(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_global, rInt),
+				Config: testAccTFEPolicySet_global(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -373,7 +373,7 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_global, rInt),
+				Config: testAccTFEPolicySet_global(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -387,7 +387,7 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populated, rInt),
+				Config: testAccTFEPolicySet_populated(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -416,7 +416,7 @@ func TestAccTFEPolicySet_updateGlobalToWorkspaceIDs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_global, rInt),
+				Config: testAccTFEPolicySet_global(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -430,7 +430,7 @@ func TestAccTFEPolicySet_updateGlobalToWorkspaceIDs(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
+				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -472,7 +472,7 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getTestAccTFEPolicySetVCS(rInt),
+				Config: testAccTFEPolicySet_vcs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -520,7 +520,7 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getTestAccTFEPolicySetVCS(rInt),
+				Config: testAccTFEPolicySet_vcs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -541,7 +541,7 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 				),
 			},
 			{
-				Config: getTestAccTFEPolicySetUpdateVCSBranch(rInt),
+				Config: testAccTFEPolicySet_updateVCSBranch(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -574,7 +574,7 @@ func TestAccTFEPolicySet_invalidName(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccTFEPolicySet_invalidName, rInt),
+				Config:      testAccTFEPolicySet_invalidName(rInt),
 				ExpectError: regexp.MustCompile(`can only include letters, numbers, -, and _.`),
 			},
 		},
@@ -590,7 +590,7 @@ func TestAccTFEPolicySetImport(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEPolicySet_populatedWorkspaceIDs, rInt),
+				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
 			},
 
 			{
@@ -772,7 +772,8 @@ func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFEPolicySet_basic = `
+func testAccTFEPolicySet_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -789,9 +790,11 @@ resource "tfe_policy_set" "foobar" {
   description  = "Policy Set"
   organization = "${tfe_organization.foobar.id}"
   policy_ids   = ["${tfe_sentinel_policy.foo.id}"]
-}`
+}`, rInt)
+}
 
-const testAccTFEPolicySet_empty = `
+func testAccTFEPolicySet_empty(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -800,9 +803,11 @@ resource "tfe_organization" "foobar" {
   name         = "tst-terraform"
   description  = "Policy Set"
   organization = "${tfe_organization.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFEPolicySet_populated = `
+func testAccTFEPolicySet_populated(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -824,9 +829,11 @@ resource "tfe_policy_set" "foobar" {
   organization           = "${tfe_organization.foobar.id}"
   policy_ids             = ["${tfe_sentinel_policy.foo.id}"]
   workspace_external_ids = ["${tfe_workspace.foo.id}"]
-}`
+}`, rInt)
+}
 
-const testAccTFEPolicySet_populatedWorkspaceIDs = `
+func testAccTFEPolicySet_populatedWorkspaceIDs(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -848,9 +855,11 @@ resource "tfe_policy_set" "foobar" {
   organization  = "${tfe_organization.foobar.id}"
   policy_ids    = ["${tfe_sentinel_policy.foo.id}"]
   workspace_ids = ["${tfe_workspace.foo.id}"]
-}`
+}`, rInt)
+}
 
-const testAccTFEPolicySet_updatePopulated = `
+func testAccTFEPolicySet_updatePopulated(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -883,9 +892,11 @@ resource "tfe_policy_set" "foobar" {
   organization           = "${tfe_organization.foobar.id}"
   policy_ids             = ["${tfe_sentinel_policy.bar.id}"]
   workspace_external_ids = ["${tfe_workspace.bar.id}"]
-}`
+}`, rInt)
+}
 
-const testAccTFEPolicySet_updatePopulatedWorkspaceIDs = `
+func testAccTFEPolicySet_updatePopulatedWorkspaceIDs(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -918,9 +929,11 @@ resource "tfe_policy_set" "foobar" {
   organization  = "${tfe_organization.foobar.id}"
   policy_ids    = ["${tfe_sentinel_policy.bar.id}"]
   workspace_ids = ["${tfe_workspace.bar.id}"]
-}`
+}`, rInt)
+}
 
-const testAccTFEPolicySet_global = `
+func testAccTFEPolicySet_global(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -942,9 +955,10 @@ resource "tfe_policy_set" "foobar" {
   organization = "${tfe_organization.foobar.id}"
   global       = true
   policy_ids   = ["${tfe_sentinel_policy.foo.id}"]
-}`
+}`, rInt)
+}
 
-func getTestAccTFEPolicySetVCS(rInt int) string {
+func testAccTFEPolicySet_vcs(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
@@ -979,7 +993,7 @@ resource "tfe_policy_set" "foobar" {
 	)
 }
 
-func getTestAccTFEPolicySetUpdateVCSBranch(rInt int) string {
+func testAccTFEPolicySet_updateVCSBranch(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
@@ -1015,7 +1029,8 @@ resource "tfe_policy_set" "foobar" {
 	)
 }
 
-const testAccTFEPolicySet_invalidName = `
+func testAccTFEPolicySet_invalidName(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1032,4 +1047,5 @@ resource "tfe_policy_set" "foobar" {
   description  = "Policy Set"
   organization = "${tfe_organization.foobar.id}"
   policy_ids   = ["${tfe_sentinel_policy.foo.id}"]
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_registry_module_test.go
+++ b/tfe/resource_tfe_registry_module_test.go
@@ -27,7 +27,7 @@ func TestAccTFERegistryModule_vcs(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getTestAccTFERegistryModuleVCS(rInt),
+				Config: testAccTFERegistryModule_vcs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
 						"tfe_registry_module.foobar", orgName, registryModule),
@@ -62,7 +62,7 @@ func TestAccTFERegistryModule_emptyVCSRepo(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(testAccTFERegistryModule_emptyVCSRepo, rInt, GITHUB_TOKEN),
+				Config:      testAccTFERegistryModule_emptyVCSRepo(rInt, GITHUB_TOKEN),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 		},
@@ -81,7 +81,7 @@ func TestAccTFERegistryModuleImport(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getTestAccTFERegistryModuleVCS(rInt),
+				Config: testAccTFERegistryModule_vcs(rInt),
 			},
 			{
 				ResourceName:        "tfe_registry_module.foobar",
@@ -221,7 +221,7 @@ func getRegistryModuleProvider() string {
 	return strings.SplitN(getRegistryModuleRepository(), "-", 3)[1]
 }
 
-func getTestAccTFERegistryModuleVCS(rInt int) string {
+func testAccTFERegistryModule_vcs(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
  name  = "tst-terraform-%d"
@@ -249,7 +249,8 @@ resource "tfe_registry_module" "foobar" {
 		GITHUB_REGISTRY_MODULE_IDENTIFIER)
 }
 
-const testAccTFERegistryModule_emptyVCSRepo = `
+func testAccTFERegistryModule_emptyVCSRepo(rInt int, token string) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
  name  = "tst-terraform-%d"
  email = "admin@company.com"
@@ -265,4 +266,5 @@ resource "tfe_oauth_client" "foobar" {
 
 resource "tfe_registry_module" "foobar" {
  vcs_repo {}
-}`
+}`, rInt, token)
+}

--- a/tfe/resource_tfe_registry_module_test.go
+++ b/tfe/resource_tfe_registry_module_test.go
@@ -2,9 +2,11 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -13,6 +15,8 @@ import (
 
 func TestAccTFERegistryModule_vcs(t *testing.T) {
 	registryModule := &tfe.RegistryModule{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -23,13 +27,13 @@ func TestAccTFERegistryModule_vcs(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERegistryModule_vcs,
+				Config: getTestAccTFERegistryModuleVCS(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
-						"tfe_registry_module.foobar", registryModule),
-					testAccCheckTFERegistryModuleAttributes(registryModule),
+						"tfe_registry_module.foobar", orgName, registryModule),
+					testAccCheckTFERegistryModuleAttributes(registryModule, orgName),
 					resource.TestCheckResourceAttr(
-						"tfe_registry_module.foobar", "organization", "tst-terraform"),
+						"tfe_registry_module.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
 						"tfe_registry_module.foobar", "name", getRegistryModuleName()),
 					resource.TestCheckResourceAttr(
@@ -47,6 +51,8 @@ func TestAccTFERegistryModule_vcs(t *testing.T) {
 }
 
 func TestAccTFERegistryModule_emptyVCSRepo(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -56,7 +62,7 @@ func TestAccTFERegistryModule_emptyVCSRepo(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFERegistryModule_emptyVCSRepo,
+				Config:      fmt.Sprintf(testAccTFERegistryModule_emptyVCSRepo, rInt, GITHUB_TOKEN),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 		},
@@ -64,6 +70,8 @@ func TestAccTFERegistryModule_emptyVCSRepo(t *testing.T) {
 }
 
 func TestAccTFERegistryModuleImport(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -73,19 +81,19 @@ func TestAccTFERegistryModuleImport(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERegistryModule_vcs,
+				Config: getTestAccTFERegistryModuleVCS(rInt),
 			},
 			{
 				ResourceName:        "tfe_registry_module.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: fmt.Sprintf("tst-terraform/%v/%v/", getRegistryModuleName(), getRegistryModuleProvider()),
+				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/%v/%v/", rInt, getRegistryModuleName(), getRegistryModuleProvider()),
 				ImportStateVerify:   true,
 			},
 		},
 	})
 }
 
-func testAccCheckTFERegistryModuleExists(n string, registryModule *tfe.RegistryModule) resource.TestCheckFunc {
+func testAccCheckTFERegistryModuleExists(n, orgName string, registryModule *tfe.RegistryModule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		tfeClient := testAccProvider.Meta().(*tfe.Client)
 
@@ -98,7 +106,7 @@ func testAccCheckTFERegistryModuleExists(n string, registryModule *tfe.RegistryM
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		rm, err := tfeClient.RegistryModules.Read(ctx, "tst-terraform", getRegistryModuleName(), getRegistryModuleProvider())
+		rm, err := tfeClient.RegistryModules.Read(ctx, orgName, getRegistryModuleName(), getRegistryModuleProvider())
 		if err != nil {
 			return err
 		}
@@ -113,7 +121,7 @@ func testAccCheckTFERegistryModuleExists(n string, registryModule *tfe.RegistryM
 	}
 }
 
-func testAccCheckTFERegistryModuleAttributes(registryModule *tfe.RegistryModule) resource.TestCheckFunc {
+func testAccCheckTFERegistryModuleAttributes(registryModule *tfe.RegistryModule, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if registryModule.Name != getRegistryModuleName() {
 			return fmt.Errorf("Bad name: %s", registryModule.Name)
@@ -123,7 +131,7 @@ func testAccCheckTFERegistryModuleAttributes(registryModule *tfe.RegistryModule)
 			return fmt.Errorf("Bad module_provider: %s", registryModule.Provider)
 		}
 
-		if registryModule.Organization.Name != "tst-terraform" {
+		if registryModule.Organization.Name != orgName {
 			return fmt.Errorf("Bad organization: %v", registryModule.Organization.Name)
 		}
 
@@ -213,9 +221,10 @@ func getRegistryModuleProvider() string {
 	return strings.SplitN(getRegistryModuleRepository(), "-", 3)[1]
 }
 
-var testAccTFERegistryModule_vcs = fmt.Sprintf(`
+func getTestAccTFERegistryModuleVCS(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
- name  = "tst-terraform"
+ name  = "tst-terraform-%d"
  email = "admin@company.com"
 }
 
@@ -234,14 +243,15 @@ resource "tfe_registry_module" "foobar" {
    oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
  }
 }`,
-	GITHUB_TOKEN,
-	GITHUB_REGISTRY_MODULE_IDENTIFIER,
-	GITHUB_REGISTRY_MODULE_IDENTIFIER,
-)
+		rInt,
+		GITHUB_TOKEN,
+		GITHUB_REGISTRY_MODULE_IDENTIFIER,
+		GITHUB_REGISTRY_MODULE_IDENTIFIER)
+}
 
 const testAccTFERegistryModule_emptyVCSRepo = `
 resource "tfe_organization" "foobar" {
- name  = "tst-terraform"
+ name  = "tst-terraform-%d"
  email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_run_trigger_test.go
+++ b/tfe/resource_tfe_run_trigger_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,6 +13,8 @@ import (
 
 func TestAccTFERunTrigger_basic(t *testing.T) {
 	runTrigger := &tfe.RunTrigger{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,11 +22,11 @@ func TestAccTFERunTrigger_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERunTrigger_basic,
+				Config: fmt.Sprintf(testAccTFERunTrigger_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERunTriggerExists(
 						"tfe_run_trigger.foobar", runTrigger),
-					testAccCheckTFERunTriggerAttributes(runTrigger),
+					testAccCheckTFERunTriggerAttributes(runTrigger, orgName),
 				),
 			},
 		},
@@ -31,6 +35,8 @@ func TestAccTFERunTrigger_basic(t *testing.T) {
 
 func TestAccTFERunTrigger_basicWorkspaceID(t *testing.T) {
 	runTrigger := &tfe.RunTrigger{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -38,11 +44,11 @@ func TestAccTFERunTrigger_basicWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERunTrigger_basicWorkspaceID,
+				Config: fmt.Sprintf(testAccTFERunTrigger_basicWorkspaceID, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERunTriggerExists(
 						"tfe_run_trigger.foobar", runTrigger),
-					testAccCheckTFERunTriggerAttributes(runTrigger),
+					testAccCheckTFERunTriggerAttributes(runTrigger, orgName),
 				),
 			},
 		},
@@ -51,6 +57,8 @@ func TestAccTFERunTrigger_basicWorkspaceID(t *testing.T) {
 
 func TestAccTFERunTrigger_updateWorkspaceExternalIDToWorkspaceID(t *testing.T) {
 	runTrigger := &tfe.RunTrigger{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -58,19 +66,19 @@ func TestAccTFERunTrigger_updateWorkspaceExternalIDToWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERunTrigger_basic,
+				Config: fmt.Sprintf(testAccTFERunTrigger_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERunTriggerExists(
 						"tfe_run_trigger.foobar", runTrigger),
-					testAccCheckTFERunTriggerAttributes(runTrigger),
+					testAccCheckTFERunTriggerAttributes(runTrigger, orgName),
 				),
 			},
 			{
-				Config: testAccTFERunTrigger_basicWorkspaceID,
+				Config: fmt.Sprintf(testAccTFERunTrigger_basicWorkspaceID, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERunTriggerExists(
 						"tfe_run_trigger.foobar", runTrigger),
-					testAccCheckTFERunTriggerAttributes(runTrigger),
+					testAccCheckTFERunTriggerAttributes(runTrigger, orgName),
 				),
 			},
 		},
@@ -82,6 +90,7 @@ func TestAccTFERunTrigger_many(t *testing.T) {
 	for i := range checks {
 		checks[i] = resource.TestCheckResourceAttrSet(fmt.Sprintf("tfe_run_trigger.foobar.%d", i), "id")
 	}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -89,7 +98,7 @@ func TestAccTFERunTrigger_many(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERunTrigger_many,
+				Config: fmt.Sprintf(testAccTFERunTrigger_many, rInt),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -97,13 +106,15 @@ func TestAccTFERunTrigger_many(t *testing.T) {
 }
 
 func TestAccTFERunTriggerImport(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERunTrigger_basicWorkspaceID,
+				Config: fmt.Sprintf(testAccTFERunTrigger_basicWorkspaceID, rInt),
 			},
 
 			{
@@ -139,18 +150,18 @@ func testAccCheckTFERunTriggerExists(n string, runTrigger *tfe.RunTrigger) resou
 	}
 }
 
-func testAccCheckTFERunTriggerAttributes(runTrigger *tfe.RunTrigger) resource.TestCheckFunc {
+func testAccCheckTFERunTriggerAttributes(runTrigger *tfe.RunTrigger, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		tfeClient := testAccProvider.Meta().(*tfe.Client)
 
 		workspaceID := runTrigger.Workspace.ID
-		workspace, _ := tfeClient.Workspaces.Read(ctx, "tst-terraform", "workspace-test")
+		workspace, _ := tfeClient.Workspaces.Read(ctx, orgName, "workspace-test")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong workspace: %v", workspace.ID)
 		}
 
 		sourceableID := runTrigger.Sourceable.ID
-		sourceable, _ := tfeClient.Workspaces.Read(ctx, "tst-terraform", "sourceable-test")
+		sourceable, _ := tfeClient.Workspaces.Read(ctx, orgName, "sourceable-test")
 		if sourceable.ID != sourceableID {
 			return fmt.Errorf("Wrong sourceable: %v", sourceable.ID)
 		}
@@ -182,7 +193,7 @@ func testAccCheckTFERunTriggerDestroy(s *terraform.State) error {
 
 const testAccTFERunTrigger_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -203,7 +214,7 @@ resource "tfe_run_trigger" "foobar" {
 
 const testAccTFERunTrigger_basicWorkspaceID = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -224,7 +235,7 @@ resource "tfe_run_trigger" "foobar" {
 
 const testAccTFERunTrigger_many = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_run_trigger_test.go
+++ b/tfe/resource_tfe_run_trigger_test.go
@@ -22,7 +22,7 @@ func TestAccTFERunTrigger_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFERunTrigger_basic, rInt),
+				Config: testAccTFERunTrigger_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERunTriggerExists(
 						"tfe_run_trigger.foobar", runTrigger),
@@ -44,7 +44,7 @@ func TestAccTFERunTrigger_basicWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFERunTrigger_basicWorkspaceID, rInt),
+				Config: testAccTFERunTrigger_basicWorkspaceID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERunTriggerExists(
 						"tfe_run_trigger.foobar", runTrigger),
@@ -66,7 +66,7 @@ func TestAccTFERunTrigger_updateWorkspaceExternalIDToWorkspaceID(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFERunTrigger_basic, rInt),
+				Config: testAccTFERunTrigger_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERunTriggerExists(
 						"tfe_run_trigger.foobar", runTrigger),
@@ -74,7 +74,7 @@ func TestAccTFERunTrigger_updateWorkspaceExternalIDToWorkspaceID(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFERunTrigger_basicWorkspaceID, rInt),
+				Config: testAccTFERunTrigger_basicWorkspaceID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERunTriggerExists(
 						"tfe_run_trigger.foobar", runTrigger),
@@ -98,7 +98,7 @@ func TestAccTFERunTrigger_many(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFERunTrigger_many, rInt),
+				Config: testAccTFERunTrigger_many(rInt),
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
@@ -114,7 +114,7 @@ func TestAccTFERunTriggerImport(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFERunTrigger_basicWorkspaceID, rInt),
+				Config: testAccTFERunTrigger_basicWorkspaceID(rInt),
 			},
 
 			{
@@ -191,7 +191,8 @@ func testAccCheckTFERunTriggerDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFERunTrigger_basic = `
+func testAccTFERunTrigger_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -210,9 +211,11 @@ resource "tfe_workspace" "sourceable" {
 resource "tfe_run_trigger" "foobar" {
   workspace_external_id = "${tfe_workspace.workspace.id}"
   sourceable_id         = "${tfe_workspace.sourceable.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFERunTrigger_basicWorkspaceID = `
+func testAccTFERunTrigger_basicWorkspaceID(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -231,9 +234,11 @@ resource "tfe_workspace" "sourceable" {
 resource "tfe_run_trigger" "foobar" {
   workspace_id = "${tfe_workspace.workspace.id}"
   sourceable_id         = "${tfe_workspace.sourceable.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFERunTrigger_many = `
+func testAccTFERunTrigger_many(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -256,4 +261,5 @@ resource "tfe_run_trigger" "foobar" {
 
   workspace_external_id = "${tfe_workspace.workspace.external_id}"
   sourceable_id         = "${tfe_workspace.sourceable[count.index].external_id}"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_sentinel_policy_test.go
+++ b/tfe/resource_tfe_sentinel_policy_test.go
@@ -21,7 +21,7 @@ func TestAccTFESentinelPolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFESentinelPolicy_basic, rInt),
+				Config: testAccTFESentinelPolicy_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESentinelPolicyExists(
 						"tfe_sentinel_policy.foobar", policy),
@@ -50,7 +50,7 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFESentinelPolicy_basic, rInt),
+				Config: testAccTFESentinelPolicy_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESentinelPolicyExists(
 						"tfe_sentinel_policy.foobar", policy),
@@ -67,7 +67,7 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFESentinelPolicy_update, rInt),
+				Config: testAccTFESentinelPolicy_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESentinelPolicyExists(
 						"tfe_sentinel_policy.foobar", policy),
@@ -95,7 +95,7 @@ func TestAccTFESentinelPolicy_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFESentinelPolicy_basic, rInt),
+				Config: testAccTFESentinelPolicy_basic(rInt),
 			},
 
 			{
@@ -188,7 +188,8 @@ func testAccCheckTFESentinelPolicyDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFESentinelPolicy_basic = `
+func testAccTFESentinelPolicy_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -200,9 +201,11 @@ resource "tfe_sentinel_policy" "foobar" {
   organization = "${tfe_organization.foobar.id}"
   policy       = "main = rule { true }"
   enforce_mode = "hard-mandatory"
-}`
+}`, rInt)
+}
 
-const testAccTFESentinelPolicy_update = `
+func testAccTFESentinelPolicy_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -214,4 +217,5 @@ resource "tfe_sentinel_policy" "foobar" {
   organization = "${tfe_organization.foobar.id}"
   policy       = "main = rule { false }"
   enforce_mode = "soft-mandatory"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_sentinel_policy_test.go
+++ b/tfe/resource_tfe_sentinel_policy_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,6 +13,7 @@ import (
 
 func TestAccTFESentinelPolicy_basic(t *testing.T) {
 	policy := &tfe.Policy{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +21,7 @@ func TestAccTFESentinelPolicy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFESentinelPolicy_basic,
+				Config: fmt.Sprintf(testAccTFESentinelPolicy_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESentinelPolicyExists(
 						"tfe_sentinel_policy.foobar", policy),
@@ -39,6 +42,7 @@ func TestAccTFESentinelPolicy_basic(t *testing.T) {
 
 func TestAccTFESentinelPolicy_update(t *testing.T) {
 	policy := &tfe.Policy{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -46,7 +50,7 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFESentinelPolicy_basic,
+				Config: fmt.Sprintf(testAccTFESentinelPolicy_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESentinelPolicyExists(
 						"tfe_sentinel_policy.foobar", policy),
@@ -63,7 +67,7 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFESentinelPolicy_update,
+				Config: fmt.Sprintf(testAccTFESentinelPolicy_update, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESentinelPolicyExists(
 						"tfe_sentinel_policy.foobar", policy),
@@ -83,19 +87,21 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 }
 
 func TestAccTFESentinelPolicy_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFESentinelPolicy_basic,
+				Config: fmt.Sprintf(testAccTFESentinelPolicy_basic, rInt),
 			},
 
 			{
 				ResourceName:        "tfe_sentinel_policy.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: "tst-terraform/",
+				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/", rInt),
 				ImportStateVerify:   true,
 			},
 		},
@@ -184,7 +190,7 @@ func testAccCheckTFESentinelPolicyDestroy(s *terraform.State) error {
 
 const testAccTFESentinelPolicy_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -198,7 +204,7 @@ resource "tfe_sentinel_policy" "foobar" {
 
 const testAccTFESentinelPolicy_update = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_ssh_key_test.go
+++ b/tfe/resource_tfe_ssh_key_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,6 +13,7 @@ import (
 
 func TestAccTFESSHKey_basic(t *testing.T) {
 	sshKey := &tfe.SSHKey{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +21,7 @@ func TestAccTFESSHKey_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFESSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFESSHKey_basic,
+				Config: fmt.Sprintf(testAccTFESSHKey_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESSHKeyExists(
 						"tfe_ssh_key.foobar", sshKey),
@@ -35,6 +38,7 @@ func TestAccTFESSHKey_basic(t *testing.T) {
 
 func TestAccTFESSHKey_update(t *testing.T) {
 	sshKey := &tfe.SSHKey{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -42,7 +46,7 @@ func TestAccTFESSHKey_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFESSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFESSHKey_basic,
+				Config: fmt.Sprintf(testAccTFESSHKey_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESSHKeyExists(
 						"tfe_ssh_key.foobar", sshKey),
@@ -55,7 +59,7 @@ func TestAccTFESSHKey_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFESSHKey_update,
+				Config: fmt.Sprintf(testAccTFESSHKey_update, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESSHKeyExists(
 						"tfe_ssh_key.foobar", sshKey),
@@ -142,7 +146,7 @@ func testAccCheckTFESSHKeyDestroy(s *terraform.State) error {
 
 const testAccTFESSHKey_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -154,7 +158,7 @@ resource "tfe_ssh_key" "foobar" {
 
 const testAccTFESSHKey_update = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_ssh_key_test.go
+++ b/tfe/resource_tfe_ssh_key_test.go
@@ -21,7 +21,7 @@ func TestAccTFESSHKey_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFESSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFESSHKey_basic, rInt),
+				Config: testAccTFESSHKey_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESSHKeyExists(
 						"tfe_ssh_key.foobar", sshKey),
@@ -46,7 +46,7 @@ func TestAccTFESSHKey_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFESSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFESSHKey_basic, rInt),
+				Config: testAccTFESSHKey_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESSHKeyExists(
 						"tfe_ssh_key.foobar", sshKey),
@@ -59,7 +59,7 @@ func TestAccTFESSHKey_update(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFESSHKey_update, rInt),
+				Config: testAccTFESSHKey_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFESSHKeyExists(
 						"tfe_ssh_key.foobar", sshKey),
@@ -144,7 +144,8 @@ func testAccCheckTFESSHKeyDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFESSHKey_basic = `
+func testAccTFESSHKey_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -154,9 +155,11 @@ resource "tfe_ssh_key" "foobar" {
   name         = "ssh-key-test"
   organization = "${tfe_organization.foobar.id}"
   key          = "SSH-KEY-CONTENT"
-}`
+}`, rInt)
+}
 
-const testAccTFESSHKey_update = `
+func testAccTFESSHKey_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -166,4 +169,5 @@ resource "tfe_ssh_key" "foobar" {
   name         = "ssh-key-updated"
   organization = "${tfe_organization.foobar.id}"
   key          = "UPDATED-SSH-KEY-CONTENT"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_team_access_test.go
+++ b/tfe/resource_tfe_team_access_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,6 +13,8 @@ import (
 
 func TestAccTFETeamAccess_write(t *testing.T) {
 	tmAccess := &tfe.TeamAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	expectedPermissions := map[string]interface{}{
 		"runs":              tfe.RunsPermissionApply,
 		"variables":         tfe.VariablesPermissionWrite,
@@ -25,7 +29,7 @@ func TestAccTFETeamAccess_write(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamAccess_write,
+				Config: fmt.Sprintf(testAccTFETeamAccess_write, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -45,6 +49,7 @@ func TestAccTFETeamAccess_write(t *testing.T) {
 
 func TestAccTFETeamAccess_custom(t *testing.T) {
 	tmAccess := &tfe.TeamAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,7 +57,7 @@ func TestAccTFETeamAccess_custom(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamAccess_custom,
+				Config: fmt.Sprintf(testAccTFETeamAccess_custom, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -81,6 +86,7 @@ func TestAccTFETeamAccess_custom(t *testing.T) {
 
 func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 	tmAccess := &tfe.TeamAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -88,7 +94,7 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamAccess_write,
+				Config: fmt.Sprintf(testAccTFETeamAccess_write, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -112,7 +118,7 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFETeamAccess_custom,
+				Config: fmt.Sprintf(testAccTFETeamAccess_custom, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -141,6 +147,7 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 
 func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 	tmAccess := &tfe.TeamAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -148,7 +155,7 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamAccess_custom,
+				Config: fmt.Sprintf(testAccTFETeamAccess_custom, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -172,7 +179,7 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFETeamAccess_plan,
+				Config: fmt.Sprintf(testAccTFETeamAccess_plan, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -200,19 +207,21 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 }
 
 func TestAccTFETeamAccess_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamAccess_write,
+				Config: fmt.Sprintf(testAccTFETeamAccess_write, rInt),
 			},
 
 			{
 				ResourceName:        "tfe_team_access.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: "tst-terraform/workspace-test/",
+				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/workspace-test/", rInt),
 				ImportStateVerify:   true,
 			},
 		},
@@ -301,7 +310,7 @@ func testAccCheckTFETeamAccessDestroy(s *terraform.State) error {
 
 const testAccTFETeamAccess_write = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -323,7 +332,7 @@ resource "tfe_team_access" "foobar" {
 
 const testAccTFETeamAccess_plan = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -345,7 +354,7 @@ resource "tfe_team_access" "foobar" {
 
 const testAccTFETeamAccess_custom = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_access_test.go
+++ b/tfe/resource_tfe_team_access_test.go
@@ -29,7 +29,7 @@ func TestAccTFETeamAccess_write(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamAccess_write, rInt),
+				Config: testAccTFETeamAccess_write(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -57,7 +57,7 @@ func TestAccTFETeamAccess_custom(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamAccess_custom, rInt),
+				Config: testAccTFETeamAccess_custom(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -94,7 +94,7 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamAccess_write, rInt),
+				Config: testAccTFETeamAccess_write(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -118,7 +118,7 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFETeamAccess_custom, rInt),
+				Config: testAccTFETeamAccess_custom(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -155,7 +155,7 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamAccess_custom, rInt),
+				Config: testAccTFETeamAccess_custom(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -179,7 +179,7 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFETeamAccess_plan, rInt),
+				Config: testAccTFETeamAccess_plan(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
@@ -215,7 +215,7 @@ func TestAccTFETeamAccess_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamAccess_write, rInt),
+				Config: testAccTFETeamAccess_write(rInt),
 			},
 
 			{
@@ -308,7 +308,8 @@ func testAccCheckTFETeamAccessDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFETeamAccess_write = `
+func testAccTFETeamAccess_write(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -328,9 +329,11 @@ resource "tfe_team_access" "foobar" {
   access       = "write"
   team_id      = "${tfe_team.foobar.id}"
   workspace_id = "${tfe_workspace.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFETeamAccess_plan = `
+func testAccTFETeamAccess_plan(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -350,9 +353,11 @@ resource "tfe_team_access" "foobar" {
   access       = "plan"
   team_id      = "${tfe_team.foobar.id}"
   workspace_id = "${tfe_workspace.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFETeamAccess_custom = `
+func testAccTFETeamAccess_custom(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -378,4 +383,5 @@ resource "tfe_team_access" "foobar" {
   }
   team_id      = "${tfe_team.foobar.id}"
   workspace_id = "${tfe_workspace.foobar.id}"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_team_member_test.go
+++ b/tfe/resource_tfe_team_member_test.go
@@ -88,7 +88,7 @@ func TestAccTFETeamMember_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamMember_basic, rInt),
+				Config: testAccTFETeamMember_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamMemberExists(
 						"tfe_team_member.foobar", user),
@@ -110,7 +110,7 @@ func TestAccTFETeamMember_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamMember_basic, rInt),
+				Config: testAccTFETeamMember_basic(rInt),
 			},
 
 			{
@@ -213,7 +213,8 @@ func testAccCheckTFETeamMemberDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFETeamMember_basic = `
+func testAccTFETeamMember_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -227,4 +228,5 @@ resource "tfe_team" "foobar" {
 resource "tfe_team_member" "foobar" {
   team_id  = "${tfe_team.foobar.id}"
   username = "admin"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_team_member_test.go
+++ b/tfe/resource_tfe_team_member_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -78,6 +80,7 @@ func TestUnpackTeamMemberID(t *testing.T) {
 
 func TestAccTFETeamMember_basic(t *testing.T) {
 	user := &tfe.User{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -85,7 +88,7 @@ func TestAccTFETeamMember_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamMember_basic,
+				Config: fmt.Sprintf(testAccTFETeamMember_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamMemberExists(
 						"tfe_team_member.foobar", user),
@@ -99,13 +102,15 @@ func TestAccTFETeamMember_basic(t *testing.T) {
 }
 
 func TestAccTFETeamMember_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFETeamMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamMember_basic,
+				Config: fmt.Sprintf(testAccTFETeamMember_basic, rInt),
 			},
 
 			{
@@ -210,7 +215,7 @@ func testAccCheckTFETeamMemberDestroy(s *terraform.State) error {
 
 const testAccTFETeamMember_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_members_test.go
+++ b/tfe/resource_tfe_team_members_test.go
@@ -30,7 +30,7 @@ func TestAccTFETeamMembers_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getTestAccTFETeamMembersBasic(rInt),
+				Config: testAccTFETeamMembers_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamMembersExists(
 						"tfe_team_members.foobar", &users),
@@ -68,7 +68,7 @@ func TestAccTFETeamMembers_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getTestAccTFETeamMembersBasic(rInt),
+				Config: testAccTFETeamMembers_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamMembersExists(
 						"tfe_team_members.foobar", &users),
@@ -83,7 +83,7 @@ func TestAccTFETeamMembers_update(t *testing.T) {
 			},
 
 			{
-				Config: getTestAccTFETeamMembersUpdate(rInt),
+				Config: testAccTFETeamMembers_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamMembersExists(
 						"tfe_team_members.foobar", &users),
@@ -114,7 +114,7 @@ func TestAccTFETeamMembers_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: getTestAccTFETeamMembersBasic(rInt),
+				Config: testAccTFETeamMembers_basic(rInt),
 			},
 
 			{
@@ -206,7 +206,7 @@ func testAccCheckTFETeamMembersDestroy(s *terraform.State) error {
 	return nil
 }
 
-func getTestAccTFETeamMembersBasic(rInt int) string {
+func testAccTFETeamMembers_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
@@ -224,7 +224,7 @@ resource "tfe_team_members" "foobar" {
 }`, rInt, TFE_USER1)
 }
 
-func getTestAccTFETeamMembersUpdate(rInt int) string {
+func testAccTFETeamMembers_update(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"

--- a/tfe/resource_tfe_team_members_test.go
+++ b/tfe/resource_tfe_team_members_test.go
@@ -2,8 +2,10 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -15,6 +17,7 @@ func TestAccTFETeamMembers_basic(t *testing.T) {
 	t.Skip("Skipping, due to current testing limitations; namely, an organization membership must first be confirmed.")
 	users := []*tfe.User{}
 	TFE_USER1_HASH := hashSchemaString(TFE_USER1)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -27,7 +30,7 @@ func TestAccTFETeamMembers_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamMembers_basic,
+				Config: getTestAccTFETeamMembersBasic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamMembersExists(
 						"tfe_team_members.foobar", &users),
@@ -49,6 +52,7 @@ func TestAccTFETeamMembers_update(t *testing.T) {
 	users := []*tfe.User{}
 	TFE_USER1_HASH := hashSchemaString(TFE_USER1)
 	TFE_USER2_HASH := hashSchemaString(TFE_USER2)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -64,7 +68,7 @@ func TestAccTFETeamMembers_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamMembers_basic,
+				Config: getTestAccTFETeamMembersBasic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamMembersExists(
 						"tfe_team_members.foobar", &users),
@@ -79,7 +83,7 @@ func TestAccTFETeamMembers_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFETeamMembers_update,
+				Config: getTestAccTFETeamMembersUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamMembersExists(
 						"tfe_team_members.foobar", &users),
@@ -98,6 +102,7 @@ func TestAccTFETeamMembers_update(t *testing.T) {
 
 func TestAccTFETeamMembers_import(t *testing.T) {
 	t.Skip("Skipping, due to current testing limitations; namely, an organization membership must first be confirmed.")
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -109,7 +114,7 @@ func TestAccTFETeamMembers_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamMembers_basic,
+				Config: getTestAccTFETeamMembersBasic(rInt),
 			},
 
 			{
@@ -201,9 +206,10 @@ func testAccCheckTFETeamMembersDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccTFETeamMembers_basic = fmt.Sprintf(`
+func getTestAccTFETeamMembersBasic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -215,11 +221,13 @@ resource "tfe_team" "foobar" {
 resource "tfe_team_members" "foobar" {
   team_id   = "${tfe_team.foobar.id}"
   usernames = ["%s"]
-}`, TFE_USER1)
+}`, rInt, TFE_USER1)
+}
 
-var testAccTFETeamMembers_update = fmt.Sprintf(`
+func getTestAccTFETeamMembersUpdate(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -231,4 +239,5 @@ resource "tfe_team" "foobar" {
 resource "tfe_team_members" "foobar" {
   team_id   = "${tfe_team.foobar.id}"
   usernames = ["%s", "%s"]
-}`, TFE_USER1, TFE_USER2)
+}`, rInt, TFE_USER1, TFE_USER2)
+}

--- a/tfe/resource_tfe_team_organization_member_test.go
+++ b/tfe/resource_tfe_team_organization_member_test.go
@@ -82,7 +82,7 @@ func TestAccTFETeamOrganizationMember_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamOrganizationMember_basic, rInt),
+				Config: testAccTFETeamOrganizationMember_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamOrganizationMemberExists(
 						"tfe_team_organization_member.foobar", organizationMembership),
@@ -102,7 +102,7 @@ func TestAccTFETeamOrganizationMember_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamOrganizationMember_basic, rInt),
+				Config: testAccTFETeamOrganizationMember_basic(rInt),
 			},
 
 			{
@@ -205,7 +205,8 @@ func testAccCheckTFETeamOrganizationMemberDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFETeamOrganizationMember_basic = `
+func testAccTFETeamOrganizationMember_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -224,4 +225,5 @@ resource "tfe_organization_membership" "foobar" {
 resource "tfe_team_organization_member" "foobar" {
   team_id  = "${tfe_team.foobar.id}"
   organization_membership_id = "${tfe_organization_membership.foobar.id}"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_team_organization_member_test.go
+++ b/tfe/resource_tfe_team_organization_member_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -72,6 +74,7 @@ func TestUnpackTeamOrganizationMemberID(t *testing.T) {
 
 func TestAccTFETeamOrganizationMember_basic(t *testing.T) {
 	organizationMembership := &tfe.OrganizationMembership{ID: "sauce"}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -79,7 +82,7 @@ func TestAccTFETeamOrganizationMember_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamOrganizationMember_basic,
+				Config: fmt.Sprintf(testAccTFETeamOrganizationMember_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamOrganizationMemberExists(
 						"tfe_team_organization_member.foobar", organizationMembership),
@@ -91,13 +94,15 @@ func TestAccTFETeamOrganizationMember_basic(t *testing.T) {
 }
 
 func TestAccTFETeamOrganizationMember_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamOrganizationMember_basic,
+				Config: fmt.Sprintf(testAccTFETeamOrganizationMember_basic, rInt),
 			},
 
 			{
@@ -202,7 +207,7 @@ func testAccCheckTFETeamOrganizationMemberDestroy(s *terraform.State) error {
 
 const testAccTFETeamOrganizationMember_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,6 +13,7 @@ import (
 
 func TestAccTFETeam_basic(t *testing.T) {
 	team := &tfe.Team{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +21,7 @@ func TestAccTFETeam_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeam_basic,
+				Config: fmt.Sprintf(testAccTFETeam_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamExists(
 						"tfe_team.foobar", team),
@@ -33,6 +36,7 @@ func TestAccTFETeam_basic(t *testing.T) {
 
 func TestAccTFETeam_full(t *testing.T) {
 	team := &tfe.Team{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,7 +44,7 @@ func TestAccTFETeam_full(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeam_full,
+				Config: fmt.Sprintf(testAccTFETeam_full, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamExists(
 						"tfe_team.foobar", team),
@@ -63,6 +67,7 @@ func TestAccTFETeam_full(t *testing.T) {
 
 func TestAccTFETeam_full_update(t *testing.T) {
 	team := &tfe.Team{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -70,7 +75,7 @@ func TestAccTFETeam_full_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeam_full,
+				Config: fmt.Sprintf(testAccTFETeam_full, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamExists(
 						"tfe_team.foobar", team),
@@ -88,7 +93,7 @@ func TestAccTFETeam_full_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFETeam_full_update,
+				Config: fmt.Sprintf(testAccTFETeam_full_update, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamExists(
 						"tfe_team.foobar", team),
@@ -110,19 +115,21 @@ func TestAccTFETeam_full_update(t *testing.T) {
 }
 
 func TestAccTFETeam_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeam_basic,
+				Config: fmt.Sprintf(testAccTFETeam_basic, rInt),
 			},
 
 			{
 				ResourceName:        "tfe_team.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: "tst-terraform/",
+				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/", rInt),
 				ImportStateVerify:   true,
 			},
 		},
@@ -241,7 +248,7 @@ func testAccCheckTFETeamDestroy(s *terraform.State) error {
 
 const testAccTFETeam_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -252,7 +259,7 @@ resource "tfe_team" "foobar" {
 
 const testAccTFETeam_full = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -271,7 +278,7 @@ resource "tfe_team" "foobar" {
 
 const testAccTFETeam_full_update = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -21,7 +21,7 @@ func TestAccTFETeam_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeam_basic, rInt),
+				Config: testAccTFETeam_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamExists(
 						"tfe_team.foobar", team),
@@ -44,7 +44,7 @@ func TestAccTFETeam_full(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeam_full, rInt),
+				Config: testAccTFETeam_full(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamExists(
 						"tfe_team.foobar", team),
@@ -75,7 +75,7 @@ func TestAccTFETeam_full_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeam_full, rInt),
+				Config: testAccTFETeam_full(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamExists(
 						"tfe_team.foobar", team),
@@ -93,7 +93,7 @@ func TestAccTFETeam_full_update(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFETeam_full_update, rInt),
+				Config: testAccTFETeam_full_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamExists(
 						"tfe_team.foobar", team),
@@ -123,7 +123,7 @@ func TestAccTFETeam_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeam_basic, rInt),
+				Config: testAccTFETeam_basic(rInt),
 			},
 
 			{
@@ -246,7 +246,8 @@ func testAccCheckTFETeamDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFETeam_basic = `
+func testAccTFETeam_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -255,9 +256,11 @@ resource "tfe_organization" "foobar" {
 resource "tfe_team" "foobar" {
   name         = "team-test"
   organization = "${tfe_organization.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFETeam_full = `
+func testAccTFETeam_full(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -274,9 +277,11 @@ resource "tfe_team" "foobar" {
     manage_workspaces = true
     manage_vcs_settings = true
   }
-}`
+}`, rInt)
+}
 
-const testAccTFETeam_full_update = `
+func testAccTFETeam_full_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -293,4 +298,5 @@ resource "tfe_team" "foobar" {
     manage_workspaces = false
     manage_vcs_settings = false
   }
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -22,7 +22,7 @@ func TestAccTFETeamToken_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamToken_basic, rInt),
+				Config: testAccTFETeamToken_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
@@ -42,7 +42,7 @@ func TestAccTFETeamToken_existsWithoutForce(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamToken_basic, rInt),
+				Config: testAccTFETeamToken_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
@@ -50,7 +50,7 @@ func TestAccTFETeamToken_existsWithoutForce(t *testing.T) {
 			},
 
 			{
-				Config:      fmt.Sprintf(testAccTFETeamToken_existsWithoutForce, rInt),
+				Config:      testAccTFETeamToken_existsWithoutForce(rInt),
 				ExpectError: regexp.MustCompile(`token already exists`),
 			},
 		},
@@ -67,7 +67,7 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamToken_basic, rInt),
+				Config: testAccTFETeamToken_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
@@ -75,7 +75,7 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFETeamToken_existsWithForce, rInt),
+				Config: testAccTFETeamToken_existsWithForce(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.regenerated", token),
@@ -94,7 +94,7 @@ func TestAccTFETeamToken_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFETeamToken_basic, rInt),
+				Config: testAccTFETeamToken_basic(rInt),
 			},
 
 			{
@@ -157,7 +157,8 @@ func testAccCheckTFETeamTokenDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFETeamToken_basic = `
+func testAccTFETeamToken_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -170,9 +171,11 @@ resource "tfe_team" "foobar" {
 
 resource "tfe_team_token" "foobar" {
   team_id = "${tfe_team.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFETeamToken_existsWithoutForce = `
+func testAccTFETeamToken_existsWithoutForce(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -189,9 +192,11 @@ resource "tfe_team_token" "foobar" {
 
 resource "tfe_team_token" "error" {
   team_id = "${tfe_team.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFETeamToken_existsWithForce = `
+func testAccTFETeamToken_existsWithForce(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -209,4 +214,5 @@ resource "tfe_team_token" "foobar" {
 resource "tfe_team_token" "regenerated" {
   team_id          = "${tfe_team.foobar.id}"
   force_regenerate = true
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -2,8 +2,10 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"regexp"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -12,6 +14,7 @@ import (
 
 func TestAccTFETeamToken_basic(t *testing.T) {
 	token := &tfe.TeamToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,7 +22,7 @@ func TestAccTFETeamToken_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamToken_basic,
+				Config: fmt.Sprintf(testAccTFETeamToken_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
@@ -31,6 +34,7 @@ func TestAccTFETeamToken_basic(t *testing.T) {
 
 func TestAccTFETeamToken_existsWithoutForce(t *testing.T) {
 	token := &tfe.TeamToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -38,7 +42,7 @@ func TestAccTFETeamToken_existsWithoutForce(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamToken_basic,
+				Config: fmt.Sprintf(testAccTFETeamToken_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
@@ -46,7 +50,7 @@ func TestAccTFETeamToken_existsWithoutForce(t *testing.T) {
 			},
 
 			{
-				Config:      testAccTFETeamToken_existsWithoutForce,
+				Config:      fmt.Sprintf(testAccTFETeamToken_existsWithoutForce, rInt),
 				ExpectError: regexp.MustCompile(`token already exists`),
 			},
 		},
@@ -55,6 +59,7 @@ func TestAccTFETeamToken_existsWithoutForce(t *testing.T) {
 
 func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 	token := &tfe.TeamToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -62,7 +67,7 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamToken_basic,
+				Config: fmt.Sprintf(testAccTFETeamToken_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
@@ -70,7 +75,7 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFETeamToken_existsWithForce,
+				Config: fmt.Sprintf(testAccTFETeamToken_existsWithForce, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.regenerated", token),
@@ -81,13 +86,15 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 }
 
 func TestAccTFETeamToken_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamToken_basic,
+				Config: fmt.Sprintf(testAccTFETeamToken_basic, rInt),
 			},
 
 			{
@@ -152,7 +159,7 @@ func testAccCheckTFETeamTokenDestroy(s *terraform.State) error {
 
 const testAccTFETeamToken_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -167,7 +174,7 @@ resource "tfe_team_token" "foobar" {
 
 const testAccTFETeamToken_existsWithoutForce = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -186,7 +193,7 @@ resource "tfe_team_token" "error" {
 
 const testAccTFETeamToken_existsWithForce = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,6 +13,7 @@ import (
 
 func TestAccTFEVariable_basic(t *testing.T) {
 	variable := &tfe.Variable{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +21,7 @@ func TestAccTFEVariable_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEVariable_basic,
+				Config: fmt.Sprintf(testAccTFEVariable_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", variable),
@@ -43,6 +46,7 @@ func TestAccTFEVariable_basic(t *testing.T) {
 
 func TestAccTFEVariable_update(t *testing.T) {
 	variable := &tfe.Variable{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,7 +54,7 @@ func TestAccTFEVariable_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEVariable_basic,
+				Config: fmt.Sprintf(testAccTFEVariable_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", variable),
@@ -71,7 +75,7 @@ func TestAccTFEVariable_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEVariable_update,
+				Config: fmt.Sprintf(testAccTFEVariable_update, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", variable),
@@ -97,6 +101,7 @@ func TestAccTFEVariable_update(t *testing.T) {
 func TestAccTFEVariable_update_key_sensitive(t *testing.T) {
 	first := &tfe.Variable{}
 	second := &tfe.Variable{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -104,7 +109,7 @@ func TestAccTFEVariable_update_key_sensitive(t *testing.T) {
 		CheckDestroy: testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEVariable_update,
+				Config: fmt.Sprintf(testAccTFEVariable_update, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", first),
@@ -124,7 +129,7 @@ func TestAccTFEVariable_update_key_sensitive(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEVariable_update_key_sensitive,
+				Config: fmt.Sprintf(testAccTFEVariable_update_key_sensitive, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", second),
@@ -149,19 +154,21 @@ func TestAccTFEVariable_update_key_sensitive(t *testing.T) {
 }
 
 func TestAccTFEVariable_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEVariable_basic,
+				Config: fmt.Sprintf(testAccTFEVariable_basic, rInt),
 			},
 
 			{
 				ResourceName:        "tfe_variable.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: "tst-terraform/workspace-test/",
+				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/workspace-test/", rInt),
 				ImportStateVerify:   true,
 			},
 		},
@@ -327,7 +334,7 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 
 const testAccTFEVariable_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -346,7 +353,7 @@ resource "tfe_variable" "foobar" {
 
 const testAccTFEVariable_update = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -367,7 +374,7 @@ resource "tfe_variable" "foobar" {
 
 const testAccTFEVariable_update_key_sensitive = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -21,7 +21,7 @@ func TestAccTFEVariable_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEVariable_basic, rInt),
+				Config: testAccTFEVariable_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", variable),
@@ -54,7 +54,7 @@ func TestAccTFEVariable_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEVariable_basic, rInt),
+				Config: testAccTFEVariable_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", variable),
@@ -75,7 +75,7 @@ func TestAccTFEVariable_update(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEVariable_update, rInt),
+				Config: testAccTFEVariable_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", variable),
@@ -109,7 +109,7 @@ func TestAccTFEVariable_update_key_sensitive(t *testing.T) {
 		CheckDestroy: testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEVariable_update, rInt),
+				Config: testAccTFEVariable_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", first),
@@ -129,7 +129,7 @@ func TestAccTFEVariable_update_key_sensitive(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFEVariable_update_key_sensitive, rInt),
+				Config: testAccTFEVariable_update_key_sensitive(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableExists(
 						"tfe_variable.foobar", second),
@@ -162,7 +162,7 @@ func TestAccTFEVariable_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEVariable_basic, rInt),
+				Config: testAccTFEVariable_basic(rInt),
 			},
 
 			{
@@ -332,7 +332,8 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFEVariable_basic = `
+func testAccTFEVariable_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -349,9 +350,11 @@ resource "tfe_variable" "foobar" {
   description  = "some description"
   category     = "env"
   workspace_id = "${tfe_workspace.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFEVariable_update = `
+func testAccTFEVariable_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -370,9 +373,11 @@ resource "tfe_variable" "foobar" {
   hcl          = true
   sensitive    = true
   workspace_id = "${tfe_workspace.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFEVariable_update_key_sensitive = `
+func testAccTFEVariable_update_key_sensitive(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -391,4 +396,5 @@ resource "tfe_variable" "foobar" {
   hcl          = true
   sensitive    = true
   workspace_id = "${tfe_workspace.foobar.id}"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -24,7 +24,7 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -60,7 +60,7 @@ func TestAccTFEWorkspace_panic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config:             testAccTFEWorkspace_basic(rInt),
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
@@ -82,7 +82,7 @@ func TestAccTFEWorkspace_monorepo(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_monorepo, rInt),
+				Config: testAccTFEWorkspace_monorepo(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -110,6 +110,7 @@ func TestAccTFEWorkspace_monorepo(t *testing.T) {
 func TestAccTFEWorkspace_renamed(t *testing.T) {
 	workspace := &tfe.Workspace{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -117,7 +118,7 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -136,8 +137,8 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 			},
 
 			{
-				PreConfig: testAccCheckTFEWorkspaceRename(fmt.Sprintf("tst-terraform-%d", rInt)),
-				Config:    fmt.Sprintf(testAccTFEWorkspace_renamed, rInt),
+				PreConfig: testAccCheckTFEWorkspaceRename(orgName),
+				Config:    testAccTFEWorkspace_renamed(rInt),
 				PlanOnly:  true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
@@ -169,7 +170,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -187,7 +188,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_update, rInt),
+				Config: testAccTFEWorkspace_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -228,7 +229,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -246,7 +247,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_updateAddWorkingDirectory, rInt),
+				Config: testAccTFEWorkspace_updateAddWorkingDirectory(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -258,7 +259,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_updateRemoveWorkingDirectory, rInt),
+				Config: testAccTFEWorkspace_updateRemoveWorkingDirectory(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -283,7 +284,7 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -293,7 +294,7 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basicFileTriggersOff, rInt),
+				Config: testAccTFEWorkspace_basicFileTriggersOff(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -315,7 +316,7 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_triggerPrefixes, rInt),
+				Config: testAccTFEWorkspace_triggerPrefixes(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -329,7 +330,7 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_updateEmptyTriggerPrefixes, rInt),
+				Config: testAccTFEWorkspace_updateEmptyTriggerPrefixes(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -352,7 +353,7 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -362,7 +363,7 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basicSpeculativeOff, rInt),
+				Config: testAccTFEWorkspace_basicSpeculativeOff(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -395,7 +396,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -443,7 +444,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_updateRemoveVCSRepo, rInt),
+				Config: testAccTFEWorkspace_updateRemoveVCSRepo(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedRemoveVCSRepoAttributes(workspace),
@@ -466,7 +467,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -475,7 +476,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_sshKey, rInt),
+				Config: testAccTFEWorkspace_sshKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -486,7 +487,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 			},
 
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_noSSHKey, rInt),
+				Config: testAccTFEWorkspace_noSSHKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -506,7 +507,7 @@ func TestAccTFEWorkspace_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
+				Config: testAccTFEWorkspace_basic(rInt),
 			},
 
 			{
@@ -873,7 +874,8 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFEWorkspace_basic = `
+func testAccTFEWorkspace_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -883,9 +885,11 @@ resource "tfe_workspace" "foobar" {
   name         = "workspace-test"
   organization = "${tfe_organization.foobar.id}"
   auto_apply   = true
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_basicFileTriggersOff = `
+func testAccTFEWorkspace_basicFileTriggersOff(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -896,9 +900,11 @@ resource "tfe_workspace" "foobar" {
   organization          = "${tfe_organization.foobar.id}"
   auto_apply            = true
   file_triggers_enabled = false
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_basicSpeculativeOff = `
+func testAccTFEWorkspace_basicSpeculativeOff(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -909,9 +915,11 @@ resource "tfe_workspace" "foobar" {
   organization          = "${tfe_organization.foobar.id}"
   auto_apply            = true
   speculative_enabled = false
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_monorepo = `
+func testAccTFEWorkspace_monorepo(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -923,9 +931,11 @@ resource "tfe_workspace" "foobar" {
   file_triggers_enabled = true
   trigger_prefixes      = ["/modules", "/shared"]
   working_directory     = "/db"
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_renamed = `
+func testAccTFEWorkspace_renamed(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -935,9 +945,11 @@ resource "tfe_workspace" "foobar" {
   name         = "renamed-out-of-band"
   organization = "${tfe_organization.foobar.id}"
   auto_apply   = true
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_update = `
+func testAccTFEWorkspace_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -953,9 +965,11 @@ resource "tfe_workspace" "foobar" {
   trigger_prefixes      = ["/modules", "/shared"]
   working_directory     = "terraform/test"
   operations            = false
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_updateAddWorkingDirectory = `
+func testAccTFEWorkspace_updateAddWorkingDirectory(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -966,9 +980,11 @@ resource "tfe_workspace" "foobar" {
   organization          = "${tfe_organization.foobar.id}"
   auto_apply            = false
   working_directory     = "terraform/test"
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_updateRemoveWorkingDirectory = `
+func testAccTFEWorkspace_updateRemoveWorkingDirectory(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -978,9 +994,11 @@ resource "tfe_workspace" "foobar" {
   name                  = "workspace-updated"
   organization          = "${tfe_organization.foobar.id}"
   auto_apply            = false
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_sshKey = `
+func testAccTFEWorkspace_sshKey(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -997,9 +1015,11 @@ resource "tfe_workspace" "foobar" {
   organization = "${tfe_organization.foobar.id}"
   auto_apply   = true
   ssh_key_id   = "${tfe_ssh_key.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_noSSHKey = `
+func testAccTFEWorkspace_noSSHKey(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1015,9 +1035,11 @@ resource "tfe_workspace" "foobar" {
   name         = "workspace-test"
   organization = "${tfe_organization.foobar.id}"
   auto_apply   = true
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_triggerPrefixes = `
+func testAccTFEWorkspace_triggerPrefixes(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1027,9 +1049,11 @@ resource "tfe_workspace" "foobar" {
   name                  = "workspace"
   organization          = "${tfe_organization.foobar.id}"
   trigger_prefixes      = ["/modules", "/shared"]
-}`
+}`, rInt)
+}
 
-const testAccTFEWorkspace_updateEmptyTriggerPrefixes = `
+func testAccTFEWorkspace_updateEmptyTriggerPrefixes(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1038,7 +1062,8 @@ resource "tfe_workspace" "foobar" {
   name                  = "workspace-test"
   organization          = "${tfe_organization.foobar.id}"
   auto_apply            = true
-}`
+}`, rInt)
+}
 
 func testAccTFEWorkspace_updateAddVCSRepo(rInt int) string {
 	return fmt.Sprintf(`
@@ -1104,7 +1129,8 @@ resource "tfe_workspace" "foobar" {
 	)
 }
 
-const testAccTFEWorkspace_updateRemoveVCSRepo = `
+func testAccTFEWorkspace_updateRemoveVCSRepo(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
   email = "admin@company.com"
@@ -1115,4 +1141,5 @@ resource "tfe_workspace" "foobar" {
   organization = "${tfe_organization.foobar.id}"
   auto_apply   = true
 }
-`
+`, rInt)
+}

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -14,6 +16,7 @@ import (
 
 func TestAccTFEWorkspace_basic(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,7 +24,7 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -49,13 +52,15 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 }
 
 func TestAccTFEWorkspace_panic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccTFEWorkspace_basic,
+				Config:             fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
@@ -69,6 +74,7 @@ func TestAccTFEWorkspace_panic(t *testing.T) {
 
 func TestAccTFEWorkspace_monorepo(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -76,7 +82,7 @@ func TestAccTFEWorkspace_monorepo(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_monorepo,
+				Config: fmt.Sprintf(testAccTFEWorkspace_monorepo, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -103,6 +109,7 @@ func TestAccTFEWorkspace_monorepo(t *testing.T) {
 
 func TestAccTFEWorkspace_renamed(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -110,7 +117,7 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -129,8 +136,8 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 			},
 
 			{
-				PreConfig: testAccCheckTFEWorkspaceRename,
-				Config:    testAccTFEWorkspace_renamed,
+				PreConfig: testAccCheckTFEWorkspaceRename(fmt.Sprintf("tst-terraform-%d", rInt)),
+				Config:    fmt.Sprintf(testAccTFEWorkspace_renamed, rInt),
 				PlanOnly:  true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
@@ -154,6 +161,7 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 
 func TestAccTFEWorkspace_update(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -161,7 +169,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -179,7 +187,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_update,
+				Config: fmt.Sprintf(testAccTFEWorkspace_update, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -212,6 +220,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 
 func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -219,7 +228,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -237,7 +246,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_updateAddWorkingDirectory,
+				Config: fmt.Sprintf(testAccTFEWorkspace_updateAddWorkingDirectory, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -249,7 +258,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_updateRemoveWorkingDirectory,
+				Config: fmt.Sprintf(testAccTFEWorkspace_updateRemoveWorkingDirectory, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -266,6 +275,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 
 func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -273,7 +283,7 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -283,7 +293,7 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEWorkspace_basicFileTriggersOff,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basicFileTriggersOff, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -297,6 +307,7 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 
 func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -304,7 +315,7 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_triggerPrefixes,
+				Config: fmt.Sprintf(testAccTFEWorkspace_triggerPrefixes, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -318,7 +329,7 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEWorkspace_updateEmptyTriggerPrefixes,
+				Config: fmt.Sprintf(testAccTFEWorkspace_updateEmptyTriggerPrefixes, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -333,6 +344,7 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 
 func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -340,7 +352,7 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -350,7 +362,7 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEWorkspace_basicSpeculativeOff,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basicSpeculativeOff, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -364,6 +376,7 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 
 func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -382,7 +395,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -400,7 +413,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_updateAddVCSRepo,
+				Config: testAccTFEWorkspace_updateAddVCSRepo(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedAddVCSRepoAttributes(workspace),
@@ -415,7 +428,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_updateUpdateVCSRepoBranch,
+				Config: testAccTFEWorkspace_updateUpdateVCSRepoBranch(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedUpdateVCSRepoBranchAttributes(workspace),
@@ -430,7 +443,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_updateRemoveVCSRepo,
+				Config: fmt.Sprintf(testAccTFEWorkspace_updateRemoveVCSRepo, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedRemoveVCSRepoAttributes(workspace),
@@ -445,6 +458,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 
 func TestAccTFEWorkspace_sshKey(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -452,7 +466,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -461,7 +475,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEWorkspace_sshKey,
+				Config: fmt.Sprintf(testAccTFEWorkspace_sshKey, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -472,7 +486,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEWorkspace_noSSHKey,
+				Config: fmt.Sprintf(testAccTFEWorkspace_noSSHKey, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -484,13 +498,15 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 }
 
 func TestAccTFEWorkspace_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: fmt.Sprintf(testAccTFEWorkspace_basic, rInt),
 			},
 
 			{
@@ -504,6 +520,7 @@ func TestAccTFEWorkspace_import(t *testing.T) {
 
 func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -523,7 +540,7 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_updateUpdateVCSRepoBranch,
+				Config: testAccTFEWorkspace_updateUpdateVCSRepoBranch(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedUpdateVCSRepoBranchAttributes(workspace),
@@ -674,21 +691,23 @@ func testAccCheckTFEWorkspaceMonorepoAttributes(
 	}
 }
 
-func testAccCheckTFEWorkspaceRename() {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+func testAccCheckTFEWorkspaceRename(orgName string) func() {
+	return func() {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
 
-	w, err := tfeClient.Workspaces.Update(
-		context.Background(),
-		"tst-terraform",
-		"workspace-test",
-		tfe.WorkspaceUpdateOptions{Name: tfe.String("renamed-out-of-band")},
-	)
-	if err != nil {
-		log.Fatalf("Could not rename the workspace out of band: %v", err)
-	}
+		w, err := tfeClient.Workspaces.Update(
+			context.Background(),
+			orgName,
+			"workspace-test",
+			tfe.WorkspaceUpdateOptions{Name: tfe.String("renamed-out-of-band")},
+		)
+		if err != nil {
+			log.Fatalf("Could not rename the workspace out of band: %v", err)
+		}
 
-	if w.Name != "renamed-out-of-band" {
-		log.Fatalf("Failed to rename the workspace out of band: %v", err)
+		if w.Name != "renamed-out-of-band" {
+			log.Fatalf("Failed to rename the workspace out of band: %v", err)
+		}
 	}
 }
 
@@ -856,7 +875,7 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 
 const testAccTFEWorkspace_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -868,7 +887,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_basicFileTriggersOff = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -881,7 +900,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_basicSpeculativeOff = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -894,7 +913,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_monorepo = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -908,7 +927,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_renamed = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -920,7 +939,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_update = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -938,7 +957,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_updateAddWorkingDirectory = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -951,7 +970,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_updateRemoveWorkingDirectory = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -963,7 +982,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_sshKey = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -982,7 +1001,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_noSSHKey = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1000,7 +1019,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_triggerPrefixes = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1012,7 +1031,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_updateEmptyTriggerPrefixes = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 resource "tfe_workspace" "foobar" {
@@ -1021,9 +1040,10 @@ resource "tfe_workspace" "foobar" {
   auto_apply            = true
 }`
 
-var testAccTFEWorkspace_updateAddVCSRepo = fmt.Sprintf(`
+func testAccTFEWorkspace_updateAddVCSRepo(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1045,13 +1065,16 @@ resource "tfe_workspace" "foobar" {
   }
 }
 `,
-	GITHUB_TOKEN,
-	GITHUB_WORKSPACE_IDENTIFIER,
-)
+		rInt,
+		GITHUB_TOKEN,
+		GITHUB_WORKSPACE_IDENTIFIER,
+	)
+}
 
-var testAccTFEWorkspace_updateUpdateVCSRepoBranch = fmt.Sprintf(`
+func testAccTFEWorkspace_updateUpdateVCSRepoBranch(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1074,14 +1097,16 @@ resource "tfe_workspace" "foobar" {
   }
 }
 `,
-	GITHUB_TOKEN,
-	GITHUB_WORKSPACE_IDENTIFIER,
-	GITHUB_WORKSPACE_BRANCH,
-)
+		rInt,
+		GITHUB_TOKEN,
+		GITHUB_WORKSPACE_IDENTIFIER,
+		GITHUB_WORKSPACE_BRANCH,
+	)
+}
 
 const testAccTFEWorkspace_updateRemoveVCSRepo = `
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 


### PR DESCRIPTION
We are adding a suffix to the org name for each test. That way we can
have multiple people running the acceptance tests on the same instance.

Also a potential panic mid-test does not require an immediate cleanup
since the next run will create a different org.