### PR TITLE
Use Dockerhub Mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ test_results_dir: &test_results_dir /tmp/test_results
 jobs:
   run-tests:
     docker:
-      - image: circleci/golang:1.11.13
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.11.13
         environment:
           TEST_RESULTS_DIR: *test_results_dir
 


### PR DESCRIPTION
## Description

Dockerhub is going to rate limit unauthenticated pulls.

Use internal mirror for CI and Dockerfiles built in CI.

## Testing plan

1.  CI Passes
