### PR TITLE
Add `cost_estimation_enabled` to `tfe_organization` resource

### DIFF
--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -61,7 +61,7 @@ func resourceTFEOrganization() *schema.Resource {
 			"cost_estimation_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 		},
 	}

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -75,13 +75,8 @@ func resourceTFEOrganizationCreate(d *schema.ResourceData, meta interface{}) err
 
 	// Create a new options struct.
 	options := tfe.OrganizationCreateOptions{
-		Name:                   tfe.String(name),
-		Email:                  tfe.String(d.Get("email").(string)),
-		SessionTimeout:         tfe.Int(d.Get("session_timeout_minutes").(int)),
-		SessionRemember:        tfe.Int(d.Get("session_remember_minutes").(int)),
-		CollaboratorAuthPolicy: tfe.AuthPolicy(tfe.AuthPolicyType(d.Get("collaborator_auth_policy").(string))),
-		OwnersTeamSAMLRoleID:   tfe.String(d.Get("owners_team_saml_role_id").(string)),
-		CostEstimationEnabled:  tfe.Bool(d.Get("cost_estimation_enabled").(bool)),
+		Name:  tfe.String(name),
+		Email: tfe.String(d.Get("email").(string)),
 	}
 
 	log.Printf("[DEBUG] Create new organization: %s", name)

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -57,6 +57,12 @@ func resourceTFEOrganization() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"cost_estimation_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -105,6 +111,7 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("session_remember_minutes", org.SessionRemember)
 	d.Set("collaborator_auth_policy", org.CollaboratorAuthPolicy)
 	d.Set("owners_team_saml_role_id", org.OwnersTeamSAMLRoleID)
+	d.Set("cost_estimation_enabled", org.CostEstimationEnabled)
 
 	return nil
 }
@@ -136,6 +143,11 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 	// If owners_team_saml_role_id is supplied, set it using the options struct.
 	if ownersTeamSAMLRoleID, ok := d.GetOk("owners_team_saml_role_id"); ok {
 		options.OwnersTeamSAMLRoleID = tfe.String(ownersTeamSAMLRoleID.(string))
+	}
+
+	// If cost_estimation_enabled is supplied, set it using the options struct.
+	if costEstimationEnabled, ok := d.GetOkExists("cost_estimation_enabled"); ok {
+		options.CostEstimationEnabled = tfe.Bool(costEstimationEnabled.(bool))
 	}
 
 	log.Printf("[DEBUG] Update configuration of organization: %s", d.Id())

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -75,8 +75,13 @@ func resourceTFEOrganizationCreate(d *schema.ResourceData, meta interface{}) err
 
 	// Create a new options struct.
 	options := tfe.OrganizationCreateOptions{
-		Name:  tfe.String(name),
-		Email: tfe.String(d.Get("email").(string)),
+		Name:                   tfe.String(name),
+		Email:                  tfe.String(d.Get("email").(string)),
+		SessionTimeout:         tfe.Int(d.Get("session_timeout_minutes").(int)),
+		SessionRemember:        tfe.Int(d.Get("session_remember_minutes").(int)),
+		CollaboratorAuthPolicy: tfe.AuthPolicy(tfe.AuthPolicyType(d.Get("collaborator_auth_policy").(string))),
+		OwnersTeamSAMLRoleID:   tfe.String(d.Get("owners_team_saml_role_id").(string)),
+		CostEstimationEnabled:  tfe.Bool(d.get("cost_estimation_enabled").(bool)),
 	}
 
 	log.Printf("[DEBUG] Create new organization: %s", name)

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -81,7 +81,7 @@ func resourceTFEOrganizationCreate(d *schema.ResourceData, meta interface{}) err
 		SessionRemember:        tfe.Int(d.Get("session_remember_minutes").(int)),
 		CollaboratorAuthPolicy: tfe.AuthPolicy(tfe.AuthPolicyType(d.Get("collaborator_auth_policy").(string))),
 		OwnersTeamSAMLRoleID:   tfe.String(d.Get("owners_team_saml_role_id").(string)),
-		CostEstimationEnabled:  tfe.Bool(d.get("cost_estimation_enabled").(bool)),
+		CostEstimationEnabled:  tfe.Bool(d.Get("cost_estimation_enabled").(bool)),
 	}
 
 	log.Printf("[DEBUG] Create new organization: %s", name)

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `collaborator_auth_policy` - (Optional) Authentication policy (`password`
   or `two_factor_mandatory`). Defaults to `password`.
 * `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
+* `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to `false`.
 
 ## Attributes Reference
 

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `collaborator_auth_policy` - (Optional) Authentication policy (`password`
   or `two_factor_mandatory`). Defaults to `password`.
 * `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
-* `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to `false`.
+* `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

The `tfe_organization` resource is missing an option to set cost estimation settings for its workspaces. 

The TFE API already supports setting this attribute: https://www.terraform.io/docs/cloud/api/organizations.html#request-body

## Testing plan

1. Create a TFE organization without setting `cost_estimation_enabled`.
  a. From my observations, TFE sets the default value to `true` if Cost Estimation is globally enabled through [TFE Admin Settings](https://www.terraform.io/docs/enterprise/admin/integration.html#cost-estimation-integration), and sets default to `false` if Cost Estimation is not globally enabled. This complicates checking the `cost_estimation_enabled` default value, so I did not include that in the tests.
2. Explicitly set `cost_estimation_enabled` to `true`, verify the change is made.
3. Explicitly set `cost_estimation_enabled` to `false`, verify the change is made.

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEOrganization_\(update\|basic\)" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEOrganization_\(update\|basic\) -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEOrganization_basic
--- PASS: TestAccTFEOrganization_basic (1.79s)
=== RUN   TestAccTFEOrganization_update
--- PASS: TestAccTFEOrganization_update (3.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	6.011s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```