### PR TITLE
Enable setting SSH private key on all available OAuth clients for cloning Git submodules

### DIFF
--- a/vendor/github.com/hashicorp/go-tfe/oauth_client.go
+++ b/vendor/github.com/hashicorp/go-tfe/oauth_client.go
@@ -140,9 +140,6 @@ func (o OAuthClientCreateOptions) valid() error {
 	if o.ServiceProvider == nil {
 		return errors.New("service provider is required")
 	}
-	if validString(o.PrivateKey) && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {
-		return errors.New("Private Key can only be present with Azure DevOps Server service provider")
-	}
 	return nil
 }
 

--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 * `http_url` - (Required) The homepage of your VCS provider (e.g.
   `https://github.com` or `https://ghe.example.com`).
 * `oauth_token` - (Required) The token string you were given by your VCS provider.
-* `private_key` - (Required for `ado_server`) The text of the private key associated with your Azure DevOps Server account
+* `private_key` - (Required for `ado_server`) The text of the private key associated with your OAuth client. Required for cloning Git submodules.
 * `service_provider` - (Required) The VCS provider being connected with. Valid
   options are `ado_server`, `ado_services`, `github`, `github_enterprise`, `gitlab_hosted`,
   `gitlab_community_edition`, or `gitlab_enterprise_edition`.


### PR DESCRIPTION
## Description

I have a VCS Provider (Gitlab EE) that I need to clone submodules for, and according to the [docs](https://www.terraform.io/docs/cloud/vcs/index.html#ssh-keys), I need to specify the private key for my OAuth client.

> However, if the organization repositories include Git submodules that can only be accessed via SSH, an SSH key can be added along with the OAuth credentials.

The problem is that the `tfe_oauth_client` resource is blocking me from doing so, since I do not use Azure DevOps Server.

I've manually set the private key in TFE to verify this can work, but I'd like this resource to let me do so from Terraform.

I am also happy to update the [API docs](https://github.com/hashicorp/terraform-website/blob/master/content/source/docs/cloud/api/oauth-clients.html.md) as well, to clarify that the private key is required for ADO Server and Git submodules.

## Testing plan
Verified I can set private key on OAuth client manually (as described in docs above), and TFE is able to clone submodules successfully.
