### PR TITLE
Add support for Terraform Cloud Agents

### DIFF
--- a/tfe/data_source_agent_pool.go
+++ b/tfe/data_source_agent_pool.go
@@ -1,0 +1,61 @@
+package tfe
+
+import (
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceTFEAgentPool() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTFEAgentPoolRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// Get the name and organization.
+	name := d.Get("name").(string)
+	organization := d.Get("organization").(string)
+
+	// Create an options struct.
+	options := tfe.AgentPoolListOptions{}
+
+	for {
+		l, err := tfeClient.AgentPools.List(ctx, organization, options)
+		if err != nil {
+			return fmt.Errorf("Error retrieving agent pools: %v", err)
+		}
+
+		for _, k := range l.Items {
+			if k.Name == name {
+				d.SetId(k.ID)
+				return nil
+			}
+		}
+
+		// Exit the loop when we've seen all pages.
+		if l.CurrentPage >= l.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		options.PageNumber = l.NextPage
+	}
+
+	return fmt.Errorf("Could not find agent pool %s/%s", organization, name)
+}

--- a/tfe/data_source_agent_pool_test.go
+++ b/tfe/data_source_agent_pool_test.go
@@ -1,0 +1,76 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccTFEAgentPoolDataSource_basic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	// HACK: Agent pools do not have a full resource lifecycle at the
+	// moment, so a matching resource does not exist.  This makes testing
+	// with the provider SDK...difficult. Here we hackily init the provider
+	// with a dummy resource config just to get access to the API client to
+	// then set up an organization and agent pool out-of-band to test...for now.
+	testAccProvider.Configure(&terraform.ResourceConfig{})
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	testAccTFEAgentPoolDataSourceSetup(tfeClient, orgName)
+	defer testAccTFEAgentPoolDataSourceCleanup(tfeClient, orgName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEAgentPoolDataSourceConfig(orgName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_agent_pool.foobar", "name", "Default"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_agent_pool.foobar", "organization", orgName),
+					resource.TestCheckResourceAttrSet("data.tfe_agent_pool.foobar", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFEAgentPoolDataSourceSetup(tfeClient *tfe.Client, orgName string) {
+	org, err := tfeClient.Organizations.Create(
+		context.Background(),
+		tfe.OrganizationCreateOptions{Name: tfe.String(orgName), Email: tfe.String("admin@company.com")},
+	)
+	if err != nil {
+		log.Fatalf("Failed to create organization out of band: %v", err)
+	}
+
+	_, err = tfeClient.AgentPools.Create(context.Background(), org.Name, tfe.AgentPoolCreateOptions{})
+	if err != nil {
+		log.Fatalf("Failed to create agent pool out of band: %v", err)
+	}
+}
+
+func testAccTFEAgentPoolDataSourceCleanup(tfeClient *tfe.Client, orgName string) {
+	err := tfeClient.Organizations.Delete(context.Background(), orgName)
+	if err != nil {
+		log.Fatalf("WARNING: Failed to clean up organization out of band: %v", err)
+	}
+}
+
+func testAccTFEAgentPoolDataSourceConfig(orgName string) string {
+	return fmt.Sprintf(`
+data "tfe_agent_pool" "foobar" {
+  name         = "Default"
+  organization = "%s"
+}`, orgName)
+}

--- a/tfe/data_source_agent_pool_test.go
+++ b/tfe/data_source_agent_pool_test.go
@@ -1,76 +1,49 @@
 package tfe
 
 import (
-	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"testing"
 	"time"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccTFEAgentPoolDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	// HACK: Agent pools do not have a full resource lifecycle at the
-	// moment, so a matching resource does not exist.  This makes testing
-	// with the provider SDK...difficult. Here we hackily init the provider
-	// with a dummy resource config just to get access to the API client to
-	// then set up an organization and agent pool out-of-band to test...for now.
-	testAccProvider.Configure(&terraform.ResourceConfig{})
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
-	testAccTFEAgentPoolDataSourceSetup(tfeClient, orgName)
-	defer testAccTFEAgentPoolDataSourceCleanup(tfeClient, orgName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEAgentPoolDataSourceConfig(orgName),
+				Config: testAccTFEAgentPoolDataSourceConfig(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.tfe_agent_pool.foobar", "name", "Default"),
-					resource.TestCheckResourceAttr(
-						"data.tfe_agent_pool.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_agent_pool.foobar", "id"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_agent_pool.foobar", "name", fmt.Sprintf("agent-pool-test-%d", rInt)),
+					resource.TestCheckResourceAttr(
+						"data.tfe_agent_pool.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 				),
 			},
 		},
 	})
 }
 
-func testAccTFEAgentPoolDataSourceSetup(tfeClient *tfe.Client, orgName string) {
-	org, err := tfeClient.Organizations.Create(
-		context.Background(),
-		tfe.OrganizationCreateOptions{Name: tfe.String(orgName), Email: tfe.String("admin@company.com")},
-	)
-	if err != nil {
-		log.Fatalf("Failed to create organization out of band: %v", err)
-	}
-
-	_, err = tfeClient.AgentPools.Create(context.Background(), org.Name, tfe.AgentPoolCreateOptions{})
-	if err != nil {
-		log.Fatalf("Failed to create agent pool out of band: %v", err)
-	}
-}
-
-func testAccTFEAgentPoolDataSourceCleanup(tfeClient *tfe.Client, orgName string) {
-	err := tfeClient.Organizations.Delete(context.Background(), orgName)
-	if err != nil {
-		log.Fatalf("WARNING: Failed to clean up organization out of band: %v", err)
-	}
-}
-
-func testAccTFEAgentPoolDataSourceConfig(orgName string) string {
+func testAccTFEAgentPoolDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_agent_pool" "foobar" {
+  name                  = "agent-pool-test-%d"
+  organization          = "${tfe_organization.foobar.id}"
+}
+
 data "tfe_agent_pool" "foobar" {
-  name         = "Default"
-  organization = "%s"
-}`, orgName)
+  name         = "${tfe_agent_pool.foobar.name}"
+  organization = "${tfe_agent_pool.foobar.organization}"
+}`, rInt, rInt)
 }

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -82,6 +82,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"tfe_agent_pool":                 resourceTFEAgentPool(),
 			"tfe_notification_configuration": resourceTFENotificationConfiguration(),
 			"tfe_oauth_client":               resourceTFEOAuthClient(),
 			"tfe_organization":               resourceTFEOrganization(),

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -71,6 +71,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"tfe_agent_pool":              dataSourceTFEAgentPool(),
 			"tfe_oauth_client":            dataSourceTFEOAuthClient(),
 			"tfe_organization_membership": dataSourceTFEOrganizationMembership(),
 			"tfe_ssh_key":                 dataSourceTFESSHKey(),

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -51,7 +51,7 @@ func resourceTFEAgentPoolCreate(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId(agentPool.ID)
 
-	return resourceTFEAgentPoolUpdate(d, meta)
+	return resourceTFEAgentPoolRead(d, meta)
 }
 
 func resourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error {

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -1,0 +1,107 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceTFEAgentPool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTFEAgentPoolCreate,
+		Read:   resourceTFEAgentPoolRead,
+		Update: resourceTFEAgentPoolUpdate,
+		Delete: resourceTFEAgentPoolDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceTFEAgentPoolCreate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// Get the name and organization.
+	name := d.Get("name").(string)
+	organization := d.Get("organization").(string)
+
+	// Create a new options struct.
+	options := tfe.AgentPoolCreateOptions{
+		Name: tfe.String(name),
+	}
+
+	log.Printf("[DEBUG] Create new agent pool for organization: %s", organization)
+	agentPool, err := tfeClient.AgentPools.Create(ctx, organization, options)
+	if err != nil {
+		return fmt.Errorf(
+			"Error creating agent pool %s for organization %s: %v", name, organization, err)
+	}
+
+	d.SetId(agentPool.ID)
+
+	return resourceTFEAgentPoolUpdate(d, meta)
+}
+
+func resourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Read configuration of agent pool: %s", d.Id())
+	agentPool, err := tfeClient.AgentPools.Read(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			log.Printf("[DEBUG] agent pool %s does no longer exist", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading configuration of agent pool %s: %v", d.Id(), err)
+	}
+
+	// Update the config.
+	d.Set("name", agentPool.Name)
+
+	return nil
+}
+
+func resourceTFEAgentPoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// Create a new options struct.
+	options := tfe.AgentPoolUpdateOptions{
+		Name: tfe.String(d.Get("name").(string)),
+	}
+
+	log.Printf("[DEBUG] Update agent pool: %s", d.Id())
+	_, err := tfeClient.AgentPools.Update(ctx, d.Id(), options)
+	if err != nil {
+		return fmt.Errorf("Error updating agent pool %s: %v", d.Id(), err)
+	}
+
+	return resourceTFEAgentPoolRead(d, meta)
+}
+
+func resourceTFEAgentPoolDelete(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Delete agent pool: %s", d.Id())
+	err := tfeClient.AgentPools.Delete(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			return nil
+		}
+		return fmt.Errorf("Error deleting agent pool %s: %v", d.Id(), err)
+	}
+
+	return nil
+}

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -14,6 +14,9 @@ func resourceTFEAgentPool() *schema.Resource {
 		Read:   resourceTFEAgentPoolRead,
 		Update: resourceTFEAgentPoolUpdate,
 		Delete: resourceTFEAgentPoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -73,6 +73,7 @@ func resourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Update the config.
 	d.Set("name", agentPool.Name)
+	d.Set("organization", agentPool.Organization.Name)
 
 	return nil
 }

--- a/tfe/resource_tfe_agent_pool_test.go
+++ b/tfe/resource_tfe_agent_pool_test.go
@@ -1,0 +1,157 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccTFEAgentPool_basic(t *testing.T) {
+	agentPool := &tfe.AgentPool{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEAgentPool_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEAgentPoolExists(
+						"tfe_agent_pool.foobar", agentPool),
+					testAccCheckTFEAgentPoolAttributes(agentPool),
+					resource.TestCheckResourceAttr(
+						"tfe_agent_pool.foobar", "name", "agent-pool-test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEAgentPool_update(t *testing.T) {
+	agentPool := &tfe.AgentPool{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEAgentPool_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEAgentPoolExists(
+						"tfe_agent_pool.foobar", agentPool),
+					testAccCheckTFEAgentPoolAttributes(agentPool),
+					resource.TestCheckResourceAttr(
+						"tfe_agent_pool.foobar", "name", "agent-pool-test"),
+				),
+			},
+
+			{
+				Config: testAccTFEAgentPool_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEAgentPoolExists(
+						"tfe_agent_pool.foobar", agentPool),
+					testAccCheckTFEAgentPoolAttributesUpdated(agentPool),
+					resource.TestCheckResourceAttr(
+						"tfe_agent_pool.foobar", "name", "agent-pool-updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTFEAgentPoolExists(
+	n string, agentPool *tfe.AgentPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		sk, err := tfeClient.AgentPools.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if sk == nil {
+			return fmt.Errorf("agent pool not found")
+		}
+
+		*agentPool = *sk
+
+		return nil
+	}
+}
+
+func testAccCheckTFEAgentPoolAttributes(
+	agentPool *tfe.AgentPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if agentPool.Name != "agent-pool-test" {
+			return fmt.Errorf("Bad name: %s", agentPool.Name)
+		}
+		return nil
+	}
+}
+
+func testAccCheckTFEAgentPoolAttributesUpdated(
+	agentPool *tfe.AgentPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if agentPool.Name != "agent-pool-updated" {
+			return fmt.Errorf("Bad name: %s", agentPool.Name)
+		}
+		return nil
+	}
+}
+
+func testAccCheckTFEAgentPoolDestroy(s *terraform.State) error {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_agent_pool" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := tfeClient.AgentPools.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("agent pool %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+const testAccTFEAgentPool_basic = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_agent_pool" "foobar" {
+  name         = "agent-pool-test"
+  organization = "${tfe_organization.foobar.id}"
+}`
+
+const testAccTFEAgentPool_update = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_agent_pool" "foobar" {
+  name         = "agent-pool-updated"
+  organization = "${tfe_organization.foobar.id}"
+}`

--- a/tfe/resource_tfe_agent_pool_test.go
+++ b/tfe/resource_tfe_agent_pool_test.go
@@ -68,6 +68,27 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 	})
 }
 
+func TestAccTFEAgentPool_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEAgentPool_basic(rInt),
+			},
+
+			{
+				ResourceName:      "tfe_agent_pool.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFEAgentPoolExists(
 	n string, agentPool *tfe.AgentPool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_agent_pool_test.go
+++ b/tfe/resource_tfe_agent_pool_test.go
@@ -2,7 +2,9 @@ package tfe
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -11,6 +13,7 @@ import (
 
 func TestAccTFEAgentPool_basic(t *testing.T) {
 	agentPool := &tfe.AgentPool{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +21,7 @@ func TestAccTFEAgentPool_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEAgentPool_basic,
+				Config: testAccTFEAgentPool_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEAgentPoolExists(
 						"tfe_agent_pool.foobar", agentPool),
@@ -33,6 +36,7 @@ func TestAccTFEAgentPool_basic(t *testing.T) {
 
 func TestAccTFEAgentPool_update(t *testing.T) {
 	agentPool := &tfe.AgentPool{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,7 +44,7 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEAgentPool_basic,
+				Config: testAccTFEAgentPool_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEAgentPoolExists(
 						"tfe_agent_pool.foobar", agentPool),
@@ -51,7 +55,7 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEAgentPool_update,
+				Config: testAccTFEAgentPool_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEAgentPoolExists(
 						"tfe_agent_pool.foobar", agentPool),
@@ -134,24 +138,28 @@ func testAccCheckTFEAgentPoolDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFEAgentPool_basic = `
+func testAccTFEAgentPool_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
 resource "tfe_agent_pool" "foobar" {
   name         = "agent-pool-test"
   organization = "${tfe_organization.foobar.id}"
-}`
+}`, rInt)
+}
 
-const testAccTFEAgentPool_update = `
+func testAccTFEAgentPool_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
 resource "tfe_agent_pool" "foobar" {
   name         = "agent-pool-updated"
   organization = "${tfe_organization.foobar.id}"
-}`
+}`, rInt)
+}

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -30,6 +30,8 @@ func resourceTFEWorkspace() *schema.Resource {
 			},
 		},
 
+		CustomizeDiff: validateAgentExecution,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -61,9 +63,23 @@ func resourceTFEWorkspace() *schema.Resource {
 			},
 
 			"operations": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"execution_mode", "agent_pool_id"},
+			},
+
+			"execution_mode": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"operations"},
+			},
+
+			"agent_pool_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"operations"},
 			},
 
 			"queue_all_runs": {
@@ -160,6 +176,18 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
 	}
 
+	if v, ok := d.GetOk("operations"); ok {
+		options.Operations = tfe.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("execution_mode"); ok {
+		options.ExecutionMode = tfe.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
+		options.AgentPoolID = tfe.String(v.(string))
+	}
+
 	// Process all configured options.
 	if tfVersion, ok := d.GetOk("terraform_version"); ok {
 		options.TerraformVersion = tfe.String(tfVersion.(string))
@@ -231,6 +259,7 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("auto_apply", workspace.AutoApply)
 	d.Set("file_triggers_enabled", workspace.FileTriggersEnabled)
 	d.Set("operations", workspace.Operations)
+	d.Set("execution_mode", workspace.ExecutionMode)
 	d.Set("queue_all_runs", workspace.QueueAllRuns)
 	d.Set("speculative_enabled", workspace.SpeculativeEnabled)
 	d.Set("terraform_version", workspace.TerraformVersion)
@@ -244,6 +273,12 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 		sshKeyID = workspace.SSHKey.ID
 	}
 	d.Set("ssh_key_id", sshKeyID)
+
+	var agentPoolID string
+	if workspace.AgentPool != nil {
+		agentPoolID = workspace.AgentPool.ID
+	}
+	d.Set("agent_pool_id", agentPoolID)
 
 	var vcsRepo []interface{}
 	if workspace.VCSRepo != nil {
@@ -268,18 +303,36 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 	if d.HasChange("name") || d.HasChange("auto_apply") || d.HasChange("queue_all_runs") ||
 		d.HasChange("terraform_version") || d.HasChange("working_directory") || d.HasChange("vcs_repo") ||
 		d.HasChange("file_triggers_enabled") || d.HasChange("trigger_prefixes") ||
-		d.HasChange("operations") || d.HasChange("speculative_enabled") ||
-		d.HasChange("allow_destroy_plan") {
+		d.HasChange("allow_destroy_plan") || d.HasChange("speculative_enabled") ||
+		d.HasChange("operations") || d.HasChange("execution_mode") || d.HasChange("agent_pool_id") {
+
 		// Create a new options struct.
 		options := tfe.WorkspaceUpdateOptions{
 			Name:                tfe.String(d.Get("name").(string)),
 			AllowDestroyPlan:    tfe.Bool(d.Get("allow_destroy_plan").(bool)),
 			AutoApply:           tfe.Bool(d.Get("auto_apply").(bool)),
 			FileTriggersEnabled: tfe.Bool(d.Get("file_triggers_enabled").(bool)),
-			Operations:          tfe.Bool(d.Get("operations").(bool)),
 			QueueAllRuns:        tfe.Bool(d.Get("queue_all_runs").(bool)),
 			SpeculativeEnabled:  tfe.Bool(d.Get("speculative_enabled").(bool)),
 			WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
+		}
+
+		if d.HasChange("operations") {
+			if v, ok := d.GetOkExists("operations"); ok {
+				options.Operations = tfe.Bool(v.(bool))
+			}
+		}
+
+		if d.HasChange("execution_mode") {
+			if v, ok := d.GetOk("execution_mode"); ok {
+				options.ExecutionMode = tfe.String(v.(string))
+			}
+		}
+
+		if d.HasChange("agent_pool_id") {
+			if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
+				options.AgentPoolID = tfe.String(v.(string))
+			}
 		}
 
 		// Process all configured options.
@@ -373,6 +426,26 @@ func resourceTFEWorkspaceDelete(d *schema.ResourceData, meta interface{}) error 
 		}
 		return fmt.Errorf(
 			"Error deleting workspace %s: %v", id, err)
+	}
+
+	return nil
+}
+
+// An agent pool can only be specified when execution_mode is set to "agent". You currently cannot specify a
+// schema validation based on a different argument's value, so we do so here at plan time instead.
+func validateAgentExecution(d *schema.ResourceDiff, meta interface{}) error {
+	if executionMode, ok := d.GetOk("execution_mode"); ok {
+		if executionMode.(string) != "agent" && d.Get("agent_pool_id") != "" {
+			return fmt.Errorf("execution_mode must be set to 'agent' to assign agent_pool_id")
+		} else if executionMode.(string) == "agent" && d.Get("agent_pool_id") == "" {
+			return fmt.Errorf("agent_pool_id must be provided when execution_mode is 'agent'")
+		}
+	}
+
+	if d.HasChange("execution_mode") {
+		d.SetNewComputed("operations")
+	} else if d.HasChange("operations") {
+		d.SetNewComputed("execution_mode")
 	}
 
 	return nil

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -44,6 +44,12 @@ func resourceTFEWorkspace() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"agent_pool_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"operations"},
+			},
+
 			"allow_destroy_plan": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -54,6 +60,13 @@ func resourceTFEWorkspace() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+			},
+
+			"execution_mode": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"operations"},
 			},
 
 			"file_triggers_enabled": {
@@ -67,19 +80,6 @@ func resourceTFEWorkspace() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"execution_mode", "agent_pool_id"},
-			},
-
-			"execution_mode": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"operations"},
-			},
-
-			"agent_pool_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"operations"},
 			},
 
 			"queue_all_runs": {
@@ -175,16 +175,16 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
 	}
 
-	if v, ok := d.GetOk("operations"); ok {
-		options.Operations = tfe.Bool(v.(bool))
+	if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
+		options.AgentPoolID = tfe.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("execution_mode"); ok {
 		options.ExecutionMode = tfe.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
-		options.AgentPoolID = tfe.String(v.(string))
+	if v, ok := d.GetOk("operations"); ok {
+		options.Operations = tfe.Bool(v.(bool))
 	}
 
 	// Process all configured options.
@@ -316,9 +316,9 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 			WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
 		}
 
-		if d.HasChange("operations") {
-			if v, ok := d.GetOkExists("operations"); ok {
-				options.Operations = tfe.Bool(v.(bool))
+		if d.HasChange("agent_pool_id") {
+			if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
+				options.AgentPoolID = tfe.String(v.(string))
 			}
 		}
 
@@ -328,9 +328,9 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 		}
 
-		if d.HasChange("agent_pool_id") {
-			if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
-				options.AgentPoolID = tfe.String(v.(string))
+		if d.HasChange("operations") {
+			if v, ok := d.GetOkExists("operations"); ok {
+				options.Operations = tfe.Bool(v.(bool))
 			}
 		}
 

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -170,7 +170,6 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		AllowDestroyPlan:    tfe.Bool(d.Get("allow_destroy_plan").(bool)),
 		AutoApply:           tfe.Bool(d.Get("auto_apply").(bool)),
 		FileTriggersEnabled: tfe.Bool(d.Get("file_triggers_enabled").(bool)),
-		Operations:          tfe.Bool(d.Get("operations").(bool)),
 		QueueAllRuns:        tfe.Bool(d.Get("queue_all_runs").(bool)),
 		SpeculativeEnabled:  tfe.Bool(d.Get("speculative_enabled").(bool)),
 		WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
@@ -437,7 +436,7 @@ func validateAgentExecution(d *schema.ResourceDiff, meta interface{}) error {
 	if executionMode, ok := d.GetOk("execution_mode"); ok {
 		if executionMode.(string) != "agent" && d.Get("agent_pool_id") != "" {
 			return fmt.Errorf("execution_mode must be set to 'agent' to assign agent_pool_id")
-		} else if executionMode.(string) == "agent" && d.Get("agent_pool_id") == "" {
+		} else if executionMode.(string) == "agent" && d.NewValueKnown("agent_pool_id") && d.Get("agent_pool_id") == "" {
 			return fmt.Errorf("agent_pool_id must be provided when execution_mode is 'agent'")
 		}
 	}

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -7,6 +7,7 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 var workspaceIdRegexp = regexp.MustCompile("^ws-[a-zA-Z0-9]{16}$")
@@ -67,6 +68,14 @@ func resourceTFEWorkspace() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"operations"},
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"agent",
+						"local",
+						"remote",
+					},
+					false,
+				),
 			},
 
 			"file_triggers_enabled": {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -575,6 +575,84 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 	})
 }
 
+func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T) {
+	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspace_operationsTrue(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "operations", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "execution_mode", "remote"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "agent_pool_id", ""),
+				),
+			},
+			{
+				Config: testAccTFEWorkspace_executionModeLocal(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "operations", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "execution_mode", "local"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "agent_pool_id", ""),
+				),
+			},
+			{
+				Config: testAccTFEWorkspace_operationsFalse(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "operations", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "execution_mode", "local"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "agent_pool_id", ""),
+				),
+			},
+			{
+				Config: testAccTFEWorkspace_executionModeRemote(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "operations", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "execution_mode", "remote"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "agent_pool_id", ""),
+				),
+			},
+			{
+				Config: testAccTFEWorkspace_executionModeAgent(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "operations", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "execution_mode", "agent"),
+					resource.TestCheckResourceAttrSet(
+						"tfe_workspace.foobar", "agent_pool_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckTFEWorkspaceExists(
 	n string, workspace *tfe.Workspace) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -651,6 +729,10 @@ func testAccCheckTFEWorkspaceAttributes(
 
 		if workspace.Operations != true {
 			return fmt.Errorf("Bad operations: %t", workspace.Operations)
+		}
+
+		if workspace.ExecutionMode != "remote" {
+			return fmt.Errorf("Bad execution mode: %s", workspace.ExecutionMode)
 		}
 
 		if workspace.QueueAllRuns != true {
@@ -735,6 +817,10 @@ func testAccCheckTFEWorkspaceAttributesUpdated(
 
 		if workspace.Operations != false {
 			return fmt.Errorf("Bad operations: %t", workspace.Operations)
+		}
+
+		if workspace.ExecutionMode != "local" {
+			return fmt.Errorf("Bad execution mode: %s", workspace.ExecutionMode)
 		}
 
 		if workspace.QueueAllRuns != false {
@@ -911,6 +997,82 @@ resource "tfe_workspace" "foobar" {
   organization          = "${tfe_organization.foobar.id}"
   auto_apply            = true
   file_triggers_enabled = false
+}`, rInt)
+}
+
+func testAccTFEWorkspace_operationsTrue(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = "${tfe_organization.foobar.id}"
+  operations = true
+}`, rInt)
+}
+
+func testAccTFEWorkspace_operationsFalse(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = "${tfe_organization.foobar.id}"
+  operations = false
+}`, rInt)
+}
+
+func testAccTFEWorkspace_executionModeRemote(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = "${tfe_organization.foobar.id}"
+  execution_mode = "remote"
+}`, rInt)
+}
+
+func testAccTFEWorkspace_executionModeLocal(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = "${tfe_organization.foobar.id}"
+  execution_mode = "local"
+}`, rInt)
+}
+
+func testAccTFEWorkspace_executionModeAgent(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_agent_pool" "foobar" {
+  name = "agent-pool-test"
+  organization = "${tfe_organization.foobar.name}"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = "${tfe_organization.foobar.id}"
+  execution_mode = "agent"
+  agent_pool_id = "${tfe_agent_pool.foobar.id}"
 }`, rInt)
 }
 

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -1003,7 +1003,7 @@ resource "tfe_workspace" "foobar" {
 func testAccTFEWorkspace_operationsTrue(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1017,7 +1017,7 @@ resource "tfe_workspace" "foobar" {
 func testAccTFEWorkspace_operationsFalse(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1031,7 +1031,7 @@ resource "tfe_workspace" "foobar" {
 func testAccTFEWorkspace_executionModeRemote(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1045,7 +1045,7 @@ resource "tfe_workspace" "foobar" {
 func testAccTFEWorkspace_executionModeLocal(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -1059,7 +1059,7 @@ resource "tfe_workspace" "foobar" {
 func testAccTFEWorkspace_executionModeAgent(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/website/docs/d/agent_pool.html.markdown
+++ b/website/docs/d/agent_pool.html.markdown
@@ -10,8 +10,9 @@ description: |-
 
 Use this data source to get information about an agent pool.
 
-~> **NOTE:** This data source requires using the provider with Terraform Cloud.
-Agent pools are not available in Terraform Enterprise.
+~> **NOTE:** This data source requires using the provider with Terraform Cloud and a Terraform Cloud 
+for Business account. 
+[Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 ## Example Usage
 

--- a/website/docs/d/agent_pool.html.markdown
+++ b/website/docs/d/agent_pool.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_agent_pool"
+sidebar_current: "docs-datasource-tfe-agent-pool"
+description: |-
+  Get information on an agent pool.
+---
+
+# Data Source: tfe_agent_pool
+
+Use this data source to get information about an agent pool.
+
+~> **NOTE:** This data source requires using the provider with Terraform Cloud.
+Agent pools are not available in Terraform Enterprise.
+
+## Example Usage
+
+```hcl
+data "tfe_agent_pool" "test" {
+  name          = "my-agent-pool-name"
+  organization  = "my-org-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the agent pool.
+* `organization` - (Required) Name of the organization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The agent pool ID.

--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_agent_pool"
+sidebar_current: "docs-resource-tfe-agent-pool"
+description: |-
+  Manages agent pools
+---
+
+# tfe_agent_pool
+
+An agent pool represents a group of agents, often related to one another by sharing a common 
+network segment or purpose. A workspace may be configured to use one of the organization's agent 
+pools to run remote operations with isolated, private, or on-premises infrastructure.
+
+~> **NOTE:** This resource requires using the provider with Terraform Cloud and a Terraform Cloud 
+for Business account. 
+[Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_agent_pool" "test-agent-pool" {
+  name         = "my-agent-pool-name"
+  organization = tfe_organization.test-organization.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the agent pool.
+* `organization` - (Required) Name of the organization.
+
+## Attributes Reference
+
+* `id` - The ID of the agent pool.
+* `name` - The name of agent pool.
+* `organization` - The name of the organization associated with the agent pool.
+
+## Import
+
+Agent pools can be imported; use `<AGENT POOL ID>` as the import ID. For example:
+
+```shell
+terraform import tfe_agent_pool.test apool-rW0KoLSlnuNb5adB
+```

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -59,9 +59,10 @@ The following arguments are supported:
 * `allow_destroy_plan` - (Optional) Whether destroy plans can be queued on the workspace.
 * `auto_apply` - (Optional) Whether to automatically apply changes when a
   Terraform plan is successful. Defaults to `false`.
-* `execution_mode` - (Optional) Which [execution mode](https://www.terraform.io/docs/cloud/workspaces/settings.html#execution-mode) 
-  to use. Valid values are `remote`, `local` or `agent`. When set to `local`, the workspace will be used 
-  for state storage only. Defaults to `remote`. This value _must not_ be provided if `operations` is provided.
+* `execution_mode` - (Optional) Which [execution mode](https://www.terraform.io/docs/cloud/workspaces/settings.html#execution-mode) to use. Using Terraform Cloud, valid
+  values are `remote`, `local` or `agent`. Using Terraform Enterprise, only `remote` and `local` execution modes are
+  valid.  When set to `local`, the workspace will be used for state storage only. Defaults to `remote`. This value _must
+  not_ be provided if `operations` is provided.
 * `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files 
   in a VCS push. If enabled, the working directory and trigger prefixes describe a set of 
   paths which must contain changes for a VCS push to trigger a run. If disabled, any push will 

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -15,9 +15,35 @@ Provides a workspace resource.
 Basic usage:
 
 ```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
 resource "tfe_workspace" "test" {
   name         = "my-workspace-name"
-  organization = "my-org-name"
+  organization = tfe_organization.test-organization.id
+}
+```
+
+(**TFC only**) With `execution_mode` of `agent`:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_agent_pool" "test-agent-pool" {
+  name         = "my-agent-pool-name"
+  organization = tfe_organization.test-organization.id
+}
+
+resource "tfe_workspace" "test" {
+  name           = "my-workspace-name"
+  organization   = tfe_organization.test-organization.id
+  agent_pool_id  = tfe_organization.test-agent-pool.id
+  execution_mode = "agent"
 }
 ```
 
@@ -27,13 +53,22 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the workspace.
 * `organization` - (Required) Name of the organization.
+* `agent_pool_id` - (Optional) The ID of an agent pool to assign to the workspace. Required when `execution_mode` 
+  is set to `agent`. This value _must not_ be provided if `execution_mode` is set to `remote` or `local` or if 
+  `operations` is set to `true`.
 * `allow_destroy_plan` - (Optional) Whether destroy plans can be queued on the workspace.
 * `auto_apply` - (Optional) Whether to automatically apply changes when a
   Terraform plan is successful. Defaults to `false`.
-* `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files in a VCS push. If enabled, the working directory and trigger prefixes describe a set of paths which must contain changes for a VCS push to trigger a run. If disabled, any push will trigger a run. Defaults to `true`.
-* `operations` - (Optional) Whether to use remote execution mode. When set
-  to `false`, the workspace will be used for state storage only.
-  Defaults to `true`.
+* `execution_mode` - (Optional) Which [execution mode](https://www.terraform.io/docs/cloud/workspaces/settings.html#execution-mode) 
+  to use. Valid values are `remote`, `local` or `agent`. When set to `local`, the workspace will be used 
+  for state storage only. Defaults to `remote`. This value _must not_ be provided if `operations` is provided.
+* `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files 
+  in a VCS push. If enabled, the working directory and trigger prefixes describe a set of 
+  paths which must contain changes for a VCS push to trigger a run. If disabled, any push will 
+  trigger a run. Defaults to `true`.
+* `operations` - **Deprecated** Whether to use remote execution mode. When set to `false`, the workspace will 
+  be used for state storage only. Defaults to `true`. This value _must not_ be provided if `execution_mode` is 
+  provided.
 * `queue_all_runs` - (Optional) Whether all runs should be queued. When set
   to `false`, runs triggered by a VCS change will not be queued until at least
   one run is manually queued. Defaults to `true`.
@@ -43,8 +78,10 @@ The following arguments are supported:
   security if the VCS repository is public or includes untrusted contributors.
   Defaults to `true`.
 * `ssh_key_id` - (Optional) The ID of an SSH key to assign to the workspace.
-* `terraform_version` - (Optional) The version of Terraform to use for this workspace. Defaults to the latest available version.
-* `trigger_prefixes` - (Optional) List of repository-root-relative paths which describe all locations to be tracked for changes.
+* `terraform_version` - (Optional) The version of Terraform to use for this workspace. Defaults to 
+  the latest available version.
+* `trigger_prefixes` - (Optional) List of repository-root-relative paths which describe all locations 
+  to be tracked for changes.
 * `working_directory` - (Optional) A relative path that Terraform will execute
   within.  Defaults to the root of your repository.
 * `vcs_repo` - (Optional) Settings for the workspace's VCS repository.

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -53,9 +53,9 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the workspace.
 * `organization` - (Required) Name of the organization.
-* `agent_pool_id` - (Optional) The ID of an agent pool to assign to the workspace. Required when `execution_mode` 
-  is set to `agent`. This value _must not_ be provided if `execution_mode` is set to `remote` or `local` or if 
-  `operations` is set to `true`.
+* `agent_pool_id` - (Optional) The ID of an agent pool to assign to the workspace. Requires `execution_mode`
+  to be set to `agent`. This value _must not_ be provided if `execution_mode` is set to any other value or if `operations` is
+  provided.
 * `allow_destroy_plan` - (Optional) Whether destroy plans can be queued on the workspace.
 * `auto_apply` - (Optional) Whether to automatically apply changes when a
   Terraform plan is successful. Defaults to `false`.

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -50,9 +50,14 @@
                 <li<%= sidebar_current("docs-tfe-resource") %>>
                     <a href="#">Resources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-resource-tfe-agent-pool") %>>
+                            <a href="/docs/providers/tfe/r/agent_pool.html">tfe_agent_pool</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-resource-tfe-notification-configuration") %>>
                             <a href="/docs/providers/tfe/r/notification_configuration.html">tfe_notification_configuration</a>
                         </li>
+
                         <li<%= sidebar_current("docs-resource-tfe-oauth-client") %>>
                             <a href="/docs/providers/tfe/r/oauth_client.html">tfe_oauth_client</a>
                         </li>

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -13,9 +13,14 @@
                 <li<%= sidebar_current("docs-tfe-datasource") %>>
                     <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-datasource-tfe-agent-pool") %>>
+                            <a href="/docs/providers/tfe/d/agent_pool.html">tfe_agent_pool</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-datasource-tfe-oauth-client-x") %>>
                             <a href="/docs/providers/tfe/d/oauth_client.html">tfe_oauth_client</a>
                         </li>
+
                         <li<%= sidebar_current("docs-datasource-tfe-organization-membership") %>>
                             <a href="/docs/providers/tfe/d/organization_membership.html">tfe_organization_membership</a>
                         </li>


### PR DESCRIPTION
## Description

This adds support for [Terraform Cloud Agents](https://www.terraform.io/docs/cloud/agents/index.html), now that [agent pools have a full resource lifecycle](https://www.terraform.io/docs/cloud/agents/index.html#managing-agent-pools) and can be managed via Terraform. Specifically this adds a `tfe_agent_pool` resource and datasource (https://www.terraform.io/docs/cloud/api/agents.html) and allows configuring them for use in a Terraform Cloud workspace with the new `execution-mode` attribute.

Closes #204 

## Testing plan

* Agent pool management should behave as you expect (it's a simple resource)
* Workspace configuration with `execution_mode` and `agent_pool_id` should behave smoothly, allowing for continued use of the deprecated `operations` argument or a seamless switch to `execution_mode`. Their use should be mutually exclusive.  The only known rough edge I have found is moving from `execution_mode = "agent"` back to `operations = true/false` fails schema validations, because of the limitations of validating existing state. This is acceptable though, as if you're already using execution_mode there is _no_ reason to revert back to operations.
* Agent pool imports should work: simply import by ID, you don't even need the org name: `terraform import tfe_agent_pool.name apool-xxxx`

## External links

* Requires https://github.com/hashicorp/go-tfe/pull/153

## TODO

- [x] Provider documentation
- [x] ~Deprecate `operations`? Might save that for a separate change.~
- [x] Add Terraform Enterprise disclaimers to documentation
- [x] Bump go-tfe, after verifying CI passes with a ref.