### PR TITLE
Remove deprecated workspace_external_id/workspace_external_ids attributes and deprecate external_id attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 ## 0.24.0 (Unreleased)
+BREAKING CHANGES: 
+* d/tfe_workspace_ids: Changed `ids` attribute to return immutable workspace IDs in the format `ws-<RANDOM STRING>` ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+* r/tfe_notification_configuration: Removed deprecated `workspace_external_id` attribute, preferring `workspace_id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+* r/tfe_policy_set: Removed deprecated `workspace_external_ids` attribute, preferring `workspace_ids` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+* r/tfe_run_trigger: Removed deprecated `workspace_external_id` attribute, preferring `workspace_id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+
+ENHANCEMENTS:
+* d/tfe_workspace: Added deprecation warning to the `external_id` attribute, preferring `id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+* d/tfe_workspace_ids: Added deprecation warning to the `external_ids` attribute, preferring `ids` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+* r/tfe_workspace: Added deprecation warning to the `external_id` attribute, preferring `id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+
+NOTES:
+* All deprecated attributes will be removed 3 months after the release of v0.24.0. You will have until April X, 2021 to migrate to the preferred attributes. 
+* More information about these deprecations can be found in the description of [#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253)
+* d/tfe_workspace: The deprecation warning for the `external_id` attribute will not go away until the attribute is removed in a future version. 
+This is due to a [limitation of the Terraform SDK](https://github.com/hashicorp/terraform/issues/7569) for deprecation warnings on attributes that aren't 
+specified in a configuration. If you have already changed all references to this data source's `external_id` attribute to the `ids` attribute, you can 
+ignore the warning. 
+* d/tfe_workspace_ids: The deprecation warning for the `external_ids` attribute will not go away until the attribute is removed in a future version. 
+This is due to a [limitation of the Terraform SDK](https://github.com/hashicorp/terraform/issues/7569) for deprecation warnings on attributes that aren't 
+specified in a configuration. If you have already changed all references to this data source's `external_ids` attribute to the `ids` attribute, you can 
+ignore the warning.  
+
 
 
 ## 0.23.0 (November 20, 2020)

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -10,7 +10,8 @@ import (
 
 func dataSourceTFEWorkspace() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceTFEWorkspaceRead,
+		DeprecationMessage: "Data source \"tfe_workspace\"\n\n\"external_id\": [DEPRECATED] Use id instead. The external_id attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.24.0/CHANGELOG.md",
+		Read:               dataSourceTFEWorkspaceRead,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -98,8 +99,9 @@ func dataSourceTFEWorkspace() *schema.Resource {
 			},
 
 			"external_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use id instead. The external_id attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.24.0/CHANGELOG.md",
 			},
 		},
 	}
@@ -131,6 +133,7 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("terraform_version", workspace.TerraformVersion)
 	d.Set("trigger_prefixes", workspace.TriggerPrefixes)
 	d.Set("working_directory", workspace.WorkingDirectory)
+	// TODO: remove when external_id is removed
 	d.Set("external_id", workspace.ID)
 
 	if workspace.SSHKey != nil {

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -20,14 +20,19 @@ func TestAccTFEWorkspaceIDsDataSource_basic(t *testing.T) {
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_basic(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					// names attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.#", "2"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.0", fmt.Sprintf("workspace-foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.1", fmt.Sprintf("workspace-bar-%d", rInt)),
+
+					// organization attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "organization", orgName),
+
+					// full_names attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "full_names.%", "2"),
 					resource.TestCheckResourceAttr(
@@ -40,24 +45,24 @@ func TestAccTFEWorkspaceIDsDataSource_basic(t *testing.T) {
 						fmt.Sprintf("full_names.workspace-bar-%d", rInt),
 						fmt.Sprintf("tst-terraform-%d/workspace-bar-%d", rInt, rInt),
 					),
+
+					// ids attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "ids.%", "2"),
-					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar",
-						fmt.Sprintf("ids.workspace-foo-%d", rInt),
-						fmt.Sprintf("tst-terraform-%d/workspace-foo-%d", rInt, rInt),
-					),
-					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar",
-						fmt.Sprintf("ids.workspace-bar-%d", rInt),
-						fmt.Sprintf("tst-terraform-%d/workspace-bar-%d", rInt, rInt),
-					),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-foo-%d", rInt)),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-bar-%d", rInt)),
+
+					// external_ids attributes
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "external_ids.%", "2"),
 					resource.TestCheckResourceAttrSet(
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-foo-%d", rInt)),
 					resource.TestCheckResourceAttrSet(
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-bar-%d", rInt)),
+
+					// id attribute
 					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),
 				),
 			},
@@ -77,12 +82,17 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					// names attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.#", "1"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.0", "*"),
+
+					// organization attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "organization", orgName),
+
+					// full_names attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "full_names.%", "3"),
 					resource.TestCheckResourceAttr(
@@ -100,23 +110,18 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 						fmt.Sprintf("full_names.workspace-dummy-%d", rInt),
 						fmt.Sprintf("tst-terraform-%d/workspace-dummy-%d", rInt, rInt),
 					),
+
+					// ids attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "ids.%", "3"),
-					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar",
-						fmt.Sprintf("ids.workspace-foo-%d", rInt),
-						fmt.Sprintf("tst-terraform-%d/workspace-foo-%d", rInt, rInt),
-					),
-					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar",
-						fmt.Sprintf("ids.workspace-bar-%d", rInt),
-						fmt.Sprintf("tst-terraform-%d/workspace-bar-%d", rInt, rInt),
-					),
-					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar",
-						fmt.Sprintf("ids.workspace-dummy-%d", rInt),
-						fmt.Sprintf("tst-terraform-%d/workspace-dummy-%d", rInt, rInt),
-					),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-foo-%d", rInt)),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-bar-%d", rInt)),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-dummy-%d", rInt)),
+
+					// external_ids attribute
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "external_ids.%", "3"),
 					resource.TestCheckResourceAttrSet(
@@ -125,6 +130,8 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-bar-%d", rInt)),
 					resource.TestCheckResourceAttrSet(
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-dummy-%d", rInt)),
+
+					// id attribute
 					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),
 				),
 			},

--- a/tfe/resource_tfe_notification_configuration_test.go
+++ b/tfe/resource_tfe_notification_configuration_test.go
@@ -44,37 +44,6 @@ func TestAccTFENotificationConfiguration_basic(t *testing.T) {
 	})
 }
 
-func TestAccTFENotificationConfiguration_basicWorkspaceID(t *testing.T) {
-	notificationConfiguration := &tfe.NotificationConfiguration{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFENotificationConfiguration_basicWorkspaceID(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFENotificationConfigurationExists(
-						"tfe_notification_configuration.foobar", notificationConfiguration),
-					testAccCheckTFENotificationConfigurationAttributes(notificationConfiguration),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "destination_type", "generic"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "name", "notification_basic"),
-					// Just test the number of items in triggers
-					// Values in triggers attribute are tested by testCheckTFENotificationConfigurationAttributes
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "triggers.#", "0"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccTFENotificationConfiguration_emailUserIDs(t *testing.T) {
 	notificationConfiguration := &tfe.NotificationConfiguration{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -135,130 +104,6 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 			},
 			{
 				Config: testAccTFENotificationConfiguration_update(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFENotificationConfigurationExists(
-						"tfe_notification_configuration.foobar", notificationConfiguration),
-					testAccCheckTFENotificationConfigurationAttributesUpdate(notificationConfiguration),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "destination_type", "generic"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "name", "notification_update"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "token", "1234567890_update"),
-					// Just test the number of items in triggers
-					// Values in triggers attribute are tested by testCheckTFENotificationConfigurationAttributesUpdate
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "triggers.#", "2"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com/?update=true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFENotificationConfiguration_updateWorkspaceID(t *testing.T) {
-	notificationConfiguration := &tfe.NotificationConfiguration{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFENotificationConfiguration_basicWorkspaceID(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFENotificationConfigurationExists(
-						"tfe_notification_configuration.foobar", notificationConfiguration),
-					testAccCheckTFENotificationConfigurationAttributes(notificationConfiguration),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "destination_type", "generic"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "name", "notification_basic"),
-					// Just test the number of items in triggers
-					// Values in triggers attribute are tested by testCheckTFENotificationConfigurationAttributes
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "triggers.#", "0"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
-				),
-			},
-			{
-				Config: testAccTFENotificationConfiguration_updateWorkspaceID(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFENotificationConfigurationExists(
-						"tfe_notification_configuration.foobar", notificationConfiguration),
-					testAccCheckTFENotificationConfigurationAttributesUpdate(notificationConfiguration),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "destination_type", "generic"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "name", "notification_update"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "token", "1234567890_update"),
-					// Just test the number of items in triggers
-					// Values in triggers attribute are tested by testCheckTFENotificationConfigurationAttributesUpdate
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "triggers.#", "2"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com/?update=true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFENotificationConfiguration_updateWorkspaceExternalIDToWorkspaceID(t *testing.T) {
-	notificationConfiguration := &tfe.NotificationConfiguration{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFENotificationConfiguration_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFENotificationConfigurationExists(
-						"tfe_notification_configuration.foobar", notificationConfiguration),
-					testAccCheckTFENotificationConfigurationAttributes(notificationConfiguration),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "destination_type", "generic"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "name", "notification_basic"),
-					// Just test the number of items in triggers
-					// Values in triggers attribute are tested by testCheckTFENotificationConfigurationAttributes
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "triggers.#", "0"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
-				),
-			},
-			{
-				Config: testAccTFENotificationConfiguration_basicWorkspaceID(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFENotificationConfigurationExists(
-						"tfe_notification_configuration.foobar", notificationConfiguration),
-					testAccCheckTFENotificationConfigurationAttributes(notificationConfiguration),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "destination_type", "generic"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "name", "notification_basic"),
-					// Just test the number of items in triggers
-					// Values in triggers attribute are tested by testCheckTFENotificationConfigurationAttributes
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "triggers.#", "0"),
-					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
-				),
-			},
-			{
-				Config: testAccTFENotificationConfiguration_updateWorkspaceID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENotificationConfigurationExists(
 						"tfe_notification_configuration.foobar", notificationConfiguration),
@@ -563,22 +408,6 @@ func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 	})
 }
 
-func TestAccTFENotificationConfiguration_noWorkspaceID(t *testing.T) {
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccTFENotificationConfiguration_noWorkspaceID(rInt),
-				ExpectError: regexp.MustCompile(`One of workspace_id or workspace_external_id must be set`),
-			},
-		},
-	})
-}
-
 func TestAccTFENotificationConfigurationImport_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -595,7 +424,7 @@ func TestAccTFENotificationConfigurationImport_basic(t *testing.T) {
 				ResourceName:            "tfe_notification_configuration.foobar",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"token", "workspace_external_id"},
+				ImportStateVerifyIgnore: []string{"token"},
 			},
 		},
 	})
@@ -617,7 +446,7 @@ func TestAccTFENotificationConfigurationImport_emailUserIDs(t *testing.T) {
 				ResourceName:            "tfe_notification_configuration.foobar",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"token", "workspace_external_id"},
+				ImportStateVerifyIgnore: []string{"token"},
 			},
 		},
 	})
@@ -639,7 +468,7 @@ func TestAccTFENotificationConfigurationImport_emptyEmailUserIDs(t *testing.T) {
 				ResourceName:            "tfe_notification_configuration.foobar",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"token", "workspace_external_id"},
+				ImportStateVerifyIgnore: []string{"token"},
 			},
 		},
 	})
@@ -871,10 +700,10 @@ resource "tfe_workspace" "foobar" {
 }
 
 resource "tfe_notification_configuration" "foobar" {
-  name                  = "notification_basic"
-  destination_type      = "generic"
-  url                   = "http://example.com"
-  workspace_external_id = tfe_workspace.foobar.id
+  name             = "notification_basic"
+  destination_type = "generic"
+  url              = "http://example.com"
+  workspace_id     = tfe_workspace.foobar.id
 }`, rInt)
 }
 
@@ -915,30 +744,10 @@ resource "tfe_workspace" "foobar" {
 }
 
 resource "tfe_notification_configuration" "foobar" {
-  name                  = "notification_slack"
-  destination_type      = "slack"
-  url                   = "http://example.com"
-  workspace_external_id = tfe_workspace.foobar.id
-}`, rInt)
-}
-
-func testAccTFENotificationConfiguration_basicWorkspaceID(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name         = "workspace-test"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_notification_configuration" "foobar" {
-  name                  = "notification_basic"
-  destination_type      = "generic"
-  url                   = "http://example.com"
-  workspace_id          = tfe_workspace.foobar.id
+  name             = "notification_slack"
+  destination_type = "slack"
+  url              = "http://example.com"
+  workspace_id     = tfe_workspace.foobar.id
 }`, rInt)
 }
 
@@ -955,36 +764,13 @@ resource "tfe_workspace" "foobar" {
 }
 
 resource "tfe_notification_configuration" "foobar" {
-  name                  = "notification_update"
-  destination_type      = "generic"
-  enabled               = true
-  token                 = "1234567890_update"
-  triggers              = ["run:created", "run:needs_attention"]
-  url                   = "http://example.com/?update=true"
-  workspace_external_id = tfe_workspace.foobar.id
-}`, rInt)
-}
-
-func testAccTFENotificationConfiguration_updateWorkspaceID(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name         = "workspace-test"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_notification_configuration" "foobar" {
-  name                  = "notification_update"
-  destination_type      = "generic"
-  enabled               = true
-  token                 = "1234567890_update"
-  triggers              = ["run:created", "run:needs_attention"]
-  url                   = "http://example.com/?update=true"
-  workspace_id          = tfe_workspace.foobar.id
+  name             = "notification_update"
+  destination_type = "generic"
+  enabled          = true
+  token            = "1234567890_update"
+  triggers         = ["run:created", "run:needs_attention"]
+  url              = "http://example.com/?update=true"
+  workspace_id     = tfe_workspace.foobar.id
 }`, rInt)
 }
 
@@ -1216,29 +1002,10 @@ resource "tfe_workspace" "foobar" {
 }
 
 resource "tfe_notification_configuration" "foobar" {
-  name                  = "notification_duplicate_triggers"
-  destination_type      = "generic"
-  triggers              = ["run:created", "run:created", "run:created"]
-  url                   = "http://example.com"
-  workspace_external_id = tfe_workspace.foobar.id
-}`, rInt)
-}
-
-func testAccTFENotificationConfiguration_noWorkspaceID(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name         = "workspace-test"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_notification_configuration" "foobar" {
-  name                  = "notification_basic"
-  destination_type      = "generic"
-  url                   = "http://example.com"
+  name             = "notification_duplicate_triggers"
+  destination_type = "generic"
+  triggers         = ["run:created", "run:created", "run:created"]
+  url              = "http://example.com"
+  workspace_id     = tfe_workspace.foobar.id
 }`, rInt)
 }

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -78,65 +78,6 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "policy_ids.#", "1"),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "workspace_external_ids.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFEPolicySet_updateWorkspaceIDs(t *testing.T) {
-	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEPolicySet_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetAttributes(policySet),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "tst-terraform"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "description", "Policy Set"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-				),
-			},
-			{
-				Config: testAccTFEPolicySet_populated(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-populated"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "workspace_external_ids.#", "1"),
-				),
-			},
-			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-populated"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "workspace_ids.#", "1"),
 				),
 			},
@@ -168,6 +109,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 						"tfe_policy_set.foobar", "policy_ids.#", "1"),
 				),
 			},
+
 			{
 				Config: testAccTFEPolicySet_empty(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -209,57 +151,12 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "policy_ids.#", "1"),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "workspace_external_ids.#", "1"),
-				),
-			},
-
-			{
-				Config: testAccTFEPolicySet_updatePopulated(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulatedUpdated(policySet, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-populated-updated"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "workspace_external_ids.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFEPolicySet_updatePopulatedWorkspaceIDs(t *testing.T) {
-	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-populated"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "workspace_ids.#", "1"),
 				),
 			},
 
 			{
-				Config: testAccTFEPolicySet_updatePopulatedWorkspaceIDs(rInt),
+				Config: testAccTFEPolicySet_updatePopulated(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulatedUpdated(policySet, orgName),
@@ -289,49 +186,6 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_populated(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-populated"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "workspace_external_ids.#", "1"),
-				),
-			},
-
-			{
-				Config: testAccTFEPolicySet_global(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetGlobal(policySet),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-global"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "true"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFEPolicySet_updateWorkspaceIDsToGlobal(t *testing.T) {
-	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -389,49 +243,6 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 
 			{
 				Config: testAccTFEPolicySet_populated(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-populated"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "workspace_external_ids.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFEPolicySet_updateGlobalToWorkspaceIDs(t *testing.T) {
-	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEPolicySet_global(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetGlobal(policySet),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-global"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "global", "true"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
-				),
-			},
-
-			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetPopulated(policySet, orgName),
@@ -541,6 +352,7 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 						"tfe_policy_set.foobar", "policies_path", GITHUB_POLICY_SET_PATH),
 				),
 			},
+
 			{
 				Config: testAccTFEPolicySet_updateVCSBranch(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -591,7 +403,7 @@ func TestAccTFEPolicySetImport(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populatedWorkspaceIDs(rInt),
+				Config: testAccTFEPolicySet_populated(rInt),
 			},
 
 			{
@@ -826,32 +638,6 @@ resource "tfe_workspace" "foo" {
 }
 
 resource "tfe_policy_set" "foobar" {
-  name                   = "terraform-populated"
-  organization           = tfe_organization.foobar.id
-  policy_ids             = [tfe_sentinel_policy.foo.id]
-  workspace_external_ids = [tfe_workspace.foo.id]
-}`, rInt)
-}
-
-func testAccTFEPolicySet_populatedWorkspaceIDs(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_sentinel_policy" "foo" {
-  name         = "policy-foo"
-  policy       = "main = rule { true }"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_workspace" "foo" {
-  name         = "workspace-foo"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_policy_set" "foobar" {
   name          = "terraform-populated"
   organization  = tfe_organization.foobar.id
   policy_ids    = [tfe_sentinel_policy.foo.id]
@@ -860,43 +646,6 @@ resource "tfe_policy_set" "foobar" {
 }
 
 func testAccTFEPolicySet_updatePopulated(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_sentinel_policy" "foo" {
-  name         = "policy-foo"
-  policy       = "main = rule { true }"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_sentinel_policy" "bar" {
-  name         = "policy-bar"
-  policy       = "main = rule { false }"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_workspace" "foo" {
-  name         = "workspace-foo"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_workspace" "bar" {
-  name         = "workspace-bar"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_policy_set" "foobar" {
-  name                   = "terraform-populated-updated"
-  organization           = tfe_organization.foobar.id
-  policy_ids             = [tfe_sentinel_policy.bar.id]
-  workspace_external_ids = [tfe_workspace.bar.id]
-}`, rInt)
-}
-
-func testAccTFEPolicySet_updatePopulatedWorkspaceIDs(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"

--- a/tfe/resource_tfe_run_trigger.go
+++ b/tfe/resource_tfe_run_trigger.go
@@ -1,13 +1,10 @@
 package tfe
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
 	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,45 +15,16 @@ func resourceTFERunTrigger() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTFERunTriggerCreate,
 		Read:   resourceTFERunTriggerRead,
-		Update: resourceTFERunTriggerUpdate,
 		Delete: resourceTFERunTriggerDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		CustomizeDiff: customdiff.Sequence(
-			// ForceNew if workspace_external_id is changing from a non-empty value to another non-empty value
-			// If workspace_external_id is changing from an empty value to a non-empty value or a non-empty value
-			// to an empty value, we know we are switching between workspace_external_id and workspace_id because
-			// we ensure later that one of them has to be set.
-			customdiff.ForceNewIfChange("workspace_external_id", func(_ context.Context, old, new, meta interface{}) bool {
-				oldWorkspaceExternalID := old.(string)
-				newWorkspaceExternalID := new.(string)
-				return oldWorkspaceExternalID != "" && newWorkspaceExternalID != ""
-			}),
-			// ForceNew if workspace_id is changing from a non-empty value to another non-empty value
-			// If workspace_id is changing from an empty value to a non-empty value or a non-empty value
-			// to an empty value, we know we are switching between workspace_external_id and workspace_id because
-			// we ensure later that one of them has to be set.
-			customdiff.ForceNewIfChange("workspace_id", func(_ context.Context, old, new, meta interface{}) bool {
-				oldWorkspaceID := old.(string)
-				newWorkspaceID := new.(string)
-				return oldWorkspaceID != "" && newWorkspaceID != ""
-			}),
-		),
 
 		Schema: map[string]*schema.Schema{
-			"workspace_external_id": {
-				Type:          schema.TypeString,
-				Computed:      true,
-				Optional:      true,
-				ConflictsWith: []string{"workspace_id"},
-				Deprecated:    "Use workspace_id instead. The workspace_external_id attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.18.0/CHANGELOG.md",
-			},
 			"workspace_id": {
-				Type:          schema.TypeString,
-				Computed:      true,
-				Optional:      true,
-				ConflictsWith: []string{"workspace_external_id"},
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"sourceable_id": {
 				Type:     schema.TypeString,
@@ -70,21 +38,8 @@ func resourceTFERunTrigger() *schema.Resource {
 func resourceTFERunTriggerCreate(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get workspace ID
-	workspaceExternalIDValue, workspaceExternalIDValueOk := d.GetOk("workspace_external_id")
-	workspaceIDValue, workspaceIDValueOk := d.GetOk("workspace_id")
-	if !workspaceExternalIDValueOk && !workspaceIDValueOk {
-		return fmt.Errorf("One of workspace_id or workspace_external_id must be set")
-	}
-
-	var workspaceID string
-	if workspaceExternalIDValueOk {
-		workspaceID = workspaceExternalIDValue.(string)
-	} else {
-		workspaceID = workspaceIDValue.(string)
-	}
-
 	// Get attributes
+	workspaceID := d.Get("workspace_id").(string)
 	sourceableID := d.Get("sourceable_id").(string)
 
 	// Create a new options struct
@@ -131,22 +86,10 @@ func resourceTFERunTriggerRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading run trigger %s: %v", d.Id(), err)
 	}
 
-	// TODO: remove once workspace_external_id has been removed
-	d.Set("workspace_external_id", runTrigger.Workspace.ID)
-
 	d.Set("workspace_id", runTrigger.Workspace.ID)
 	d.Set("sourceable_id", runTrigger.Sourceable.ID)
 
 	return nil
-}
-
-// TODO: remove once workspace_external_id has been removed
-// This update function is here because if you don't have an update function,
-// you must set ForceNew. We can't set ForceNew right now because we need to use
-// a customDiff to force new only if the value in workspace_id or workspace_external_id
-// changes.
-func resourceTFERunTriggerUpdate(d *schema.ResourceData, meta interface{}) error {
-	return resourceTFERunTriggerRead(d, meta)
 }
 
 func resourceTFERunTriggerDelete(d *schema.ResourceData, meta interface{}) error {

--- a/tfe/resource_tfe_run_trigger_test.go
+++ b/tfe/resource_tfe_run_trigger_test.go
@@ -33,58 +33,6 @@ func TestAccTFERunTrigger_basic(t *testing.T) {
 	})
 }
 
-func TestAccTFERunTrigger_basicWorkspaceID(t *testing.T) {
-	runTrigger := &tfe.RunTrigger{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERunTriggerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFERunTrigger_basicWorkspaceID(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFERunTriggerExists(
-						"tfe_run_trigger.foobar", runTrigger),
-					testAccCheckTFERunTriggerAttributes(runTrigger, orgName),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFERunTrigger_updateWorkspaceExternalIDToWorkspaceID(t *testing.T) {
-	runTrigger := &tfe.RunTrigger{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERunTriggerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFERunTrigger_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFERunTriggerExists(
-						"tfe_run_trigger.foobar", runTrigger),
-					testAccCheckTFERunTriggerAttributes(runTrigger, orgName),
-				),
-			},
-			{
-				Config: testAccTFERunTrigger_basicWorkspaceID(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFERunTriggerExists(
-						"tfe_run_trigger.foobar", runTrigger),
-					testAccCheckTFERunTriggerAttributes(runTrigger, orgName),
-				),
-			},
-		},
-	})
-}
-
 func TestAccTFERunTrigger_many(t *testing.T) {
 	checks := make([]resource.TestCheckFunc, 10)
 	for i := range checks {
@@ -114,9 +62,8 @@ func TestAccTFERunTriggerImport(t *testing.T) {
 		CheckDestroy: testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERunTrigger_basicWorkspaceID(rInt),
+				Config: testAccTFERunTrigger_basic(rInt),
 			},
-
 			{
 				ResourceName:      "tfe_run_trigger.foobar",
 				ImportState:       true,
@@ -184,7 +131,7 @@ func testAccCheckTFERunTriggerDestroy(s *terraform.State) error {
 
 		_, err := tfeClient.RunTriggers.Read(ctx, rs.Primary.ID)
 		if err == nil {
-			return fmt.Errorf("Notification configuration %s still exists", rs.Primary.ID)
+			return fmt.Errorf("Run trigger %s still exists", rs.Primary.ID)
 		}
 	}
 
@@ -209,31 +156,8 @@ resource "tfe_workspace" "sourceable" {
 }
 
 resource "tfe_run_trigger" "foobar" {
-  workspace_external_id = tfe_workspace.workspace.id
-  sourceable_id         = tfe_workspace.sourceable.id
-}`, rInt)
-}
-
-func testAccTFERunTrigger_basicWorkspaceID(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "workspace" {
-  name         = "workspace-test"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_workspace" "sourceable" {
-  name         = "sourceable-test"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_run_trigger" "foobar" {
-  workspace_id = tfe_workspace.workspace.id
-  sourceable_id         = tfe_workspace.sourceable.id
+  workspace_id  = tfe_workspace.workspace.id
+  sourceable_id = tfe_workspace.sourceable.id
 }`, rInt)
 }
 
@@ -259,7 +183,7 @@ resource "tfe_workspace" "sourceable" {
 resource "tfe_run_trigger" "foobar" {
   count = 10
 
-  workspace_external_id = tfe_workspace.workspace.external_id
-  sourceable_id         = tfe_workspace.sourceable[count.index].external_id
+  workspace_id  = tfe_workspace.workspace.id
+  sourceable_id = tfe_workspace.sourceable[count.index].id
 }`, rInt)
 }

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -128,7 +128,7 @@ func resourceTFETeamAccess() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringMatch(
 					workspaceIdRegexp,
-					"must be the workspace's external_id",
+					"must be a valid workspace ID (ws-<RANDOM STRING>)",
 				),
 			},
 		},

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -80,7 +80,7 @@ func resourceTFEVariable() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringMatch(
 					workspaceIdRegexp,
-					"must be the workspace's external_id",
+					"must be a valid workspace ID (ws-<RANDOM STRING>)",
 				),
 			},
 		},

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -397,16 +397,13 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	// TODO: Why does this use the old value of external_id?
-	// external_id shouldn't change so can we change externalID to just id/d.Id()?
 	if d.HasChange("ssh_key_id") {
 		sshKeyID := d.Get("ssh_key_id").(string)
-		externalID, _ := d.GetChange("external_id")
 
 		if sshKeyID != "" {
 			_, err := tfeClient.Workspaces.AssignSSHKey(
 				ctx,
-				externalID.(string),
+				id,
 				tfe.WorkspaceAssignSSHKeyOptions{
 					SSHKeyID: tfe.String(sshKeyID),
 				},
@@ -415,7 +412,7 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 				return fmt.Errorf("Error assigning SSH key to workspace %s: %v", id, err)
 			}
 		} else {
-			_, err := tfeClient.Workspaces.UnassignSSHKey(ctx, externalID.(string))
+			_, err := tfeClient.Workspaces.UnassignSSHKey(ctx, id)
 			if err != nil {
 				return fmt.Errorf("Error unassigning SSH key from workspace %s: %v", id, err)
 			}

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -160,8 +160,9 @@ func resourceTFEWorkspace() *schema.Resource {
 			},
 
 			"external_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use id instead. The external_id attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.24.0/CHANGELOG.md",
 			},
 		},
 	}
@@ -274,6 +275,7 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("terraform_version", workspace.TerraformVersion)
 	d.Set("trigger_prefixes", workspace.TriggerPrefixes)
 	d.Set("working_directory", workspace.WorkingDirectory)
+	// TODO: remove when external_id is removed
 	d.Set("external_id", workspace.ID)
 	d.Set("organization", workspace.Organization.Name)
 

--- a/website/docs/d/workspace_ids.html.markdown
+++ b/website/docs/d/workspace_ids.html.markdown
@@ -3,12 +3,12 @@ layout: "tfe"
 page_title: "Terraform Enterprise: tfe_workspace_ids"
 sidebar_current: "docs-datasource-tfe-workspace-ids"
 description: |-
-  Get information on (external) workspace IDs.
+  Get information on workspace IDs.
 ---
 
 # Data Source: tfe_workspace_ids
 
-Use this data source to get a map of (external) workspace IDs.
+Use this data source to get a map of workspace IDs.
 
 ## Example Usage
 
@@ -42,14 +42,13 @@ In addition to all arguments above, the following attributes are exported:
 ~> **NOTE** In versions < 0.15.1, workspace IDs were in the format 
 `<ORGANIZATION NAME>/<WORKSPACE NAME>` for some resources. This format 
 has been deprecated in favor of the immutable workspace ID in the format `ws-<RANDOM STRING>`.
-The `ids` attribute for this resource return workspace IDs in the deprecated
-format so you should use `external_ids` instead.
 
-~> **NOTE** The deprecation warning for the ids attribute will not go away until it is removed. 
-This is due to a [limitation of the 1.0 version of the Terraform SDK](https://github.com/hashicorp/terraform/issues/7569) for deprecation warnings on attributes that aren't specified in a configuration.
-If you have made sure to change all references to this data source's `ids` attribute to the new `full_names` attribute, you can ignore the warning.  
+~> **NOTE** The deprecation warning for the external_ids attribute will not go away until it is removed. 
+This is due to a [limitation of the 1.0 version of the Terraform SDK](https://github.com/hashicorp/terraform/issues/7569) 
+for deprecation warnings on attributes that aren't specified in a configuration. If you have made sure 
+to change all references to this data source's `external_ids` attribute to the `ids` attribute, you can ignore the warning.  
 
 * `full_names` - A map of workspace names and their full names, which look like `<ORGANIZATION>/<WORKSPACE>`. 
-* `ids` - **Deprecated** Use `full_names` instead. A map of workspace names and their full names, which look like `<ORGANIZATION>/<WORKSPACE>`. 
-* `external_ids` - A map of workspace names and their opaque, immutable IDs, which
+* `ids` - A map of workspace names and their opaque, immutable IDs, which look like `ws-<RANDOM STRING>`.
+* `external_ids` - **Deprecated** A map of workspace names and their opaque, immutable IDs, which
   look like `ws-<RANDOM STRING>`.

--- a/website/docs/r/notification_configuration.html.markdown
+++ b/website/docs/r/notification_configuration.html.markdown
@@ -32,12 +32,12 @@ resource "tfe_workspace" "test" {
 }
 
 resource "tfe_notification_configuration" "test" {
-  name                      = "my-test-notification-configuration"
-  enabled                   = true
-  destination_type          = "generic"
-  triggers                  = ["run:created", "run:planning", "run:errored"]
-  url                       = "https://example.com"
-  workspace_external_id     = tfe_workspace.test.id
+  name             = "my-test-notification-configuration"
+  enabled          = true
+  destination_type = "generic"
+  triggers         = ["run:created", "run:planning", "run:errored"]
+  url              = "https://example.com"
+  workspace_id     = tfe_workspace.test.id
 }
 ```
 
@@ -60,12 +60,12 @@ resource "tfe_organization_membership" "test" {
 }
 
 resource "tfe_notification_configuration" "test" {
-  name                  = "my-test-email-notification-configuration"
-  enabled               = true
-  destination_type      = "email"
-  email_user_ids        = [tfe_organization_membership.test.user_id]
-  triggers              = ["run:created", "run:planning", "run:errored"]
-  workspace_external_id = tfe_workspace.test.id
+  name             = "my-test-email-notification-configuration"
+  enabled          = true
+  destination_type = "email"
+  email_user_ids   = [tfe_organization_membership.test.user_id]
+  triggers         = ["run:created", "run:planning", "run:errored"]
+  workspace_id     = tfe_workspace.test.id
 }
 ```
 
@@ -88,13 +88,13 @@ resource "tfe_organization_membership" "test" {
 }
 
 resource "tfe_notification_configuration" "test" {
-  name                  = "my-test-email-notification-configuration"
-  enabled               = true
-  destination_type      = "email"
-  email_user_ids        = [tfe_organization_membership.test.user_id]
-  email_addresses       = ["user1@company.com", "user2@company.com", "user3@company.com"]
-  triggers              = ["run:created", "run:planning", "run:errored"]
-  workspace_external_id = tfe_workspace.test.id
+  name             = "my-test-email-notification-configuration"
+  enabled          = true
+  destination_type = "email"
+  email_user_ids   = [tfe_organization_membership.test.user_id]
+  email_addresses  = ["user1@company.com", "user2@company.com", "user3@company.com"]
+  triggers         = ["run:created", "run:planning", "run:errored"]
+  workspace_id     = tfe_workspace.test.id
 }
 ```
 
@@ -121,12 +121,7 @@ The following arguments are supported:
 * `url` - (Required if `destination_type` is `generic` or `slack`) The HTTP or HTTPS URL of the notification 
   configuration where notification requests will be made. This value _must not_ be provided if `destination_type` 
   is `email`.
-* `workspace_id` - The id of the workspace that owns the notification configuration. 
-  This value _must not_ be provided if `workspace_external_id` is provided.
-* `workspace_external_id` - **Deprecated** Use `workspace_id` instead. The id of the workspace that owns the 
-  notification configuration. This value _must not_ be provided if `workspace_id` is provided.
-  
--> **Note:** One of `workspace_id` or `workspace_external_id` _must_ be provided.
+* `workspace_id` - (Required) The id of the workspace that owns the notification configuration. 
 
 ## Attributes Reference
 

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -57,19 +57,18 @@ The following arguments are supported:
 * `description` - (Optional) A description of the policy set's purpose.
 * `global` - (Optional) Whether or not policies in this set will apply to
   all workspaces. Defaults to `false`. This value _must not_ be provided if
-  `workspace_ids` or `workspace_external_ids` are provided.
+  `workspace_ids` is provided.
 * `organization` - (Required) Name of the organization.
 * `policies_path` - (Optional) The sub-path within the attached VCS repository
   to ingress when using `vcs_repo`. All files and directories outside of this
   sub-path will be ignored. This option can only be supplied when `vcs_repo` is
   present. Forces a new resource if changed.
-* `policy_ids` - (Optional) A list of Sentinel policy IDs. This value _must not_ be provided if `vcs_repo` is provided.
+* `policy_ids` - (Optional) A list of Sentinel policy IDs. This value _must not_ be provided 
+  if `vcs_repo` is provided.
 * `vcs_repo` - (Optional) Settings for the policy sets VCS repository. Forces a
   new resource if changed. This value _must not_ be provided if `policy_ids` are provided.
-* `workspace_ids` - (Optional) A list of workspace IDs. This
-  value _must not_ be provided if `global` or `workspace_external_ids` is provided.
-* `workspace_external_ids` - **Deprecated** Use `workspace_ids` instead. (Optional) A list of workspace IDs. This
-  value _must not_ be provided if `global` or `workspace_ids` is provided.
+* `workspace_ids` - (Optional) A list of workspace IDs. This value _must not_ be provided 
+  if `global` is provided.
 
 -> **Note:** When neither `vcs_repo` or `policy_ids` is not specified, the current
 default is to create an empty non-VCS policy set.

--- a/website/docs/r/run_trigger.html.markdown
+++ b/website/docs/r/run_trigger.html.markdown
@@ -8,9 +8,10 @@ description: |-
 
 # tfe_run_trigger
 
-Terraform Cloud provides a way to connect your workspace to one or more workspaces within your organization, known as "source workspaces". 
-These connections, called run triggers, allow runs to queue automatically in your workspace on successful apply of runs in any of the source workspaces. 
-You can connect your workspace to up to 20 source workspaces.
+Terraform Cloud provides a way to connect your workspace to one or more workspaces within your organization, 
+known as "source workspaces". These connections, called run triggers, allow runs to queue automatically in 
+your workspace on successful apply of runs in any of the source workspaces. You can connect your workspace 
+to up to 20 source workspaces.
 
 ## Example Usage
 
@@ -33,8 +34,8 @@ resource "tfe_workspace" "test-sourceable" {
 }
 
 resource "tfe_run_trigger" "test" {
-  workspace_external_id = tfe_workspace.test-workspace.id
-  sourceable_id         = tfe_workspace.test-sourceable.id
+  workspace_id  = tfe_workspace.test-workspace.id
+  sourceable_id = tfe_workspace.test-sourceable.id
 }
 ```
 
@@ -42,13 +43,9 @@ resource "tfe_run_trigger" "test" {
 
 The following arguments are supported:
 
-* `workspace_id` - The id of the workspace that owns the run trigger. This is the workspace where runs will be triggered.
-  This value _must not_ be provided if `workspace_external_id` is provided.
-* `workspace_external_id` - **Deprecated** Use `workspace_id` instead. The id of the workspace that owns the run trigger. This is the workspace where runs will be triggered.
-  This value _must not_ be provided if `workspace_id` is provided.
+* `workspace_id` - (Required) The id of the workspace that owns the run trigger. This is the 
+  workspace where runs will be triggered.
 * `sourceable_id` - (Required) The id of the sourceable. The sourceable must be a workspace.
-
--> **Note:** One of `workspace_id` or `workspace_external_id` _must_ be provided.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This PR removes the deprecated `workspace_external_id` attributes from resources `tfe_notification_configuration` & `tfe_run_trigger`, and `workspace_external_ids` attribute from resource `tfe_policy_set`. 
**This is a breaking change. Please change your config to use `workspace_id`/`workspace_ids` before upgrading.** 

This PR also adds deprecation warnings to the `external_id` attribute for resource `tfe_workspace`, the `external_id` attribute for data source `tfe_workspace`, and the `external_ids` attribute for data source `tfe_workspace_ids`. 

It also adds a little bit of extra context to the `DeprecationMessage` on `d/tfe_workspace` and `d/tfe_workspace_ids` [because that context has gone missing in V2 of the SDK](https://github.com/hashicorp/terraform-plugin-sdk/issues/660). 

#### The following data sources are impacted:
   * `tfe_workspace` - `external_id` is deprecated and will show a deprecation warning but will not cause any errors. You should use `id` instead.

   * `tfe_workspace_ids` - `ids` now returns the immutable ID for each workspace. `external_ids` is deprecated and will show a deprecation warning but will not cause any errors. You should use `ids` instead. 
   
**NOTE:** If you use the `tfe_workspace` or `tfe_workspace_ids` data sources, this deprecation warning won't go away until it is removed. This is due to a limitation in Terraform SDK with deprecating attributes that aren't specified via config. [See this issue for more information](https://github.com/hashicorp/terraform/issues/7569).

#### The following resources are impacted:
   * `tfe_notification_configuration` - The deprecated `workspace_external_id` attribute has been removed. If you are still using this attribute, you will get errors. You should use `workspace_id` instead
   * `tfe_policy_set` - The deprecated `workspace_external_ids` attribute has been removed. If you are still using this attribute, you will get errors. You should use `workspace_ids` instead
   * `tfe_run_trigger` - The deprecated `workspace_external_id` attribute has been removed. If you are still using this attribute, you will get errors. You should use `workspace_id` instead
   * `tfe_workspace` - `external_id` is deprecated and will show a deprecation warning but will not cause any errors. You should use `id` instead

### Why are these attributes being deprecated?
After #106 migrated workspace ids to the immutable id format (`ws-<random string>`), we still had some inconsistent usages of `external_id`, `workspace_external_id`, and `workspace_external_ids`. In order to clean this up and make the provider consistent and easier to understand when working with workspace IDs, we will be replacing all usages of `workspace_external_id`/`workspace_external_ids` with `workspace_id`/`workspace_ids`.

###  Deprecation plan:
To minimize disruption and give everyone time to migrate over, we will be doing this in 3 phases. 

#### [COMPLETE] Phase 1:
**This phase was completed in #182 and released in version 0.18.0.**

<details>
   <summary>Click to expand for phase 1 details</summary>
   
   **tfe_workspace_ids Data Source:** We will add a new computed attribute to the tfe_workspace_ids data source called `full_names` that will mimic the current behavior of the `ids` attribute. In this phase, both attributes will return the old human-readable workspace ID format of `<organization_name>/<workspace_name>`. We will add deprecation warnings to the `ids` attribute explaining that users should begin using `full_names` instead, as the behavior of `ids` will be changing soon.

   **Remainder of TFE Provider:** We will add a new attribute to impacted resources called `workspace_id` or `workspace_ids` (depending on which is required for the specific resource) which will hold the same value as the current `workspace_external_id`/`workspace_external_ids` attributes. Deprecation warnings will be added to all of these, recommending the user move to `workspace_id`/ `workspace_ids` instead.
</details>

#### [YOU ARE HERE] Phase 2:
**You are here. That's what this PR is for :]**

This phase happens 3 months after phase 1 is released. 

**tfe_workspace_ids Data Source:** We will officially change the behavior of the `ids` attribute so it returns the immutable workspace ID in format `ws-<random_string>`, just as the `external_ids` attribute currently does. We will add a deprecation warning to the `external_ids` attribute, alerting them that it will be deprecated soon and they should use `ids` instead.

**tfe_workspace Data Source:** We will add a deprecation warning to the `external_id` attribute, recommending the user move to `id` instead.

**tfe_workspace Resource:** We will add a deprecation warning to the `external_id` attribute, recommending the user move to `id` instead.

**Remainder of TFE Provider:** We will remove the `workspace_external_id `/ `workspace_external_ids` attributes from all the impacted resources.

#### Phase 3:
This phase happens 3 months after phase 2 is released. 

**tfe_workspace_ids Data Source:** We will remove `external_ids` from this data source entirely, leaving behind `ids` returning the immutable workspace ID in the format `ws-<random_string>`, and `full_names` returning the format `<organization_name>/<workspace_name>`.

**tfe_workspace Data Source:** We will remove the `external_id` attribute.

**tfe_workspace Resource:** We will remove the `external_id` attribute.

## BREAKING CHANGE

This PR removes `workspace_external_id `/ `workspace_external_ids` from `r/tfe_notification_configuration`, `r/tfe_policy_set`, and `r/tfe_run_trigger`. You should change your config to use `workspace_id `/ `workspace_ids` before upgrading. 

## Testing plan

To run through this test plan you'll need: 
1. Terraform 0.13 installed. I used 0.13.5
1. Your own copies of a [terraform-random repo](https://github.com/caseylang/terraform-random) and this [test-policy-set repo](https://github.com/lafentres/test-policy-set). 

#### Provision resources for all impacted resources and data sources
1. Save this config as `main.tf`, replacing values with your own information as needed.
   ```terraform
   terraform {
     required_providers {
       tfe = {
         source  = "hashicorp/tfe"
         version = "0.23.0"
       }
     }
   }

   provider "tfe" {
     hostname = "YOUR_TFE_INSTANCE_HOSTNAME"
   }

   resource "tfe_organization" "test-org" {
     name  = "tst-deprecation-test-org"
     email = "YOUR_EMAIL"
   }

   resource "tfe_oauth_client" "test-oauth-client" {
     organization     = tfe_organization.test-org.name
     api_url          = "https://api.github.com"
     http_url         = "https://github.com"
     oauth_token      = "YOUR_GITHUB_TOKEN"
     service_provider = "github"
   }

   resource "tfe_workspace" "workspace-1" {
     name         = "workspace-1"
     organization = tfe_organization.test-org.name
     vcs_repo {
       identifier     = "YOUR_GITHUB_USERNAME/terraform-random-1"
       oauth_token_id = tfe_oauth_client.test-oauth-client.oauth_token_id
     }
   }

   output "workspace1_external_id" {
     value = tfe_workspace.workspace-1.external_id
   }

   resource "tfe_team" "test-team" {
     name         = "test-team"
     organization = tfe_organization.test-org.id
   }

   resource "tfe_team_access" "test" {
     access       = "read"
     team_id      = tfe_team.test-team.id
     workspace_id = tfe_workspace.workspace-1.id
   }

   resource "tfe_variable" "test" {
     key          = "test_var"
     value        = "test"
     category     = "terraform"
     workspace_id = tfe_workspace.workspace-1.id
     description  = "a useful description"
   }

   resource "tfe_workspace" "workspace-2" {
     name         = "workspace-2"
     organization = tfe_organization.test-org.name
     vcs_repo {
       identifier     = "YOUR_GITHUB_USERNAME/terraform-random-1"
       oauth_token_id = tfe_oauth_client.test-oauth-client.oauth_token_id
     }
   }

   resource "tfe_workspace" "workspace-3" {
     name         = "workspace-3"
     organization = tfe_organization.test-org.name
     vcs_repo {
       identifier     = "YOUR_GITHUB_USERNAME/terraform-random-1"
       oauth_token_id = tfe_oauth_client.test-oauth-client.oauth_token_id
     }
   }

   resource "tfe_run_trigger" "run-trigger-1" {
     workspace_id  = tfe_workspace.workspace-1.id
     sourceable_id = tfe_workspace.workspace-2.id
   }

   resource "tfe_notification_configuration" "notification_config" {
     name             = "my-test-notification-configuration"
     enabled          = true
     destination_type = "generic"
     triggers         = ["run:created", "run:planning", "run:errored"]
     url              = "https://example.com"
     workspace_id     = tfe_workspace.workspace-1.id
   }

   resource "tfe_policy_set" "policy-set" {
     name          = "my-policy-set"
     description   = "A brand new policy set"
     organization  = tfe_organization.test-org.name
     policies_path = "policy-sets/foo"
     workspace_ids = [tfe_workspace.workspace-1.id]
     vcs_repo {
       identifier         = "YOUR_GITHUB_USERNAME/test-policy-set"
       branch             = "master"
       ingress_submodules = false
       oauth_token_id     = tfe_oauth_client.test-oauth-client.oauth_token_id
     }
   }

   data "tfe_workspace" "workspace-1-ds" {
     name         = "workspace-1"
     organization = tfe_organization.test-org.name
     depends_on = [
       tfe_workspace.workspace-1,
     ]
   }

   output "workspace1_ds_external_id" {
     value = data.tfe_workspace.workspace-1-ds.external_id
   }

   data "tfe_workspace_ids" "all" {
     names        = [tfe_workspace.workspace-1.name, tfe_workspace.workspace-2.name]
     organization = tfe_organization.test-org.name
     depends_on = [
       tfe_workspace.workspace-1,
       tfe_workspace.workspace-2,
     ]
   }

   output "workspace_ids" {
     value = data.tfe_workspace_ids.all.ids
   }

   output "workspace_external_ids" {
     value = data.tfe_workspace_ids.all.external_ids
   }

   output "workspace_full_names" {
     value = data.tfe_workspace_ids.all.full_names
   }
   ```
1. Run `terraform init` and `terraform version`. Your provider version should look report back as v0.23.0
   ```
   provider.tfe v0.23.0
   ```
1. Run `terraform apply`. This should succeed. You should only see one deprecation notice and it should be from the `tfe_workspace_ids` data source called `all`
1. Run `terraform plan`. There should be no changes.

#### Upgrade provider version to local build of this branch
This changed a lot in 0.13. I'm going to do my best to explain how to do a local filesystem mirror here.
1. Create a directory in an easily accessible place like your desktop with the following path: `providers/registry.terraform.io/hashicorp/tfe/1.2.3/darwin_amd64`
1. Add the following to your `~/.terraformrc` file, substituting your own information as needed:
   ```
   provider_installation {
     filesystem_mirror {
       path    = "/Users/YOUR_USERNAME/desktop/providers"
       include = ["registry.terraform.io/hashicorp/tfe"]
     }
     direct {
       exclude = ["registry.terraform.io/hashicorp/tfe"]
     }
   }
   ```
1. Follow the steps in the [README](https://github.com/hashicorp/terraform-provider-tfe/blob/master/README.md#manually-building-the-provider) to make a local build of the provider from this branch. 
1. Copy that build to your `providers/registry.terraform.io/hashicorp/tfe/1.2.3/darwin_amd64` directory. 
1.  In the directory where you saved your `main.tf`, delete your `.terraform` folder.
1. In your `main.tf`, change the `version` in your tfe provider block to our made up version `1.2.3`
   ```terraform
   terraform {
     required_providers {
       tfe = {
         source  = "hashicorp/tfe"
         version = "1.2.3"
       }
     }
   }
   ```
1. Run `terraform init` and `terraform version`. Your provider version should now show `1.2.3`
   ```
   provider.tfe v1.2.3
   ```
1. Run `terraform plan`. There should be no changes but you should see some changes to the output of `workspace_ids` and some deprecation warnings. Your output should look something like this:
   ```
   Plan: 0 to add, 0 to change, 0 to destroy.

   Changes to Outputs:
     ~ workspace_ids = {
         ~ "workspace-1" = "tst-deprecation-test-org/workspace-1" -> "ws-fA7fYnroJqYUjh2Q"
         ~ "workspace-2" = "tst-deprecation-test-org/workspace-2" -> "ws-ycFvf1Fx5zZNvAtd"
       }

   Warning: Deprecated Resource

   Data source "tfe_workspace"

   "external_id": [DEPRECATED] Use id instead. The external_id attribute will be
   removed in the future. See the CHANGELOG to learn more:
   https://github.com/hashicorp/terraform-provider-tfe/blob/v0.2X.0/CHANGELOG.md


   Warning: Deprecated Resource

   Data source "tfe_workspace_ids"

   "external_ids": [DEPRECATED] Use ids instead. The external_ids attribute will
   be removed in the future. See the CHANGELOG to learn more:
   https://github.com/hashicorp/terraform-provider-tfe/blob/v0.2X.0/CHANGELOG.md
   ```
1. Run `terraform apply` to update the outputs. 
1. Run `terraform plan` again. There should be no updates.

#### Make sure you can still update workspace_id/workspace_ids
1. Change `workspace_id` in the `tfe_notification_configuration` and `tfe_run_trigger` resources to use `workspace-3`. Change `workspace_ids` in the `tfe_policy_set` resource to use `workspace-3`.
   ```
   resource "tfe_run_trigger" "run-trigger-1" {
     workspace_id = tfe_workspace.workspace-3.id
     sourceable_id = tfe_workspace.workspace-2.id
   }

   resource "tfe_notification_configuration" "notification_config" {
     name                  = "my-test-notification-configuration"
     enabled               = true
     destination_type      = "generic"
     triggers              = ["run:created", "run:planning", "run:errored"]
     url                   = "https://example.com"
     workspace_id = tfe_workspace.workspace-3.id
   }

   resource "tfe_policy_set" "policy-set" {
     name                   = "my-policy-set"
     description            = "A brand new policy set"
     organization           = tfe_organization.test-org.name
     policies_path          = "policy-sets/foo"
     workspace_ids = [tfe_workspace.workspace-3.id]
     vcs_repo {
       identifier         = "GITHUB_USERNAME/test-policy-set"
       branch             = "master"
       ingress_submodules = false
       oauth_token_id     = tfe_oauth_client.test-oauth-client.oauth_token_id
     }
   }
   ```
1. Run `terraform apply`. The output should show `Plan: 2 to add, 1 to change, 2 to destroy.`. It should show that:
   * `tfe_notification_configuration.notification_config` must be replaced
   * `tfe_policy_set.policy-set` will be updated in-place
   * `tfe_run_trigger.run-trigger-1` must be replaced
1. Type `yes` to confirm the apply. This should succeed and the output should show `Apply complete! Resources: 2 added, 1 changed, 2 destroyed.`.
1. Run `terraform plan`. There should be no changes.
1. Change `workspace_id` in the `tfe_notification_configuration` and `tfe_run_trigger` resources back to `workspace-1`. Change `workspace_ids` in the `tfe_policy_set` resource back `workspace-1`.
1. Run `terraform apply`. This should succeed. 
1. Run `terraform plan`. There should be no changes.

#### Try to change workspace_id/workspace_ids to workspace_external_id/workspace_external_ids
1. Change `workspace_id` in the `tfe_notification_configuration` and `tfe_run_trigger` resources to `workspace_external_id`. Change `workspace_ids` in the `tfe_policy_set` resource to `workspace_external_ids`
   ```terraform
   resource "tfe_run_trigger" "run-trigger-1" {
     workspace_external_id  = tfe_workspace.workspace-1.id
     sourceable_id          = tfe_workspace.workspace-2.id
   }

   resource "tfe_notification_configuration" "notification_config" {
     name                  = "my-test-notification-configuration"
     enabled               = true
     destination_type      = "generic"
     triggers              = ["run:created", "run:planning", "run:errored"]
     url                   = "https://example.com"
     workspace_external_id          = tfe_workspace.workspace-1.id
   }

   resource "tfe_policy_set" "policy-set" {
     name                   = "my-policy-set"
     description            = "A brand new policy set"
     organization           = tfe_organization.test-org.name
     policies_path          = "policy-sets/foo"
     workspace_external_ids          = [tfe_workspace.workspace-1.id]
     vcs_repo {
       identifier         = "GITHUB_USERNAME/test-policy-set"
       branch             = "master"
       ingress_submodules = false
       oauth_token_id     = tfe_oauth_client.test-oauth-client.oauth_token_id
     }
   }
   ```
1. Run `terraform apply`. This should fail with errors. Your output should look something like this for each resource:
   ```
   Error: Missing required argument

     on main.tf line 77, in resource "tfe_run_trigger" "run-trigger-1":
     77: resource "tfe_run_trigger" "run-trigger-1" {

   The argument "workspace_id" is required, but no definition was found.

   Error: Unsupported argument

     on main.tf line 78, in resource "tfe_run_trigger" "run-trigger-1":
     78:   workspace_external_id  = tfe_workspace.workspace-3.id

   An argument named "workspace_external_id" is not expected here.
   ...
   ```
1. Change things back to `workspace_id` and `workspace_ids`.
1. Run `terraform plan`. There should be no changes.

#### Test out the `ids`, `external_ids`, and `full_names` attribute on `r/tfe_workspace_ids`:
1. Run `terraform apply`. Make sure the outputs `workspace_external_ids` and `workspace_ids` are the same. Your output should look like this:
   ```
   Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

   Outputs:

   workspace1_ds_external_id = ws-2vJNu2yqFymsTo5r
   workspace1_external_id = ws-2vJNu2yqFymsTo5r
   workspace_external_ids = {
     "workspace-1" = "ws-2vJNu2yqFymsTo5r"
     "workspace-2" = "ws-o66DHMtQTqTnLaAH"
   }
   workspace_full_names = {
     "workspace-1" = "tst-deprecation-test-org/workspace-1"
     "workspace-2" = "tst-deprecation-test-org/workspace-2"
   }
   workspace_ids = {
     "workspace-1" = "ws-2vJNu2yqFymsTo5r"
     "workspace-2" = "ws-o66DHMtQTqTnLaAH"
   }
   ```

#### Make sure the workspce ID validation for `r/tfe_variable` and `r/tfe_team_access` still work
1. Change the `workspace_id` for `r/tfe_variable` and `r/tfe_team_access` to something invalid like `"bad-id"`:
   ```
   resource "tfe_team_access" "test" {
     access       = "read"
     team_id      = tfe_team.test-team.id
     workspace_id = "bad-id"
   }

   resource "tfe_variable" "test" {
     key          = "test_var"
     value        = "test"
     category     = "terraform"
     workspace_id = "bad-id"
     description  = "a useful description"
   }
   ```
1. Run `terraform plan`. You should see errors that look like this:
   ```
   Error: invalid value for workspace_id (must be the workspace's immutable ID, which looks like ws-<RANDOM STRING>)

     on main.tf line 48, in resource "tfe_team_access" "test":
     48:   workspace_id = "bad-id"

   Error: invalid value for workspace_id (must be the workspace's immutable ID, which looks like ws-<RANDOM STRING>)

     on main.tf line 55, in resource "tfe_variable" "test":
     55:   workspace_id = "bad-id"
   ```
1. Change the `workspace_id` for `r/tfe_variable` and `r/tfe_team_access` back to `tfe_workspace.workspace-1.id`
1. Run `terraform plan`. There should be no changes.

#### Make sure destroy still works
1. Run `terraform destroy`. This should succeed. 

#### Make sure a fresh create on this new version works
1. Run `terraform apply`. This should succeed. 

#### Check the documentation and CHANGELOG:
1. Please read over the documentation updates for each resource and make sure they make sense. Please let me know if you have any suggestions or additions. 
1. Please read over the CHANGELOG entry and make sure it makes sense. Please let me know if you have any suggestions or additions. 

## External links

- [Phase 1 PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/182) 
- [Related PR #106](https://github.com/terraform-providers/terraform-provider-tfe/pull/106) 
- [Related go-tfe PR](https://github.com/hashicorp/go-tfe/pull/122)

## Output from acceptance tests

#### data source tfe_workspace:

<details>
   <summary>Click to expand for test output</summary>

```
$ TESTARGS="-run TestAccTFEWorkspaceDataSource" envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceDataSource -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (19.30s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 19.456s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
</details>

#### data source tfe_workspace_ids:

<details>
   <summary>Click to expand for test output</summary>

```
$ TESTARGS="-run TestAccTFEWorkspaceIDsDataSource" envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceIDsDataSource -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (9.11s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (9.08s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 18.357s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
</details>

#### resource tfe_notification_configuration:

<details>
   <summary>Click to expand for test output</summary>

```
$ TESTARGS="-run TestAccTFENotificationConfiguration" envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFENotificationConfiguration -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFENotificationConfiguration_basic
--- PASS: TestAccTFENotificationConfiguration_basic (7.91s)
=== RUN   TestAccTFENotificationConfiguration_emailUserIDs
--- PASS: TestAccTFENotificationConfiguration_emailUserIDs (7.95s)
=== RUN   TestAccTFENotificationConfiguration_update
--- PASS: TestAccTFENotificationConfiguration_update (12.72s)
=== RUN   TestAccTFENotificationConfiguration_updateEmailUserIDs
--- PASS: TestAccTFENotificationConfiguration_updateEmailUserIDs (14.35s)
=== RUN   TestAccTFENotificationConfiguration_validateSchemaAttributesEmail
--- PASS: TestAccTFENotificationConfiguration_validateSchemaAttributesEmail (6.84s)
=== RUN   TestAccTFENotificationConfiguration_validateSchemaAttributesGeneric
--- PASS: TestAccTFENotificationConfiguration_validateSchemaAttributesGeneric (9.64s)
=== RUN   TestAccTFENotificationConfiguration_validateSchemaAttributesSlack
--- PASS: TestAccTFENotificationConfiguration_validateSchemaAttributesSlack (11.82s)
=== RUN   TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail
--- PASS: TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail (13.34s)
=== RUN   TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric
--- PASS: TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric (15.66s)
=== RUN   TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack
--- PASS: TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack (17.25s)
=== RUN   TestAccTFENotificationConfiguration_duplicateTriggers
--- PASS: TestAccTFENotificationConfiguration_duplicateTriggers (7.26s)
=== RUN   TestAccTFENotificationConfigurationImport_basic
--- PASS: TestAccTFENotificationConfigurationImport_basic (8.28s)
=== RUN   TestAccTFENotificationConfigurationImport_emailUserIDs
--- PASS: TestAccTFENotificationConfigurationImport_emailUserIDs (9.09s)
=== RUN   TestAccTFENotificationConfigurationImport_emptyEmailUserIDs
--- PASS: TestAccTFENotificationConfigurationImport_emptyEmailUserIDs (9.08s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 151.357s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
</details>

#### resource tfe_policy_set:

<details>
   <summary>Click to expand for test output</summary>

```
$ TESTARGS="-run TestAccTFEPolicySet" envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEPolicySet -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEPolicySetParameter_basic
--- PASS: TestAccTFEPolicySetParameter_basic (8.77s)
=== RUN   TestAccTFEPolicySetParameter_update
--- PASS: TestAccTFEPolicySetParameter_update (15.31s)
=== RUN   TestAccTFEPolicySetParameter_import
--- PASS: TestAccTFEPolicySetParameter_import (10.02s)
=== RUN   TestAccTFEPolicySet_basic
--- PASS: TestAccTFEPolicySet_basic (9.58s)
=== RUN   TestAccTFEPolicySet_update
--- PASS: TestAccTFEPolicySet_update (18.09s)
=== RUN   TestAccTFEPolicySet_updateEmpty
--- PASS: TestAccTFEPolicySet_updateEmpty (15.76s)
=== RUN   TestAccTFEPolicySet_updatePopulated
--- PASS: TestAccTFEPolicySet_updatePopulated (22.35s)
=== RUN   TestAccTFEPolicySet_updateToGlobal
--- PASS: TestAccTFEPolicySet_updateToGlobal (18.65s)
=== RUN   TestAccTFEPolicySet_updateToWorkspace
--- PASS: TestAccTFEPolicySet_updateToWorkspace (18.00s)
=== RUN   TestAccTFEPolicySet_vcs
--- PASS: TestAccTFEPolicySet_vcs (13.12s)
=== RUN   TestAccTFEPolicySet_updateVCSBranch
--- PASS: TestAccTFEPolicySet_updateVCSBranch (19.96s)
=== RUN   TestAccTFEPolicySet_invalidName
--- PASS: TestAccTFEPolicySet_invalidName (0.95s)
=== RUN   TestAccTFEPolicySetImport
--- PASS: TestAccTFEPolicySetImport (11.76s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 182.575s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
</details>

#### resource tfe_run_trigger:

<details>
   <summary>Click to expand for test output</summary>

```
$ TESTARGS="-run TestAccTFERunTrigger" envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFERunTrigger -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFERunTrigger_basic
--- PASS: TestAccTFERunTrigger_basic (9.25s)
=== RUN   TestAccTFERunTrigger_many
--- PASS: TestAccTFERunTrigger_many (23.58s)
=== RUN   TestAccTFERunTriggerImport
--- PASS: TestAccTFERunTriggerImport (11.11s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 44.107s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
</details>

#### resource tfe_team_access:

<details>
   <summary>Click to expand for test output</summary>

```
$ TESTARGS="-run TestAccTFETeamAccess" envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFETeamAccess -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFETeamAccessDataSource_basic
--- PASS: TestAccTFETeamAccessDataSource_basic (10.19s)
=== RUN   TestAccTFETeamAccess_write
--- PASS: TestAccTFETeamAccess_write (8.88s)
=== RUN   TestAccTFETeamAccess_custom
--- PASS: TestAccTFETeamAccess_custom (8.22s)
=== RUN   TestAccTFETeamAccess_updateToCustom
--- PASS: TestAccTFETeamAccess_updateToCustom (15.34s)
=== RUN   TestAccTFETeamAccess_updateFromCustom
--- PASS: TestAccTFETeamAccess_updateFromCustom (14.39s)
=== RUN   TestAccTFETeamAccess_import
--- PASS: TestAccTFETeamAccess_import (10.02s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 67.213s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
</details>

#### resource tfe_variable:

<details>
   <summary>Click to expand for test output</summary>

```
$ TESTARGS="-run TestAccTFEVariable" envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEVariable -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEVariable_basic
--- PASS: TestAccTFEVariable_basic (9.46s)
=== RUN   TestAccTFEVariable_update
--- PASS: TestAccTFEVariable_update (16.60s)
=== RUN   TestAccTFEVariable_update_key_sensitive
--- PASS: TestAccTFEVariable_update_key_sensitive (15.93s)
=== RUN   TestAccTFEVariable_import
--- PASS: TestAccTFEVariable_import (9.66s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 51.818s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
</details>

#### resource tfe_workspace:

<details>
   <summary>Click to expand for test output</summary>

```
$ TESTARGS="-run TestAccTFEWorkspace" envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspace -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (8.91s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (9.50s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (7.02s)
=== RUN   TestAccTFEWorkspace_basic
--- PASS: TestAccTFEWorkspace_basic (6.56s)
=== RUN   TestAccTFEWorkspace_panic
--- PASS: TestAccTFEWorkspace_panic (6.47s)
=== RUN   TestAccTFEWorkspace_monorepo
--- PASS: TestAccTFEWorkspace_monorepo (6.60s)
=== RUN   TestAccTFEWorkspace_renamed
--- PASS: TestAccTFEWorkspace_renamed (10.53s)
=== RUN   TestAccTFEWorkspace_update
--- PASS: TestAccTFEWorkspace_update (11.96s)
=== RUN   TestAccTFEWorkspace_updateWorkingDirectory
--- PASS: TestAccTFEWorkspace_updateWorkingDirectory (16.56s)
=== RUN   TestAccTFEWorkspace_updateFileTriggers
--- PASS: TestAccTFEWorkspace_updateFileTriggers (11.51s)
=== RUN   TestAccTFEWorkspace_updateTriggerPrefixes
--- PASS: TestAccTFEWorkspace_updateTriggerPrefixes (12.71s)
=== RUN   TestAccTFEWorkspace_updateSpeculative
--- PASS: TestAccTFEWorkspace_updateSpeculative (11.68s)
=== RUN   TestAccTFEWorkspace_updateVCSRepo
--- PASS: TestAccTFEWorkspace_updateVCSRepo (34.34s)
=== RUN   TestAccTFEWorkspace_sshKey
--- PASS: TestAccTFEWorkspace_sshKey (19.33s)
=== RUN   TestAccTFEWorkspace_import
--- PASS: TestAccTFEWorkspace_import (7.84s)
=== RUN   TestAccTFEWorkspace_importVCSBranch
--- PASS: TestAccTFEWorkspace_importVCSBranch (14.05s)
=== RUN   TestAccTFEWorkspace_operationsAndExecutionModeInteroperability
--- PASS: TestAccTFEWorkspace_operationsAndExecutionModeInteroperability (27.97s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 223.733s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
</details>