### PR TITLE
Add IP Ranges datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,18 @@
 ## 0.24.0 (Unreleased)
 FEATURES:
 * **New Resource:** r/tfe_agent_token ([#259](https://github.com/hashicorp/terraform-provider-tfe/pull/259))
+* **New Data Source:** d/tfe_ip_ranges ([#262](https://github.com/hashicorp/terraform-provider-tfe/pull/262))
+
+ENHANCEMENTS:
+* d/tfe_workspace: Added deprecation warning to the `external_id` attribute, preferring `id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+* d/tfe_workspace_ids: Added deprecation warning to the `external_ids` attribute, preferring `ids` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
+* r/tfe_workspace: Added deprecation warning to the `external_id` attribute, preferring `id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
 
 BREAKING CHANGES: 
 * d/tfe_workspace_ids: Changed `ids` attribute to return immutable workspace IDs in the format `ws-<RANDOM STRING>` ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
 * r/tfe_notification_configuration: Removed deprecated `workspace_external_id` attribute, preferring `workspace_id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
 * r/tfe_policy_set: Removed deprecated `workspace_external_ids` attribute, preferring `workspace_ids` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
 * r/tfe_run_trigger: Removed deprecated `workspace_external_id` attribute, preferring `workspace_id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
-
-ENHANCEMENTS:
-* d/tfe_workspace: Added deprecation warning to the `external_id` attribute, preferring `id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
-* d/tfe_workspace_ids: Added deprecation warning to the `external_ids` attribute, preferring `ids` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
-* r/tfe_workspace: Added deprecation warning to the `external_id` attribute, preferring `id` instead ([#253](https://github.com/hashicorp/terraform-provider-tfe/pull/253))
 
 NOTES:
 * All deprecated attributes will be removed 3 months after the release of v0.24.0. You will have until April X, 2021 to migrate to the preferred attributes. 

--- a/tfe/data_source_ip_ranges.go
+++ b/tfe/data_source_ip_ranges.go
@@ -1,0 +1,56 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceTFEIPRanges() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTFEIPRangesRead,
+
+		Schema: map[string]*schema.Schema{
+			"api": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"notifications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"sentinel": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vcs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceTFEIPRangesRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Reading IP Ranges")
+	ipRanges, err := tfeClient.Meta.IPRanges.Read(ctx, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving IP ranges: %v", err)
+	}
+
+	d.SetId("ip-ranges")
+	d.Set("api", ipRanges.API)
+	d.Set("notifications", ipRanges.Notifications)
+	d.Set("sentinel", ipRanges.Sentinel)
+	d.Set("vcs", ipRanges.VCS)
+
+	return nil
+}

--- a/tfe/data_source_ip_ranges_test.go
+++ b/tfe/data_source_ip_ranges_test.go
@@ -1,0 +1,38 @@
+package tfe
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFEIPRangesDataSource_basic(t *testing.T) {
+	ipRegex := regexp.MustCompile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/([1-9]|[1-9][0-9])$`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEIPRangesDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.tfe_ip_ranges.ips", "id"),
+					resource.TestCheckResourceAttrSet("data.tfe_ip_ranges.ips", "api.0"),
+					resource.TestMatchResourceAttr("data.tfe_ip_ranges.ips", "api.0", ipRegex),
+					resource.TestCheckResourceAttrSet("data.tfe_ip_ranges.ips", "notifications.0"),
+					resource.TestMatchResourceAttr("data.tfe_ip_ranges.ips", "notifications.0", ipRegex),
+					resource.TestCheckResourceAttrSet("data.tfe_ip_ranges.ips", "sentinel.0"),
+					resource.TestMatchResourceAttr("data.tfe_ip_ranges.ips", "sentinel.0", ipRegex),
+					resource.TestCheckResourceAttrSet("data.tfe_ip_ranges.ips", "vcs.0"),
+					resource.TestMatchResourceAttr("data.tfe_ip_ranges.ips", "vcs.0", ipRegex),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFEIPRangesDataSourceConfig() string {
+	return fmt.Sprintf(`data "tfe_ip_ranges" "ips" {}`)
+}

--- a/tfe/data_source_ip_ranges_test.go
+++ b/tfe/data_source_ip_ranges_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccTFEIPRangesDataSource_basic(t *testing.T) {
-	ipRegex := regexp.MustCompile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\/([1-9]|[1-9][0-9])$`)
+	ipRegex := regexp.MustCompile(`^([\d]{1,3}\.){3}[\d]{1,3}/[\d]{1,3}$`)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -71,6 +71,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"tfe_agent_pool":              dataSourceTFEAgentPool(),
+			"tfe_ip_ranges":               dataSourceTFEIPRanges(),
 			"tfe_oauth_client":            dataSourceTFEOAuthClient(),
 			"tfe_organization_membership": dataSourceTFEOrganizationMembership(),
 			"tfe_ssh_key":                 dataSourceTFESSHKey(),

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_ip_ranges"
+sidebar_current: "docs-datasource-tfe-ip-ranges"
+description: |-
+  Get Terraform Cloud/Enterprise's IP ranges of its services
+---
+
+# Data Source: tfe_ip_ranges
+
+Use this data source to retrieve a list of Terraform Cloud's IP ranges. For more information about these IP ranges, view our [documentation about Terraform Cloud IP Ranges](https://www.terraform.io/docs/cloud/architectural-details/ip-ranges.html).
+
+## Example Usage
+
+```hcl
+data "tfe_ip_ranges" "addresses" {}
+
+output "notifications_ips" {
+  value = data.tfe_ip_ranges.addresses.notifications
+}
+```
+
+## Argument Reference
+
+No arguments are required for this datasource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `api` - The list of IP ranges in CIDR notation used for connections from user site to Terraform Cloud APIs.
+* `notifications` - The list of IP ranges in CIDR notation used for notifications.
+* `sentinel` - The list of IP ranges in CIDR notation used for outbound requests from Sentinel policies.
+* `vcs` - The list of IP ranges in CIDR notation used for connecting to VCS providers.
+

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -17,6 +17,10 @@
                             <a href="/docs/providers/tfe/d/agent_pool.html">tfe_agent_pool</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-datasource-tfe-ip-ranges") %>>
+                            <a href="/docs/providers/tfe/d/ip_ranges.html">tfe_ip_ranges</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-datasource-tfe-oauth-client-x") %>>
                             <a href="/docs/providers/tfe/d/oauth_client.html">tfe_oauth_client</a>
                         </li>


### PR DESCRIPTION
## Description

Adds a new `tfe_ip_ranges` datasource to fetch a list of Terraform Cloud and Enterprise's IP ranges from the [IP Ranges API](https://www.terraform.io/docs/cloud/api/ip-ranges.html).

```
» TF_ACC=1 go test -v ./tfe -timeout=30m -run TestAccTFEIPRanges
=== RUN   TestAccTFEIPRangesDataSource_basic
--- PASS: TestAccTFEIPRangesDataSource_basic (4.73s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe (cached)
```