### PR TITLE
[DOCS] Some addition clarification on 'queue_all_runs'

### DIFF
--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -35,7 +35,9 @@ In addition to all arguments above, the following attributes are exported:
 * `auto_apply` - Indicates whether to automatically apply changes when a Terraform plan is successful.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `operations` - Indicates whether the workspace is using remote execution mode. Set to `false` to switch execution mode to local. `true` by default.
-* `queue_all_runs` - Indicates whether all runs should be queued.
+* `queue_all_runs` - Indicates whether the workspace will automatically perform runs
+  in response to webhooks immediately after its creation. If `false`, an initial run must
+  be manually queued to enable future automatic runs.
 * `speculative_enabled` - Indicates whether this workspace allows speculative plans.
 * `ssh_key_id` - The ID of an SSH key assigned to the workspace.
 * `terraform_version` - The version of Terraform used for this workspace.

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -70,9 +70,12 @@ The following arguments are supported:
 * `operations` - **Deprecated** Whether to use remote execution mode. When set to `false`, the workspace will 
   be used for state storage only. Defaults to `true`. This value _must not_ be provided if `execution_mode` is 
   provided.
-* `queue_all_runs` - (Optional) Whether all runs should be queued. When set
-  to `false`, runs triggered by a VCS change will not be queued until at least
-  one run is manually queued. Defaults to `true`.
+* `queue_all_runs` - (Optional) Whether the workspace should start automatically performing
+  runs immediately after its creation. When set to `false`, runs triggered by a webhook
+  (such as a commit in VCS) will not be queued until at least one run has been manually
+  queued. Defaults to `true`. **Note:** This default differs from the Terraform Cloud API default, which is `false`.
+  The provider uses `true` as any workspace provisioned with `false` would need to then have a run manually queued out-of-band
+  before accepting webhooks.
 * `speculative_enabled` - (Optional) Whether this workspace allows speculative
   plans. Setting this to `false` prevents Terraform Cloud or the Terraform
   Enterprise instance from running plans on pull requests, which can improve


### PR DESCRIPTION
## Description

Just some additional clarification on this setting and why the default here in the provider is the opposite of the API default.