### PR TITLE
Add Manage Policy Overrides permission

### DIFF
--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -44,6 +44,11 @@ func resourceTFETeam() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"manage_policy_overrides": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 						"manage_workspaces": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -86,9 +91,10 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 		organizationAccess := v.([]interface{})[0].(map[string]interface{})
 
 		options.OrganizationAccess = &tfe.OrganizationAccessOptions{
-			ManagePolicies:    tfe.Bool(organizationAccess["manage_policies"].(bool)),
-			ManageWorkspaces:  tfe.Bool(organizationAccess["manage_workspaces"].(bool)),
-			ManageVCSSettings: tfe.Bool(organizationAccess["manage_vcs_settings"].(bool)),
+			ManagePolicies:        tfe.Bool(organizationAccess["manage_policies"].(bool)),
+			ManagePolicyOverrides: tfe.Bool(organizationAccess["manage_policy_overrides"].(bool)),
+			ManageWorkspaces:      tfe.Bool(organizationAccess["manage_workspaces"].(bool)),
+			ManageVCSSettings:     tfe.Bool(organizationAccess["manage_vcs_settings"].(bool)),
 		}
 	}
 
@@ -126,9 +132,10 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", team.Name)
 	if team.OrganizationAccess != nil {
 		organizationAccess := []map[string]bool{{
-			"manage_policies":     team.OrganizationAccess.ManagePolicies,
-			"manage_workspaces":   team.OrganizationAccess.ManageWorkspaces,
-			"manage_vcs_settings": team.OrganizationAccess.ManageVCSSettings,
+			"manage_policies":         team.OrganizationAccess.ManagePolicies,
+			"manage_policy_overrides": team.OrganizationAccess.ManagePolicyOverrides,
+			"manage_workspaces":       team.OrganizationAccess.ManageWorkspaces,
+			"manage_vcs_settings":     team.OrganizationAccess.ManageVCSSettings,
 		}}
 		if err := d.Set("organization_access", organizationAccess); err != nil {
 			return fmt.Errorf("error setting organization access for team %s: %s", d.Id(), err)
@@ -154,9 +161,10 @@ func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
 		organizationAccess := v.([]interface{})[0].(map[string]interface{})
 
 		options.OrganizationAccess = &tfe.OrganizationAccessOptions{
-			ManagePolicies:    tfe.Bool(organizationAccess["manage_policies"].(bool)),
-			ManageWorkspaces:  tfe.Bool(organizationAccess["manage_workspaces"].(bool)),
-			ManageVCSSettings: tfe.Bool(organizationAccess["manage_vcs_settings"].(bool)),
+			ManagePolicies:        tfe.Bool(organizationAccess["manage_policies"].(bool)),
+			ManagePolicyOverrides: tfe.Bool(organizationAccess["manage_policy_overrides"].(bool)),
+			ManageWorkspaces:      tfe.Bool(organizationAccess["manage_workspaces"].(bool)),
+			ManageVCSSettings:     tfe.Bool(organizationAccess["manage_vcs_settings"].(bool)),
 		}
 	}
 

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -280,7 +280,7 @@ resource "tfe_team" "foobar" {
   
   organization_access {
     manage_policies = true
-	manage_policy_overrides = true
+    manage_policy_overrides = true
     manage_workspaces = true
     manage_vcs_settings = true
   }
@@ -302,7 +302,7 @@ resource "tfe_team" "foobar" {
   
   organization_access {
     manage_policies = false
-	manage_policy_overrides = false
+    manage_policy_overrides = false
     manage_workspaces = false
     manage_vcs_settings = false
   }

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -56,6 +56,8 @@ func TestAccTFETeam_full(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_policies", "true"),
 					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_policy_overrides", "true"),
+					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_workspaces", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_vcs_settings", "true"),
@@ -87,6 +89,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_policies", "true"),
 					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_policy_overrides", "true"),
+					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_workspaces", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_vcs_settings", "true"),
@@ -104,6 +108,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "visibility", "secret"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_policies", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_policy_overrides", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_workspaces", "false"),
 					resource.TestCheckResourceAttr(
@@ -274,6 +280,7 @@ resource "tfe_team" "foobar" {
   
   organization_access {
     manage_policies = true
+	manage_policy_overrides = true
     manage_workspaces = true
     manage_vcs_settings = true
   }
@@ -295,6 +302,7 @@ resource "tfe_team" "foobar" {
   
   organization_access {
     manage_policies = false
+	manage_policy_overrides = false
     manage_workspaces = false
     manage_vcs_settings = false
   }

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -32,7 +32,8 @@ The following arguments are supported:
 
 The `organization_access` block supports:
 
-* `manage_policies` - (Optional) Allows members to create, edit, and delete the organization's Sentinel policies and override soft-mandatory policy checks.
+* `manage_policies` - (Optional) Allows members to create, edit, and delete the organization's Sentinel policies.
+* `manage_policy_overrides` - (Optional) Allows members to override soft-mandatory policy checks.
 * `manage_workspaces` - (Optional) Allows members to create and administrate all workspaces within the organization.
 * `manage_vcs_settings` - (Optional) Allows members to manage the organization's VCS Providers and SSH keys.
 


### PR DESCRIPTION
## Description

A new permission, `Manage Policy Overrides` is being added to the `Organization Access` for teams. This PR adds the field as required.

## External links

- [go-tfe PR](https://github.com/hashicorp/go-tfe/pull/198)
- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe#OrganizationAccess)
- [API documentation PR](https://github.com/hashicorp/terraform-website/pull/1667)
- [API documentation](https://www.terraform.io/docs/cloud/users-teams-organizations/permissions.html#organization-permissions)