### PR TITLE
Add branch attribute to vcs_repo block of tfe_workspace data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ENHANCEMENTS:
 * Use Go 1.16 to provide support for Apple Silicon (darwin/arm64).
 * d/tfe_workspace: Added new fields from the API ([#287](https://github.com/hashicorp/terraform-provider-tfe/pull/287))
+* d/tfe_workspace: Added `branch` attribute to `vcs_repo` block ([#290](https://github.com/hashicorp/terraform-provider-tfe/pull/290))
 
 ## 0.24.0 (January 22, 2021)
 

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -85,6 +85,11 @@ func dataSourceTFEWorkspace() *schema.Resource {
 							Computed: true,
 						},
 
+						"branch": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"ingress_submodules": {
 							Type:     schema.TypeBool,
 							Computed: true,
@@ -168,6 +173,7 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	if workspace.VCSRepo != nil {
 		vcsConfig := map[string]interface{}{
 			"identifier":         workspace.VCSRepo.Identifier,
+			"branch":             workspace.VCSRepo.Branch,
 			"ingress_submodules": workspace.VCSRepo.IngressSubmodules,
 			"oauth_token_id":     workspace.VCSRepo.OAuthTokenID,
 		}

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -55,6 +55,7 @@ The `vcs_repo` block contains:
 * `identifier` - A reference to your VCS repository in the format `<organization>/<repository>`
   where `<organization>` and `<repository>` refer to the organization and repository in your VCS
   provider.
+* `branch` - The repository branch that Terraform will execute from.
 * `ingress_submodules` - Indicates whether submodules should be fetched when
   cloning the VCS repository.
 * `oauth_token_id` - OAuth token ID of the configured VCS connection.


### PR DESCRIPTION
## Description

Currently we cannot get the VCS Repo Branch attribute value using `tfe_workspace` data source as opposed to being able to specify it using the resource version. This PR adds branch attribute to the data source and fixes this duality.

## Output from acceptance tests

Full test timed out after 15m, so instead of increasing the timeout and trying again, I just ran individual test named `TestAccTFEWorkspaceDataSource` since the changes were only in this data source. However, vcs_repo block is not being tested in any tests, so this run does not mean anything.

```
$ TESTARGS="-run TestAccTFEWorkspaceDataSource" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceDataSource -timeout 150m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (9.90s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 9.907s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
