### PR TITLE
Remove deprecated external_id/external_ids attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased 0.25.0
+
+BREAKING CHANGES:
+* d/tfe_workspace: Removed deprecated `external_id` attribute, preferring `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
+* d/tfe_workspace_ids: Removed deprecated `external_ids` attribute, preferring `ids` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
+* r/tfe_workspace: Removed deprecated `external_id` attribute, preferring `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
+
+NOTES:
+* You will need to migrate to the preferred attributes to update to the latest version of this
+  provider. More information about these deprecations can be found in the description of [#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295)
+
 ## Unreleased 0.24.1
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,21 @@
 ## Unreleased 0.25.0
 
 BREAKING CHANGES:
-* d/tfe_workspace: Removed deprecated `external_id` attribute, preferring `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
-* d/tfe_workspace_ids: Removed deprecated `external_ids` attribute, preferring `ids` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
-* r/tfe_workspace: Removed deprecated `external_id` attribute, preferring `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
-
-NOTES:
-* You will need to migrate to the preferred attributes to update to the latest version of this
-  provider. More information about these deprecations can be found in the description of [#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295)
-
-## Unreleased 0.24.1
+* d/tfe_workspace: Removed deprecated `external_id` attribute. Use `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
+* d/tfe_workspace_ids: Removed deprecated `external_ids` attribute. Use `ids` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
+* r/tfe_workspace: Removed deprecated `external_id` attribute. Use `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
 
 ENHANCEMENTS:
 * Use Go 1.16 to provide support for Apple Silicon (darwin/arm64).
 * d/tfe_workspace: Added new fields from the API ([#287](https://github.com/hashicorp/terraform-provider-tfe/pull/287))
 * d/tfe_workspace: Added `branch` attribute to `vcs_repo` block ([#290](https://github.com/hashicorp/terraform-provider-tfe/pull/290))
+
+NOTES:
+* You will need to migrate to the new attributes in your configuration to update to the latest
+  version of this provider. The tfe_workspace resource will continue to migrate old workspace
+  resources in state (schema version 0, using `external_id`) to new ones (schema version 1, using `id`) for
+  the foreseeable future and will only be removed in a breaking major version (likely v1.0.0). More information
+  about these deprecations can be found in the description of [#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295)
 
 ## 0.24.0 (January 22, 2021)
 

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -10,8 +10,7 @@ import (
 
 func dataSourceTFEWorkspace() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Data source \"tfe_workspace\"\n\n\"external_id\": [DEPRECATED] Use id instead. The external_id attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.24.0/CHANGELOG.md",
-		Read:               dataSourceTFEWorkspaceRead,
+		Read: dataSourceTFEWorkspaceRead,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -127,12 +126,6 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-
-			"external_id": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Use id instead. The external_id attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.24.0/CHANGELOG.md",
-			},
 		},
 	}
 }
@@ -168,8 +161,6 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("policy_check_failures", workspace.PolicyCheckFailures)
 	d.Set("run_failures", workspace.RunFailures)
 	d.Set("runs_count", workspace.RunsCount)
-	// TODO: remove when external_id is removed
-	d.Set("external_id", workspace.ID)
 
 	if workspace.SSHKey != nil {
 		d.Set("ssh_key_id", workspace.SSHKey.ID)

--- a/tfe/data_source_workspace_ids.go
+++ b/tfe/data_source_workspace_ids.go
@@ -9,8 +9,7 @@ import (
 
 func dataSourceTFEWorkspaceIDs() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Data source \"tfe_workspace_ids\"\n\n\"external_ids\": [DEPRECATED] Use ids instead. The external_ids attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.24.0/CHANGELOG.md",
-		Read:               dataSourceTFEWorkspaceIDsRead,
+		Read: dataSourceTFEWorkspaceIDsRead,
 
 		Schema: map[string]*schema.Schema{
 			"names": {
@@ -27,12 +26,6 @@ func dataSourceTFEWorkspaceIDs() *schema.Resource {
 			"ids": {
 				Type:     schema.TypeMap,
 				Computed: true,
-			},
-
-			"external_ids": {
-				Type:       schema.TypeMap,
-				Computed:   true,
-				Deprecated: "Use ids instead. The external_ids attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.24.0/CHANGELOG.md",
 			},
 
 			"full_names": {
@@ -85,8 +78,6 @@ func dataSourceTFEWorkspaceIDsRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.Set("ids", ids)
-	// TODO: remove once external_ids is removed
-	d.Set("external_ids", ids)
 	d.Set("full_names", fullNames)
 	d.SetId(fmt.Sprintf("%s/%d", organization, schema.HashString(id)))
 

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -54,14 +54,6 @@ func TestAccTFEWorkspaceIDsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-bar-%d", rInt)),
 
-					// external_ids attributes
-					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar", "external_ids.%", "2"),
-					resource.TestCheckResourceAttrSet(
-						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-foo-%d", rInt)),
-					resource.TestCheckResourceAttrSet(
-						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-bar-%d", rInt)),
-
 					// id attribute
 					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),
 				),
@@ -120,16 +112,6 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-bar-%d", rInt)),
 					resource.TestCheckResourceAttrSet(
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-dummy-%d", rInt)),
-
-					// external_ids attribute
-					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar", "external_ids.%", "3"),
-					resource.TestCheckResourceAttrSet(
-						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-foo-%d", rInt)),
-					resource.TestCheckResourceAttrSet(
-						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-bar-%d", rInt)),
-					resource.TestCheckResourceAttrSet(
-						"data.tfe_workspace_ids.foobar", fmt.Sprintf("external_ids.workspace-dummy-%d", rInt)),
 
 					// id attribute
 					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -48,7 +48,6 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "working_directory", "terraform/test"),
 
-					resource.TestCheckResourceAttrSet("data.tfe_workspace.foobar", "external_id"),
 					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "resource_count", "0"),
 					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "policy_check_failures", "0"),
 					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "run_failures", "0"),

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -163,12 +163,6 @@ func resourceTFEWorkspace() *schema.Resource {
 					},
 				},
 			},
-
-			"external_id": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Use id instead. The external_id attribute will be removed in the future. See the CHANGELOG to learn more: https://github.com/hashicorp/terraform-provider-tfe/blob/v0.24.0/CHANGELOG.md",
-			},
 		},
 	}
 }
@@ -282,8 +276,6 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("terraform_version", workspace.TerraformVersion)
 	d.Set("trigger_prefixes", workspace.TriggerPrefixes)
 	d.Set("working_directory", workspace.WorkingDirectory)
-	// TODO: remove when external_id is removed
-	d.Set("external_id", workspace.ID)
 	d.Set("organization", workspace.Organization.Name)
 
 	var sshKeyID string

--- a/website/docs/d/workspace_ids.html.markdown
+++ b/website/docs/d/workspace_ids.html.markdown
@@ -39,16 +39,5 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-~> **NOTE** In versions < 0.15.1, workspace IDs were in the format 
-`<ORGANIZATION NAME>/<WORKSPACE NAME>` for some resources. This format 
-has been deprecated in favor of the immutable workspace ID in the format `ws-<RANDOM STRING>`.
-
-~> **NOTE** The deprecation warning for the external_ids attribute will not go away until it is removed. 
-This is due to a [limitation of the 1.0 version of the Terraform SDK](https://github.com/hashicorp/terraform/issues/7569) 
-for deprecation warnings on attributes that aren't specified in a configuration. If you have made sure 
-to change all references to this data source's `external_ids` attribute to the `ids` attribute, you can ignore the warning.  
-
 * `full_names` - A map of workspace names and their full names, which look like `<ORGANIZATION>/<WORKSPACE>`. 
 * `ids` - A map of workspace names and their opaque, immutable IDs, which look like `ws-<RANDOM STRING>`.
-* `external_ids` - **Deprecated** A map of workspace names and their opaque, immutable IDs, which
-  look like `ws-<RANDOM STRING>`.


### PR DESCRIPTION
## Description

This PR removes the deprecated `external_id` attribute from resource `tfe_workspace`, the `external_id` attribute from data source `tfe_workspace`, and the `external_ids` attribute from data source `tfe_workspace_ids`.  
**This is a breaking change. Please change your config to use `id`/`ids` before upgrading.** 

#### The following data sources are impacted:
   * `tfe_workspace` - The deprecated `external_id` attribute has been removed. If you are still using this attribute, you will get errors. You should use `id` instead.
   * `tfe_workspace_ids` - The deprecated `external_ids` attribute has been removed. If you are still using this attribute, you will get errors. You should use `ids` instead.

#### The following resources are impacted:
   * `tfe_workspace` - The deprecated `external_id` attribute has been removed. If you are still using this attribute, you will get errors. You should use `id` instead

### Why are these attributes being deprecated?
After #106 migrated workspace ids to the immutable id format (`ws-<random string>`), we still had some inconsistent usages of `external_id`, `workspace_external_id`, and `workspace_external_ids`. In order to clean this up and make the provider consistent and easier to understand when working with workspace IDs, we will be replacing all usages of `workspace_external_id`/`workspace_external_ids` with `workspace_id`/`workspace_ids`.

###  Deprecation plan:
To minimize disruption and give everyone time to migrate over, we will be doing this in 3 phases. 

#### [COMPLETE] Phase 1:
**This phase was completed in #182 and released in version 0.18.0.**

<details>
   <summary>Click to expand for phase 1 details</summary>
   
   **tfe_workspace_ids Data Source:** We will add a new computed attribute to the tfe_workspace_ids data source called `full_names` that will mimic the current behavior of the `ids` attribute. In this phase, both attributes will return the old human-readable workspace ID format of `<organization_name>/<workspace_name>`. We will add deprecation warnings to the `ids` attribute explaining that users should begin using `full_names` instead, as the behavior of `ids` will be changing soon.

   **Remainder of TFE Provider:** We will add a new attribute to impacted resources called `workspace_id` or `workspace_ids` (depending on which is required for the specific resource) which will hold the same value as the current `workspace_external_id`/`workspace_external_ids` attributes. Deprecation warnings will be added to all of these, recommending the user move to `workspace_id`/ `workspace_ids` instead.
</details>

#### [COMPLETE] Phase 2:
**This phase was completed in #253 and released in version 0.24.0.**

<details>
   <summary>Click to expand for phase 2 details</summary>

   **tfe_workspace_ids Data Source:** We will officially change the behavior of the `ids` attribute so it returns the immutable workspace ID in format `ws-<random_string>`, just as the `external_ids` attribute currently does. We will add a deprecation warning to the `external_ids` attribute, alerting them that it will be deprecated soon and they should use `ids` instead.

   **tfe_workspace Data Source:** We will add a deprecation warning to the `external_id` attribute, recommending the user move to `id` instead.

   **tfe_workspace Resource:** We will add a deprecation warning to the `external_id` attribute, recommending the user move to `id` instead.

   **Remainder of TFE Provider:** We will remove the `workspace_external_id `/ `workspace_external_ids` attributes from all the impacted resources.
</details>

#### [YOU ARE HERE] Phase 3:
**You are here. That's what this PR is for :]**

**tfe_workspace_ids Data Source:** We will remove `external_ids` from this data source entirely, leaving behind `ids` returning the immutable workspace ID in the format `ws-<random_string>`, and `full_names` returning the format `<organization_name>/<workspace_name>`.

**tfe_workspace Data Source:** We will remove the `external_id` attribute.

**tfe_workspace Resource:** We will remove the `external_id` attribute.

## BREAKING CHANGE

This PR removes `external_id `/ `external_ids` from `r/tfe_workspace`, `d/tfe_workspace`, and `d/tfe_workspace_ids`. You should change your config to use `id `/ `ids` before upgrading. 

## Testing plan

As these changes just remove certain arguments, the testing plan is mostly just to have an existing 0.24.0 configuration/state and then 'upgrade' using a built provider with this branch:

* `external_id(s)` should not be usable anymore at all on the datasource or resource.
* No deprecation warnings should be emitted anymore from d/tfe_workspace.
* Perhaps most importantly: The behavior of what happens with the existing `external_id` attribute in state should be monitored - the attributes should disappear without incident, not causing any drift or awkward half-states.
