### PR TITLE
Fix remote state consumer tests

### DIFF
--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -859,9 +859,9 @@ func testAccCheckTFEWorkspaceHasRemoteConsumers(ws string, wsConsumers []string)
 			if !ok {
 				return fmt.Errorf("Not found: %s", consumer)
 			}
-			consumerExternalID := remoteConsumer.Primary.Attributes["external_id"]
-			if _, hasConsumer := remoteConsumerMap[consumerExternalID]; !hasConsumer {
-				return fmt.Errorf("The Workspace %s does not appear to be a remote state consumer for %s", rsWorkspace.Primary.ID, consumerExternalID)
+			consumerID := remoteConsumer.Primary.Attributes["id"]
+			if _, hasConsumer := remoteConsumerMap[consumerID]; !hasConsumer {
+				return fmt.Errorf("The Workspace %s does not appear to be a remote state consumer for %s", rsWorkspace.Primary.ID, consumerID)
 			}
 		}
 


### PR DESCRIPTION
## Description

In a unfortunate twist of fate and unbelievable timing, the attribute in state that this test function was depending on was just ripped out from underneath it in the deprecation removals of #295  😆 Use `id`, not `external_id`, which is now removed.

## Testing plan

CI should pass.