### PR TITLE
organization: ignore diffs in name case

### DIFF
--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -23,6 +24,9 @@ func resourceTFEOrganization() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 
 			"email": {

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -159,6 +159,38 @@ func TestAccTFEOrganization_update(t *testing.T) {
 	})
 }
 
+func TestAccTFEOrganization_case(t *testing.T) {
+	org := &tfe.Organization{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEOrganizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEOrganization_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEOrganizationExists(
+						"tfe_organization.foobar", org),
+					testAccCheckTFEOrganizationAttributesBasic(org, orgName),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "name", orgName),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "email", "admin@company.com"),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
+				),
+			},
+			{
+				Config:   testAccTFEOrganization_title_case(rInt),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccTFEOrganization_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -323,6 +355,14 @@ func testAccTFEOrganization_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}`, rInt)
+}
+
+func testAccTFEOrganization_title_case(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "Tst-Terraform-%d"
   email = "admin@company.com"
 }`, rInt)
 }


### PR DESCRIPTION
## Description

The TFE API ignores case when specifying a `tfe_organization`'s `name` attribute. This configures the provider to suppress the diff when the `name` has changed but the value is equal when case is ignored.

See #299

## Testing plan

1.  Declare a `tfe_organization`
1.  `terraform apply`
1.  Update the case of the `tfe_organization`'s name
1.  `terraform plan`

The plan will include the replace of the `tfe_organization`.

## External links

* [API docs](https://www.terraform.io/docs/cloud/api/organizations.html): these don't mention case handling

## Output from acceptance tests

_Please run the full suite of acceptance tests locally and include the output here._

```
$ make testacc TESTARGS='-run TestAccTFEOrganization_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEOrganization_ -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEOrganization_basic
--- PASS: TestAccTFEOrganization_basic (16.90s)
=== RUN   TestAccTFEOrganization_full
--- PASS: TestAccTFEOrganization_full (16.78s)
=== RUN   TestAccTFEOrganization_update
--- PASS: TestAccTFEOrganization_update (41.21s)
=== RUN   TestAccTFEOrganization_case
--- PASS: TestAccTFEOrganization_case (24.96s)
=== RUN   TestAccTFEOrganization_import
--- PASS: TestAccTFEOrganization_import (21.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	121.983s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```
