### PR TITLE
Update CHANGELOG.md to note incompatibility with older TFE versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,20 @@
 ## 0.25.0 (April 29, 2021)
 
 BREAKING CHANGES:
+* d/tfe_workspace: Due to the addition of remote controlled state consumer functionality, using this data source requires using the provider with Terraform Cloud or an instance of Terraform Enterprise at least as recent as v202104-1 ([#292](https://github.com/hashicorp/terraform-provider-tfe/pull/292))
 * d/tfe_workspace: Removed deprecated `external_id` attribute. Use `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
 * d/tfe_workspace_ids: Removed deprecated `external_ids` attribute. Use `ids` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
 * r/tfe_workspace: Removed deprecated `external_id` attribute. Use `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
+* r/tfe_workspace: Due to the addition of remote controlled state consumer functionality, using this resource requires using the provider with Terraform Cloud or an instance of Terraform Enterprise at least as recent as v202104-1 ([#292](https://github.com/hashicorp/terraform-provider-tfe/pull/292))
 
 ENHANCEMENTS:
-* Use Go 1.16 to provide support for Apple Silicon (darwin/arm64) ([#288](https://github.com/hashicorp/terraform-provider-tfe/pull/288))
-* Add Manage Policy Overrides permission for teams ([#285](https://github.com/hashicorp/terraform-provider-tfe/pull/285))
-* r/tfe_workspace: Add remote state consumer functionality ([#292](https://github.com/hashicorp/terraform-provider-tfe/pull/292))
+* provider: Updated to use Go 1.16 to provide support for Apple Silicon (darwin/arm64) ([#288](https://github.com/hashicorp/terraform-provider-tfe/pull/288))
+* provider: Improved error message for missing token ([#273](https://github.com/hashicorp/terraform-provider-tfe/pull/273))
+* r/tfe_team: Added Manage Policy Overrides permission for teams ([#285](https://github.com/hashicorp/terraform-provider-tfe/pull/285))
+* r/tfe_workspace: Added remote state consumer functionality ([#292](https://github.com/hashicorp/terraform-provider-tfe/pull/292))
 * r/tfe_workspace: Added description parameter to TFE workspace ([#271](https://github.com/hashicorp/terraform-provider-tfe/pull/271))
 * d/tfe_workspace: Added new workspace fields from the API ([#287](https://github.com/hashicorp/terraform-provider-tfe/pull/287))
 * d/tfe_workspace: Added `branch` attribute to `vcs_repo` block ([#290](https://github.com/hashicorp/terraform-provider-tfe/pull/290))
-* Improved error message for missing token ([#273](https://github.com/hashicorp/terraform-provider-tfe/pull/273))
 
 NOTES:
 * You will need to migrate to the new attributes in your configuration to update to the latest


### PR DESCRIPTION
## Description

The addition of remote state consumer functionality makes version r/tfe_workspace and d/tfe_workspace in version 0.25.0 incompatible with TFE versions older than v202104-1. We will be releasing a patch fix soon to pin the provider to specific TFE versions but in the meantime, this is helpful context to have in the changelog.

## Testing plan

1. Make sure the changelog entries make sense and the doc updates make sense.

## External links

- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/292)

## Output from acceptance tests

Didn't run these since I didn't make changes to code covered by these tests.
