### PR TITLE
Fix remote state consumers compatibility for Terraform Enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.25.1 (Unreleased)
+
+BUG FIXES:
+* r/organization: Ignore diffs in name case sensitivity ([#300](https://github.com/hashicorp/terraform-provider-tfe/pull/300))
+
 ## 0.25.0 (April 29, 2021)
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ BUG FIXES:
 * r/workspace: Fix remote state consumer regression for Terraform Enterprise ([#303](https://github.com/hashicorp/terraform-provider-tfe/pull/303))
 * r/organization: Ignore diffs in name case sensitivity ([#300](https://github.com/hashicorp/terraform-provider-tfe/pull/300))
 
+NOTES:
+* This release includes a fix for a major regression from a backwards incompatible change
+  erroneously introduced in v0.25.0, where any Terraform Enterprise version < v20210401-1 would
+  experience failures using the tfe_workspace resource.
+
 ## 0.25.0 (April 29, 2021)
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,18 @@
 ## 0.25.0 (April 29, 2021)
 
 BREAKING CHANGES:
-* d/tfe_workspace: Due to the addition of remote controlled state consumer functionality, using this data source requires using the provider with Terraform Cloud or an instance of Terraform Enterprise at least as recent as v202104-1 ([#292](https://github.com/hashicorp/terraform-provider-tfe/pull/292))
 * d/tfe_workspace: Removed deprecated `external_id` attribute. Use `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
 * d/tfe_workspace_ids: Removed deprecated `external_ids` attribute. Use `ids` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
 * r/tfe_workspace: Removed deprecated `external_id` attribute. Use `id` instead ([#295](https://github.com/hashicorp/terraform-provider-tfe/pull/295))
-* r/tfe_workspace: Due to the addition of remote controlled state consumer functionality, using this resource requires using the provider with Terraform Cloud or an instance of Terraform Enterprise at least as recent as v202104-1 ([#292](https://github.com/hashicorp/terraform-provider-tfe/pull/292))
 
 ENHANCEMENTS:
-* provider: Updated to use Go 1.16 to provide support for Apple Silicon (darwin/arm64) ([#288](https://github.com/hashicorp/terraform-provider-tfe/pull/288))
-* provider: Improved error message for missing token ([#273](https://github.com/hashicorp/terraform-provider-tfe/pull/273))
-* r/tfe_team: Added Manage Policy Overrides permission for teams ([#285](https://github.com/hashicorp/terraform-provider-tfe/pull/285))
-* r/tfe_workspace: Added remote state consumer functionality ([#292](https://github.com/hashicorp/terraform-provider-tfe/pull/292))
+* Use Go 1.16 to provide support for Apple Silicon (darwin/arm64) ([#288](https://github.com/hashicorp/terraform-provider-tfe/pull/288))
+* Add Manage Policy Overrides permission for teams ([#285](https://github.com/hashicorp/terraform-provider-tfe/pull/285))
+* r/tfe_workspace: Add remote state consumer functionality ([#292](https://github.com/hashicorp/terraform-provider-tfe/pull/292))
 * r/tfe_workspace: Added description parameter to TFE workspace ([#271](https://github.com/hashicorp/terraform-provider-tfe/pull/271))
 * d/tfe_workspace: Added new workspace fields from the API ([#287](https://github.com/hashicorp/terraform-provider-tfe/pull/287))
 * d/tfe_workspace: Added `branch` attribute to `vcs_repo` block ([#290](https://github.com/hashicorp/terraform-provider-tfe/pull/290))
+* Improved error message for missing token ([#273](https://github.com/hashicorp/terraform-provider-tfe/pull/273))
 
 NOTES:
 * You will need to migrate to the new attributes in your configuration to update to the latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.25.1 (Unreleased)
 
 BUG FIXES:
+* r/workspace: Fix remote state consumer regression for Terraform Enterprise ([#303](https://github.com/hashicorp/terraform-provider-tfe/pull/303))
 * r/organization: Ignore diffs in name case sensitivity ([#300](https://github.com/hashicorp/terraform-provider-tfe/pull/300))
 
 ## 0.25.0 (April 29, 2021)

--- a/tfe/resource_tfe_team_access_migrate_test.go
+++ b/tfe/resource_tfe_team_access_migrate_test.go
@@ -21,7 +21,7 @@ func testResourceTfeTeamAccessStateDataV1() map[string]interface{} {
 }
 
 func TestResourceTfeTeamAccessStateUpgradeV0(t *testing.T) {
-	client := testTfeClient(t, "ws-123")
+	client := testTfeClient(t, testClientOptions{defaultWorkspaceID: "ws-123"})
 	name := "a-workspace"
 	client.Workspaces.Create(nil, "hashicorp", tfe.WorkspaceCreateOptions{
 		Name: &name,

--- a/tfe/resource_tfe_variable_migrate_test.go
+++ b/tfe/resource_tfe_variable_migrate_test.go
@@ -21,7 +21,7 @@ func testResourceTfeVariableStateDataV1() map[string]interface{} {
 }
 
 func TestResourceTfeVariableStateUpgradeV0(t *testing.T) {
-	client := testTfeClient(t, "ws-123")
+	client := testTfeClient(t, testClientOptions{defaultWorkspaceID: "ws-123"})
 	name := "a-workspace"
 
 	client.Workspaces.Create(nil, "hashicorp", tfe.WorkspaceCreateOptions{

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -355,9 +355,7 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		d.Set("global_remote_state", globalRemoteState)
-		if !globalRemoteState {
-			d.Set("remote_state_consumer_ids", remoteStateConsumerIDs)
-		}
+		d.Set("remote_state_consumer_ids", remoteStateConsumerIDs)
 	}
 
 	return nil

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -6,9 +6,14 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 )
 
+type testClientOptions struct {
+	defaultWorkspaceID           string
+	remoteStateConsumersResponse string
+}
+
 // testTfeClient creates a mock client that creates workspaces with their ID
 // set to workspaceID.
-func testTfeClient(t *testing.T, workspaceID string) *tfe.Client {
+func testTfeClient(t *testing.T, options testClientOptions) *tfe.Client {
 	config := &tfe.Config{
 		Token: "not-a-token",
 	}
@@ -18,7 +23,7 @@ func testTfeClient(t *testing.T, workspaceID string) *tfe.Client {
 		t.Fatalf("error creating tfe client: %v", err)
 	}
 
-	client.Workspaces = newMockWorkspaces(workspaceID)
+	client.Workspaces = newMockWorkspaces(options)
 
 	return client
 }

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this data source to get information about a workspace.
 
+~> **NOTE:** Using `global_remote_state` or `remote_state_consumer_ids` requires using the provider with Terraform Cloud or an instance of Terraform Enterprise at least as recent as v202104-1.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a workspace resource.
 
+~> **NOTE:** Using `global_remote_state` or `remote_state_consumer_ids` requires using the provider with Terraform Cloud or an instance of Terraform Enterprise at least as recent as v202104-1.
+
 ## Example Usage
 
 Basic usage:


### PR DESCRIPTION
## Description

In v0.25.0, a regression was introduced when adding the new remote state consumers feature. Unlike other relationships in the provider - which are serialized in the same original resource document - remote state consumers on a workspace only exist at a separate endpoint which must be read. When the endpoint can't be read in the case of a preexisting Terraform Enterprise installation without the feature, it causes a failure when doing anything with the tfe_workspace resource.

An ideal scenario would be for a version check to determine whether a call should be made - but the current tooling here is minimal. Instead, we apply the following heuristic to make it backwards compatible for TFE:

If a call to the remote state consumers endpoint fails and is a 404 Not Found, assume that the only plausible reason for it is an old TFE installation: ignore it entirely and set the computed global_remote_state attribute to an implicit 'true' value (which indicates the old behavior which is not configurable until you upgrade your Terraform Enterprise installation). This is reasonable because having reached that point, the primary call to read the workspace succeeded, meaning you are authorized to the workspace and the likelihood of the remote state consumers call failing from a Not Found error for any other reason is exceedingly small.

Note this proposes a change from what was indicated in de8f3fa (requiring TFE v20210401 to use >=0.25.x of this provider), instead making the change backwards compatible as a bugfix.

## Testing plan

Do all of the following with any released Terraform Enterprise version:

1. **Apply** the following configuration using 0.24.0 of the provider. This are just pretest conditions; you're creating a workspace that simulates an existing workspace in an older TFE before 'upgrading' to the proposed changes.

```
provider "tfe" {
  hostname = "your.tfe.host"
  token = var.provider_token
}

variable "provider_token" {
  type = string
}

resource "tfe_workspace" "preexisting_workspace" {
    name                  = "workspace-from-older-tfe"
    organization          = "your-org"
}
```

2. Now, build this branch and do an override to use it.
3. Change the configuration like this:

```
provider "tfe" {
  hostname = "your.tfe.host"
  token = var.provider_token
}

variable "provider_token" {
  type = string
}

resource "tfe_workspace" "preexisting_workspace" {
    name                  = "workspace-from-older-tfe"
    organization          = "your-org"
}

resource "tfe_workspace" "new_workspace" {
    name                  = "new-workspace-from-older-tfe"
    organization          = "your-org"
}
```

4. **Start an apply.** In the plan, the only changes should be the new workspace you added (no change to the existing workspace).
5. In addition, the new workspace plan should include `global_remote_state = (known after apply)`.
6. **Apply it.** Running `terraform plan` after that should result in a happy empty plan.
7. **Check your state** - `global_remote_state` for both the workspaces should be `true`.
8. Add `global_remote_state = true` to one of the workspaces. **Plan it.** Should be an empty, no-op plan.
9. Now change `global_remote_state = false`. **Apply it.** This will succeed, but be ignored - a plan afterward should again try to suggest to change it to true. This is expected behavior. You cannot change the behavior of this (faux) attribute in TFE < v20210401.

Before continuing, "upgrade" your Terraform Enterprise installation to the v202104-1 release. (For external contributors: Note that as of this writing, this Terraform Enterprise version has not yet been released).

10. **Do a `terraform plan`.** This should result in an empty, happy plan.
11. Use the remote state consumers features as normal and indicated in the documentation. Should work!
