### PR TITLE
Add description argument to tfe_workspace

### DIFF
--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the workspace.
 * `organization` - (Required) Name of the organization.
+* `description` - (Optional) A description for the workspace.
 * `agent_pool_id` - (Optional) The ID of an agent pool to assign to the workspace. Requires `execution_mode`
   to be set to `agent`. This value _must not_ be provided if `execution_mode` is set to any other value or if `operations` is
   provided.


### PR DESCRIPTION
## Description

The argument is [supported](https://github.com/hashicorp/terraform-provider-tfe/blob/1a85ccb03625b26e7711015ecbb39519b4766d03/tfe/resource_tfe_workspace.go#L381) but not documented.

## Testing plan

N/A

## External links

- [Existing support for the argument in the code](https://github.com/hashicorp/terraform-provider-tfe/blob/1a85ccb03625b26e7711015ecbb39519b4766d03/tfe/resource_tfe_workspace.go#L381)
- [API documentation](https://www.terraform.io/docs/cloud/api/workspaces.html#request-body)

## Output from acceptance tests

N/A