### PR TITLE
add ability to skip tests for TFE

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -44,6 +44,7 @@ these values with the environment variables specified below:
 1. `GITHUB_WORKSPACE_IDENTIFIER` - GitHub workspace repository identifier in the format `username/repository`. Required for running workspace tests.
 1. `GITHUB_WORKSPACE_BRANCH`: A GitHub branch for the repository specified by `GITHUB_WORKSPACE_IDENTIFIER`. Required for running workspace tests.
 1. `SKIP_PAID` - Some tests depend on paid only features. By setting `SKIP_PAID=1`, you will skip tests that access paid features.
+1. `ENABLE_TFE` - Some tests cover features available only in Terraform Cloud. To skip these tests when running against a Terraform Enterprise instance, set `ENABLE_TFE=1`.
 
 You can set your environment variables up however you prefer. The following are instructions for setting up environment variables using [envchain](https://github.com/sorah/envchain).
    1. Make sure you have envchain installed. [Instructions for this can be found in the envchain README](https://github.com/sorah/envchain#installation).

--- a/tfe/data_source_agent_pool_test.go
+++ b/tfe/data_source_agent_pool_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccTFEAgentPoolDataSource_basic(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfEnterprise(t)
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 

--- a/tfe/data_source_ip_ranges_test.go
+++ b/tfe/data_source_ip_ranges_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccTFEIPRangesDataSource_basic(t *testing.T) {
+	skipIfEnterprise(t)
 	ipRegex := regexp.MustCompile(`^([\d]{1,3}\.){3}[\d]{1,3}/[\d]{1,3}$`)
 
 	resource.Test(t, resource.TestCase{

--- a/tfe/resource_tfe_agent_pool_test.go
+++ b/tfe/resource_tfe_agent_pool_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccTFEAgentPool_basic(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfEnterprise(t)
 
 	agentPool := &tfe.AgentPool{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -38,6 +39,7 @@ func TestAccTFEAgentPool_basic(t *testing.T) {
 
 func TestAccTFEAgentPool_update(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfEnterprise(t)
 
 	agentPool := &tfe.AgentPool{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -74,6 +76,7 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 
 func TestAccTFEAgentPool_import(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfEnterprise(t)
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 

--- a/tfe/resource_tfe_agent_token_test.go
+++ b/tfe/resource_tfe_agent_token_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccTFEAgentToken_basic(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfEnterprise(t)
 
 	agentToken := &tfe.AgentToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()

--- a/tfe/resource_tfe_team_member_test.go
+++ b/tfe/resource_tfe_team_member_test.go
@@ -78,6 +78,9 @@ func TestUnpackTeamMemberID(t *testing.T) {
 
 }
 
+// Thanks to a quirk of our CI environment, this test assumes that
+// the token used to run the tests (aka the TFE_TOKEN environment variable)
+// belongs to a user with the username "admin" and will fail otherwise.
 func TestAccTFETeamMember_basic(t *testing.T) {
 	user := &tfe.User{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -101,6 +104,9 @@ func TestAccTFETeamMember_basic(t *testing.T) {
 	})
 }
 
+// Thanks to a quirk of our CI environment, this test assumes that
+// the token used to run the tests (aka the TFE_TOKEN environment variable)
+// belongs to a user with the username "admin" and will fail otherwise.
 func TestAccTFETeamMember_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -584,6 +584,7 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 
 func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfEnterprise(t)
 
 	workspace := &tfe.Workspace{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -37,3 +37,10 @@ func skipIfFreeOnly(t *testing.T) {
 		t.Skip("Skipping test that requires a paid feature. Remove 'SKIP_PAID=1' if you want to run this test")
 	}
 }
+
+func skipIfEnterprise(t *testing.T) {
+	skip := os.Getenv("ENABLE_TFE") == "1"
+	if skip {
+		t.Skip("Skipping test for a feature unavailable in Terraform Enterprise. Set 'ENABLE_TFE=0' to run.")
+	}
+}


### PR DESCRIPTION
## Description

When running tests against TFE to prep for a release, it's easy to miss genuine failures amid the flurry of tests that _always_ fail for TFE (because they're testing Terraform-Cloud-only features).

This adds a `ENABLE_TFE` environment variable (to echo the go-tfe env var) that, when set to 1, will skip tests known to fail in TFE.

## Testing plan

1. Run the tests against the most recent TFE release and confirm that they pass.
