### PR TITLE
[DOCS] Update description of vcs_repo argument for workspace resource

### DIFF
--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -101,7 +101,7 @@ The `vcs_repo` block supports:
 
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization and repository
-  in your VCS provider.
+  in your VCS provider. The format for Azure DevOps is <organization>/<project>/_git/<repository>.
 * `branch` - (Optional) The repository branch that Terraform will execute from.
   Default to `master`.
 * `ingress_submodules` - (Optional) Whether submodules should be fetched when


### PR DESCRIPTION
Update description of vcs_repo argument for workspace resource to make it clearer when using Azure DevOps repos.