### PR TITLE
Add Admin Organizations to data source organizations

### DIFF
--- a/tfe/data_source_organizations.go
+++ b/tfe/data_source_organizations.go
@@ -26,7 +26,8 @@ func dataSourceTFEOrganizations() *schema.Resource {
 
 			"admin": {
 				Type:     schema.TypeBool,
-				Optional: false,
+				Default:  false,
+				Optional: true,
 			},
 		},
 	}

--- a/tfe/data_source_organizations.go
+++ b/tfe/data_source_organizations.go
@@ -26,7 +26,7 @@ func dataSourceTFEOrganizations() *schema.Resource {
 
 			"admin": {
 				Type:     schema.TypeBool,
-				Computed: true,
+				Optional: true,
 			},
 		},
 	}

--- a/tfe/data_source_organizations.go
+++ b/tfe/data_source_organizations.go
@@ -94,7 +94,11 @@ func orgsPopulateFields(client *tfe.Client) ([]string, map[string]string, error)
 	names := []string{}
 	ids := map[string]string{}
 	log.Printf("[DEBUG] Listing all organizations (non-admin)")
-	options := tfe.OrganizationListOptions{}
+	options := tfe.OrganizationListOptions{
+		ListOptions: tfe.ListOptions{
+			PageSize: 100,
+		},
+	}
 	for {
 		orgList, err := client.Organizations.List(ctx, options)
 		if err != nil {

--- a/tfe/data_source_organizations.go
+++ b/tfe/data_source_organizations.go
@@ -33,7 +33,7 @@ func dataSourceTFEOrganizationList(d *schema.ResourceData, meta interface{}) err
 	names := []string{}
 	ids := map[string]string{}
 
-	adminOrgs, err := getAdminOrgs(tfeClient)
+	adminOrgs, err := listAdminOrgs(tfeClient)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func dataSourceTFEOrganizationList(d *schema.ResourceData, meta interface{}) err
 			names = append(names, org.Name)
 		}
 	} else {
-		orgs, err := getOrgs(tfeClient)
+		orgs, err := listOrgs(tfeClient)
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ func dataSourceTFEOrganizationList(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func getAdminOrgs(client *tfe.Client) (*tfe.AdminOrganizationList, error) {
+func listAdminOrgs(client *tfe.Client) (*tfe.AdminOrganizationList, error) {
 	log.Printf("[DEBUG] Listing all organizations (admin)")
 	orgs, err := client.Admin.Organizations.List(ctx, tfe.AdminOrganizationListOptions{})
 	if err != nil {
@@ -75,7 +75,7 @@ func getAdminOrgs(client *tfe.Client) (*tfe.AdminOrganizationList, error) {
 	return orgs, nil
 }
 
-func getOrgs(client *tfe.Client) (*tfe.OrganizationList, error) {
+func listOrgs(client *tfe.Client) (*tfe.OrganizationList, error) {
 	log.Printf("[DEBUG] Listing all organizations (non-admin)")
 	orgs, err := client.Organizations.List(ctx, tfe.OrganizationListOptions{})
 	if err != nil {

--- a/tfe/data_source_organizations.go
+++ b/tfe/data_source_organizations.go
@@ -62,7 +62,11 @@ func adminOrgsPopulateFields(client *tfe.Client, d *schema.ResourceData) ([]stri
 	names := []string{}
 	ids := map[string]string{}
 	log.Printf("[DEBUG] Listing all organizations (admin)")
-	options := tfe.AdminOrganizationListOptions{}
+	options := tfe.AdminOrganizationListOptions{
+		ListOptions: tfe.ListOptions{
+			PageSize: 100,
+		},
+	}
 	for {
 		orgList, err := client.Admin.Organizations.List(ctx, options)
 		if err != nil {

--- a/tfe/data_source_organizations.go
+++ b/tfe/data_source_organizations.go
@@ -26,7 +26,7 @@ func dataSourceTFEOrganizations() *schema.Resource {
 
 			"admin": {
 				Type:     schema.TypeBool,
-				Optional: true,
+				Optional: false,
 			},
 		},
 	}

--- a/website/docs/d/organizations.html.markdown
+++ b/website/docs/d/organizations.html.markdown
@@ -27,3 +27,8 @@ The following attributes are exported:
 
 * `names` - A list of names of every organization.
 * `ids` - A map of organization names and their IDs.
+* `admin` - A boolean field that determines  the list of organizations that should
+  be retrieved. If it is true, then the [Admin Organizations
+endpoint](https://www.terraform.io/docs/cloud/api/admin/organizations.html#list-all-organizations)
+  will be used, otherwise if it is false or not included, then the [Organizations
+endpoint](https://www.terraform.io/docs/cloud/api/organizations.html#list-organizations) will be used.

--- a/website/docs/d/organizations.html.markdown
+++ b/website/docs/d/organizations.html.markdown
@@ -19,7 +19,12 @@ data "tfe_organizations" "foo" {
 
 ## Argument Reference
 
-No arguments are required. This retrieves the names and IDs of all the organizations readable by the provided token.
+The following argument(s) are supported:
+
+* `admin` - This field is for Terraform Enterprise only. It is a boolean field that determines
+  the list of organizations that should be retrieved. If it is true, then it will retrieve all
+  the organizations for the entire installation. If it is false, then it will retrieve the
+  organizations available as per permissions of the API Token.
 
 ## Attributes Reference
 
@@ -27,8 +32,3 @@ The following attributes are exported:
 
 * `names` - A list of names of every organization.
 * `ids` - A map of organization names and their IDs.
-* `admin` - A boolean field that determines  the list of organizations that should
-  be retrieved. If it is true, then the [Admin Organizations
-endpoint](https://www.terraform.io/docs/cloud/api/admin/organizations.html#list-all-organizations)
-  will be used, otherwise if it is false or not included, then the [Organizations
-endpoint](https://www.terraform.io/docs/cloud/api/organizations.html#list-organizations) will be used.


### PR DESCRIPTION
## Description

In #320, two a data source for listing all organizations was added. That data source returns the organizations that the user (token) has access to. 

This PR augments that data source. We add a boolean field `admin` that determines if we should retrieve the organizations from using the [Admin Organizations endpoint](https://www.terraform.io/docs/cloud/api/admin/organizations.html#list-all-organizations) or the [Organizationsendpoint](https://www.terraform.io/docs/cloud/api/organizations.html#list-organizations) will be used.

Added docs.

## Testing plan

This can only be properly tested with access to Site Admin on your Terraform Enterprise instance. 

The testing plan is as follows:

Create a terraform config using the `tfe` provider, and add this bit:
```
data "tfe_organizations" "orgs" {
  admin = true 
}

output "many_orgs" {
  value = data.tfe_organizations.orgs
}
```

1. Using your API token (assuming you have Site Admin access), add  `admin = true` to the data source in the config, run `terraform apply` and you will see the output of all the organizations.
2. Create a new organization, and create an Organization token from this new organization.
3. Remove the `admin=true` from the data source, and run `terraform apply` using this organization token.
4. Confirm that you only see one organization, and not all of the organizations as in step 1.


## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/320)

Closes #281
Closes #272

## Followup

We will add the ability to query specific organizations as a follow up to this task.