### PR TITLE
Issue/PR templates adjustments, CoC

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+HashiCorp Community Guidelines apply to you when interacting with the community here on GitHub and contributing code.
+
+Please read the full text at https://www.hashicorp.com/community-guidelines

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,73 @@
+---
+name: Bug report
+about: Let us know about an unexpected error, a crash, or an incorrect behavior.
+labels: bug
+
+---
+
+<!--
+Hi there,
+
+Thank you for opening an issue! Please note that we try to keep the this issue tracker reserved for
+bug reports and feature requests related to the Terraform Cloud/Enterprise provider. If you know
+your issue relates to the Terraform Cloud/Enterprise platform itself, please contact
+tf-cloud@hashicorp.support. For general usage questions, please post to our community forum:
+https://discuss.hashicorp.com.
+-->
+
+#### Terraform Cloud/Enterprise version
+
+<!---
+Are you using Terraform Cloud or Terraform Enterprise? If Terraform Enterprise, please include the version
+Example: Terraform Enterprise v202104-1
+-->
+
+
+#### Terraform version
+<!---
+If you are using Terraform CLI, run `terraform version` to show the version.
+
+If you are using Terraform Cloud or Terraform Enterprise, see the Terraform version being used by a
+workspace in the workspace's Overview tab.
+
+Paste the result between the ``` marks below.
+-->
+
+```plaintext
+...
+```
+
+#### Terraform Configuration Files
+<!--
+Paste the relevant parts of your Terraform configuration between the ``` marks below.
+-->
+
+```terraform
+...
+```
+
+#### Debug Output
+<!--
+Full debug output can be obtained by running Terraform with the environment variable `TF_LOG=trace`. Please create a GitHub Gist containing the debug output. Please do _not_ paste the debug output in the issue, since debug output is long.
+
+Debug output may contain sensitive information. Please review it before posting publicly, and if you are concerned feel free to encrypt the files using the HashiCorp security public key.
+-->
+
+```plaintext
+...
+```
+
+#### Expected Behavior
+<!--
+What should have happened?
+-->
+
+#### Actual Behavior
+<!--
+What actually happened?
+-->
+
+#### Additional Context
+<!--
+Are there anything atypical about your situation that we should know? For example: is Terraform running in a wrapper script or in a CI system? Are you passing any unusual command line options or environment variables to opt-in to non-default behavior?
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Terraform Cloud/Enterprise Troubleshooting and Feature Requests
+    url: https://support.hashicorp.com/hc/en-us/requests/new
+    about: For issues and feature requests concerning the Terraform Cloud/Enterprise platform itself, please submit a HashiCorp support request or email tf-cloud@hashicorp.support
+  - name: Terraform Language or Workflow Questions
+    url: https://discuss.hashicorp.com
+    about: Please ask Terraform language or workflow related questions through the HashiCorp Discuss forum

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,44 @@
+---
+name: Feature request
+about: Suggest a new feature or other enhancement.
+labels: feature-request
+
+---
+
+<!--
+Hi there,
+
+Thank you for opening a request! Please note that we try to keep the this issue tracker reserved for
+bug reports and feature requests related to the Terraform Cloud/Enterprise provider. If you know
+your request relates to the Terraform Cloud/Enterprise platform itself, please contact
+tf-cloud@hashicorp.support. For general usage questions, please post to our community forum:
+https://discuss.hashicorp.com.
+-->
+
+
+#### Use-cases
+<!---
+In order to properly evaluate a feature request, it is necessary to understand the use-cases for it.
+
+Please describe below the _end goal_ you are trying to achieve that has led you to request this feature.
+
+Please keep this section focused on the problem and not on the suggested solution. We'll get to that in a moment, below!
+-->
+
+#### Attempted Solutions
+<!---
+If you've already tried to solve the problem with existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
+
+Ideally, this would include real configuration snippets that you tried, real Terraform command lines you ran, and what results you got in each case.
+
+Please remove any sensitive information such as passwords before sharing configuration snippets and command lines.
+-->
+
+#### Proposal
+<!---
+If you have an idea for a way to address the problem via a change to this provider, please describe it below.
+
+In this section, it's helpful to include specific examples of how what you are suggesting might look in configuration files, or on the command line, since that allows us to understand the full picture of what you are proposing.
+
+If you don't know what you'd propose or are unsure of some details, don't worry! When we evaluate the feature request we'll be happy to help.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ contributor, your contribution(s) will first be reviewed before running them aga
 CI pipeline._
 
 ```
-$ go test -v ./... -run TestAccTFEWorkspace # runs all workspace tests
+$ TESTARGS="-run TestAccTFEWorkspace" make testacc 
 
 ...
 ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,13 +2,6 @@
 
 _Describe why you're making this change._
 
-## BREAKING CHANGE
-
-_Delete this section if your change is not introducing a breaking change to the provider or a breaking change from the TFE API_
-
-- [ ] New TFE API version created
-- [ ] Provider restricted to TFE API version
-
 ## Testing plan
 
 1.  _Describe how to replicate_
@@ -26,10 +19,12 @@ _Include any links here that might be helpful for people reviewing your PR. If t
 
 ## Output from acceptance tests
 
-_Please run the full suite of acceptance tests locally and include the output here._
+_Please run applicable acceptance tests locally and include the output here. If you are an external
+contributor, your contribution(s) will first be reviewed before running them against the project's
+CI pipeline._
 
 ```
-$ make testacc
+$ go test -v ./... -run TestAccTFEWorkspace # runs all workspace tests
 
 ...
 ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,9 +19,9 @@ _Include any links here that might be helpful for people reviewing your PR. If t
 
 ## Output from acceptance tests
 
-_Please run applicable acceptance tests locally and include the output here. If you are an external
-contributor, your contribution(s) will first be reviewed before running them against the project's
-CI pipeline._
+_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._
+
+_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._
 
 ```
 $ TESTARGS="-run TestAccTFEWorkspace" make testacc 


### PR DESCRIPTION
## Description

Adds the usual HashiCorp Community Guidelines CoC + an overhaul of issue templates. The issue templates are [similar to Terraform CLI's](https://github.com/hashicorp/terraform/tree/main/.github/ISSUE_TEMPLATE).