### PR TITLE
tfe_workspace: add structured_run_output_enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.8 // indirect
 	github.com/hashicorp/go-slug v0.7.0 // indirect
-	github.com/hashicorp/go-tfe v0.15.0
+	github.com/hashicorp/go-tfe v0.17.0
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoD
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-slug v0.7.0 h1:8HIi6oreWPtnhpYd8lIGQBgp4rXzDWQTOhfILZm+nok=
 github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
-github.com/hashicorp/go-tfe v0.15.0 h1:vdnz1NjOhvmap+cj8iPsL8SbS4iFFVuNYFkGpF5SdoA=
-github.com/hashicorp/go-tfe v0.15.0/go.mod h1:c8glB5p6XzocEWLNkuy5RxcjqN5X2PpY6NF3f2W6nIo=
+github.com/hashicorp/go-tfe v0.17.0 h1:COB2c5MeQU/NjR8EQFfUrcF7b3ZX7kogc59A/eu8zX0=
+github.com/hashicorp/go-tfe v0.17.0/go.mod h1:c8glB5p6XzocEWLNkuy5RxcjqN5X2PpY6NF3f2W6nIo=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/tfe/client_mock.go
+++ b/tfe/client_mock.go
@@ -53,6 +53,10 @@ func (m *mockWorkspaces) Read(ctx context.Context, organization string, workspac
 	return w, nil
 }
 
+func (m *mockWorkspaces) ReadByIDWithOptions(ctx context.Context, workspaceID string, options *tfe.WorkspaceReadOptions) (*tfe.Workspace, error) {
+	panic("not implemented")
+}
+
 func (m *mockWorkspaces) Readme(ctx context.Context, workspaceID string) (io.Reader, error) {
 	panic("not implemented")
 }

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -59,8 +59,28 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Computed: true,
 			},
 
+			"policy_check_failures": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
 			"queue_all_runs": {
 				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"resource_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"run_failures": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"runs_count": {
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
@@ -71,6 +91,11 @@ func dataSourceTFEWorkspace() *schema.Resource {
 
 			"ssh_key_id": {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"structured_run_output_enabled": {
+				Type:     schema.TypeBool,
 				Computed: true,
 			},
 
@@ -117,26 +142,6 @@ func dataSourceTFEWorkspace() *schema.Resource {
 					},
 				},
 			},
-
-			"resource_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
-			"policy_check_failures": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
-			"run_failures": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
-			"runs_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -170,15 +175,16 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("global_remote_state", globalRemoteState)
 	d.Set("remote_state_consumer_ids", remoteStateConsumerIDs)
 	d.Set("operations", workspace.Operations)
+	d.Set("policy_check_failures", workspace.PolicyCheckFailures)
 	d.Set("queue_all_runs", workspace.QueueAllRuns)
+	d.Set("resource_count", workspace.ResourceCount)
+	d.Set("run_failures", workspace.RunFailures)
+	d.Set("runs_count", workspace.RunsCount)
 	d.Set("speculative_enabled", workspace.SpeculativeEnabled)
+	d.Set("structured_run_output_enabled", workspace.StructuredRunOutputEnabled)
 	d.Set("terraform_version", workspace.TerraformVersion)
 	d.Set("trigger_prefixes", workspace.TriggerPrefixes)
 	d.Set("working_directory", workspace.WorkingDirectory)
-	d.Set("resource_count", workspace.ResourceCount)
-	d.Set("policy_check_failures", workspace.PolicyCheckFailures)
-	d.Set("run_failures", workspace.RunFailures)
-	d.Set("runs_count", workspace.RunsCount)
 
 	if workspace.SSHKey != nil {
 		d.Set("ssh_key_id", workspace.SSHKey.ID)

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -34,9 +34,19 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "file_triggers_enabled", "true"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "policy_check_failures", "0"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "queue_all_runs", "false"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "resource_count", "0"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "run_failures", "0"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "runs_count", "0"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "speculative_enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "structured_run_output_enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "terraform_version", "0.11.1"),
 					resource.TestCheckResourceAttr(
@@ -47,11 +57,6 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 						"data.tfe_workspace.foobar", "trigger_prefixes.1", "/shared"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "working_directory", "terraform/test"),
-
-					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "resource_count", "0"),
-					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "policy_check_failures", "0"),
-					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "run_failures", "0"),
-					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "runs_count", "0"),
 				),
 			},
 		},

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -139,6 +139,12 @@ func resourceTFEWorkspace() *schema.Resource {
 				Default:  "",
 			},
 
+			"structured_run_output_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"terraform_version": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -200,14 +206,15 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 
 	// Create a new options struct.
 	options := tfe.WorkspaceCreateOptions{
-		Name:                tfe.String(name),
-		AllowDestroyPlan:    tfe.Bool(d.Get("allow_destroy_plan").(bool)),
-		AutoApply:           tfe.Bool(d.Get("auto_apply").(bool)),
-		Description:         tfe.String(d.Get("description").(string)),
-		FileTriggersEnabled: tfe.Bool(d.Get("file_triggers_enabled").(bool)),
-		QueueAllRuns:        tfe.Bool(d.Get("queue_all_runs").(bool)),
-		SpeculativeEnabled:  tfe.Bool(d.Get("speculative_enabled").(bool)),
-		WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
+		Name:                       tfe.String(name),
+		AllowDestroyPlan:           tfe.Bool(d.Get("allow_destroy_plan").(bool)),
+		AutoApply:                  tfe.Bool(d.Get("auto_apply").(bool)),
+		Description:                tfe.String(d.Get("description").(string)),
+		FileTriggersEnabled:        tfe.Bool(d.Get("file_triggers_enabled").(bool)),
+		QueueAllRuns:               tfe.Bool(d.Get("queue_all_runs").(bool)),
+		SpeculativeEnabled:         tfe.Bool(d.Get("speculative_enabled").(bool)),
+		StructuredRunOutputEnabled: tfe.Bool(d.Get("structured_run_output_enabled").(bool)),
+		WorkingDirectory:           tfe.String(d.Get("working_directory").(string)),
 	}
 
 	// Send global_remote_state if it's set; otherwise, let it be computed.
@@ -315,6 +322,7 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("execution_mode", workspace.ExecutionMode)
 	d.Set("queue_all_runs", workspace.QueueAllRuns)
 	d.Set("speculative_enabled", workspace.SpeculativeEnabled)
+	d.Set("structured_run_output_enabled", workspace.StructuredRunOutputEnabled)
 	d.Set("terraform_version", workspace.TerraformVersion)
 	d.Set("trigger_prefixes", workspace.TriggerPrefixes)
 	d.Set("working_directory", workspace.WorkingDirectory)
@@ -371,19 +379,20 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		d.HasChange("allow_destroy_plan") || d.HasChange("speculative_enabled") ||
 		d.HasChange("operations") || d.HasChange("execution_mode") ||
 		d.HasChange("description") || d.HasChange("agent_pool_id") ||
-		d.HasChange("global_remote_state") {
+		d.HasChange("global_remote_state") || d.HasChange("structured_run_output_enabled") {
 
 		// Create a new options struct.
 		options := tfe.WorkspaceUpdateOptions{
-			Name:                tfe.String(d.Get("name").(string)),
-			AllowDestroyPlan:    tfe.Bool(d.Get("allow_destroy_plan").(bool)),
-			AutoApply:           tfe.Bool(d.Get("auto_apply").(bool)),
-			Description:         tfe.String(d.Get("description").(string)),
-			FileTriggersEnabled: tfe.Bool(d.Get("file_triggers_enabled").(bool)),
-			GlobalRemoteState:   tfe.Bool(d.Get("global_remote_state").(bool)),
-			QueueAllRuns:        tfe.Bool(d.Get("queue_all_runs").(bool)),
-			SpeculativeEnabled:  tfe.Bool(d.Get("speculative_enabled").(bool)),
-			WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
+			Name:                       tfe.String(d.Get("name").(string)),
+			AllowDestroyPlan:           tfe.Bool(d.Get("allow_destroy_plan").(bool)),
+			AutoApply:                  tfe.Bool(d.Get("auto_apply").(bool)),
+			Description:                tfe.String(d.Get("description").(string)),
+			FileTriggersEnabled:        tfe.Bool(d.Get("file_triggers_enabled").(bool)),
+			GlobalRemoteState:          tfe.Bool(d.Get("global_remote_state").(bool)),
+			QueueAllRuns:               tfe.Bool(d.Get("queue_all_runs").(bool)),
+			SpeculativeEnabled:         tfe.Bool(d.Get("speculative_enabled").(bool)),
+			StructuredRunOutputEnabled: tfe.Bool(d.Get("structured_run_output_enabled").(bool)),
+			WorkingDirectory:           tfe.String(d.Get("working_directory").(string)),
 		}
 
 		if d.HasChange("agent_pool_id") {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -47,6 +47,8 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "speculative_enabled", "true"),
 					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "structured_run_output_enabled", "true"),
+					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "working_directory", ""),
@@ -386,6 +388,38 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 						"tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "speculative_enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspace_updateStructuredRunOutput(t *testing.T) {
+	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspace_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "structured_run_output_enabled", "true"),
+				),
+			},
+
+			{
+				Config: testAccTFEWorkspace_updateStructuredRunOutput(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "structured_run_output_enabled", "false"),
 				),
 			},
 		},
@@ -1562,5 +1596,20 @@ resource "tfe_workspace" "foobar_one" {
 resource "tfe_workspace" "foobar_two" {
   name               = "workspace-test-2"
   organization       = tfe_organization.foobar.id
+}`, rInt)
+}
+
+func testAccTFEWorkspace_updateStructuredRunOutput(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name                          = "workspace-test"
+  organization                  = tfe_organization.foobar.id
+  auto_apply                    = true
+  structured_run_output_enabled = false
 }`, rInt)
 }

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -394,7 +394,7 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 	})
 }
 
-func TestAccTFEWorkspace_updateStructuredRunOutput(t *testing.T) {
+func TestAccTFEWorkspace_structuredRunOutputDisabled(t *testing.T) {
 	workspace := &tfe.Workspace{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -39,19 +39,20 @@ In addition to all arguments above, the following attributes are exported:
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument).
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` is set to `true`.
 * `operations` - Indicates whether the workspace is using remote execution mode. Set to `false` to switch execution mode to local. `true` by default.
+* `policy_check_failures` - The number of policy check failures from the latest run.
 * `queue_all_runs` - Indicates whether the workspace will automatically perform runs
   in response to webhooks immediately after its creation. If `false`, an initial run must
   be manually queued to enable future automatic runs.
+* `resource_count` - The number of resources managed by the workspace.
+* `run_failures` - The number of run failures on the workspace.
+* `runs_count` - The number of runs on the workspace.
 * `speculative_enabled` - Indicates whether this workspace allows speculative plans.
 * `ssh_key_id` - The ID of an SSH key assigned to the workspace.
+* `structured_run_output_enabled` - Indicated whether runs in this workspace use the enhanced output UI. 
 * `terraform_version` - The version of Terraform used for this workspace.
 * `trigger_prefixes` - List of repository-root-relative paths which describe all locations to be tracked for changes.
 * `vcs_repo` - Settings for the workspace's VCS repository.
 * `working_directory` - A relative path that Terraform will execute within.
-* `resource_count` - The number of resources managed by the workspace.
-* `policy_check_failures` - The number of policy check failures from the latest run.
-* `run_failures` - The number of run failures on the workspace.
-* `runs_count` - The number of runs on the workspace.
 
 
 The `vcs_repo` block contains:

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -48,7 +48,7 @@ In addition to all arguments above, the following attributes are exported:
 * `runs_count` - The number of runs on the workspace.
 * `speculative_enabled` - Indicates whether this workspace allows speculative plans.
 * `ssh_key_id` - The ID of an SSH key assigned to the workspace.
-* `structured_run_output_enabled` - Indicated whether runs in this workspace use the enhanced output UI. 
+* `structured_run_output_enabled` - Indicates whether runs in this workspace use the enhanced apply UI. 
 * `terraform_version` - The version of Terraform used for this workspace.
 * `trigger_prefixes` - List of repository-root-relative paths which describe all locations to be tracked for changes.
 * `vcs_repo` - Settings for the workspace's VCS repository.

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -86,6 +86,7 @@ The following arguments are supported:
   Enterprise instance from running plans on pull requests, which can improve
   security if the VCS repository is public or includes untrusted contributors.
   Defaults to `true`.
+* `structured_run_output_enabled` - (Optional) Whether this workspace should show output from Terraform runs using the enhanced UI when available. Setting this to `false` ensures that all runs in this workspace will display their output as text logs. Defaults to `true`.
 * `ssh_key_id` - (Optional) The ID of an SSH key to assign to the workspace.
 * `terraform_version` - (Optional) The version of Terraform to use for this workspace. Defaults to 
   the latest available version.

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -62,35 +62,43 @@ The following arguments are supported:
 * `allow_destroy_plan` - (Optional) Whether destroy plans can be queued on the workspace.
 * `auto_apply` - (Optional) Whether to automatically apply changes when a
   Terraform plan is successful. Defaults to `false`.
-* `execution_mode` - (Optional) Which [execution mode](https://www.terraform.io/docs/cloud/workspaces/settings.html#execution-mode) to use. Using Terraform Cloud, valid
-  values are `remote`, `local` or `agent`. Using Terraform Enterprise, only `remote` and `local` execution modes are
-  valid.  When set to `local`, the workspace will be used for state storage only. Defaults to `remote`. This value _must
-  not_ be provided if `operations` is provided.
-* `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files 
-  in a VCS push. If enabled, the working directory and trigger prefixes describe a set of 
-  paths which must contain changes for a VCS push to trigger a run. If disabled, any push will 
-  trigger a run. Defaults to `true`.
+* `execution_mode` - (Optional) Which [execution mode](https://www.terraform.io/docs/cloud/workspaces/settings.html#execution-mode)
+  to use. Using Terraform Cloud, valid values are `remote`, `local` or`agent`. 
+  Defaults to `remote`. Using Terraform Enterprise, only `remote`and `local` 
+  execution modes are valid.  When set to `local`, the workspace will be used 
+  for state storage only. This value _must not_ be provided if `operations` 
+  is provided.
+* `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files
+  in a VCS push. Defaults to `true`. If enabled, the working directory and 
+  trigger prefixes describe a set of paths which must contain changes for a 
+  VCS push to trigger a run. If disabled, any push will trigger a run. 
 * `global_remote_state` - (Optional) Whether the workspace allows all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (`remote_state_consumer_ids`).
 * `remote_state_consumer_ids` - (Optional) The set of workspace IDs set as explicit remote state consumers for the given workspace.
-* `operations` - **Deprecated** Whether to use remote execution mode. When set to `false`, the workspace will 
-  be used for state storage only. Defaults to `true`. This value _must not_ be provided if `execution_mode` is 
+* `operations` - **Deprecated** Whether to use remote execution mode. 
+  Defaults to `true`. When set to `false`, the workspace will be used for 
+  state storage only. This value _must not_ be provided if `execution_mode` is
   provided.
-* `queue_all_runs` - (Optional) Whether the workspace should start automatically performing
-  runs immediately after its creation. When set to `false`, runs triggered by a webhook
-  (such as a commit in VCS) will not be queued until at least one run has been manually
-  queued. Defaults to `true`. **Note:** This default differs from the Terraform Cloud API default, which is `false`.
-  The provider uses `true` as any workspace provisioned with `false` would need to then have a run manually queued out-of-band
-  before accepting webhooks.
+* `queue_all_runs` - (Optional) Whether the workspace should start
+  automatically performing runs immediately after its creation. Defaults to
+  `true`. When set to `false`, runs triggered by a webhook (such as a commit
+  in VCS) will not be queued until at least one run has been manually queued.
+  **Note:** This default differs from the Terraform Cloud API default, which 
+  is `false`. The provider uses `true` as any workspace provisioned with 
+  `false` would need to then have a run manually queued out-of-band before 
+  accepting webhooks.
 * `speculative_enabled` - (Optional) Whether this workspace allows speculative
-  plans. Setting this to `false` prevents Terraform Cloud or the Terraform
-  Enterprise instance from running plans on pull requests, which can improve
-  security if the VCS repository is public or includes untrusted contributors.
-  Defaults to `true`.
-* `structured_run_output_enabled` - (Optional) Whether this workspace should show output from Terraform runs using the enhanced UI when available. Setting this to `false` ensures that all runs in this workspace will display their output as text logs. Defaults to `true`.
+  plans. Defaults to `true`. Setting this to `false` prevents Terraform Cloud
+  or the Terraform Enterprise instance from running plans on pull requests,
+  which can improve security if the VCS repository is public or includes
+  untrusted contributors.
+* `structured_run_output_enabled` - (Optional) Whether this workspace should
+  show output from Terraform runs using the enhanced UI when available.
+  Defaults to `true`. Setting this to `false` ensures that all runs in this
+  workspace will display their output as text logs.
 * `ssh_key_id` - (Optional) The ID of an SSH key to assign to the workspace.
-* `terraform_version` - (Optional) The version of Terraform to use for this workspace. Defaults to 
+* `terraform_version` - (Optional) The version of Terraform to use for this workspace. Defaults to
   the latest available version.
-* `trigger_prefixes` - (Optional) List of repository-root-relative paths which describe all locations 
+* `trigger_prefixes` - (Optional) List of repository-root-relative paths which describe all locations
   to be tracked for changes.
 * `working_directory` - (Optional) A relative path that Terraform will execute
   within.  Defaults to the root of your repository.


### PR DESCRIPTION
## Description

Add support for enabling the new redesigned apply UI for a workspace (`structured_run_output_enabled`). See #327 and https://github.com/hashicorp/go-tfe/pull/233.

## Testing plan

1. Ensure that toggling `structured_run_output_enabled` on a workspace changes the setting appropriately.

## External links

[blog post](https://www.hashicorp.com/blog/new-apply-user-interface-for-terraform-cloud)
