### PR TITLE
Outputs example doc typo

### DIFF
--- a/website/docs/d/outputs.html.markdown
+++ b/website/docs/d/outputs.html.markdown
@@ -27,7 +27,7 @@ data "tfe_outputs" "foo" {
   workspace = "my-workspace"
 }
 
-resource "random_vpc_resource" "vpc_id" {
+resource "random_id" "vpc_id" {
   keepers = {
     # Generate a new ID any time the value of 'bar' in workspace 'my-org/my-workspace' changes.
     bar = data.tfe_outputs.foo.values.bar


### PR DESCRIPTION
Oop! The last commit in #344 changed this resource type name to an example one, but the intention here was to use the real resource of [`random_id`](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id), a common one used. 