### PR TITLE
Fix make test and skipIFUnitTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,18 @@ jobs:
           name: go vet
           command: make vet
 
+      # This is added because `make test` is run as part of the release process
+      # Most of our tests are Acceptance tests, and therefore are skipped when
+      # part of this. But we want to catch future mistakes by ensuring this
+      # passes.
+      - run:
+          name: go test
+          command: make test
+
       - run:
           name: Run tests
           command: |
-              gotestsum --format short-verbose --junitfile \
+              TF_ACC=1 gotestsum --format short-verbose --junitfile \
               $TEST_RESULTS_DIR/tests.xml -- `go list ./... |grep -v 'vendor'` -v -timeout 30m
           no_output_timeout: 1800
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
+	go test -v $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 

--- a/tfe/data_source_outputs_test.go
+++ b/tfe/data_source_outputs_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestAccTFEOutputs(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfUnitTest(t)
 
 	client, err := getClientUsingEnv()
 	if err != nil {
@@ -58,6 +59,7 @@ func TestAccTFEOutputs(t *testing.T) {
 
 func TestAccTFEOutputs_emptyOutputs(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfUnitTest(t)
 
 	client, err := getClientUsingEnv()
 	if err != nil {

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -396,6 +396,7 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 
 func TestAccTFEPolicySet_versionedSlug(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfUnitTest(t)
 
 	policySet := &tfe.PolicySet{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -436,6 +437,7 @@ func TestAccTFEPolicySet_versionedSlug(t *testing.T) {
 
 func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
 	skipIfFreeOnly(t)
+	skipIfUnitTest(t)
 
 	policySet := &tfe.PolicySet{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -44,3 +44,19 @@ func skipIfEnterprise(t *testing.T) {
 		t.Skip("Skipping test for a feature unavailable in Terraform Enterprise. Set 'ENABLE_TFE=0' to run.")
 	}
 }
+
+func isAcceptanceTest() bool {
+	return os.Getenv("TF_ACC") == "1"
+}
+
+// Most tests rely on terraform-plugin-sdk/helper/resource.Test to run.  That test helper ensures
+// that TF_ACC=1 or else it skips. In some rare cases, however, tests do not use the SDK helper and
+// are acceptance tests.
+// This `skipIfUnitTest` is used when you are doing some extra setup work that may fail when `go
+// test` is run without additional environment variables for acceptance tests. By adding this at the
+// top of the test, it will skip the test if `TF_ACC=1` is not set.
+func skipIfUnitTest(t *testing.T) {
+	if !isAcceptanceTest() {
+		t.Skip("Skipping test because this test is an acceptance test, and is run as a unit test. Set 'TF_ACC=1' to run.")
+	}
+}


### PR DESCRIPTION
## Description

For all of our existing tests, we rely on the [terraform-plug-sdk/helpers](https://github.com/hashicorp/terraform-plugin-sdk/blob/fa81bfcad90ed4e2b688d0070390fd311a5449df/helper/resource/testing.go#L523) to test the provider. Any test that has this is skipped if `TF_ACC=1` is not set. 

These tests are run as `make testacc` which ensures that `TF_ACC` is set, and therefore the tests run using this make target. 

But in our release process, we run `make test`, which does not set `TF_ACC`. A previous PR introduced a few tests that had to rely on some environment variables set as part of acceptance set.

This PR introduces a `skipIfUnitTest` to ensure that these tests are not run unless it is an acceptance test. 

I also added a step in CI to run `make test` so we can catch these things before they happen as part of a release.

```
terraform-provider-tfe % make test
==> Checking that code complies with gofmt requirements...
go test -v $(go list ./... |grep -v 'vendor') || exit 1
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEAgentPoolDataSource_basic
    data_source_agent_pool_test.go:18: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccTFEAgentPoolDataSource_basic (0.00s)
=== RUN   TestAccTFEIPRangesDataSource_basic
    data_source_ip_ranges_test.go:15: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccTFEIPRangesDataSource_basic (0.00s)
=== RUN   TestAccTFEOAuthClientDataSource_basic
    data_source_oauth_client_test.go:14: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccTFEOAuthClientDataSource_basic (0.00s)
...
...
...
=== RUN   TestAccTFEWorkspace_createWithRemoteStateConsumers
    resource_tfe_workspace_test.go:798: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccTFEWorkspace_createWithRemoteStateConsumers (0.00s)
=== RUN   TestFetchWorkspaceExternalID
=== RUN   TestFetchWorkspaceExternalID/non_exisiting_organization
=== RUN   TestFetchWorkspaceExternalID/non_exisiting_workspace
=== RUN   TestFetchWorkspaceExternalID/found_workspace
--- PASS: TestFetchWorkspaceExternalID (1.98s)
    --- PASS: TestFetchWorkspaceExternalID/non_exisiting_organization (0.00s)
    --- PASS: TestFetchWorkspaceExternalID/non_exisiting_workspace (0.00s)
    --- PASS: TestFetchWorkspaceExternalID/found_workspace (0.00s)
=== RUN   TestFetchWorkspaceHumanID
=== RUN   TestFetchWorkspaceHumanID/found_workspace
=== RUN   TestFetchWorkspaceHumanID/non_exisiting_workspace
--- PASS: TestFetchWorkspaceHumanID (0.00s)
    --- PASS: TestFetchWorkspaceHumanID/found_workspace (0.00s)
    --- PASS: TestFetchWorkspaceHumanID/non_exisiting_workspace (0.00s)
=== RUN   TestPackWorkspaceID
--- PASS: TestPackWorkspaceID (0.00s)
=== RUN   TestUnpackWorkspaceID
--- PASS: TestUnpackWorkspaceID (0.00s)
=== RUN   TestReadWorkspaceStateConsumers
--- PASS: TestReadWorkspaceStateConsumers (6.75s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 9.931s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
echo $(go list ./... |grep -v 'vendor') | \
                xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 github.com/hashicorp/terraform-provider-tfe github.com/hashicorp/terraform-provider-tfe/tfe github.com/hashicorp/terraform-provider-tfe/version
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
ok      github.com/hashicorp/terraform-provider-tfe/tfe (cached)
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```