### PR TITLE
Fix 0.26.0 configuration regressions

### DIFF
--- a/tfe/plugin_provider_test.go
+++ b/tfe/plugin_provider_test.go
@@ -1,0 +1,95 @@
+package tfe
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestPluginProvider_providerMeta(t *testing.T) {
+	cases := map[string]struct {
+		hostname      string
+		token         string
+		sslSkipVerify bool
+		err           error
+	}{
+		"has none": {},
+		"has only hostname": {
+			hostname: "terraform.io",
+		},
+		"has only token": {
+			token: "secret",
+		},
+		"has only ssl_skip_verify": {
+			sslSkipVerify: true,
+		},
+		"has hostname and token": {
+			hostname: "terraform.io",
+			token:    "secret",
+		},
+		"has hostname and ssl_skip_verify": {
+			hostname:      "terraform.io",
+			sslSkipVerify: true,
+		},
+		"has token and ssl_skip_verify": {
+			token:         "secret",
+			sslSkipVerify: true,
+		},
+	}
+
+	for name, tc := range cases {
+		config, err := tfprotov5.NewDynamicValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"hostname":        tftypes.String,
+				"token":           tftypes.String,
+				"ssl_skip_verify": tftypes.Bool,
+			},
+		}, tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"hostname":        tftypes.String,
+				"token":           tftypes.String,
+				"ssl_skip_verify": tftypes.Bool,
+			},
+		}, map[string]tftypes.Value{
+			"hostname":        tftypes.NewValue(tftypes.String, tc.hostname),
+			"token":           tftypes.NewValue(tftypes.String, tc.token),
+			"ssl_skip_verify": tftypes.NewValue(tftypes.Bool, tc.sslSkipVerify),
+		}))
+
+		req := &tfprotov5.ConfigureProviderRequest{
+			Config: &config,
+		}
+
+		meta, err := retrieveProviderMeta(req)
+		if err != tc.err {
+			t.Fatalf("Test %s: should not be error", name)
+		}
+
+		if tc.hostname == "" && meta.hostname != "" {
+			t.Fatalf("Test %s: hostname was not set in config and meta hostname should be empty in this moment (in retrieveProviderMeta). It is parsed later in wihtin the `getClient` function", name)
+		}
+
+		if tc.hostname != "" && meta.hostname != tc.hostname {
+			t.Fatalf("Test %s: hostname was set in config and meta hostname %s  has not been set to what was given %s", name, meta.hostname, tc.hostname)
+		}
+
+		if tc.token == "" && meta.token != "" {
+			t.Fatalf("Test %s: token was not set in config and meta.token %s has been incorrectly set", name, meta.token)
+		}
+
+		if tc.token != "" && meta.token != tc.token {
+			t.Fatalf("Test %s: token was set in config and input token %s  does not have the same value in meta %s", name, tc.token, meta.token)
+		}
+
+		if tc.sslSkipVerify == false && meta.sslSkipVerify != defaultSSLSkipVerify {
+			t.Fatalf("Test %s: ssl_skip_verify was not set in config and has not been set to default", name)
+		}
+
+		if tc.sslSkipVerify != false {
+			if meta.sslSkipVerify != tc.sslSkipVerify {
+				t.Fatalf("Test %s: ssl_skip_verify was set in config but does not have the same value in meta %t", name, meta.sslSkipVerify)
+			}
+		}
+	}
+}

--- a/tfe/provider_test.go
+++ b/tfe/provider_test.go
@@ -42,14 +42,13 @@ func init() {
 }
 
 func getClientUsingEnv() (*tfe.Client, error) {
-	if os.Getenv("TFE_HOSTNAME") == "" && (os.Getenv("TFE_TOKEN") == "") {
-		return nil, fmt.Errorf("must provide environment variables TFE_HOSTNAME and TFE_TOKEN")
+	hostname := defaultHostname
+	if os.Getenv("TFE_HOSTNAME") != "" {
+		hostname = os.Getenv("TFE_HOSTNAME")
 	}
-	hostname := os.Getenv("TFE_HOSTNAME")
 	token := os.Getenv("TFE_TOKEN")
-	insecure := os.Getenv("TFE_INSECURE") != ""
 
-	client, err := getClient(hostname, token, insecure)
+	client, err := getClient(hostname, token, defaultSSLSkipVerify)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting client: %s", err)
 	}


### PR DESCRIPTION
## Description

Closes #353 

The 0.26.0 release introduced features with #344 that required muxing the existing provider built with [terraform-plugin-sdk](https://github.com/hashicorp/terraform-plugin-sdk) and another one built with a lower level provider package, [terraform-plugin-go](https://github.com/hashicorp/terraform-plugin-go). What this means is that there are two providers which must interpret the same configuration/settings, in one. 

The SDK schema [usually provides a default hostname value with DefaultFunc](https://github.com/hashicorp/terraform-provider-tfe/blob/7bb6b0f0b1717c5bcd722d14940ca6c93f0c8874/tfe/provider.go#L54), and unfortunately this behavior was not translated to an equivalent in new lower level provider now muxed in, causing a regression where unless a hostname is explicitly set in configuration or `TFE_HOSTNAME`, the provider configuration will error. 

As an aside, `ssl_skip_verify` was also not respected by the muxed plugin provider, and has also been corrected here.