### PR TITLE
Feature/add variables output to workspace data source

### DIFF
--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -61,6 +61,7 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 						"data.tfe_workspace.foobar", "trigger_prefixes.1", "/shared"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "working_directory", "terraform/test"),
+					resource.TestCheckOutput("foobar", "foo"),
 				),
 			},
 		},
@@ -89,8 +90,19 @@ resource "tfe_workspace" "foobar" {
   working_directory     = "terraform/test"
 }
 
+resource "tfe_variable" "foobar" {
+	workspace_id = tfe_workspace.foobar.id
+	category = "terraform"
+	key = "foo"
+	value = "bar"
+}
+
 data "tfe_workspace" "foobar" {
   name         = tfe_workspace.foobar.name
   organization = tfe_workspace.foobar.organization
+}
+
+output "foobar" {
+	value = data.tfe_workspace.foobar.variables[0]["name"]
 }`, rInt, rInt)
 }

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -70,6 +70,6 @@ The `vcs_repo` block contains:
 The `variables` block contains:
 
 * `name` - The variable Key name
-* `value` -  The variable value if the variable it's marked as sensitive it showos "\*\*\*"
+* `value` -  The variable value if the variable it's marked as sensitive it shows "\*\*\*"
 * `category` -  The category of the variable (terraform or environment)
 * `hcl` - If the variable is marked as HCL or not

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -48,11 +48,12 @@ In addition to all arguments above, the following attributes are exported:
 * `runs_count` - The number of runs on the workspace.
 * `speculative_enabled` - Indicates whether this workspace allows speculative plans.
 * `ssh_key_id` - The ID of an SSH key assigned to the workspace.
-* `structured_run_output_enabled` - Indicates whether runs in this workspace use the enhanced apply UI. 
+* `structured_run_output_enabled` - Indicates whether runs in this workspace use the enhanced apply UI.
 * `tag_names` - The names of tags added to this workspace.
 * `terraform_version` - The version of Terraform used for this workspace.
 * `trigger_prefixes` - List of repository-root-relative paths which describe all locations to be tracked for changes.
 * `vcs_repo` - Settings for the workspace's VCS repository.
+* `variables` - List containing variables configured on the workspace
 * `working_directory` - A relative path that Terraform will execute within.
 
 
@@ -65,3 +66,10 @@ The `vcs_repo` block contains:
 * `ingress_submodules` - Indicates whether submodules should be fetched when
   cloning the VCS repository.
 * `oauth_token_id` - OAuth token ID of the configured VCS connection.
+
+The `variables` block contains:
+
+* `name` - The variable Key name
+* `value` -  The variable value if the variable it's marked as sensitive it showos "\*\*\*"
+* `category` -  The category of the variable (terraform or environment)
+* `hcl` - If the variable is marked as HCL or not


### PR DESCRIPTION
## Description

Hi all, this change add the variables output to the workspace data source.
Please let me know if you need anything from me

Regards

## Testing plan
Create some variables on a workspace and output the values like this:
```sh
data "tfe_workspace" "tst" {
  name         = "tst_tfe_prov_vars"
  organization = "sgtd1weuorgctopanda001"
}

output "tst" {
  value = data.tfe_workspace.tst.variables
}
```

## Output from acceptance tests
I'm also adding some changes to the data_source_workspace_test.go file to include the check of the new code.

```
$ TESTARGS="-run TestAccTFEWorkspaceDataSource_basic" make testacc 

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceDataSource_basic -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (20.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	20.703s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]

```
