### PR TITLE
Note - managing policy individually is deprecated

### DIFF
--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -15,6 +15,8 @@ Policies are configured on a per-organization level and are organized and
 grouped into policy sets, which define the workspaces on which policies are
 enforced during runs.
 
+~> **NOTE:** As per the [Terraform for Cloud documentation](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html#policies-and-policy-sets), although it's possible to manage policies and policy sets individually, this is a deprecated feature in Terraform Cloud, and we recommend always using versioned policy sets to manage policies.
+
 ## Example Usage
 
 Basic usage:


### PR DESCRIPTION


## Description

managing policy individually is deprecated according to [Terraform for Cloud documentation](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html#policies-and-policy-sets)

## Testing plan
Just documentation change, hopefully no test is required.
## External links

- [Terraform for Cloud documentation](https://www.terraform.io/docs/cloud/sentinel/manage-policies.html#policies-and-policy-sets)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc 

...
```
