### PR TITLE
Docs: you can set a version constraint for terraform_version

### DIFF
--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -50,7 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 * `ssh_key_id` - The ID of an SSH key assigned to the workspace.
 * `structured_run_output_enabled` - Indicates whether runs in this workspace use the enhanced apply UI. 
 * `tag_names` - The names of tags added to this workspace.
-* `terraform_version` - The version of Terraform used for this workspace.
+* `terraform_version` - The version (or version constraint) of Terraform used for this workspace.
 * `trigger_prefixes` - List of repository-root-relative paths which describe all locations to be tracked for changes.
 * `vcs_repo` - Settings for the workspace's VCS repository.
 * `working_directory` - A relative path that Terraform will execute within.

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -97,8 +97,12 @@ The following arguments are supported:
   Defaults to `true`. Setting this to `false` ensures that all runs in this
   workspace will display their output as text logs.
 * `ssh_key_id` - (Optional) The ID of an SSH key to assign to the workspace.
-* `terraform_version` - (Optional) The version of Terraform to use for this workspace. Defaults to
-  the latest available version.
+* `terraform_version` - (Optional) The version of Terraform to use for this
+  workspace. This can be either an exact version or a
+  [version constraint](https://www.terraform.io/docs/language/expressions/version-constraints.html)
+  (like `~> 1.0.0`); if you specify a constraint, the workspace will always use
+  the newest release that meets that constraint. Defaults to the latest
+  available version.
 * `trigger_prefixes` - (Optional) List of repository-root-relative paths which describe all locations
   to be tracked for changes.
 * `tag_names` - (Optional) A list of tag names for this workspace.


### PR DESCRIPTION
## Description

You can set a version constraint for `terraform_version` on a `tfe_workspace` resource! This already works in the API today, and has done since before it was called Terraform Cloud. We never really exposed this in the docs, but we've recently come around to considering it generally good and useful, for users who feel like using it.

## Testing plan

1.  Go ahead and set a workspace's terraform_version to `~> 1.0.0`. Feels good, doesn't it? 

## External links

- [API docs PR to terraform-website.](https://github.com/hashicorp/terraform-website/pull/1886) This one is in draft state, because it also includes docs for an unreleased feature (adding version constraints to the select menu in the UI).

## Output from acceptance tests

n/a; docs only.