### PR TITLE
Update oauth_client.html.markdown

### DIFF
--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -46,7 +46,7 @@ resource "tfe_oauth_client" "test" {
 
 The following arguments are supported:
 
-* `organization` - (Required) Name of the organization.
+* `organization` - (Required) Name of the Terraform organization.
 * `api_url` - (Required) The base URL of your VCS provider's API (e.g.
   `https://api.github.com` or `https://ghe.example.com/api/v3`).
 * `http_url` - (Required) The homepage of your VCS provider (e.g.


### PR DESCRIPTION
Customer was having a problem with the organization argument and did not realize that the documentation was referring to a TFE org and not a GitHub org.

## Description

Changed the wording of this argument documentation to clarify what type of org this is referring to.

```
