### PR TITLE
fix example from agent_pool resource docs

### DIFF
--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -8,12 +8,12 @@ description: |-
 
 # tfe_agent_pool
 
-An agent pool represents a group of agents, often related to one another by sharing a common 
-network segment or purpose. A workspace may be configured to use one of the organization's agent 
+An agent pool represents a group of agents, often related to one another by sharing a common
+network segment or purpose. A workspace may be configured to use one of the organization's agent
 pools to run remote operations with isolated, private, or on-premises infrastructure.
 
-~> **NOTE:** This resource requires using the provider with Terraform Cloud and a Terraform Cloud 
-for Business account. 
+~> **NOTE:** This resource requires using the provider with Terraform Cloud and a Terraform Cloud
+for Business account.
 [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
 ## Example Usage
@@ -28,7 +28,7 @@ resource "tfe_organization" "test-organization" {
 
 resource "tfe_agent_pool" "test-agent-pool" {
   name         = "my-agent-pool-name"
-  organization = tfe_organization.test-organization.id
+  organization = tfe_organization.test-organization.name
 }
 ```
 


### PR DESCRIPTION
## Description

Incorrectly uses organization.id in place of organization.name

New preview:

![Screen Shot 2021-10-19 at 1 39 33 PM](https://user-images.githubusercontent.com/174332/137979530-f1f68a87-b826-486d-be1d-cf37a58e25b1.png)


