### PR TITLE
Clarify on character requirements of tag names.

### DIFF
--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -105,7 +105,7 @@ The following arguments are supported:
   available version.
 * `trigger_prefixes` - (Optional) List of repository-root-relative paths which describe all locations
   to be tracked for changes.
-* `tag_names` - (Optional) A list of tag names for this workspace.
+* `tag_names` - (Optional) A list of tag names for this workspace. Note that tags must only contain letters, numbers or colons. 
 * `working_directory` - (Optional) A relative path that Terraform will execute
   within.  Defaults to the root of your repository.
 * `vcs_repo` - (Optional) Settings for the workspace's VCS repository, enabling the [UI/VCS-driven run workflow](https://www.terraform.io/docs/cloud/run/ui.html).


### PR DESCRIPTION
## Description

To update documentation on clarify on the character restrictions when adding a new tag to a workspace.

When creating tags like 

```
  tag_names = [
    "category:x-force",
    "book_title:x-force"
  ]
```

I get the error `Error adding tags to workspace ws-xxx: invalid attribute Tags must only contain letters, numbers or colons`

To make clear to future users, it might be better to clarify that tags must conform with the character restrictions