### PR TITLE
Allow Importing workspaces using workspace name

### DIFF
--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -21,7 +21,7 @@ func resourceTFEWorkspace() *schema.Resource {
 		Update: resourceTFEWorkspaceUpdate,
 		Delete: resourceTFEWorkspaceDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceTFEWorkspaceImporter,
 		},
 
 		SchemaVersion: 1,
@@ -641,4 +641,27 @@ func validateRemoteState(_ context.Context, d *schema.ResourceDiff, meta interfa
 	}
 
 	return nil
+}
+
+func resourceTFEWorkspaceImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	tfeClient := meta.(*tfe.Client)
+
+	s := strings.SplitN(d.Id(), "/", 2)
+	if len(s) >= 3 {
+		return nil, fmt.Errorf(
+			"invalid workspace input format: %s (expected <ORGANIZATION>/<WORKSPACE NAME> or <WORKSPACE ID>)",
+			d.Id(),
+		)
+	} else if len(s) == 2 {
+		workspaceID, err := fetchWorkspaceExternalID(s[0]+"/"+s[1], tfeClient)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error retrieving workspace with name %s from organization %s %v", s[1], s[0], err)
+		}
+
+		d.SetId(workspaceID)
+		return []*schema.ResourceData{d}, nil
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -646,7 +646,7 @@ func validateRemoteState(_ context.Context, d *schema.ResourceDiff, meta interfa
 func resourceTFEWorkspaceImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	tfeClient := meta.(*tfe.Client)
 
-	s := strings.SplitN(d.Id(), "/", 2)
+	s := strings.Split(d.Id(), "/")
 	if len(s) >= 3 {
 		return nil, fmt.Errorf(
 			"invalid workspace input format: %s (expected <ORGANIZATION>/<WORKSPACE NAME> or <WORKSPACE ID>)",
@@ -660,7 +660,6 @@ func resourceTFEWorkspaceImporter(d *schema.ResourceData, meta interface{}) ([]*
 		}
 
 		d.SetId(workspaceID)
-		return []*schema.ResourceData{d}, nil
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -685,6 +685,12 @@ func TestAccTFEWorkspace_import(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				ResourceName:      "tfe_workspace.foobar",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("tst-terraform-%d/workspace-test", rInt),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -132,12 +132,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-~> **NOTE** In versions < 0.15.1, the import ID was in the format `<ORGANIZATION NAME>/<WORKSPACE NAME>`.
-This format has been deprecated in favor of the immutable workspace ID in the format `ws-<RANDOM STRING>`.
-
-Workspaces can be imported; use `<WORKSPACE ID>` as the
+Workspaces can be imported; use `<WORKSPACE ID>` or `<ORGANIZATION NAME>/<WORKSPACE NAME>` as the
 import ID. For example:
 
 ```shell
 terraform import tfe_workspace.test ws-CH5in3chf8RJjrVd
+```
+
+```shell
+terraform import tfe_workspace.test my-org-name/my-wkspace-name 
 ```


### PR DESCRIPTION
## Description

This PR adds support for importing workspaces using a `<ORGANIZATION NAME>/<WORKSPACE NAME>` nested combo. You can still pass a workspace external id.

An example import command looks as follows:

```sh
terraform import tfe_workspace.test my-org-name/my-wkspace-name
```


### How to test
**To run acceptance tests**:

```sh
TESTARGS="-run TestAccTFEWorkspace_import" make testacc
```

**To smoke test**:

1. Create a Terraform configuration file, setting the tfe provider and the workspace resource we'll import to.

```hcl
provider "tfe" {
  hostname = "my-tfe-host"
  token = "my-tfe-token
}

resource "tfe_workspace" "test" {}
```

Ensure you have the dev overrides set to the compiled binary of this PR in your `go/bin`. 

2. Create an organization in your TFE host and workspace.
3. Import!

```sh
terraform import tfe_workspace.test org-name/wkspace-name
```

