### PR TITLE
Fix doc bug in tfe_policy_set resource example

### DIFF
--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -32,7 +32,7 @@ resource "tfe_policy_set" "test" {
     identifier         = "my-org-name/my-policy-set-repository"
     branch             = "main"
     ingress_submodules = false
-    oauth_token_id     = tfe_oauth_client.test.id
+    oauth_token_id     = tfe_oauth_client.test.oauth_token_id
   }
 }
 ```


### PR DESCRIPTION
## Description

The example usage for the tfe_policy_set resource contains the following ```oauth_token_id     = tfe_oauth_client.test.id```. This doesn't work, as ```id``` refers to the oauth client id, not the token id. The correct working code is ```oauth_token_id     = tfe_oauth_client.test.oauth_token_id```.

## Testing plan

I've included the output from the doc preview tool below.

## Output from acceptance tests

Documentation preview:
![image](https://user-images.githubusercontent.com/95770274/148429357-60cc8a0c-2d29-4c45-81c1-94b3dd786a62.png)
