### PR TITLE
Import Terraform Versions using version number

### DIFF
--- a/tfe/resource_tfe_terraform_version_test.go
+++ b/tfe/resource_tfe_terraform_version_test.go
@@ -44,6 +44,34 @@ func TestAccTFETerraformVersion_basic(t *testing.T) {
 	})
 }
 
+func TestAccTFETerraformVersion_import(t *testing.T) {
+	sha := genSha(t, "secret", "data")
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	version := genVersion(rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETerraformVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETerraformVersion_basic(version, sha),
+			},
+			{
+				ResourceName:      "tfe_terraform_version.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "tfe_terraform_version.foobar",
+				ImportState:       true,
+				ImportStateId:     version,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccTFETerraformVersion_full(t *testing.T) {
 	skipIfFreeOnly(t)
 

--- a/tfe/tool_helpers.go
+++ b/tfe/tool_helpers.go
@@ -1,0 +1,46 @@
+package tfe
+
+import (
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+// fetchTerraformVersionID returns a Terraform Version ID for the given Terraform version number
+func fetchTerraformVersionID(version string, client *tfe.Client) (string, error) {
+	versionID := ""
+	pageNum := 0
+
+found:
+	for {
+		versions, err := client.Admin.TerraformVersions.List(ctx, tfe.AdminTerraformVersionsListOptions{
+			ListOptions: tfe.ListOptions{
+				PageNumber: pageNum,
+				PageSize:   20,
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("error reading Terraform versions: %w", err)
+		}
+
+		// we've run out of versions to search
+		if len(versions.Items) == 0 {
+			break
+		}
+
+		for _, v := range versions.Items {
+			if v.Version == version {
+				versionID = v.ID
+				break found
+			}
+		}
+
+		pageNum++
+	}
+
+	if versionID == "" {
+		return "", fmt.Errorf("terraform version not found")
+	}
+
+	return versionID, nil
+}

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -32,7 +32,7 @@ resource "tfe_policy_set" "test" {
     identifier         = "my-org-name/my-policy-set-repository"
     branch             = "main"
     ingress_submodules = false
-    oauth_token_id     = tfe_oauth_client.test.id
+    oauth_token_id     = tfe_oauth_client.test.oauth_token_id
   }
 }
 ```

--- a/website/docs/r/terraform_version.html.markdown
+++ b/website/docs/r/terraform_version.html.markdown
@@ -39,10 +39,14 @@ The following arguments are supported:
 
 ## Import
 
-Terraform versions can be imported; use `<TERRAFORM VERSION ID>` as the import ID. For example:
+Terraform versions can be imported; use `<TERRAFORM VERSION ID>` or `<TERRAFORM VERSION NUMBER>` as the import ID. For example:
 
 ```shell
 terraform import tfe_terraform_version.test tool-L4oe7rNwn7J4E5Yr 
+```
+
+```shell
+terraform import tfe_terraform_version.test 1.1.2 
 ```
 
 -> **Note:** You can fetch a Terraform version ID from the URL of an exisiting version in the Terraform Cloud UI. The ID is in the format `tool-<RANDOM STRING>` 


### PR DESCRIPTION
## Description

This is a very simple PR that introduces the ability to use a Terraform version number as an alternative import ID when importing Terraform versions. I'm not particularly proud of the implementation to search for a tool version that matches the version specified, but it's currently an API limitation that doesn't allow querying/filtering Terraform versions by version. It effectively loops through the [List Terraform Versions](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions#list-all-terraform-versions) endpoint until it finds a match. If no match is found, the import will fail.

## Testing plan

1.  Ensure you have a `.tfrc` file that overrides the Terraform provider to your locally compiled binary. It should look something like this:

```
provider_installation {
    dev_overrides {
        "hashicorp/tfe" = "path/to/bin" # Usually $GOPATH/bin
    }

    direct {}
}
```
2. Create a sample Terraform configuration, I'm omitting the `tfe` provider block:

```hcl
resource "tfe_terraform_version" "1_1_2" {}
```

3. Import, ensure you override `TF_CLI_CONFIG_FILE` var! 

```sh
TF_CLI_CONFIG_FILE=path/to/my/tfrc terraform import tfe_terraform_version.1_1_2 1.1.2
```

To run the acceptance test

```
$ TESTARGS="-run TestAccTFETerraformVersion_import" make testacc 
```
