### PR TITLE
Add in Service Providers for BitBucket in Documentation

### DIFF
--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -84,7 +84,7 @@ Application Link.
 text of the SSH public key associated with your BitBucket Server Application
 Link.
 * `service_provider` - (Required) The VCS provider being connected with. Valid
-  options are `ado_server`, `ado_services`, `github`, `github_enterprise`, `gitlab_hosted`,
+  options are `ado_server`, `ado_services`, `bitbucket_hosted`, `bitbucket_server`, `github`, `github_enterprise`, `gitlab_hosted`,
   `gitlab_community_edition`, or `gitlab_enterprise_edition`.
 
 ## Attributes Reference


### PR DESCRIPTION
## Description

Documentation is lacking BitBucket Providers this change adds in missing Service Providers for bitbucket.


## Testing plan

Documentation Only 


## External links

Provider: https://github.com/hashicorp/terraform-provider-tfe/blob/main/tfe/resource_tfe_oauth_client.go#L87
Library: https://github.com/hashicorp/go-tfe/blob/main/oauth_client.go#L48


