### PR TITLE
Add the 'name' field to the documentation for the tfe_oauth_client resource

### DIFF
--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -19,6 +19,7 @@ Basic usage:
 
 ```hcl
 resource "tfe_oauth_client" "test" {
+  name             = "my-github-oauth-client"
   organization     = "my-org-name"
   api_url          = "https://api.github.com"
   http_url         = "https://github.com"
@@ -35,6 +36,7 @@ See [documentation for TFC/E setup](https://www.terraform.io/docs/cloud/vcs/azur
 
 ```hcl
 resource "tfe_oauth_client" "test" {
+  name             = "my-ado-oauth-client"
   organization     = "my-org-name"
   api_url          = "https://ado.example.com"
   http_url         = "https://ado.example.com"
@@ -53,6 +55,7 @@ When using BitBucket Server, you must use three required fields: `key`, `secret`
 
 ```hcl
 resource "tfe_oauth_client" "test" {
+  name             = "my-bbs-oauth-client"
   organization     = "my-org-name"
   api_url          = "https://bbs.example.com"
   http_url         = "https://bss.example.com"
@@ -67,6 +70,7 @@ resource "tfe_oauth_client" "test" {
 
 The following arguments are supported:
 
+* `name` - (Optional) Display name for the OAuth Client. Defaults to the `service_provider` if not supplied.
 * `organization` - (Required) Name of the Terraform organization.
 * `api_url` - (Required) The base URL of your VCS provider's API (e.g.
   `https://api.github.com` or `https://ghe.example.com/api/v3`).


### PR DESCRIPTION
## Description

The tfe_oauth_client resource implements a 'name' field, which is missing from the website documentation. This PR is to add the field to the docs and make it easier for customers to consume the resource and differentiate between different VCS providers in the UI of Terraform Enterprise and Terraform Cloud.

## Testing plan

1.  The MarkDown has been copied into the test area and is shown here;

![registry terraform io_tools_doc-preview](https://user-images.githubusercontent.com/1612200/150508073-c1f01641-4b0d-4076-b52c-63a2348f1f20.png)
