### PR TITLE
fix: don't populate data.remote_state_consumer_ids if global

### DIFF
--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -3,11 +3,54 @@ package tfe
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func TestAccTFEWorkspaceDataSource_remoteStateConsumers(t *testing.T) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rInt1 := r.Int()
+	rInt2 := r.Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceDataSourceConfig_remoteStateConsumers(rInt1, rInt2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.tfe_workspace.foobar", "id"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "name", fmt.Sprintf("workspace-test-%d", rInt1)),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "global_remote_state", "false"),
+					testAccCheckTFEWorkspaceDataSourceHasRemoteStateConsumers("data.tfe_workspace.foobar", 1),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTFEWorkspaceDataSourceHasRemoteStateConsumers(dataWorkspace string, idsLen int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		org, ok := s.RootModule().Resources[dataWorkspace]
+		if !ok {
+			return fmt.Errorf("Data workspace '%s' not found.", dataWorkspace)
+		}
+		numRemoteStateConsumersStr := org.Primary.Attributes["remote_state_consumer_ids.#"]
+		numRemoteStateConsumers, _ := strconv.Atoi(numRemoteStateConsumersStr)
+
+		if numRemoteStateConsumers != idsLen {
+			return fmt.Errorf("Expected %d remote_state_consumer_ids, but found %d.", idsLen, numRemoteStateConsumers)
+		}
+
+		return nil
+	}
+}
 
 func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -27,6 +70,8 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 						"data.tfe_workspace.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "description", "provider-testing"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "global_remote_state", "true"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "allow_destroy_plan", "false"),
 					resource.TestCheckResourceAttr(
@@ -87,10 +132,38 @@ resource "tfe_workspace" "foobar" {
   terraform_version     = "0.11.1"
   trigger_prefixes      = ["/modules", "/shared"]
   working_directory     = "terraform/test"
+	global_remote_state   = true
 }
 
 data "tfe_workspace" "foobar" {
   name         = tfe_workspace.foobar.name
   organization = tfe_workspace.foobar.organization
+	depends_on   = [tfe_workspace.foobar]
 }`, rInt, rInt)
+}
+
+func testAccTFEWorkspaceDataSourceConfig_remoteStateConsumers(rInt1, rInt2 int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "buzz" {
+  name                      = "workspace-test-%d"
+  organization              = tfe_organization.foobar.id
+}
+
+resource "tfe_workspace" "foobar" {
+  name                      = "workspace-test-%d"
+  organization              = tfe_organization.foobar.id
+	global_remote_state       = false
+	remote_state_consumer_ids = [resource.tfe_workspace.buzz.id]
+}
+
+data "tfe_workspace" "foobar" {
+  name         = tfe_workspace.foobar.name
+  organization = tfe_workspace.foobar.organization
+	depends_on   = [tfe_workspace.foobar]
+}`, rInt1, rInt2, rInt1)
 }


### PR DESCRIPTION
## Description

The memory leak described in #407 is actually a workspace data source bug where we always fetch all remote_state_consumer_ids, even if the workspace data source is global. The API happily enumerates all other workspaces in this case. If you have many pages of workspaces, this could take a very long time to plan.

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TFE_TOKEN="$(tfc_local_token)" TFE_HOSTNAME="$(tfc_local_hostname)" TF_ACC=1 go test ./... -v -tags=integration -run TestAccTFEWorkspaceDataSource
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEWorkspaceDataSource_remoteStateConsumers
--- PASS: TestAccTFEWorkspaceDataSource_remoteStateConsumers (38.45s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (35.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	76.658s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```

Fixes #407 