### PR TITLE
Optimize Terraform Version Importer func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-slug v0.7.0
-	github.com/hashicorp/go-tfe v0.22.0
+	github.com/hashicorp/go-tfe v0.24.0
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl/v2 v2.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/hashicorp/go-slug v0.7.0 h1:8HIi6oreWPtnhpYd8lIGQBgp4rXzDWQTOhfILZm+n
 github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-tfe v0.22.0 h1:FBK3LscU90EhQGS/p2NJJdJt2GzwiGNqHgex8SjZ+LM=
 github.com/hashicorp/go-tfe v0.22.0/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
+github.com/hashicorp/go-tfe v0.24.0 h1:7RyYTafFXGN6I6ayASJOpw6pARtKKSPdA9KRiovKQRM=
+github.com/hashicorp/go-tfe v0.24.0/go.mod h1:gyXLXbpBVxA2F/6opah8XBsOkZJxHYQmghl0OWi8keI=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=

--- a/tfe/tool_helpers.go
+++ b/tfe/tool_helpers.go
@@ -8,39 +8,16 @@ import (
 
 // fetchTerraformVersionID returns a Terraform Version ID for the given Terraform version number
 func fetchTerraformVersionID(version string, client *tfe.Client) (string, error) {
-	versionID := ""
-	pageNum := 0
-
-found:
-	for {
-		versions, err := client.Admin.TerraformVersions.List(ctx, tfe.AdminTerraformVersionsListOptions{
-			ListOptions: tfe.ListOptions{
-				PageNumber: pageNum,
-				PageSize:   20,
-			},
-		})
-		if err != nil {
-			return "", fmt.Errorf("error reading Terraform versions: %w", err)
-		}
-
-		// we've run out of versions to search
-		if len(versions.Items) == 0 {
-			break
-		}
-
-		for _, v := range versions.Items {
-			if v.Version == version {
-				versionID = v.ID
-				break found
-			}
-		}
-
-		pageNum++
+	versions, err := client.Admin.TerraformVersions.List(ctx, tfe.AdminTerraformVersionsListOptions{
+		Filter: &version,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error reading Terraform versions: %w", err)
 	}
 
-	if versionID == "" {
+	if len(versions.Items) == 0 {
 		return "", fmt.Errorf("terraform version not found")
 	}
 
-	return versionID, nil
+	return versions.Items[0].ID, nil
 }


### PR DESCRIPTION
## Description

This is a simple PR that makes use of the newly added query params to filter a Terraform version when importing a Terraform version by version number. This will drastically reduce the calls needed to find the tool version ID. 

This PR also bumps the go-tfe version to `0.24` which includes the query params as list opts. 

## External links

- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/408)
