### PR TITLE
adds entitlment error message for creating Teams

### DIFF
--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -107,6 +107,9 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			entitlements, _ := tfeClient.Organizations.Entitlements(ctx, organization)
+			if entitlements == nil {
+				return fmt.Errorf("Error creating team %s for organization %s: %v", name, organization, err)
+			}
 			if !entitlements.Teams {
 				return fmt.Errorf("Error creating team %s for organization %s: missing entitlements to create teams", name, organization)
 			}

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -105,8 +105,13 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Create team %s for organization: %s", name, organization)
 	team, err := tfeClient.Teams.Create(ctx, organization, options)
 	if err != nil {
-		return fmt.Errorf(
-			"Error creating team %s for organization %s: %v", name, organization, err)
+		if err == tfe.ErrResourceNotFound {
+			entitlements, _ := tfeClient.Organizations.Entitlements(ctx, organization)
+			if !entitlements.Teams {
+				return fmt.Errorf("Error creating team %s for organization %s: missing entitlements to create teams", name, organization)
+			}
+		}
+		return fmt.Errorf("Error creating team %s for organization %s: %v", name, organization, err)
 	}
 
 	d.SetId(team.ID)


### PR DESCRIPTION
## Description

This PR resolves [Issue 171](https://github.com/hashicorp/terraform-provider-tfe/issues/171). Previously when a User on the Free Tier tried to create a team using the tfe provider, the CLI would return an error message like : `Error: Error creating team my-team-name for organization raoul-staging: resource not found`. This error does not explain to the user that they cannot create a team because the Free tier does not have the proper entitlements. 

These changes check entitlements after the `ErrResourceNotFound` error and if there is an error surfaces an error message like: `Error creating team my-team-name for organization raoul-staging: missing entitlements to create teams` 

## Testing plan

1.  Run tfe provider locally against staging.
1.  Create an Organization and set the Feature Set to Free tier.
1. Using the CLI run `terraform apply` to create a team in the Org - This should surface an error due to entitlements 
1. Set the Organization to Business and re-run the `apply` - This should not surface any error. 


