### PR TITLE
Add deprecated arguments to Terraform version resource

### DIFF
--- a/tfe/resource_tfe_terraform_version.go
+++ b/tfe/resource_tfe_terraform_version.go
@@ -47,6 +47,16 @@ func resourceTFETerraformVersion() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"deprecated": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"deprecated_reason": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  nil,
+			},
 		},
 	}
 }
@@ -55,12 +65,14 @@ func resourceTFETerraformVersionCreate(d *schema.ResourceData, meta interface{})
 	tfeClient := meta.(*tfe.Client)
 
 	opts := tfe.AdminTerraformVersionCreateOptions{
-		Version:  tfe.String(d.Get("version").(string)),
-		URL:      tfe.String(d.Get("url").(string)),
-		Sha:      tfe.String(d.Get("sha").(string)),
-		Official: tfe.Bool(d.Get("official").(bool)),
-		Enabled:  tfe.Bool(d.Get("enabled").(bool)),
-		Beta:     tfe.Bool(d.Get("beta").(bool)),
+		Version:          tfe.String(d.Get("version").(string)),
+		URL:              tfe.String(d.Get("url").(string)),
+		Sha:              tfe.String(d.Get("sha").(string)),
+		Official:         tfe.Bool(d.Get("official").(bool)),
+		Enabled:          tfe.Bool(d.Get("enabled").(bool)),
+		Beta:             tfe.Bool(d.Get("beta").(bool)),
+		Deprecated:       tfe.Bool(d.Get("deprecated").(bool)),
+		DeprecatedReason: tfe.String(d.Get("deprecated_reason").(string)),
 	}
 
 	log.Printf("[DEBUG] Create new Terraform version: %s", *opts.Version)
@@ -94,6 +106,8 @@ func resourceTFETerraformVersionRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("official", v.Official)
 	d.Set("enabled", v.Enabled)
 	d.Set("beta", v.Beta)
+	d.Set("deprecated", v.Deprecated)
+	d.Set("deprecated_reason", v.DeprecatedReason)
 
 	return nil
 }
@@ -102,12 +116,14 @@ func resourceTFETerraformVersionUpdate(d *schema.ResourceData, meta interface{})
 	tfeClient := meta.(*tfe.Client)
 
 	opts := tfe.AdminTerraformVersionUpdateOptions{
-		Version:  tfe.String(d.Get("version").(string)),
-		URL:      tfe.String(d.Get("url").(string)),
-		Sha:      tfe.String(d.Get("sha").(string)),
-		Official: tfe.Bool(d.Get("official").(bool)),
-		Enabled:  tfe.Bool(d.Get("enabled").(bool)),
-		Beta:     tfe.Bool(d.Get("beta").(bool)),
+		Version:          tfe.String(d.Get("version").(string)),
+		URL:              tfe.String(d.Get("url").(string)),
+		Sha:              tfe.String(d.Get("sha").(string)),
+		Official:         tfe.Bool(d.Get("official").(bool)),
+		Enabled:          tfe.Bool(d.Get("enabled").(bool)),
+		Beta:             tfe.Bool(d.Get("beta").(bool)),
+		Deprecated:       tfe.Bool(d.Get("deprecated").(bool)),
+		DeprecatedReason: tfe.String(d.Get("deprecated_reason").(string)),
 	}
 
 	log.Printf("[DEBUG] Update configuration of Terraform version: %s", d.Id())

--- a/tfe/resource_tfe_terraform_version_test.go
+++ b/tfe/resource_tfe_terraform_version_test.go
@@ -102,6 +102,10 @@ func TestAccTFETerraformVersion_full(t *testing.T) {
 						"tfe_terraform_version.foobar", "enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_terraform_version.foobar", "beta", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_terraform_version.foobar", "deprecated", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_terraform_version.foobar", "deprecated_reason", "foobar"),
 				),
 			},
 		},
@@ -201,6 +205,14 @@ func testAccCheckTFETerraformVersionAttributesFull(tfVersion *tfe.AdminTerraform
 			return fmt.Errorf("Bad value for beta: %t", tfVersion.Beta)
 		}
 
+		if tfVersion.Deprecated != true {
+			return fmt.Errorf("Bad value for deprecated: %t", tfVersion.Deprecated)
+		}
+
+		if *tfVersion.DeprecatedReason != "foobar" {
+			return fmt.Errorf("Bad value for deprecated_reason: %s", *tfVersion.DeprecatedReason)
+		}
+
 		return nil
 	}
 }
@@ -223,6 +235,8 @@ resource "tfe_terraform_version" "foobar" {
   official = false
   enabled = true
   beta = true 
+  deprecated = true
+  deprecated_reason = "foobar"
 }`, version, sha)
 }
 

--- a/website/docs/r/terraform_version.html.markdown
+++ b/website/docs/r/terraform_version.html.markdown
@@ -32,6 +32,8 @@ The following arguments are supported:
 * `official` - (Optional) Whether or not this is an official release of Terraform. Defaults to "false".
 * `enabled` - (Optional) Whether or not this version of Terraform is enabled for use in Terraform Cloud/Enterprise. Defaults to "true".
 * `beta` - (Optional) Whether or not this version of Terraform is beta pre-release. Defaults to "false".
+* `deprecated` - (Optional) Whether or not this version of Terraform is deprecated. Defaults to "false".
+* `deprecated_reason` - (Optional) Additional context about why a version of Terraform is deprecated. Defaults to "null" unless `deprecated` is true.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This PR adds two new arguments supported by the [Admin Terraform Versions API](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions):

- `deprecated`: (Optional) Whether or not this version of Terraform is deprecated. Defaults to "false".
- `deprecated_reason`: (Optional) Additional context about why a version of Terraform is deprecated. Defaults to "null" unless `deprecated` is true.

## Testing plan

### In order to run the acceptance tests:

```sh
TESTARGS="-run TestAccTFETerraformVersion" make testacc
```

### In order to smoke test:

1. Pull the changes from this PR locally and compile the provider into `$GOPATH/bin`.
2. Create a [development overrides file](https://www.terraform.io/language/files/override) and override the official tfe provider to point to the compiled binary in `$GOPATH/bin`
3. Create a new Terraform configuration using the newly added arguments:

```hcl
resource "tfe_terraform_version" "foo_deprecated" {
  version = "10.10.10-deprecated"
  url = "https://hashicorp.com"
  sha = "ENTER ANY SHA HERE"
  deprecated = true
  deprecated_reason = "I have brought peace, freedom, justice and security to my new empire"
}
```
4. Ensure you set `TF_CLI_CONFIG_FILE=` to the path of your overrides file:

```sh
TF_CLI_CONFIG_FILE=/path/to/my/overrides.tfrc terraform apply
```

## Output from acceptance tests
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFETerraformVersion -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFETerraformVersion_basic
--- PASS: TestAccTFETerraformVersion_basic (24.62s)
=== RUN   TestAccTFETerraformVersion_import
--- PASS: TestAccTFETerraformVersion_import (36.70s)
=== RUN   TestAccTFETerraformVersion_full
--- PASS: TestAccTFETerraformVersion_full (24.25s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 86.638s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```