### PR TITLE
Fixing plugin crash when providing empty strings to argument

### DIFF
--- a/tfe/data_source_workspace_ids.go
+++ b/tfe/data_source_workspace_ids.go
@@ -54,6 +54,11 @@ func dataSourceTFEWorkspaceIDsRead(d *schema.ResourceData, meta interface{}) err
 	var id string
 	names := make(map[string]bool)
 	for _, name := range d.Get("names").([]interface{}) {
+		// ignore empty strings
+		if name == nil {
+			continue
+		}
+
 		id += name.(string)
 		names[name.(string)] = true
 	}

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -222,6 +222,47 @@ func TestAccTFEWorkspaceIDsDataSource_empty(t *testing.T) {
 	})
 }
 
+func TestAccTFEWorkspaceIDsDataSource_namesEmpty(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceIDsDataSourceConfig_namesEmpty(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "names.#", "2"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "names.0", ""),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "names.1", fmt.Sprintf("workspace-foo-%d", rInt)),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "organization", orgName),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.good", "full_names.%"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "full_names.%", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good",
+						fmt.Sprintf("full_names.workspace-foo-%d", rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-foo-%d", rInt, rInt),
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "ids.%", "1"),
+					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.good", "ids.%"),
+					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.good", "id"),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.good", fmt.Sprintf("ids.workspace-foo-%d", rInt)),
+				),
+			},
+		},
+	})
+}
+
 func testAccTFEWorkspaceIDsDataSourceConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
@@ -356,6 +397,32 @@ resource "tfe_workspace" "bar" {
 
 data "tfe_workspace_ids" "good" {
   names        = ["workspace-foo-%d"]
+  tag_names    = ["bar"]
+  organization = tfe_workspace.foo.organization
+}`, rInt, rInt, rInt, rInt)
+}
+
+func testAccTFEWorkspaceIDsDataSourceConfig_namesEmpty(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foo" {
+  name         = "workspace-foo-%d"
+  organization = tfe_organization.foobar.id
+  tag_names    = ["bar"]
+}
+
+resource "tfe_workspace" "bar" {
+  name         = "workspace-bar-%d"
+  organization = tfe_organization.foobar.id
+  tag_names    = ["bar"]
+}
+
+data "tfe_workspace_ids" "good" {
+  names        = ["", "workspace-foo-%d"]
   tag_names    = ["bar"]
   organization = tfe_workspace.foo.organization
 }`, rInt, rInt, rInt, rInt)


### PR DESCRIPTION
## Description

This is a really simple fix that closes #409 by preventing the user to set the `names` argument for `tfe_data_source_workspace_ids` to an array of empty strings or an array that contains empty strings. The reason for this is the plugin sdk fetches empty strings as `nil` values, causing any type casting operations to panic. 

There is an alternative up for discussion, let's say the user provides `["wkspace1", "", "wkspace2"]`, should the plugin read this as `["wkspace1", "wkspace2"]` omitting any entries that are `nil`? This might be a better alternative as `[]` is a valid assignment and therefore omitting entries that are nil (in a case where all entries are nil) would effectively be the same as `[]`.

**Update**: Decided to go with the alternative solution

## Testing plan

1.  In order to test ensure you have your provider overrides setup, and have an available Terraform configuration to test with
2. Create a data source block and apply:
```hcl
data "tfe_workspace_ids" "this" {
  names = [""],
  organization = "your-org-here"
}
```
3. You should have a successful apply

**To run acceptance test**: 
```sh
TESTARGS="-run TestAccTFEWorkspaceIDsDataSource_namesEmpty" make testacc
```