### PR TITLE
Org Membership return Username

### DIFF
--- a/tfe/data_source_organization_membership.go
+++ b/tfe/data_source_organization_membership.go
@@ -2,6 +2,7 @@ package tfe
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -22,6 +23,11 @@ func dataSourceTFEOrganizationMembership() *schema.Resource {
 			},
 
 			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"username": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/tfe/data_source_organization_membership_test.go
+++ b/tfe/data_source_organization_membership_test.go
@@ -25,6 +25,7 @@ func TestAccTFEOrganizationMembershipDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_organization_membership.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_organization_membership.foobar", "user_id"),
+					resource.TestCheckResourceAttrSet("data.tfe_organization_membership.foobar", "username"),
 				),
 			},
 		},

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -34,6 +34,11 @@ func resourceTFEOrganizationMembership() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -86,6 +91,7 @@ func resourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interfac
 	d.Set("email", membership.Email)
 	d.Set("organization", membership.Organization.Name)
 	d.Set("user_id", membership.User.ID)
+	d.Set("username", membership.User.Username)
 
 	return nil
 }

--- a/tfe/resource_tfe_organization_membership_test.go
+++ b/tfe/resource_tfe_organization_membership_test.go
@@ -32,6 +32,7 @@ func TestAccTFEOrganizationMembership_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_organization_membership.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("tfe_organization_membership.foobar", "user_id"),
+					resource.TestCheckResourceAttrSet("tfe_organization_membership.foobar", "username"),
 				),
 			},
 		},

--- a/website/docs/d/organization_membership.html.markdown
+++ b/website/docs/d/organization_membership.html.markdown
@@ -38,3 +38,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The organization membership ID.
 * `user_id` - The ID of the user associated with the organization membership.
+* `username` - The Username of the user associated with the organization membership.

--- a/website/docs/r/organization_membership.html.markdown
+++ b/website/docs/r/organization_membership.html.markdown
@@ -42,6 +42,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The organization membership ID.
 * `user_id` - The ID of the user associated with the organization membership.
+* `username` - The Username of the user associated with the organization membership.
 
 Organization memberships can be imported; use `<ORGANIZATION MEMBERSHIP ID>` as the import ID. For
 example:


### PR DESCRIPTION
## Description

- Updates the Org Membership resource and data source to return the
  username associated with the email address

All other team resources require usernames, so not being able to map a
user's email to their username adds complexity when wanting to add users
to a team

## Testing plan

create a minimum viable TF Code:

```
data "tfe_organization_membership" "test" {
  organization  = "ENTER YOUR ORG HERE"
  email = "Enter your email here"
}

output "output" {
    value = data.tfe_organization_membership.test
}
```
You should see your username in the output. 


## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc 

...
```
