### PR TITLE
fix: mark these attributes as computed because they are defaulted as lists

### DIFF
--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -112,6 +112,7 @@ func resourceTFEWorkspace() *schema.Resource {
 			"remote_state_consumer_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
@@ -162,6 +163,7 @@ func resourceTFEWorkspace() *schema.Resource {
 			"trigger_prefixes": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -1634,6 +1634,7 @@ resource "tfe_workspace" "foobar" {
   name                  = "workspace-test"
   organization          = tfe_organization.foobar.id
   auto_apply            = true
+	trigger_prefixes      = []
 }`, rInt)
 }
 
@@ -1750,6 +1751,7 @@ resource "tfe_workspace" "foobar" {
   allow_destroy_plan  = false
   auto_apply          = true
   global_remote_state = true
+	remote_state_consumer_ids = []
 }`, rInt)
 }
 


### PR DESCRIPTION
## Description

Previously, these attributes would not be added to the state but be defaulted by the API, which would be displayed as a drift

## Testing plan

1. Use this config to create a new workspace:

```
provider "tfe" {
  hostname = "HOSTNAME"
}

terraform {
  required_providers {
    tfe = {
      version = "~> 0.27.0"
    }
  }
}

resource "tfe_workspace" "test" {
  name               = "my-cool-workspace"
  organization       = "hashicorp"
  global_remote_state = false
}
```

After applying this, change the name of the workspace and plan the change.

Previously, you'd see this warning:

```
Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # tfe_workspace.test has changed
  ~ resource "tfe_workspace" "test" {
        id                            = "ws-RGzPjmdTVvADZpdb"
        name                          = "my-cool-workspace"
      + remote_state_consumer_ids     = []
      + trigger_prefixes              = []
        # (12 unchanged attributes hidden)
    }
```

After applying this change, you'll notice that the warning does not show because the state has stored the computed value, which matches the default that the API generates:

```
$ terraform state show tfe_workspace.test
# tfe_workspace.test:
resource "tfe_workspace" "test" {
    allow_destroy_plan            = true
    auto_apply                    = false
    execution_mode                = "remote"
    file_triggers_enabled         = true
    global_remote_state           = true
    id                            = "ws-cszmfpgBQYCbQGcx"
    name                          = "my-cool-workspace"
    operations                    = true
    organization                  = "hashicorp"
    queue_all_runs                = true
    remote_state_consumer_ids     = []
    speculative_enabled           = true
    structured_run_output_enabled = true
    tag_names                     = []
    terraform_version             = "1.1.4"
    trigger_prefixes              = []
}
```
