### PR TITLE
Update docker image to use cimg namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,10 @@ test_results_dir: &test_results_dir /tmp/test_results
 jobs:
   run-tests:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.16.2
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17.1
         environment:
           TF_ACC_TERRAFORM_VERSION: 1.0.0
           TEST_RESULTS_DIR: *test_results_dir
-
-    working_directory: /go/src/github.com/hashicorp/terraform-provider-tfe
 
     steps:
       - checkout


### PR DESCRIPTION
## Description

Update CI docker image to `cimg/go:X.X.XX` from `circleci/docker`

For more on this topic:

https://circleci.com/developer/images/image/cimg/go

https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034


