### PR TITLE
implement tfe_oauth_clients datasource

### DIFF
--- a/tfe/data_source_oauth_clients.go
+++ b/tfe/data_source_oauth_clients.go
@@ -1,0 +1,138 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceTFEOauthClients() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTFEOauthClientList,
+
+		Schema: map[string]*schema.Schema{
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"oauth_clients": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeMap},
+			},
+		},
+	}
+}
+
+func dataSourceTFEOauthClientList(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	organization := d.Get("organization").(string)
+
+	log.Printf("[DEBUG] Setting OauthClients Attributes for organization %s", organization)
+	err := oauthClientsPopulateFields(tfeClient, organization, d)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func oauthClientsPopulateFields(client *tfe.Client, organization string, d *schema.ResourceData) error {
+	var oauthClients []map[string]interface{}
+
+	log.Printf("[DEBUG] Listing oauth clients")
+	options := tfe.OAuthClientListOptions{
+		ListOptions: tfe.ListOptions{
+			PageSize: 100,
+		},
+	}
+	for {
+		oauthClientList, err := client.OAuthClients.List(ctx, organization, options)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve oauth Clients from organization %s: %v", organization, err)
+		}
+
+		for _, client := range oauthClientList.Items {
+			flattenedOauthClient, err := flattenOauthClient(client)
+			if err != nil {
+				return fmt.Errorf("failed to flatten oauthClient: %v", err)
+			}
+			log.Printf("[DEBUG] Flattened OauthClient: %v", flattenedOauthClient)
+
+			oauthClients = append(oauthClients, flattenedOauthClient)
+		}
+
+		// Exit the loop when we've seen all pages.
+		if oauthClientList.CurrentPage >= oauthClientList.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		options.PageNumber = oauthClientList.NextPage
+	}
+
+	d.SetId("oauth-clients")
+	return d.Set("oauth_clients", oauthClients)
+}
+
+func flattenOauthClient(in *tfe.OAuthClient) (map[string]interface{}, error) {
+	att := make(map[string]interface{})
+
+	if len(in.ID) > 0 {
+		att["oauth_client_id"] = in.ID
+	}
+	if len(in.APIURL) > 0 {
+		att["api_url"] = in.APIURL
+	}
+	if len(in.CallbackURL) > 0 {
+		att["callback_url"] = in.CallbackURL
+	}
+	if len(in.ConnectPath) > 0 {
+		att["connect_path"] = in.ConnectPath
+	}
+	if len(in.CreatedAt.Format(time.RFC3339)) > 0 {
+		att["created_at"] = in.CreatedAt.Format(time.RFC3339)
+	}
+	if len(in.HTTPURL) > 0 {
+		att["http_url"] = in.HTTPURL
+	}
+	if len(in.Key) > 0 {
+		att["key"] = in.Key
+	}
+	if len(in.ServiceProvider) > 0 {
+		att["service_provider"] = in.ServiceProvider
+	}
+	if len(in.ServiceProviderName) > 0 {
+		att["service_provider_display_name"] = in.ServiceProviderName
+	}
+
+	att["organization_name"] = flattenOrganizationName(in.Organization)
+
+	flattenedOauthTokenID, err := flattenOauthToken(in.OAuthTokens)
+	if err != nil {
+		return nil, fmt.Errorf("failed to flatten 'oauth_token_id': %v", err)
+	}
+	log.Printf("[DEBUG] Flattened oauthTokenID: %v", flattenedOauthTokenID)
+	att["oauth_token_id"] = flattenedOauthTokenID
+
+	return att, nil
+}
+
+func flattenOauthToken(in []*tfe.OAuthToken) (interface{}, error) {
+	switch len(in) {
+	case 0:
+		return "", nil
+	case 1:
+		return in[0].ID, nil
+	default:
+		return nil, fmt.Errorf("unexpected number of OAuth tokens: %d", len(in))
+	}
+}
+
+func flattenOrganizationName(in *tfe.Organization) interface{} {
+	return in.Name
+}

--- a/tfe/data_source_oauth_clients_test.go
+++ b/tfe/data_source_oauth_clients_test.go
@@ -1,0 +1,68 @@
+package tfe
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFEOAuthClientsDataSource_basic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if GITHUB_TOKEN == "" {
+				t.Skip("Please set GITHUB_TOKEN to run this test")
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{Destroy: false,
+				PreventPostDestroyRefresh: true,
+				Config:                    testAccTFEOAuthClientsDataSourceConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_oauth_clients.foobar", "oauth_clients.#", "2"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_oauth_clients.foobar", "oauth_clients.0.service_provider", "github"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_oauth_clients.foobar", "oauth_clients.1.service_provider", "github"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFEOAuthClientsDataSourceConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_organization" "foobar" {
+		name  = "tst-terraform-%d"
+		email = "admin@company.com"
+	
+	}
+	
+	resource "tfe_oauth_client" "foo" {
+		organization     = tfe_organization.foobar.id
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+	
+	resource "tfe_oauth_client" "bar" {
+		organization     = tfe_organization.foobar.id
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+	
+	data "tfe_oauth_clients" "foobar" {
+		organization = tfe_organization.foobar.id
+		depends_on   = [tfe_organization.foobar, tfe_oauth_client.foo, tfe_oauth_client.bar]
+	}
+	`, rInt, GITHUB_TOKEN, GITHUB_TOKEN)
+}

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -82,6 +82,7 @@ func Provider() *schema.Provider {
 			"tfe_agent_pool":              dataSourceTFEAgentPool(),
 			"tfe_ip_ranges":               dataSourceTFEIPRanges(),
 			"tfe_oauth_client":            dataSourceTFEOAuthClient(),
+			"tfe_oauth_clients":           dataSourceTFEOauthClients(),
 			"tfe_organization_membership": dataSourceTFEOrganizationMembership(),
 			"tfe_slug":                    dataSourceTFESlug(),
 			"tfe_ssh_key":                 dataSourceTFESSHKey(),

--- a/website/docs/d/oauth_clients.html.markdown
+++ b/website/docs/d/oauth_clients.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_oauth_clients"
+sidebar_current: "docs-datasource-tfe-oauth-clients"
+description: |-
+  Get Terraform Cloud/Enterprise's oauth clients in a given  organization.
+---
+
+# Data Source: tfe_oauth_clients
+
+Use this data source to retrieve a list of TerraformCloud/Enterprise's oauth clients in a given organization.
+
+## Example Usage
+
+```hcl
+data "tfe_oauth_clients"  "example" {
+  organization = "my-org-name"
+}
+
+output "oauth_clients" {
+  value       = data.tfe_oauth_clients.example.oauth_clients
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Required) Name of the organization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `oauth_clients` - A list of oauth clients manage by the organization. Structure is documented below.
+
+### oauth_clients
+* `oauth_client_id` - The oauth client ID.
+* `api_url` - The base URL of your VCS provider's API.
+* `callback_url` - The callback URL.
+* `connect_path` - The connect path.
+* `created_at` - The creation date.
+* `http_url` - The homepage of your VCS provider.
+* `key` - The oauth client key.
+* `service_provider` - The VCS provider being connected with.
+* `service_provider_display_name` - The display name of your VCS provider.
+* `organization_name` -  Name of the organization.
+* `oauth_token_id` - The ID of the oauth token associated with the oauth client.

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -25,6 +25,10 @@
                             <a href="/docs/providers/tfe/d/oauth_client.html">tfe_oauth_client</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-datasource-tfe-oauth-clients-x") %>>
+                            <a href="/docs/providers/tfe/d/oauth_clients.html">tfe_oauth_clients</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-datasource-tfe-organization-membership") %>>
                             <a href="/docs/providers/tfe/d/organization_membership.html">tfe_organization_membership</a>
                         </li>


### PR DESCRIPTION
## Description

Adds the new data source `tfe_oauth_clients` to retrieve a list of TerraformCloud/Enterprise's oauth clients in a given organization. This data source will ultimately allow us to lookup `oauth_client_id`s across different organizations. 
## Testing plan
* Ran acceptance tests locally against my TerraformCloud account.
```
Running tool: /usr/local/opt/go/libexec/bin/go test -timeout 30s -run ^TestAccTFEOAuthClientsDataSource_basic$ github.com/hashicorp/terraform-provider-tfe/tfe

ok  	github.com/hashicorp/terraform-provider-tfe/tfe	5.980s
```

## External links
- https://www.terraform.io/cloud-docs/api-docs/oauth-clients#list-oauth-clients
