### PR TITLE
Draft: Add sso_team_id to the tfe_team resource and data source

### DIFF
--- a/tfe/data_source_team.go
+++ b/tfe/data_source_team.go
@@ -21,6 +21,10 @@ func dataSourceTFETeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"sso_team_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -44,6 +48,7 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 		for _, tm := range l.Items {
 			if tm.Name == name {
 				d.SetId(tm.ID)
+				d.Set("sso_team_id", tm.SSOTeamID)
 				return nil
 			}
 		}

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -81,6 +81,10 @@ func resourceTFETeam() *schema.Resource {
 					"organization",
 				}, false),
 			},
+			"sso_team_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -112,6 +116,10 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("visibility"); ok {
 		options.Visibility = tfe.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("sso_team_id"); ok {
+		options.SSOTeamID = tfe.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] Create team %s for organization: %s", name, organization)
@@ -164,6 +172,7 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	d.Set("visibility", team.Visibility)
+	d.Set("sso_team_id", team.SSOTeamID)
 
 	return nil
 }
@@ -194,6 +203,12 @@ func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("visibility"); ok {
 		options.Visibility = tfe.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("sso_team_id"); ok {
+		options.SSOTeamID = tfe.String(v.(string))
+	} else {
+		options.SSOTeamID = tfe.String("")
 	}
 
 	log.Printf("[DEBUG] Update team: %s", d.Id())

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -31,3 +31,4 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the team.
+* `sso_team_id` - (Optional) The SSO Team ID of the team, if it has been defined

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `organization` - (Required) Name of the organization.
 * `visibility` - (Optional) The visibility of the team ("secret" or "organization"). Defaults to "secret".
 * `organization_access` - (Optional) Settings for the team's [organization access](https://www.terraform.io/docs/cloud/users-teams-organizations/permissions.html#organization-level-permissions).
+* `sso_team_id` - (Optional) Unique Identifier to control team membership via SAML. Defaults to `null`
 
 The `organization_access` block supports:
 


### PR DESCRIPTION
## Description

Add sso_team_id to the tfe_team resource and data source

## Testing plan

1. Create a team using the tfe provider
2. Add, change, and remove an SSO team ID for that team, through the provider
3. Read the SSO Team ID from a data source referencing said team

## Output from acceptance tests

TODO (this is why I marked as draft)

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc 

...
```
