### PR TITLE
[Docs] Fix example for tfe_variable_set with variable_set_id

### DIFF
--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -34,19 +34,19 @@ resource "tfe_variable_set" "test" {
 }
 
 resource "tfe_variable" "test" {
-  key          = "seperate_variable"
-  value        = "my_value_name"
-  category     = "terraform"
-  description  = "a useful description"
-  variable_set = tfe_variable_set.test.id
+  key             = "seperate_variable"
+  value           = "my_value_name"
+  category        = "terraform"
+  description     = "a useful description"
+  variable_set_id = tfe_variable_set.test.id
 }
 
 resource "tfe_variable" "test" {
-  key          = "another_variable"
-  value        = "my_value_name"
-  category     = "env"
-  description  = "an environment variable"
-  variable_set = tfe_variable_set.test.id
+  key             = "another_variable"
+  value           = "my_value_name"
+  category        = "env"
+  description     = "an environment variable"
+  variable_set_id = tfe_variable_set.test.id
 }
 ```
 


### PR DESCRIPTION
The argument is named `variable_set_id` not `variable_set`

https://github.com/kaefferlein/terraform-provider-tfe/blob/main/tfe/resource_tfe_variable.go#L88
