### PR TITLE
Fix incorrectly documented attribute for `tfe_variable_set`

### DIFF
--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -26,11 +26,11 @@ resource "tfe_workspace" "test" {
 }
 
 resource "tfe_variable_set" "test" {
-  name         = "Test Varset"
-  description  = "Some description."
-  global       = false
-  organization = tfe_organization.test.id
-  workspaces   = [tfe_workspace.test.id]
+  name          = "Test Varset"
+  description   = "Some description."
+  global        = false
+  organization  = tfe_organization.test.id
+  workspace_ids = [tfe_workspace.test.id]
 }
 
 resource "tfe_variable" "test" {
@@ -96,10 +96,10 @@ data "tfe_workspace_ids" "prod-apps" {
 }
 
 resource "tfe_variable_set" "test" {
-  name         = "Tag Based Varset"
-  description  = "Variable set applied to workspaces based on tag."
-  organization = tfe_organization.test.id
-  workspaces   = tfe_workspace_ids.prod-apps.ids
+  name          = "Tag Based Varset"
+  description   = "Variable set applied to workspaces based on tag."
+  organization  = tfe_organization.test.id
+  workspace_ids = tfe_workspace_ids.prod-apps.ids
 }
 ```
 
@@ -111,7 +111,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the variable set.
 * `global` - (Optional) Whether or not the variable set applies to all workspaces in the organization. Defaults to `false`.
 * `organization` - (Required) Name of the organization.
-* `workspaces` - (Optional) IDs of the workspaces that use the variable set.
+* `workspace_ids` - (Optional) IDs of the workspaces that use the variable set.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-provider-tfe/blob/a0afb917e3076c2d19cc9b2a5eed4f2f396e8748/tfe/resource_tfe_variable_set.go#L48-L53

## Description

Fix incorrectly documented attribute `workspaces`. It should be 
`workspace_ids` according to the code https://github.com/hashicorp/terraform-provider-tfe/blob/a0afb917e3076c2d19cc9b2a5eed4f2f396e8748/tfe/resource_tfe_variable_set.go#L48-L53

## Testing plan

1. Try to create a resource with `workspaces`
2. Get error 

```
│ Error: Unsupported argument
│
│   on ../../modules/variable_set/main.tf line 18, in resource "tfe_variable_set" "this":
│   18:   workspaces   = var.workspace_ids
│
│ An argument named "workspaces" is not expected here.
```

3. Replace with `workspace_ids` and apply is OK


## External links

NA

## Output from acceptance tests

NA: no code changes
