### PR TITLE
Fix example creating variable set that applies workspace_ids data

### DIFF
--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -98,7 +98,7 @@ resource "tfe_variable_set" "test" {
   name          = "Tag Based Varset"
   description   = "Variable set applied to workspaces based on tag."
   organization  = tfe_organization.test.name
-  workspace_ids = tfe_workspace_ids.prod-apps.ids
+  workspace_ids = values(data.tfe_workspace_ids.prod-apps.ids)
 }
 ```
 


### PR DESCRIPTION
## Description

Fix example creating a variable set that applies workspace_ids data

`data.tfe_workspace_ids.this.ids`  returns a `map[WS name] = ws-id` 
so to use that as input for `tfe_variable_set.workspace_ids` only values are needed 

## Testing plan

documentation update

## Output from acceptance tests

Documentation website should be updated and new example showed
