### PR TITLE
Fix resource name in variable_set examples

### DIFF
--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -49,7 +49,7 @@ resource "tfe_variable_set" "test" {
   organization = tfe_organization.test.name
 }
 
-resource "tfe_variable" "test" {
+resource "tfe_variable" "test-a" {
   key             = "seperate_variable"
   value           = "my_value_name"
   category        = "terraform"
@@ -57,7 +57,7 @@ resource "tfe_variable" "test" {
   variable_set_id = tfe_variable_set.test.id
 }
 
-resource "tfe_variable" "test" {
+resource "tfe_variable" "test-b" {
   key             = "another_variable"
   value           = "my_value_name"
   category        = "env"

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -32,7 +32,7 @@ resource "tfe_variable_set" "test" {
   workspace_ids = [tfe_workspace.test.id]
 }
 
-resource "tfe_variable" "test" {
+resource "tfe_variable" "test-a" {
   key             = "seperate_variable"
   value           = "my_value_name"
   category        = "terraform"
@@ -40,7 +40,7 @@ resource "tfe_variable" "test" {
   variable_set_id = tfe_variable_set.test.id
 }
 
-resource "tfe_variable" "test" {
+resource "tfe_variable" "test-b" {
   key             = "another_variable"
   value           = "my_value_name"
   category        = "env"
@@ -64,7 +64,7 @@ resource "tfe_variable_set" "test" {
   organization = tfe_organization.test.name
 }
 
-resource "tfe_variable" "test" {
+resource "tfe_variable" "test-a" {
   key             = "seperate_variable"
   value           = "my_value_name"
   category        = "terraform"
@@ -72,7 +72,7 @@ resource "tfe_variable" "test" {
   variable_set_id = tfe_variable_set.test.id
 }
 
-resource "tfe_variable" "test" {
+resource "tfe_variable" "test-b" {
   key             = "another_variable"
   value           = "my_value_name"
   category        = "env"


### PR DESCRIPTION
## Description

Hello! I'm not sure that it's possible to have the same resource name for the same resource types _[in the same module?]_.

```
 terraform plan
╷
│ Error: Duplicate resource "tfe_variable" configuration
│
│   on variable_set.tf line 16:
│   16: resource "tfe_variable" "test" {
│
│ A tfe_variable resource named "test" was already declared at variable_set.tf:8,1-31. Resource names must be unique per type in each module.
╵
```

## Testing plan

Copy paste the snippet, substitute the necessary values and try `terraform plan`.

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```terraform
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # tfe_variable.test-a will be created
  + resource "tfe_variable" "test-a" {
      + category        = "terraform"
      + description     = "a useful description"
      + hcl             = false
      + id              = (known after apply)
      + key             = "seperate_variable"
      + sensitive       = false
      + value           = (sensitive value)
      + variable_set_id = (known after apply)
    }

  # tfe_variable.test-b will be created
  + resource "tfe_variable" "test-b" {
      + category        = "env"
      + description     = "an environment variable"
      + hcl             = false
      + id              = (known after apply)
      + key             = "another_variable"
      + sensitive       = false
      + value           = (sensitive value)
      + variable_set_id = (known after apply)
    }

  # tfe_variable_set.test will be created
  + resource "tfe_variable_set" "test" {
      + description   = "Some description."
      + global        = false
      + id            = (known after apply)
      + name          = "Test Varset"
      + organization  = "august-feng"
      + workspace_ids = (known after apply)
    }
...
```
