### PR TITLE
allow TF_TOKEN_... variables to specify host-specific credentials

### DIFF
--- a/tfe/credentials.go
+++ b/tfe/credentials.go
@@ -1,0 +1,101 @@
+package tfe
+
+import (
+	"log"
+	"os"
+	"strings"
+
+	svchost "github.com/hashicorp/terraform-svchost"
+	"github.com/hashicorp/terraform-svchost/disco"
+)
+
+func collectCredentialsFromEnv() map[svchost.Hostname]string {
+	const prefix = "TF_TOKEN_"
+
+	ret := make(map[svchost.Hostname]string)
+	for _, ev := range os.Environ() {
+		eqIdx := strings.Index(ev, "=")
+		if eqIdx < 0 {
+			continue
+		}
+		name := ev[:eqIdx]
+		value := ev[eqIdx+1:]
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		rawHost := name[len(prefix):]
+
+		// We accept double underscores in place of hyphens because hyphens are not valid
+		// identifiers in most shells and are therefore hard to set.
+		// This is unambiguous with replacing single underscores below because
+		// hyphens are not allowed at the beginning or end of a label and therefore
+		// odd numbers of underscores will not appear together in a valid variable name.
+		rawHost = strings.ReplaceAll(rawHost, "__", "-")
+
+		// We accept underscores in place of dots because dots are not valid
+		// identifiers in most shells and are therefore hard to set.
+		// Underscores are not valid in hostnames, so this is unambiguous for
+		// valid hostnames.
+		rawHost = strings.ReplaceAll(rawHost, "_", ".")
+
+		// Because environment variables are often set indirectly by OS
+		// libraries that might interfere with how they are encoded, we'll
+		// be tolerant of them being given either directly as UTF-8 IDNs
+		// or in Punycode form, normalizing to Punycode form here because
+		// that is what the Terraform credentials helper protocol will
+		// use in its requests.
+		//
+		// Using ForDisplay first here makes this more liberal than Terraform
+		// itself would usually be in that it will tolerate pre-punycoded
+		// hostnames that Terraform normally rejects in other contexts in order
+		// to ensure stored hostnames are human-readable.
+		dispHost := svchost.ForDisplay(rawHost)
+		hostname, err := svchost.ForComparison(dispHost)
+		if err != nil {
+			// Ignore invalid hostnames
+			continue
+		}
+
+		ret[hostname] = value
+	}
+
+	return ret
+}
+
+// hostTokenFromFallbackSources returns a token credential by searching for a hostname-specific
+// environment variable, a TFE_TOKEN, or a CLI config credentials block. The host parameter
+// is expected to be in the "comparison" form, for example, hostnames containing non-ASCII
+// characters like "café.fr" should be expressed as "xn--caf-dma.fr". If the variable based
+// on the hostname is not defined, nil is returned.
+//
+// Hyphen and period characters are allowed in environment variable names, but are not valid POSIX
+// variable names. However, it's still possible to set variable names with these characters using
+// utilities like env or docker. Variable names may have periods translated to underscores and
+// hyphens translated to double underscores in the variable name.
+// For the example "café.fr", you may use the variable names "TF_TOKEN_xn____caf__dma_fr",
+// "TF_TOKEN_xn--caf-dma_fr", or "TF_TOKEN_xn--caf-dma.fr"
+func hostTokenFromFallbackSources(hostname svchost.Hostname, services *disco.Disco) string {
+	token, ok := collectCredentialsFromEnv()[hostname]
+
+	if ok {
+		log.Printf("[DEBUG] TF_TOKEN_... used for token value for host %s", hostname)
+	} else {
+		// If a token wasn't set in the host-specific variable, try and fetch it
+		// from the environment or from Terraform's CLI configuration or configured credential helper.
+		if os.Getenv("TFE_TOKEN") != "" {
+			log.Printf("[DEBUG] TFE_TOKEN used for token value")
+			return os.Getenv("TFE_TOKEN")
+		} else if services != nil {
+			log.Printf("[DEBUG] Attempting to fetch token from Terraform CLI configuration for hostname %s...", hostname)
+			creds, err := services.CredentialsForHost(hostname)
+			if err != nil {
+				log.Printf("[DEBUG] Failed to get credentials for %s: %s (ignoring)", hostname, err)
+			}
+			if creds != nil {
+				token = creds.Token()
+			}
+		}
+	}
+
+	return token
+}

--- a/tfe/plugin_provider_test.go
+++ b/tfe/plugin_provider_test.go
@@ -67,7 +67,7 @@ func TestPluginProvider_providerMeta(t *testing.T) {
 		}
 
 		if tc.hostname == "" && meta.hostname != "" {
-			t.Fatalf("Test %s: hostname was not set in config and meta hostname should be empty in this moment (in retrieveProviderMeta). It is parsed later in wihtin the `getClient` function", name)
+			t.Fatalf("Test %s: hostname was not set in config and meta hostname should be empty in this moment (in retrieveProviderMeta). It is parsed later in within the `getClient` function", name)
 		}
 
 		if tc.hostname != "" && meta.hostname != tc.hostname {

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -241,22 +241,10 @@ func getClient(tfeHost, token string, insecure bool) (*tfe.Client, error) {
 		return nil, discoErr
 	}
 
-	// If a token wasn't set in the provider configuration block, try and fetch it
-	// from the environment or from Terraform's CLI configuration or configured credential helper.
+	// If a token wasn't set in the provider configuration block, try and fetch it from the
+	// fallback methods
 	if token == "" {
-		if os.Getenv("TFE_TOKEN") != "" {
-			log.Printf("[DEBUG] TFE_TOKEN used for token value")
-			token = os.Getenv("TFE_TOKEN")
-		} else {
-			log.Printf("[DEBUG] Attempting to fetch token from Terraform CLI configuration for hostname %s...", hostname)
-			creds, err := services.CredentialsForHost(hostname)
-			if err != nil {
-				log.Printf("[DEBUG] Failed to get credentials for %s: %s (ignoring)", hostname, err)
-			}
-			if creds != nil {
-				token = creds.Token()
-			}
-		}
+		token = hostTokenFromFallbackSources(hostname, services)
 	}
 
 	// If we still don't have a token at this point, we return an error.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -42,6 +42,7 @@ There are several ways to provide the required token:
 - **Set the `token` argument in the provider configuration.** You can set
 the `token` argument in the provider configuration.  Use an input variable for
 the token.
+- **Set a host-specific environment variable:** Set a `TF_TOKEN_...` variable with the host name as the suffix, for example, `TF_TOKEN_app_terraform_io`. This example token will be used for authentication if `app.terraform.io` is configured as the host. This authentication method is shared by Terraform for all network services since version 1.2.
 - **Set the `TFE_TOKEN` environment variable:** The provider can read the
 `TFE_TOKEN` environment variable and the token stored there to authenticate.
 


### PR DESCRIPTION
## Description

This is a companion PR to a change to terraform that adds host specific env svc creds. It should be possible for tfe to use the same method when specifying credentials for a particular tfc host.

## Testing plan

0. Build this code `go build -o terraform-provider-tfe` and update your CLI config to override it (see below)
1. Don't specify a token in your tfe provider configuration block
2. Remove or modify your CLI configuration credentials for the test host
3. Run terraform using an env var  with the correct token value (see below)
4. This should work on Terraform 1.1 with local state. It would also work in latest Terraform built from source

I used this config:

```
provider "tfe" {
  hostname = "YOURHOST.com"
}

resource "tfe_organization" "test-organization" {
  name  = "my-org-name"
  email = "bcroft@hashicorp.com"
}

resource "tfe_workspace" "test" {
  name         = "my-workspace-name"
  organization = tfe_organization.test-organization.name
  tag_names    = ["test", "app"]
}
```

with this command:

`TF_CLI_CONFIG_FILE=.terraformrc TF_TOKEN_YOURHOST_COM="MY_REAL_TOKEN" terraform apply`

with this CLI config:

```
provider_installation {
  # Use /home/developer/tmp/terraform-null as an overridden package directory
  # for the hashicorp/null provider. This disables the version and checksum
  # verifications for this provider and forces Terraform to look for the
  # null provider plugin in the given directory.
  dev_overrides {
    "hashicorp/tfe" = "/Users/brandonc/hashicorp/terraform-provider-tfe"
  }

  # For all other providers, install them directly from their origin provider
  # registries as normal. If you omit this, Terraform will _only_ use
  # the dev_overrides block, and so no other providers will be available.
  direct {}
}
```

## External links

- [Related PR](https://github.com/hashicorp/terraform/pull/30878)
