### PR TITLE
fix(provider): redact sensitive headers from HTTP logging

### DIFF
--- a/tfe/logging.go
+++ b/tfe/logging.go
@@ -1,0 +1,98 @@
+package tfe
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"strings"
+)
+
+type loggingTransport struct {
+	name     string
+	delegate http.RoundTripper
+}
+
+const (
+	EnvLog = "TF_LOG"
+)
+
+// redactedHeaders is a list of lowercase headers (with trailing colons) that signal that the
+// header values should be redacted from logs
+var redactedHeaders = []string{"authorization:", "proxy-authorization:"}
+
+// IsDebugOrHigher returns whether or not the current log level is debug or trace
+func IsDebugOrHigher() bool {
+	level := strings.ToUpper(os.Getenv(EnvLog))
+	return level == "DEBUG" || level == "TRACE"
+}
+
+// RoundTrip is a transport method that logs the request and response if the TF_LOG level is
+// TRACE or DEBUG
+func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if IsDebugOrHigher() {
+		reqData, err := httputil.DumpRequestOut(req, true)
+		if err == nil {
+			log.Printf("[DEBUG] "+logReqMsg, t.name, filterAndPrettyPrintLines(reqData))
+		} else {
+			log.Printf("[ERROR] %s API Request error: %#v", t.name, err)
+		}
+	}
+
+	resp, err := t.delegate.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if IsDebugOrHigher() {
+		respData, err := httputil.DumpResponse(resp, true)
+		if err == nil {
+			log.Printf("[DEBUG] "+logRespMsg, t.name, filterAndPrettyPrintLines(respData))
+		} else {
+			log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
+		}
+	}
+
+	return resp, nil
+}
+
+// NewLoggingTransport wraps the given transport with a logger that logs request and
+// response details
+func NewLoggingTransport(name string, t http.RoundTripper) *loggingTransport {
+	return &loggingTransport{name, t}
+}
+
+// filterAndPrettyPrintLines iterates through a []byte line-by-line,
+// redacting any sensitive lines and transforming any lines that are complete json into
+// pretty-printed json.
+func filterAndPrettyPrintLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		for _, check := range redactedHeaders {
+			if strings.HasPrefix(strings.ToLower(p), check) {
+				// This looks like a sensitive header to redact, so overwrite the entire line
+				parts[i] = fmt.Sprintf("%s <REDACTED>", p[0:len(check)])
+				continue
+			}
+		}
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			_ = json.Indent(&out, b, "", " ") // already checked for validity
+			parts[i] = out.String()
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -17,7 +17,6 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	providerVersion "github.com/hashicorp/terraform-provider-tfe/version"
 	svchost "github.com/hashicorp/terraform-svchost"
@@ -184,7 +183,7 @@ func getClient(tfeHost, token string, insecure bool) (*tfe.Client, error) {
 	credsSrc := credentialsSource(config)
 	services := disco.NewWithCredentialsSource(credsSrc)
 	services.SetUserAgent(providerUaString)
-	services.Transport = logging.NewTransport("TFE Discovery", transport)
+	services.Transport = NewLoggingTransport("TFE Discovery", transport)
 
 	// Add any static host configurations service discovery object.
 	for userHost, hostConfig := range config.Hosts {
@@ -265,7 +264,7 @@ func getClient(tfeHost, token string, insecure bool) (*tfe.Client, error) {
 	}
 
 	// Wrap the configured transport to enable logging.
-	httpClient.Transport = logging.NewTransport("TFE", transport)
+	httpClient.Transport = NewLoggingTransport("TFE", transport)
 
 	// Create a new TFE client config
 	cfg := &tfe.Config{


### PR DESCRIPTION
## Description

Replaces the SDK logging transport with a similar logger that redacts certain headers ("authorization:", "proxy-authorization:") from logging output.

While we wait for the plugin SDK to implement a more robust or configurable solution for the issue of logging sensitive tokens in TRACE and DEBUG levels, we can implement a quick solution in this provider.

## Testing plan

1.  Plan any configuration that uses TFE resources using the TF_LOG=TRACE variable
2. Notice that authorization tokens are now redacted from log output made by terraform:

Example output:
```
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: 2022/04/21 12:42:13 [DEBUG] TFE API Request Details:
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: ---[ REQUEST ]---------------------------------------
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: POST /api/v2/organizations HTTP/1.1
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: Host: tfcdev-5839ba17.ngrok.io
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: User-Agent: go-tfe
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: Content-Length: 101
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: Accept: application/vnd.api+json
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: Authorization: <REDACTED>
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: Content-Type: application/vnd.api+json
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: Accept-Encoding: gzip
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: {
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:  "data": {
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:   "type": "organizations",
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:   "attributes": {
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:    "email": "bcroft@hashicorp.com",
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:    "name": "my-org-name"
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:   }
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:  }
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: }
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe:
2022-04-21T12:42:13.983-0600 [DEBUG] provider.terraform-provider-tfe: -----------------------------------------------------
```

## Notes

I lifted much of this code from the [plugin SDK logging package](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/logging/logging.go) so we should see no other logging behavior changes.