### PR TITLE
Make team access `permissions` attributes optional

### DIFF
--- a/tfe/data_source_team_access_test.go
+++ b/tfe/data_source_team_access_test.go
@@ -37,6 +37,7 @@ func TestAccTFETeamAccessDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.tfe_team_access.foobar", "team_id"),
 					resource.TestCheckResourceAttrSet("data.tfe_team_access.foobar", "workspace_id"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -58,7 +58,8 @@ func resourceTFETeamAccess() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"runs": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Default:  string(tfe.RunsPermissionRead),
 							ValidateFunc: validation.StringInSlice(
 								[]string{
 									string(tfe.RunsPermissionRead),
@@ -71,7 +72,8 @@ func resourceTFETeamAccess() *schema.Resource {
 
 						"variables": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Default:  string(tfe.VariablesPermissionNone),
 							ValidateFunc: validation.StringInSlice(
 								[]string{
 									string(tfe.VariablesPermissionNone),
@@ -84,7 +86,8 @@ func resourceTFETeamAccess() *schema.Resource {
 
 						"state_versions": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Default:  string(tfe.StateVersionsPermissionNone),
 							ValidateFunc: validation.StringInSlice(
 								[]string{
 									string(tfe.StateVersionsPermissionNone),
@@ -98,7 +101,8 @@ func resourceTFETeamAccess() *schema.Resource {
 
 						"sentinel_mocks": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Default:  string(tfe.SentinelMocksPermissionNone),
 							ValidateFunc: validation.StringInSlice(
 								[]string{
 									string(tfe.SentinelMocksPermissionNone),
@@ -110,7 +114,8 @@ func resourceTFETeamAccess() *schema.Resource {
 
 						"workspace_locking": {
 							Type:     schema.TypeBool,
-							Required: true,
+							Optional: true,
+							Default:  false,
 						},
 					},
 				},

--- a/tfe/resource_tfe_team_access_test.go
+++ b/tfe/resource_tfe_team_access_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccTFETeamAccess_write(t *testing.T) {
+	skipIfFreeOnly(t)
+
 	tmAccess := &tfe.TeamAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -42,12 +44,15 @@ func TestAccTFETeamAccess_write(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "read"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "true"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
 
 func TestAccTFETeamAccess_custom(t *testing.T) {
+	skipIfFreeOnly(t)
+
 	tmAccess := &tfe.TeamAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -85,6 +90,8 @@ func TestAccTFETeamAccess_custom(t *testing.T) {
 }
 
 func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
+	skipIfFreeOnly(t)
+
 	tmAccess := &tfe.TeamAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -116,6 +123,7 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "read"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "true"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccTFETeamAccess_custom(rInt),
@@ -146,6 +154,8 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 }
 
 func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
+	skipIfFreeOnly(t)
+
 	tmAccess := &tfe.TeamAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -201,12 +211,15 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "none"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "false"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
 
 func TestAccTFETeamAccess_import(t *testing.T) {
+	skipIfFreeOnly(t)
+
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -215,7 +228,8 @@ func TestAccTFETeamAccess_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamAccess_write(rInt),
+				Config:             testAccTFETeamAccess_write(rInt),
+				ExpectNonEmptyPlan: true,
 			},
 
 			{
@@ -223,6 +237,7 @@ func TestAccTFETeamAccess_import(t *testing.T) {
 				ImportState:         true,
 				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/workspace-test/", rInt),
 				ImportStateVerify:   true,
+				ExpectNonEmptyPlan:  true,
 			},
 		},
 	})
@@ -317,12 +332,12 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_team" "foobar" {
   name         = "team-test"
-  organization = tfe_organization.foobar.id
+  organization = tfe_organization.foobar.name
 }
 
 resource "tfe_workspace" "foobar" {
   name         = "workspace-test"
-  organization = tfe_organization.foobar.id
+  organization = tfe_organization.foobar.name
 }
 
 resource "tfe_team_access" "foobar" {

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -43,11 +43,11 @@ The following arguments are supported:
 
 The `permissions` block supports:
 
-* `runs` - (Required) The permission to grant the team on the workspace's runs. Valid values are `read`, `plan`, or `apply`.
-* `variables` - (Required) The permission to grant the team on the workspace's variables. Valid values are `none`, `read`, or `write`.
-* `state_versions` - (Required) The permission to grant the team on the workspace's state versions. Valid values are `none`, `read`, `read-outputs`, or `write`.
-* `sentinel_mocks` - (Required) The permission to grant the team on the workspace's generated Sentinel mocks, Valid values are `none` or `read`.
-* `workspace_locking` - (Required) Boolean determining whether or not to grant the team permission to manually lock/unlock the workspace.
+* `runs` - (Optional) The permission to grant the team on the workspace's runs. Valid values are `read`, `plan`, or `apply`. Defaults to `read`.
+* `variables` - (Optional) The permission to grant the team on the workspace's variables. Valid values are `none`, `read`, or `write`. Defaults to `none`.
+* `state_versions` - (Optional) The permission to grant the team on the workspace's state versions. Valid values are `none`, `read`, `read-outputs`, or `write`. Defaults to `none`.
+* `sentinel_mocks` - (Optional) The permission to grant the team on the workspace's generated Sentinel mocks, Valid values are `none` or `read`. Defaults to `none`.
+* `workspace_locking` - (Optional) Boolean determining whether or not to grant the team permission to manually lock/unlock the workspace. Defaults to `false`.
 
 -> **Note:** At least one of `access` or `permissions` _must_ be provided, but not both. Whichever is omitted will automatically reflect the state of the other.
 


### PR DESCRIPTION
## Description

_Describe why you're making this change._

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc 

...
```
