### PR TITLE
Add manage_run_tasks to Org. Team Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.32.0 (Unreleased)
+
+FEATURES:
+* r/team, d/team: Add manage_run_tasks to the tfe_team organization_access attributes ([#486](https://github.com/hashicorp/terraform-provider-tfe/pull/486))
+
 ## 0.31.0 (April 21, 2022)
 
 BUG FIXES:

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -69,6 +69,11 @@ func resourceTFETeam() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"manage_run_tasks": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -111,6 +116,7 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 			ManageVCSSettings:     tfe.Bool(organizationAccess["manage_vcs_settings"].(bool)),
 			ManageProviders:       tfe.Bool(organizationAccess["manage_providers"].(bool)),
 			ManageModules:         tfe.Bool(organizationAccess["manage_modules"].(bool)),
+			ManageRunTasks:        tfe.Bool(organizationAccess["manage_run_tasks"].(bool)),
 		}
 	}
 
@@ -166,6 +172,7 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 			"manage_vcs_settings":     team.OrganizationAccess.ManageVCSSettings,
 			"manage_providers":        team.OrganizationAccess.ManageProviders,
 			"manage_modules":          team.OrganizationAccess.ManageModules,
+			"manage_run_tasks":        team.OrganizationAccess.ManageRunTasks,
 		}}
 		if err := d.Set("organization_access", organizationAccess); err != nil {
 			return fmt.Errorf("error setting organization access for team %s: %s", d.Id(), err)
@@ -198,6 +205,7 @@ func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
 			ManageVCSSettings:     tfe.Bool(organizationAccess["manage_vcs_settings"].(bool)),
 			ManageProviders:       tfe.Bool(organizationAccess["manage_providers"].(bool)),
 			ManageModules:         tfe.Bool(organizationAccess["manage_modules"].(bool)),
+			ManageRunTasks:        tfe.Bool(organizationAccess["manage_run_tasks"].(bool)),
 		}
 	}
 

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -65,6 +65,8 @@ func TestAccTFETeam_full(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.manage_providers", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_modules", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_run_tasks", "true"),
 				),
 			},
 		},
@@ -102,6 +104,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.manage_providers", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_modules", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_run_tasks", "true"),
 				),
 			},
 			{
@@ -127,6 +131,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_modules", "false"),
 					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_run_tasks", "false"),
+					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "sso_team_id", "changed-sso-id"),
 				),
 			},
@@ -151,6 +157,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.manage_providers", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.manage_modules", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_run_tasks", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "sso_team_id", ""),
 				),
@@ -240,6 +248,9 @@ func testAccCheckTFETeamAttributes_full(
 		if !team.OrganizationAccess.ManageWorkspaces {
 			return fmt.Errorf("OrganizationAccess.ManageWorkspaces should be true")
 		}
+		if !team.OrganizationAccess.ManageRunTasks {
+			return fmt.Errorf("OrganizationAccess.ManageRunTasks should be true")
+		}
 		if *team.SSOTeamID != "team-test-sso-id" {
 			return fmt.Errorf("Bad SSO Team ID: %s", *team.SSOTeamID)
 		}
@@ -267,6 +278,9 @@ func testAccCheckTFETeamAttributes_full_update(
 		}
 		if team.OrganizationAccess.ManageWorkspaces {
 			return fmt.Errorf("OrganizationAccess.ManageWorkspaces should be false")
+		}
+		if team.OrganizationAccess.ManageRunTasks {
+			return fmt.Errorf("OrganizationAccess.ManageRunTasks should be false")
 		}
 
 		if *team.SSOTeamID != "changed-sso-id" {
@@ -323,12 +337,13 @@ resource "tfe_team" "foobar" {
   organization = tfe_organization.foobar.id
 
   visibility = "organization"
-  
+
   organization_access {
     manage_policies = true
     manage_policy_overrides = true
     manage_workspaces = true
     manage_vcs_settings = true
+    manage_run_tasks = true
 	manage_providers = true
 	manage_modules = true
   }
@@ -348,12 +363,13 @@ resource "tfe_team" "foobar" {
   organization = tfe_organization.foobar.id
 
   visibility = "secret"
-  
+
   organization_access {
     manage_policies = false
     manage_policy_overrides = false
     manage_workspaces = false
     manage_vcs_settings = false
+    manage_run_tasks = false
 	manage_providers = false
 	manage_modules = false
   }

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -51,6 +51,7 @@ The `organization_access` block supports:
 * `manage_vcs_settings` - (Optional) Allows members to manage the organization's VCS Providers and SSH keys.
 * `manage_providers` - (Optional) Allow members to publish and delete providers in the organization's private registry.
 * `manage_modules` - (Optional) Allow members to publish and delete modules in the organization's private registry.
+* `manage_run_tasks` - (Optional) Allow members to create, edit, and delete the organization's run tasks.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Run Tasks added a new Organizational access type called `manage_run_tasks`.
This commit updates the organization_access of Teams to include this new
access type.

## Testing plan

Acceptance tests are updated in the PR

## External links

- [go-tfe documentation](https://github.com/hashicorp/go-tfe/blob/main/team.go#L67)

## Output from acceptance tests

N/A - Run as part of CI