### PR TITLE
Removing note "TFC Only" - doc only

### DIFF
--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -29,7 +29,7 @@ resource "tfe_workspace" "test" {
 }
 ```
 
-(**TFC only**) With `execution_mode` of `agent`:
+With `execution_mode` of `agent`:
 
 ```hcl
 resource "tfe_organization" "test-organization" {


### PR DESCRIPTION
## Description

this note was for when agents were TFC only. now that agents exist on TFE this note can be removed

## Testing plan

DOC only

## External links

https://www.terraform.io/enterprise/admin/agents-on-tfe