### PR TITLE
Add helpful tasks to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,12 @@
 
 _Describe why you're making this change._
 
+_Remember to:_
+
+- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_
+
+- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_
+
 ## Testing plan
 
 1.  _Describe how to replicate_
@@ -24,7 +30,7 @@ _Please run applicable acceptance tests locally and include the output here. See
 _If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._
 
 ```
-$ TESTARGS="-run TestAccTFEWorkspace" make testacc 
+$ TESTARGS="-run TestAccTFEWorkspace" make testacc
 
 ...
 ```


### PR DESCRIPTION
Some of the information for contributing to this project is somewhat buried at
the end of the README which makes it easy to forget and difficult to discover
for new people.  This commit adds a simple task list with links to further
instructions for updating the changelog and documentation.
