### PR TITLE
Add keepers argument for token resources

### DIFF
--- a/tfe/resource_tfe_agent_token.go
+++ b/tfe/resource_tfe_agent_token.go
@@ -30,6 +30,12 @@ func resourceTFEAgentToken() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"keepers": {
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of resource.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
 		},
 	}
 }

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -35,6 +35,13 @@ func resourceTFEOrganizationToken() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+
+			"keepers": {
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of resource.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
 		},
 	}
 }

--- a/tfe/resource_tfe_team_token.go
+++ b/tfe/resource_tfe_team_token.go
@@ -35,6 +35,13 @@ func resourceTFETeamToken() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+
+			"keepers": {
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of resource.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
 		},
 	}
 }

--- a/website/docs/r/agent_token.html.markdown
+++ b/website/docs/r/agent_token.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
 
 * `agent_pool_id` - (Required) ID of the agent pool.
 * `description` - (Required) Description of the agent token.
+* `keepers` - (Optional) Arbitrary map of values that, when changed, will trigger
+  a new token to be generated.
 
 ## Attributes Reference
 

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -29,6 +29,8 @@ The following arguments are supported:
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!
+* `keepers` - (Optional) Arbitrary map of values that, when changed, will trigger
+  a new token to be generated.
 
 ## Attributes Reference
 

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -33,6 +33,8 @@ The following arguments are supported:
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!
+* `keepers` - (Optional) Arbitrary map of values that, when changed, will trigger
+  a new token to be generated.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Add support to recreate tokens with an argument named keepers. Adding this functionality to recreate token if resources change/update or can be used with the terraform resource time_rotating.

## Testing plan
Example: This will rotate the token after 2 minutes.
```
resource "time_rotating" "token" {
  rotation_minutes = 2
}

resource "tfe_team_token" "manage_workspaces" {
  team_id = "xxxxxx"

  keepers = {
    time_rotation = time_rotating.token.id
  }
}
```
<img width="820" alt="Screen Shot 2022-05-13 at 8 56 05 PM" src="https://user-images.githubusercontent.com/36347519/168404809-7b59095c-0661-4ad8-97a7-eca7587c3a1c.png">

## Output from acceptance tests
Currently do not have a test organization for TFC setup. 

Please let me know if any information is missing or if changes need to me made.

