### PR TITLE
Use filtering to improve performance of agent pool data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+ENHANCEMENTS:
+* d/agent_pool: Improve efficiency of reading agent pool data when the target organization has more than 20 agent pools ([#508](https://github.com/hashicorp/terraform-provider-tfe/pull/508))
+
 ## 0.33.0 (July 8th, 2022)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-slug v0.9.1
-	github.com/hashicorp/go-tfe v1.4.0
+	github.com/hashicorp/go-tfe v1.5.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl/v2 v2.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/hashicorp/go-slug v0.9.1 h1:gYNVJ3t0jAWx8AT2eYZci3Xd7NBHyjayW9AR1DU4k
 github.com/hashicorp/go-slug v0.9.1/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-tfe v1.4.0 h1:rMoQ2r1QppaglYsBdmdgFphipNTCkjTaO1oOLVj04Ec=
 github.com/hashicorp/go-tfe v1.4.0/go.mod h1:E8a90lC4kjU5Lc2c0D+SnWhUuyuoCIVm4Ewzv3jCD3A=
+github.com/hashicorp/go-tfe v1.5.0 h1:MtABkqH2s6lRFl8HaGt0qESLGAyrmMAFfecsEm+13K8=
+github.com/hashicorp/go-tfe v1.5.0/go.mod h1:E8a90lC4kjU5Lc2c0D+SnWhUuyuoCIVm4Ewzv3jCD3A=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=

--- a/tfe/data_source_agent_pool.go
+++ b/tfe/data_source_agent_pool.go
@@ -33,7 +33,11 @@ func dataSourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error 
 	organization := d.Get("organization").(string)
 
 	// Create an options struct.
-	options := tfe.AgentPoolListOptions{}
+	// to reduce the number of pages returned, search based on the name. TFE instances which
+	// do not support agent pool seach will just ignore the query parameter
+	options := tfe.AgentPoolListOptions{
+		Query: name,
+	}
 
 	for {
 		l, err := tfeClient.AgentPools.List(ctx, organization, &options)

--- a/tfe/data_source_agent_pool.go
+++ b/tfe/data_source_agent_pool.go
@@ -34,7 +34,7 @@ func dataSourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error 
 
 	// Create an options struct.
 	// to reduce the number of pages returned, search based on the name. TFE instances which
-	// do not support agent pool seach will just ignore the query parameter
+	// do not support agent pool search will just ignore the query parameter
 	options := tfe.AgentPoolListOptions{
 		Query: name,
 	}


### PR DESCRIPTION
## Description

Once agent pool filtering is enabled (currently off in production behind the `remove-agent-pool-limit` feature flag) we can filter agent pool list requests by agent pool name. This improves performance of the agent pool data source when the organization has >20 agent pools by reducing the number of API calls we need to make in order to loop through all of the pages of agent pools

## Testing plan

1.  Set up a TFC organization with >20 agent pools, and a terraform config with a data source matching one of those agent pools
1.  Verify that with the `remove-agent-pool-limit` feature flag off, the data source resolves the agent pool
2. Verify that with the `remove-agent-pool-limit` feature flag on, the data source resolves the agent pool even faster
   -  The difference for me, against an org with ~1100 agent pools, is 6s w/ the feature flag vs. 1m12s w/o the feature flag


## External links

- API documentation: In progress...
- [go-tfe PR](https://github.com/hashicorp/go-tfe/pull/417)

## Output from acceptance tests

```
 TESTARGS="-run  TestAccTFEAgentPoolDataSource_" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run  TestAccTFEAgentPoolDataSource_ -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEAgentPoolDataSource_basic
--- PASS: TestAccTFEAgentPoolDataSource_basic (8.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	8.798s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]

...
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202293596899902