### PR TITLE
Change default for `file_triggers_enabled` to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ BUG FIXES:
 FEATURES:
 * r/team, d/team: Add manage_run_tasks to the tfe_team organization_access attributes ([#486](https://github.com/hashicorp/terraform-provider-tfe/pull/486))
 
+BREAKING CHANGES:
+* r/tfe_workspace: Default value of the `file_triggers_enabled` field is changed to `false`. 
+  If the value of the `file_triggers_enabled` field was not explicitly set and either of the fields `working_directory`
+  (not an empty string) or `trigger_prefixes` was used - to keep the behavior unchanged the `file_trigger_enabled` 
+  field should now explicitly be set to `true`. 
+
 ## 0.31.0 (April 21, 2022)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ FEATURES:
 * r/team, d/team: Add manage_run_tasks to the tfe_team organization_access attributes ([#486](https://github.com/hashicorp/terraform-provider-tfe/pull/486))
 
 BREAKING CHANGES:
-* r/tfe_workspace: Default value of the `file_triggers_enabled` field is changed to `false`. 
+* r/tfe_workspace: Default value of the `file_triggers_enabled` field is changed to `false`. This will align the
+  `file_triggers_enabled` field default value with the default value for the same field in the 
+  [TFC API](https://www.terraform.io/cloud-docs/api-docs/workspaces).
   If the value of the `file_triggers_enabled` field was not explicitly set and either of the fields `working_directory`
-  (not an empty string) or `trigger_prefixes` was used - to keep the behavior unchanged the `file_trigger_enabled` 
-  field should now explicitly be set to `true`. 
+  (not an empty string) or `trigger_prefixes` was used - to keep the behavior unchanged, the `file_trigger_enabled` 
+  field should now explicitly be set to `true`. ([#510](https://github.com/hashicorp/terraform-provider-tfe/pull/510/files))
 
 ## 0.31.0 (April 21, 2022)
 

--- a/tfe/resource_tfe_workspace_migrate.go
+++ b/tfe/resource_tfe_workspace_migrate.go
@@ -29,7 +29,7 @@ func resourceTfeWorkspaceResourceV0() *schema.Resource {
 			"file_triggers_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 
 			"operations": {

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
   for state storage only. This value _must not_ be provided if `operations` 
   is provided.
 * `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files
-  in a VCS push. Defaults to `true`. If enabled, the working directory and 
+  in a VCS push. Defaults to `false`. If enabled, the working directory and 
   trigger prefixes describe a set of paths which must contain changes for a 
   VCS push to trigger a run. If disabled, any push will trigger a run. 
 * `global_remote_state` - (Optional) Whether the workspace allows all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (`remote_state_consumer_ids`).


### PR DESCRIPTION
## Description

Change default for `file_triggers_enabled` to false.

Why?
Current default is wrong and we're having a clause on the TFC side to account for this behavior.
New trigger types, e.g. tag based triggering, will depend on this field being set to `false`. We'll introduce the conflict between the new fields and `file_triggers_enabled`.

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_

## Testing plan

1. Define a new workspace without `file_triggers_enabled`
2. Newly created workspace should have the field set to `false`

