### PR TITLE
Fix panic interface conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BREAKING CHANGES:
 
 BUG FIXES:
 * Prevent overwriting `vcs_repo` attributes in `r/tfe_workspace` when update API call fails ([#498](https://github.com/hashicorp/terraform-provider-tfe/pull/498))
+* Fix panic crash on `trigger_prefixes` update in `r/tfe_workspace` when given empty strings ([#518](https://github.com/hashicorp/terraform-provider-tfe/pull/518))
 
 FEATURES:
 * r/team, d/team: Add manage_run_tasks to the tfe_team organization_access attributes ([#486](https://github.com/hashicorp/terraform-provider-tfe/pull/486))

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -442,7 +442,9 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		if tps, ok := d.GetOk("trigger_prefixes"); ok {
 			for _, tp := range tps.([]interface{}) {
-				options.TriggerPrefixes = append(options.TriggerPrefixes, tp.(string))
+				if val, ok := tp.(string); ok {
+					options.TriggerPrefixes = append(options.TriggerPrefixes, val)
+				}
 			}
 		} else {
 			// Reset trigger prefixes when none are present in the config.


### PR DESCRIPTION
## Description

This is a fix that closes #513, where a panic was occurring during an unhandled type conversion error. This is a similar problem to a fix I had done a while back (#421). To reiterate: the culprit is `[""]`. The SDK casts this value as `[nil]`, which then induces the panic whenever you try to typecast `nil` to `string`. 

For this particular issue you'll notice that initially setting `trigger_prefixes = [""]` **will work**. This is because the Create method will handle type conversion errors, as seen here:

https://github.com/hashicorp/terraform-provider-tfe/blob/59a346f8cd271712bbf22a2c508c5dc4fc940621/tfe/resource_tfe_workspace.go#L253-L259

The problem was the Update function _did not_ handle type conversion errors:
https://github.com/hashicorp/terraform-provider-tfe/blob/59a346f8cd271712bbf22a2c508c5dc4fc940621/tfe/resource_tfe_workspace.go#L443-L450

And thusly, it was a simple fix! 


## Testing plan
In order to test make sure you have your overrides file and the changes compiled locally `go install .` from this branch.  
1.  The minimum configuration you'll need to reproduce the error and fix:
```hcl
provider "tfe" {}

resource "tfe_workspace" "foo" {
  name = "panic-crash"
  organization = "star-destroyers"
  trigger_prefixes = [""]
}
```
2. Run `terraform apply` **without** overriding the provider. It should succeed. 
3. Then add another empty string to the `trigger_prefixes` list, and run `terraform apply`. Now we'll see the crash cause the Update function is called. 
4. To see the fix, simply pass your overrides file to Terraform:
```sh
TF_CLI_CONFIG_FILE=/Users/jedimaster/path/to/tfrcfile terraform apply
```
5. No panic should occur and you should get a successful apply!
