### PR TITLE
add workspace limit admin setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 FEATURES:
 * **New Resource**: `tfe_workspace_variable_set` ([#537](https://github.com/hashicorp/terraform-provider-tfe/pull/537)) adds the ability to assign a variable set to a workspace in a single, flexible resource.
 * r/tfe_workspace, d/tfe_workspace: `trigger-patterns` ([#502](https://github.com/hashicorp/terraform-provider-tfe/pull/502)) attribute is introduced to support specifying a set of [glob patterns](https://www.terraform.io/cloud-docs/workspaces/settings/vcs#glob-patterns-for-automatic-run-triggering) for automatic VCS run triggering.
+* r/organization: Add `workspace_limit` setting, available only in Terraform Enterprise ([#521](https://github.com/hashicorp/terraform-provider-tfe/pull/521))
 
 DEPRECATION NOTICE: The `workspace_ids` argument on `tfe_variable_set` has been labelled as deprecated and should not be used in conjunction with `tfe_workspace_variable_set`.
 

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -73,6 +73,20 @@ func resourceTFEOrganization() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"admin_settings": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"workspace_limit": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -124,6 +138,23 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("cost_estimation_enabled", org.CostEstimationEnabled)
 	d.Set("send_passing_statuses_for_untriggered_speculative_plans", org.SendPassingStatusesForUntriggeredSpeculativePlans)
 
+	// update admin settings
+	log.Printf("[DEBUG] Read admin settings of organization: %s", d.Id())
+	adminOrg, err := tfeClient.Admin.Organizations.Read(ctx, d.Id())
+	if err != nil {
+		return err
+	}
+	var adminSettings []interface{}
+
+	if adminOrg.WorkspaceLimit != nil && *adminOrg.WorkspaceLimit != 0 {
+		adminSettings = append(adminSettings, map[string]interface{}{
+			"workspace_limit": *adminOrg.WorkspaceLimit,
+		})
+	}
+	if err := d.Set("admin_settings", adminSettings); err != nil {
+		return fmt.Errorf("error setting admin settings for organization %s: %w", d.Id(), err)
+	}
+
 	return nil
 }
 
@@ -164,6 +195,19 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 	// If send_passing_statuses_for_untriggered_speculative_plans is supplied, set it using the options struct.
 	if sendPassingStatusesForUntriggeredSpeculativePlans, ok := d.GetOk("send_passing_statuses_for_untriggered_speculative_plans"); ok {
 		options.SendPassingStatusesForUntriggeredSpeculativePlans = tfe.Bool(sendPassingStatusesForUntriggeredSpeculativePlans.(bool))
+	}
+
+	// update workspace limit setting only if it has changed
+	if d.HasChange("admin_settings.0.workspace_limit") {
+		adminOpts := tfe.AdminOrganizationUpdateOptions{}
+
+		newLimit := d.Get("admin_settings.0.workspace_limit").(int)
+		adminOpts.WorkspaceLimit = &newLimit
+
+		_, err := tfeClient.Admin.Organizations.Update(ctx, d.Id(), adminOpts)
+		if err != nil {
+			return fmt.Errorf("Error updating admin settings for organization %s: %w", d.Id(), err)
+		}
 	}
 
 	log.Printf("[DEBUG] Update configuration of organization: %s", d.Id())

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -36,6 +36,11 @@ The following arguments are supported:
 * `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
 * `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `send_passing_statuses_for_untriggered_speculative_plans` - (Optional) Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.
+* `admin_settings` - Settings that are only available in Terraform Enterprise.
+
+* The `admin_settings` block supports:
+
+* `workspace_limit` - (Optional) The maximum number of workspaces that can exist in this organization. If this number is set to a value lower than the number of workspaces the organization currently has, it will prevent additional workspaces from being created, but existing workspaces will not be affected. If set to 0, this limit will have no effect.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Supporting the new feature that was released in the July TFE release.

Here's [a link to the slack thread](https://hashicorp.slack.com/archives/C01BR9FR8KZ/p1652808925041049) where this feature was discussed.

## Testing plan

1.  Spin up instance of TFE
2. Attempt to set `workspace_limit` via the organization resource.
3. Attempt to unset `workspace_limit` via the organization resource.

## Output from acceptance tests

Ran with the following ENV variables:
```
GITHUB_POLICY_SET_IDENTIFIER=hashicorp/test-policy-set
TF_ACC=1
ENABLE_TFE=1
TFE_HOSTNAME=<redacted>
TFE_TOKEN=<redacted>
```

```
=== RUN   TestAccTFEOrganization_update_workspaceLimit
--- PASS: TestAccTFEOrganization_update_workspaceLimit (86.91s)
```