### PR TITLE
Add exclude_tags to data_source_workspace_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ FEATURES:
 * **New Data Source**: d/tfe_organization_run_task ([#488](https://github.com/hashicorp/terraform-provider-tfe/pull/488))
 * **New Data Source**: d/tfe_workspace_run_task ([#488](https://github.com/hashicorp/terraform-provider-tfe/pull/488))
 * r/tfe_notification_configuration: Add Microsoft Teams notification type ([#484](https://github.com/hashicorp/terraform-provider-tfe/pull/484))
+* d/workspace_ids: Add `exclude_tags` to `tfe_workspace_ids` attributes ([#523](https://github.com/hashicorp/terraform-provider-tfe/pull/523))
 
 ## 0.31.0 (April 21, 2022)
 

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -263,6 +263,72 @@ func TestAccTFEWorkspaceIDsDataSource_namesEmpty(t *testing.T) {
 	})
 }
 
+func TestAccTFEWorkspaceIDsDataSource_excludeTags(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceIDsDataSourceConfig_excludeTags(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "organization", orgName),
+
+					// full_names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "full_names.%", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good",
+						fmt.Sprintf("full_names.workspace-bar-%d", rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-bar-%d", rInt, rInt),
+					),
+
+					// ids attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "ids.%", "1"),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.good", fmt.Sprintf("ids.workspace-bar-%d", rInt)),
+
+					// id attribute
+					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.good", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspaceIDsDataSource_sameTagInTagNamesAndExcludeTags(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceIDsDataSourceConfig_sameTagInTagNamesAndExcludeTags(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "organization", orgName),
+
+					// full_names attribute should be empty
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "full_names.%", "0"),
+
+					// ids attribute should be empty
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.good", "ids.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccTFEWorkspaceIDsDataSourceConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
@@ -425,5 +491,78 @@ data "tfe_workspace_ids" "good" {
   names        = ["", "workspace-foo-%d"]
   tag_names    = ["bar"]
   organization = tfe_workspace.foo.organization
+}`, rInt, rInt, rInt, rInt)
+}
+
+func testAccTFEWorkspaceIDsDataSourceConfig_excludeTags(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foo" {
+  name         = "workspace-foo-%d"
+  organization = tfe_organization.foobar.id
+  tag_names    = ["good", "happy"]
+}
+
+resource "tfe_workspace" "bar" {
+  name         = "workspace-bar-%d"
+  organization = tfe_organization.foobar.id
+  tag_names    = ["good"]
+}
+
+resource "tfe_workspace" "dummy" {
+  name         = "workspace-dummy-%d"
+  organization = tfe_organization.foobar.id
+}
+
+data "tfe_workspace_ids" "good" {
+  tag_names    = ["good"]
+	exclude_tags    = ["happy"]
+  organization = tfe_workspace.foo.organization
+  depends_on = [
+    tfe_workspace.foo,
+    tfe_workspace.bar,
+    tfe_workspace.dummy
+  ]
+}`, rInt, rInt, rInt, rInt)
+}
+
+func testAccTFEWorkspaceIDsDataSourceConfig_sameTagInTagNamesAndExcludeTags(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foo" {
+  name         = "workspace-foo-%d"
+  organization = tfe_organization.foobar.id
+  tag_names    = ["good", "happy"]
+}
+
+resource "tfe_workspace" "bar" {
+  name         = "workspace-bar-%d"
+  organization = tfe_organization.foobar.id
+  tag_names    = ["happy", "play"]
+}
+
+resource "tfe_workspace" "dummy" {
+  name         = "workspace-dummy-%d"
+  organization = tfe_organization.foobar.id
+	tag_names    = ["good", "play", "happy"]
+}
+
+data "tfe_workspace_ids" "good" {
+  tag_names    = ["good", "happy"]
+	exclude_tags    = ["happy"]
+  organization = tfe_workspace.foo.organization
+  depends_on = [
+    tfe_workspace.foo,
+    tfe_workspace.bar,
+    tfe_workspace.dummy
+  ]
 }`, rInt, rInt, rInt, rInt)
 }

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -520,9 +520,9 @@ resource "tfe_workspace" "dummy" {
 
 data "tfe_workspace_ids" "good" {
   tag_names    = ["good"]
-	exclude_tags    = ["happy"]
+	exclude_tags = ["happy"]
   organization = tfe_workspace.foo.organization
-  depends_on = [
+  depends_on   = [
     tfe_workspace.foo,
     tfe_workspace.bar,
     tfe_workspace.dummy
@@ -557,9 +557,9 @@ resource "tfe_workspace" "dummy" {
 
 data "tfe_workspace_ids" "good" {
   tag_names    = ["good", "happy"]
-	exclude_tags    = ["happy"]
+	exclude_tags = ["happy"]
   organization = tfe_workspace.foo.organization
-  depends_on = [
+  depends_on   = [
     tfe_workspace.foo,
     tfe_workspace.bar,
     tfe_workspace.dummy

--- a/website/docs/d/workspace_ids.html.markdown
+++ b/website/docs/d/workspace_ids.html.markdown
@@ -27,6 +27,12 @@ data "tfe_workspace_ids" "prod-apps" {
   tag_names    = ["prod", "app", "aws"]
   organization = "my-org-name"
 }
+
+data "tfe_workspace_ids" "prod-only" {
+  tag_names    = ["prod"]
+  exclude_tags = ["app"]
+  organization = "my-org-name"
+}
 ```
 
 ## Argument Reference
@@ -39,11 +45,12 @@ The following arguments are supported. At least one of `names` or `tag_names` mu
     To select _all_ workspaces for an organization, provide a list with a single
     asterisk, like `["*"]`. No other use of wildcards is supported.
 * `tag_names` - (Optional) A list of tag names to search for.
+* `exclude_tags` - (Optional) A list of tag names to exclude when searching.
 * `organization` - (Required) Name of the organization.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `full_names` - A map of workspace names and their full names, which look like `<ORGANIZATION>/<WORKSPACE>`. 
+* `full_names` - A map of workspace names and their full names, which look like `<ORGANIZATION>/<WORKSPACE>`.
 * `ids` - A map of workspace names and their opaque, immutable IDs, which look like `ws-<RANDOM STRING>`.


### PR DESCRIPTION
## Description

Currently the list of Workspaces within an Organization can be filtered with `tag_names` to include. This PR adds the ability to exclude workspaces by tags using the`exclude_tags` parameter.

See usecase here: https://github.com/hashicorp/terraform-provider-tfe/issues/393

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_

## Testing plan

1. Create an organization
1.  Create workspaces with tags within the organization
1.  Filtering workspaces using the `exclude_tags` options, should list all matching workspaces excluding those with the excluded tags.
1.  See example block below:
```
resource "tfe_organization" "foobar" {
  name  = "tst-terraform-1"
  email = "admin@company.com"
}
resource "tfe_workspace" "foo" {
  name         = "workspace-foo-1"
  organization = tfe_organization.foobar.id
  tag_names    = ["good", "happy"]
}
resource "tfe_workspace" "bar" {
  name         = "workspace-bar-1"
  organization = tfe_organization.foobar.id
  tag_names    = ["good"]
}
data "tfe_workspace_ids" "good" {
  tag_names    = ["good"]
  exclude_tags    = ["happy"]
  organization = tfe_workspace.foo.organization
  depends_on = [
    tfe_workspace.foo,
    tfe_workspace.bar
  ]
}

```

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe#WorkspaceListOptions)
- [API documentation](https://www.terraform.io/cloud-docs/api-docs/workspaces#query-parameters)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/438)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (9.51s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (11.21s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_tags
--- PASS: TestAccTFEWorkspaceIDsDataSource_tags (9.77s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_searchByTagAndName
--- PASS: TestAccTFEWorkspaceIDsDataSource_searchByTagAndName (8.96s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_empty
--- PASS: TestAccTFEWorkspaceIDsDataSource_empty (1.42s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_namesEmpty
--- PASS: TestAccTFEWorkspaceIDsDataSource_namesEmpty (8.94s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_excludeTags
--- PASS: TestAccTFEWorkspaceIDsDataSource_excludeTags (14.33s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_sameTagInTagNamesAndExcludeTags
--- PASS: TestAccTFEWorkspaceIDsDataSource_sameTagInTagNamesAndExcludeTags (10.58s)
PASS
```

![Screen Shot 2022-06-21 at 2 12 10 PM](https://user-images.githubusercontent.com/22062046/174869534-75e0ee16-9c89-4199-a789-df12a216df81.png)
