### PR TITLE
Ignore the terraform-provider-tfe binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.so
 *.dylib
 
+/terraform-provider-tfe
+
 # Test binary, build with `go test -c`
 *.test
 


### PR DESCRIPTION
## Description

Update the `.gitignore` to ignore the `terraform-provider-tfe` binary so we don't accidentally check it in.

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_
