### PR TITLE
fix(d/team): the wrong team can be picked within the "filter by name" fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.32.1 (June 21st, 2022)
+
+BUG FIXES:
+
+* Fixed an issue where a team data source could be populated with the wrong team.
+
 ## 0.32.0 (June 20th, 2022)
 
 0.32.0 is an impactful release that includes several bug fixes, support for [run tasks](https://www.terraform.io/cloud-docs/workspaces/settings/run-tasks#run-tasks) and several breaking changes that you should review carefully.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* Fixed an issue where a team data source could be populated with the wrong team.
+* Fixed a bug in the latest release where a team data source could be populated with the wrong team. ([#530](https://github.com/hashicorp/terraform-provider-tfe/pull/530))
 
 ## 0.32.0 (June 20th, 2022)
 

--- a/tfe/data_source_outputs_test.go
+++ b/tfe/data_source_outputs_test.go
@@ -182,13 +182,34 @@ data "tfe_outputs" "foobar" {
 
 // All of these values reference the outputs in  the file
 // 'test-fixtures/state-versions/terraform.tfstate
-output "test_output_list_string" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_list_string) }
-output "test_output_string" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_string) }
-output "test_output_tuple_number" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_tuple_number) }
-output "test_output_tuple_string" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_tuple_string) }
-output "test_output_object" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_object) }
-output "test_output_number" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_number) }
-output "test_output_bool" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_bool) }
+output "test_output_list_string" {
+	sensitive = true
+	value = data.tfe_outputs.foobar.values.test_output_list_string
+}
+output "test_output_string" {
+	sensitive = true
+	value = data.tfe_outputs.foobar.values.test_output_string
+}
+output "test_output_tuple_number" {
+	sensitive = true
+	value = data.tfe_outputs.foobar.values.test_output_tuple_number
+}
+output "test_output_tuple_string" {
+	sensitive = true
+	value = data.tfe_outputs.foobar.values.test_output_tuple_string
+}
+output "test_output_object" {
+	sensitive = true
+	value = data.tfe_outputs.foobar.values.test_output_object
+}
+output "test_output_number" {
+	sensitive = true
+	value = data.tfe_outputs.foobar.values.test_output_number
+}
+output "test_output_bool" {
+	sensitive = true
+	value = data.tfe_outputs.foobar.values.test_output_bool
+}
 `, rInt, rInt, org, workspace)
 }
 

--- a/tfe/data_source_team.go
+++ b/tfe/data_source_team.go
@@ -63,8 +63,8 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 		for {
 			for _, team := range tl.Items {
 				if team.Name == name {
-					d.SetId(tl.Items[0].ID)
-					d.Set("sso_team_id", tl.Items[0].SSOTeamID)
+					d.SetId(team.ID)
+					d.Set("sso_team_id", team.SSOTeamID)
 					return nil
 				}
 			}


### PR DESCRIPTION
## Description

This fallback method for selecting a team by name will pick the wrong team when doing a linear search

## Testing plan

Fixes https://github.com/hashicorp/terraform-provider-tfe/issues/528 - see issue details for example config
