### PR TITLE
Show file name and line numbers for linter error output on Github

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45
+          args: "--out-${NO_FUTURE}format colored-line-number"


### PR DESCRIPTION
Fixes #504. Adds a new flag to `golangci-lint`, `--out-${NO_FUTURE}format`, so that the lint output can play nicely with the Github actions output. 