### PR TITLE
add support for registry modules without vcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ FEATURES:
 * d/agent_pool: Improve efficiency of reading agent pool data when the target organization has more than 20 agent pools ([#508](https://github.com/hashicorp/terraform-provider-tfe/pull/508))
 * Added warning logs for 404 error responses ([#538](https://github.com/hashicorp/terraform-provider-tfe/pull/538))
 
+ENHANCEMENTS:
+* r/tfe_registry_module: Add ability to create both public and private `registry_modules` without VCS. ([#546](https://github.com/hashicorp/terraform-provider-tfe/pull/546))
+
+DEPRECATION NOTICE:
+* The `registry_modules` import format `<ORGANIZATION>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` has been deprecated in favour of `<ORGANIZATION>/<REGISTRY_NAME>/<NAMESPACE>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` to support public and private `registry_modules`.
+
 ## 0.33.0 (July 8th, 2022)
 
 FEATURES:
@@ -14,12 +20,8 @@ FEATURES:
 * r/tfe_workspace, d/tfe_workspace: `trigger-patterns` ([#502](https://github.com/hashicorp/terraform-provider-tfe/pull/502)) attribute is introduced to support specifying a set of [glob patterns](https://www.terraform.io/cloud-docs/workspaces/settings/vcs#glob-patterns-for-automatic-run-triggering) for automatic VCS run triggering.
 * r/organization: Add `workspace_limit` setting, available only in Terraform Enterprise ([#521](https://github.com/hashicorp/terraform-provider-tfe/pull/521))
 
-ENHANCEMENTS:
-* r/tfe_registry_module: Add ability to create both public and private `registry_modules` without VCS. ([#546](https://github.com/hashicorp/terraform-provider-tfe/pull/546))
-
 DEPRECATION NOTICE:
 * The `workspace_ids` argument on `tfe_variable_set` has been labelled as deprecated and should not be used in conjunction with `tfe_workspace_variable_set`.
-* The `registry_modules` import format `<ORGANIZATION>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` has been deprecated in favour of `<ORGANIZATION>/<REGISTRY_NAME>/<NAMESPACE>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` to support public and private `registry_modules`.
 
 ## 0.32.1 (June 21st, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ BUG FIXES:
 FEATURES:
 * d/agent_pool: Improve efficiency of reading agent pool data when the target organization has more than 20 agent pools ([#508](https://github.com/hashicorp/terraform-provider-tfe/pull/508))
 * Added warning logs for 404 error responses ([#538](https://github.com/hashicorp/terraform-provider-tfe/pull/538))
-
-ENHANCEMENTS:
 * r/tfe_registry_module: Add ability to create both public and private `registry_modules` without VCS. ([#546](https://github.com/hashicorp/terraform-provider-tfe/pull/546))
 
 DEPRECATION NOTICE:
@@ -20,8 +18,7 @@ FEATURES:
 * r/tfe_workspace, d/tfe_workspace: `trigger-patterns` ([#502](https://github.com/hashicorp/terraform-provider-tfe/pull/502)) attribute is introduced to support specifying a set of [glob patterns](https://www.terraform.io/cloud-docs/workspaces/settings/vcs#glob-patterns-for-automatic-run-triggering) for automatic VCS run triggering.
 * r/organization: Add `workspace_limit` setting, available only in Terraform Enterprise ([#521](https://github.com/hashicorp/terraform-provider-tfe/pull/521))
 
-DEPRECATION NOTICE:
-* The `workspace_ids` argument on `tfe_variable_set` has been labelled as deprecated and should not be used in conjunction with `tfe_workspace_variable_set`.
+DEPRECATION NOTICE: The `workspace_ids` argument on `tfe_variable_set` has been labelled as deprecated and should not be used in conjunction with `tfe_workspace_variable_set`.
 
 ## 0.32.1 (June 21st, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ FEATURES:
 * r/tfe_workspace, d/tfe_workspace: `trigger-patterns` ([#502](https://github.com/hashicorp/terraform-provider-tfe/pull/502)) attribute is introduced to support specifying a set of [glob patterns](https://www.terraform.io/cloud-docs/workspaces/settings/vcs#glob-patterns-for-automatic-run-triggering) for automatic VCS run triggering.
 * r/organization: Add `workspace_limit` setting, available only in Terraform Enterprise ([#521](https://github.com/hashicorp/terraform-provider-tfe/pull/521))
 
-DEPRECATION NOTICE: The `workspace_ids` argument on `tfe_variable_set` has been labelled as deprecated and should not be used in conjunction with `tfe_workspace_variable_set`.
+ENHANCEMENTS:
+* r/tfe_registry_module: Add ability to create both public and private `registry_modules` without VCS. ([#546](https://github.com/hashicorp/terraform-provider-tfe/pull/546))
+
+DEPRECATION NOTICE:
+* The `workspace_ids` argument on `tfe_variable_set` has been labelled as deprecated and should not be used in conjunction with `tfe_workspace_variable_set`.
+* The `registry_modules` import format `<ORGANIZATION>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` has been deprecated in favour of `<ORGANIZATION>/<REGISTRY_NAME>/<NAMESPACE>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` to support public and private `registry_modules`.
 
 ## 0.32.1 (June 21st, 2022)
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-slug v0.9.1
-	github.com/hashicorp/go-tfe v1.5.0
+	github.com/hashicorp/go-tfe v1.6.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl/v2 v2.10.0 // indirect
@@ -30,7 +30,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6 // indirect
 	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
+	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	google.golang.org/api v0.44.0-impersonate-preview // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/hashicorp/go-tfe v1.4.0 h1:rMoQ2r1QppaglYsBdmdgFphipNTCkjTaO1oOLVj04E
 github.com/hashicorp/go-tfe v1.4.0/go.mod h1:E8a90lC4kjU5Lc2c0D+SnWhUuyuoCIVm4Ewzv3jCD3A=
 github.com/hashicorp/go-tfe v1.5.0 h1:MtABkqH2s6lRFl8HaGt0qESLGAyrmMAFfecsEm+13K8=
 github.com/hashicorp/go-tfe v1.5.0/go.mod h1:E8a90lC4kjU5Lc2c0D+SnWhUuyuoCIVm4Ewzv3jCD3A=
+github.com/hashicorp/go-tfe v1.6.0 h1:lRfyTVLBP1njo2wShE9FimALzVZBfOqMGNuBdsor38w=
+github.com/hashicorp/go-tfe v1.6.0/go.mod h1:E8a90lC4kjU5Lc2c0D+SnWhUuyuoCIVm4Ewzv3jCD3A=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
@@ -569,6 +571,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220411224347-583f2d630306 h1:+gHMid33q6pen7kv9xvT+JRinntgeXO2AeZVd0AWD3w=
 golang.org/x/time v0.0.0-20220411224347-583f2d630306/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 h1:ftMN5LMiBFjbzleLqtoBZk7KdJwhuybIU+FckUHgoyQ=
+golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/tfe/resource_tfe_registry_module_test.go
+++ b/tfe/resource_tfe_registry_module_test.go
@@ -18,6 +18,14 @@ func TestAccTFERegistryModule_vcs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
+	expectedRegistryModuleAttributes := &tfe.RegistryModule{
+		Name:         getRegistryModuleName(),
+		Provider:     getRegistryModuleProvider(),
+		RegistryName: tfe.PrivateRegistry,
+		Namespace:    orgName,
+		Organization: &tfe.Organization{Name: orgName},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -30,14 +38,26 @@ func TestAccTFERegistryModule_vcs(t *testing.T) {
 				Config: testAccTFERegistryModule_vcs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
-						"tfe_registry_module.foobar", orgName, registryModule),
-					testAccCheckTFERegistryModuleAttributes(registryModule, orgName),
+						"tfe_registry_module.foobar",
+						tfe.RegistryModuleID{
+							Organization: orgName,
+							Name:         expectedRegistryModuleAttributes.Name,
+							Provider:     expectedRegistryModuleAttributes.Provider,
+							RegistryName: expectedRegistryModuleAttributes.RegistryName,
+							Namespace:    orgName,
+						}, registryModule),
+					testAccCheckTFERegistryModuleAttributes(registryModule, expectedRegistryModuleAttributes),
+					testAccCheckTFERegistryModuleVCSAttributes(registryModule),
 					resource.TestCheckResourceAttr(
 						"tfe_registry_module.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
-						"tfe_registry_module.foobar", "name", getRegistryModuleName()),
+						"tfe_registry_module.foobar", "name", expectedRegistryModuleAttributes.Name),
 					resource.TestCheckResourceAttr(
-						"tfe_registry_module.foobar", "module_provider", getRegistryModuleProvider()),
+						"tfe_registry_module.foobar", "module_provider", expectedRegistryModuleAttributes.Provider),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "namespace", expectedRegistryModuleAttributes.Namespace),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "registry_name", string(expectedRegistryModuleAttributes.RegistryName)),
 					resource.TestCheckResourceAttr(
 						"tfe_registry_module.foobar", "vcs_repo.0.display_identifier", GITHUB_REGISTRY_MODULE_IDENTIFIER),
 					resource.TestCheckResourceAttr(
@@ -69,7 +89,154 @@ func TestAccTFERegistryModule_emptyVCSRepo(t *testing.T) {
 	})
 }
 
-func TestAccTFERegistryModuleImport(t *testing.T) {
+func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName(t *testing.T) {
+	registryModule := &tfe.RegistryModule{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	expectedRegistryModuleAttributes := &tfe.RegistryModule{
+		Name:         "test_module",
+		Provider:     "my_provider",
+		RegistryName: tfe.PrivateRegistry,
+		Namespace:    orgName,
+		Organization: &tfe.Organization{Name: orgName},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_privateRMWithoutRegistryName(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFERegistryModuleExists(
+						"tfe_registry_module.foobar",
+						tfe.RegistryModuleID{
+							Organization: orgName,
+							Name:         expectedRegistryModuleAttributes.Name,
+							Provider:     expectedRegistryModuleAttributes.Provider,
+							RegistryName: expectedRegistryModuleAttributes.RegistryName,
+							Namespace:    expectedRegistryModuleAttributes.Namespace,
+						}, registryModule),
+					testAccCheckTFERegistryModuleAttributes(registryModule, expectedRegistryModuleAttributes),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "name", expectedRegistryModuleAttributes.Name),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "module_provider", expectedRegistryModuleAttributes.Provider),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "namespace", expectedRegistryModuleAttributes.Namespace),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "registry_name", string(expectedRegistryModuleAttributes.RegistryName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName(t *testing.T) {
+	registryModule := &tfe.RegistryModule{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	expectedRegistryModuleAttributes := &tfe.RegistryModule{
+		Name:         "another_test_module",
+		Provider:     "my_provider",
+		RegistryName: tfe.PrivateRegistry,
+		Namespace:    orgName,
+		Organization: &tfe.Organization{Name: orgName},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFERegistryModuleExists(
+						"tfe_registry_module.foobar",
+						tfe.RegistryModuleID{
+							Organization: orgName,
+							Name:         expectedRegistryModuleAttributes.Name,
+							Provider:     expectedRegistryModuleAttributes.Provider,
+							RegistryName: expectedRegistryModuleAttributes.RegistryName,
+							Namespace:    expectedRegistryModuleAttributes.Namespace,
+						}, registryModule),
+					testAccCheckTFERegistryModuleAttributes(registryModule, expectedRegistryModuleAttributes),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "name", expectedRegistryModuleAttributes.Name),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "module_provider", expectedRegistryModuleAttributes.Provider),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "namespace", expectedRegistryModuleAttributes.Namespace),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "registry_name", string(expectedRegistryModuleAttributes.RegistryName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_publicRegistryModule(t *testing.T) {
+	registryModule := &tfe.RegistryModule{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	expectedRegistryModuleAttributes := &tfe.RegistryModule{
+		Name:         "vpc",
+		Provider:     "aws",
+		RegistryName: tfe.PublicRegistry,
+		Namespace:    "terraform-aws-modules",
+		Organization: &tfe.Organization{Name: orgName},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_publicRM(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFERegistryModuleExists(
+						"tfe_registry_module.foobar",
+						tfe.RegistryModuleID{
+							Organization: orgName,
+							Name:         expectedRegistryModuleAttributes.Name,
+							Provider:     expectedRegistryModuleAttributes.Provider,
+							RegistryName: expectedRegistryModuleAttributes.RegistryName,
+							Namespace:    expectedRegistryModuleAttributes.Namespace,
+						}, registryModule),
+					testAccCheckTFERegistryModuleAttributes(registryModule, expectedRegistryModuleAttributes),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "name", expectedRegistryModuleAttributes.Name),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "module_provider", expectedRegistryModuleAttributes.Provider),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "namespace", expectedRegistryModuleAttributes.Namespace),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "registry_name", string(expectedRegistryModuleAttributes.RegistryName)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -93,7 +260,166 @@ func TestAccTFERegistryModuleImport(t *testing.T) {
 	})
 }
 
-func testAccCheckTFERegistryModuleExists(n, orgName string, registryModule *tfe.RegistryModule) resource.TestCheckFunc {
+func TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_vcs(rInt),
+			},
+			{
+				ResourceName:        "tfe_registry_module.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/%v/tst-terraform-%d/%v/%v/", rInt, "private", rInt, getRegistryModuleName(), getRegistryModuleProvider()),
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModuleImport_nonVCSPrivateRM(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
+			},
+			{
+				ResourceName:        "tfe_registry_module.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/%v/tst-terraform-%d/%v/%v/", rInt, "private", rInt, "another_test_module", "my_provider"),
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModuleImport_publicRM(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_publicRM(rInt),
+			},
+			{
+				ResourceName:        "tfe_registry_module.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("tst-terraform-%d/%v/%v/%v/%v/", rInt, "public", "terraform-aws-modules", "vpc", "aws"),
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider(),
+				ExpectError: regexp.MustCompile("\"module_provider\": only one of `module_provider,vcs_repo` can be specified,\nbut `module_provider,vcs_repo` were specified."),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_invalidRegistryName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_invalidRegistryName(),
+				ExpectError: regexp.MustCompile(`invalid value for registry-name. It must be either "private" or "public"`),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_invalidWithModuleProviderAndNoName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_invalidWithModuleProviderAndNoName(),
+				ExpectError: regexp.MustCompile("\"module_provider\": all of `module_provider,name,organization` must be\nspecified"),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization(),
+				ExpectError: regexp.MustCompile("\"module_provider\": all of `module_provider,name,organization` must be\nspecified"),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName(),
+				ExpectError: regexp.MustCompile("\"namespace\": all of `namespace,registry_name` must be specified"),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(),
+				ExpectError: regexp.MustCompile("\"registry_name\": all of `module_provider,registry_name` must be specified"),
+			},
+		},
+	})
+}
+func testAccCheckTFERegistryModuleExists(n string, rmID tfe.RegistryModuleID, registryModule *tfe.RegistryModule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		tfeClient := testAccProvider.Meta().(*tfe.Client)
 
@@ -104,12 +430,6 @@ func testAccCheckTFERegistryModuleExists(n, orgName string, registryModule *tfe.
 
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No instance ID is set")
-		}
-
-		rmID := tfe.RegistryModuleID{
-			Organization: orgName,
-			Name:         getRegistryModuleName(),
-			Provider:     getRegistryModuleProvider(),
 		}
 
 		rm, err := tfeClient.RegistryModules.Read(ctx, rmID)
@@ -127,20 +447,34 @@ func testAccCheckTFERegistryModuleExists(n, orgName string, registryModule *tfe.
 	}
 }
 
-func testAccCheckTFERegistryModuleAttributes(registryModule *tfe.RegistryModule, orgName string) resource.TestCheckFunc {
+func testAccCheckTFERegistryModuleAttributes(registryModule *tfe.RegistryModule, expectedRegistryModuleAttributes *tfe.RegistryModule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if registryModule.Name != getRegistryModuleName() {
+		if registryModule.Name != expectedRegistryModuleAttributes.Name {
 			return fmt.Errorf("Bad name: %s", registryModule.Name)
 		}
 
-		if registryModule.Provider != getRegistryModuleProvider() {
+		if registryModule.Provider != expectedRegistryModuleAttributes.Provider {
 			return fmt.Errorf("Bad module_provider: %s", registryModule.Provider)
 		}
 
-		if registryModule.Organization.Name != orgName {
+		if registryModule.Organization.Name != expectedRegistryModuleAttributes.Organization.Name {
 			return fmt.Errorf("Bad organization: %v", registryModule.Organization.Name)
 		}
 
+		if registryModule.RegistryName != expectedRegistryModuleAttributes.RegistryName {
+			return fmt.Errorf("Bad registry_name: %v", registryModule.RegistryName)
+		}
+
+		if registryModule.Namespace != expectedRegistryModuleAttributes.Namespace {
+			return fmt.Errorf("Bad namespace: %v", registryModule.Namespace)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFERegistryModuleVCSAttributes(registryModule *tfe.RegistryModule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
 		if registryModule.VCSRepo == nil {
 			return fmt.Errorf("Bad VCS repo: %v", registryModule.VCSRepo)
 		}
@@ -189,10 +523,22 @@ func testAccCheckTFERegistryModuleDestroy(s *terraform.State) error {
 			return fmt.Errorf("No module_provider is set for registry module %s", id)
 		}
 
+		namespace := rs.Primary.Attributes["namespace"]
+		if namespace == "" {
+			return fmt.Errorf("No namespace is set for registry module %s", id)
+		}
+
+		registry_name := rs.Primary.Attributes["registry_name"]
+		if registry_name == "" {
+			return fmt.Errorf("No registry_name is set for registry module %s", id)
+		}
+
 		rmID := tfe.RegistryModuleID{
 			Organization: organization,
 			Name:         name,
 			Provider:     module_provider,
+			Namespace:    rs.Primary.Attributes["namespace"],
+			RegistryName: tfe.RegistryName(rs.Primary.Attributes["registry_name"]),
 		}
 		_, err := tfeClient.RegistryModules.Read(ctx, rmID)
 		if err == nil {
@@ -278,4 +624,112 @@ resource "tfe_oauth_client" "foobar" {
 resource "tfe_registry_module" "foobar" {
  vcs_repo {}
 }`, rInt, token)
+}
+
+func testAccTFERegistryModule_privateRMWithoutRegistryName(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_registry_module" "foobar" {
+	organization    = tfe_organization.foobar.id
+  module_provider = "my_provider"
+  name            = "test_module"
+ }`,
+		rInt)
+}
+
+func testAccTFERegistryModule_privateRMWithRegistryName(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_registry_module" "foobar" {
+	organization    = tfe_organization.foobar.id
+  module_provider = "my_provider"
+  name            = "another_test_module"
+  registry_name   = "private"
+ }`,
+		rInt)
+}
+
+func testAccTFERegistryModule_publicRM(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_registry_module" "foobar" {
+  organization    = tfe_organization.foobar.id
+  namespace       = "terraform-aws-modules"
+  module_provider = "aws"
+  name            = "vpc"
+  registry_name   = "public"
+ }`,
+		rInt)
+}
+
+func testAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider() string {
+	return `
+resource "tfe_registry_module" "foobar" {
+  module_provider = "aws"
+	vcs_repo {
+		display_identifier = "hashicorp/terraform-random-module"
+		identifier         = "hashicorp/terraform-random-module"
+		oauth_token_id     = "sample-auth-token"
+	}
+ }`
+}
+
+func testAccTFERegistryModule_invalidRegistryName() string {
+	return `
+resource "tfe_registry_module" "foobar" {
+  organization    = "hashicorp"
+  module_provider = "aws"
+  name            = "eks"
+  registry_name   = "PRIVATE"
+ }`
+}
+
+func testAccTFERegistryModule_invalidWithModuleProviderAndNoName() string {
+	return `
+resource "tfe_registry_module" "foobar" {
+  organization    = "hashicorp"
+  module_provider = "aws"
+  registry_name   = "private"
+ }`
+}
+
+func testAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization() string {
+	return `
+resource "tfe_registry_module" "foobar" {
+  name            = "eks"
+  module_provider = "aws"
+  registry_name   = "private"
+ }`
+}
+
+func testAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName() string {
+	return `
+resource "tfe_registry_module" "foobar" {
+  organization    = "hashicorp"
+  module_provider = "aws"
+  name            = "eks"
+  namespace       = "terraform-aws-modules"
+ }`
+}
+
+func testAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider() string {
+	return `
+resource "tfe_registry_module" "foobar" {
+  organization    = "hashicorp"
+  name            = "eks"
+  namespace       = "terraform-aws-modules"
+	registry_name   = "private"
+ }`
 }

--- a/tfe/resource_tfe_registry_module_test.go
+++ b/tfe/resource_tfe_registry_module_test.go
@@ -35,7 +35,8 @@ func TestAccTFERegistryModule_vcs(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERegistryModule_vcs(rInt),
+				Config:             testAccTFERegistryModule_vcs(rInt),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
 						"tfe_registry_module.foobar",
@@ -110,7 +111,8 @@ func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName(t *
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERegistryModule_privateRMWithoutRegistryName(rInt),
+				Config:             testAccTFERegistryModule_privateRMWithoutRegistryName(rInt),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
 						"tfe_registry_module.foobar",
@@ -159,7 +161,8 @@ func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName(t *tes
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
+				Config:             testAccTFERegistryModule_privateRMWithRegistryName(rInt),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
 						"tfe_registry_module.foobar",
@@ -248,7 +251,8 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERegistryModule_vcs(rInt),
+				Config:             testAccTFERegistryModule_vcs(rInt),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				ResourceName:        "tfe_registry_module.foobar",
@@ -272,7 +276,8 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat(t *testing.T) 
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERegistryModule_vcs(rInt),
+				Config:             testAccTFERegistryModule_vcs(rInt),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				ResourceName:        "tfe_registry_module.foobar",
@@ -295,7 +300,8 @@ func TestAccTFERegistryModuleImport_nonVCSPrivateRM(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
+				Config:             testAccTFERegistryModule_privateRMWithRegistryName(rInt),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				ResourceName:        "tfe_registry_module.foobar",

--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -8,11 +8,11 @@ description: |-
 
 # tfe_registry_module
 
-Terraform Cloud's private module registry helps you share Terraform modules across your organization. 
+Terraform Cloud's private module registry helps you share Terraform modules across your organization.
 
 ## Example Usage
 
-Basic usage:
+Basic usage with VCS:
 
 ```hcl
 resource "tfe_organization" "test-organization" {
@@ -37,20 +37,58 @@ resource "tfe_registry_module" "test-registry-module" {
 }
 ```
 
+Create private registry module without VCS:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_registry_module" "test-private-registry-module" {
+  organization    = tfe_organization.test-organization.name
+  module_provider = "my_provider"
+  name            = "another_test_module"
+  registry_name   = "private"
+}
+```
+
+Create public registry module:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_registry_module" "test-public-registry-module" {
+  organization    = tfe_organization.test-organization.name
+  namespace       = "terraform-aws-modules"
+  module_provider = "aws"
+  name            = "vpc"
+  registry_name   = "public"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `vcs_repo` - (Required) Settings for the registry module's VCS repository. Forces a
-  new resource if changed.
+* `vcs_repo` - (Optional) Settings for the registry module's VCS repository. Forces a
+  new resource if changed. One of `vcs_repo` or `module_provider` is required.
+* `module_provider` - (Optional) Specifies the Terraform provider that this module is used for. For example, "aws"
+* `name` - (Optional) The name of registry module. It must be set if `module_provider` is used.
+* `organization` - (Optional) The name of the organization associated with the registry module. It must be set if `module_provider` is used.
+* `namespace` - (Optional) The namespace of a public registry module. It can be used if `module_provider` is set and `registry_name` is public.
+* `registry_name` - (Optional) Whether the registry module is private or public. It can be used if `module_provider` is set.
 
 The `vcs_repo` block supports:
 
 * `display_identifier` - (Required) The display identifier for your VCS repository.
-   For most VCS providers outside of BitBucket Cloud, this will match the `identifier` 
+   For most VCS providers outside of BitBucket Cloud, this will match the `identifier`
    string.
 * `identifier` - (Required) A reference to your VCS repository in the format
-  `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server) 
+  `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)
   and repository in your VCS provider. The format for Azure DevOps is <organization>/<project>/_git/<repository>.
 * `oauth_token_id` - (Required) Token ID of the VCS Connection (OAuth Connection Token)
   to use.
@@ -58,13 +96,21 @@ The `vcs_repo` block supports:
 ## Attributes Reference
 
 * `id` - The ID of the registry module.
-* `module_provider` - The provider of the registry module.
+* `module_provider` - The Terraform provider that this module is used for.
 * `name` - The name of registry module.
 * `organization` - The name of the organization associated with the registry module.
+* `namespace` - The namespace of the module. For private modules this is the name of the organization that owns the module.
+* `registry_name` - The registry name of the registry module depicting whether the registry module is private or public.
 
 ## Import
 
-Registry modules can be imported; use `<ORGANIZATION NAME>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` as the import ID. For example:
+Registry modules can be imported; use `<ORGANIZATION>/<REGISTRY_NAME>/<NAMESPACE>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` as the import ID. For example:
+
+```shell
+terraform import tfe_registry_module.test my-org-name/public/namespace/name/provider/mod-qV9JnKRkmtMa4zcA
+```
+
+**Deprecated** use `<ORGANIZATION NAME>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` as the import ID. For example:
 
 ```shell
 terraform import tfe_registry_module.test my-org-name/name/provider/mod-qV9JnKRkmtMa4zcA


### PR DESCRIPTION
## Description

_This PR adds changes that support creating `both private and public registry modules` without using a VCS. It also extends the ability to `import` both private and public registry module by including the `namespace` and `registry-name` in the import id._

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_

## Testing plan

1.  _With existing code a registry module can only be created via the required VCS block_
1.  _After code changes, both private and public modules can be added without the vcs block_
1.  _The import identifier includes the namespace and registry_name and should be able to import private and public modules_
1.  _Some sample config to test modules:_
```
## should create public module successfully
resource "tfe_registry_module" "public-registry-module-without-vcs" {
  organization         = "an-org"
  namespace          = "terraform-aws-modules"
  module_provider = "aws"
  name                    = "iam"
  registry_name     = "public"
}

## should create private module successfully
resource "tfe_registry_module" "private-registry-module-without-registry-name" {
  organization    = "hashicorp"
  module_provider = "aws"
  name            = "vpc"
}

## should create private module successfully
resource "tfe_registry_module" "private-registry-module-without-vcs" {
  organization    = "hashicorp"
  module_provider = "aws"
  name            = "eks"
  registry_name   = "private"
}
```
**Deprecated import format `<ORGANIZATION>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` works for only private module:**
#should succeed
```
terraform import tfe_registry_module.test-private my-org-name/name/provider/mod-qV9JnKRkmtMa4zcA
```
#should fail
```
terraform import tfe_registry_module.test-public my-org-name/name/provider/mod-qV9JnKRkmtMa4rzA
```

**New import format `<ORGANIZATION>/<REGISTRY_NAME>/<NAMESPACE>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>` works for both public and private module:**
#should succeed
```
terraform import tfe_registry_module.test-private my-org-name/private/namespace/name/provider/mod-qV9JnKRkmtMa4zcA
```
#should succeed
```
terraform import tfe_registry_module.test-public my-org-name/public/namespace/name/provider/mod-qV9JnKRkmtMa4rzA
```

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://www.terraform.io/cloud-docs/api-docs/private-registry/modules)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/460)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFERegistryModule" make testacc

=== RUN   TestAccTFERegistryModule_vcs
--- PASS: TestAccTFERegistryModule_vcs (10.62s)
=== RUN   TestAccTFERegistryModule_emptyVCSRepo
--- PASS: TestAccTFERegistryModule_emptyVCSRepo (0.97s)
=== RUN   TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName
--- PASS: TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName (7.02s)
=== RUN   TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName
--- PASS: TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName (6.84s)
=== RUN   TestAccTFERegistryModule_publicRegistryModule
--- PASS: TestAccTFERegistryModule_publicRegistryModule (7.12s)
=== RUN   TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat
--- PASS: TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat (9.85s)
=== RUN   TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat
--- PASS: TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat (11.60s)
=== RUN   TestAccTFERegistryModuleImport_nonVCSPrivateRM
--- PASS: TestAccTFERegistryModuleImport_nonVCSPrivateRM (11.80s)
=== RUN   TestAccTFERegistryModuleImport_publicRM
--- PASS: TestAccTFERegistryModuleImport_publicRM (7.36s)
=== RUN   TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider
--- PASS: TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider (0.71s)
=== RUN   TestAccTFERegistryModule_invalidRegistryName
--- PASS: TestAccTFERegistryModule_invalidRegistryName (2.35s)
=== RUN   TestAccTFERegistryModule_invalidWithModuleProviderAndNoName
--- PASS: TestAccTFERegistryModule_invalidWithModuleProviderAndNoName (0.70s)
=== RUN   TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization
--- PASS: TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization (0.70s)
=== RUN   TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName
--- PASS: TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName (0.85s)
=== RUN   TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider
--- PASS: TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider (0.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	79.993s
```


---
<img width="984" alt="Screen Shot 2022-07-18 at 11 00 05 AM" src="https://user-images.githubusercontent.com/22062046/179541411-137c7c4f-2c07-4004-8fbd-d048b4d41e8f.png">
<img width="944" alt="Screen Shot 2022-07-18 at 11 00 30 AM" src="https://user-images.githubusercontent.com/22062046/179541413-6cd11cf3-1518-4986-9299-67442c443fef.png">
<img width="1153" alt="Screen Shot 2022-07-18 at 11 00 43 AM" src="https://user-images.githubusercontent.com/22062046/179541416-9c798de8-c5a8-4af3-b3c2-b8330c8298b2.png">
