### PR TITLE
Add support for managing health assessment (drift detection) settings on workspaces and organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Unreleased
  * r/tfe_workspace: Changes in `agent_pool_id` and `execution_mode` attributes are now detected and applied. ([#607](https://github.com/hashicorp/terraform-provider-tfe/pull/607))
- * r/tfe_workspace: Added attribute for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
- * d/tfe_workspace: Added attribute for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * r/tfe_workspace: Added attribute, `assessments_enabled`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * d/tfe_workspace: Added attribute, `assessments_enabled`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * r/tfe_organization: Added attribute, `assessments_enforced`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * d/tfe_organization: Added attribute, `assessments_enforced`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
 
 FEATURES:
 * r/tfe_workspace_run_task, d/tfe_workspace_run_task: Add `stage` attribute to workspace run tasks. ([#555](https://github.com/hashicorp/terraform-provider-tfe/pull/555))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Unreleased
  * r/tfe_workspace: Changes in `agent_pool_id` and `execution_mode` attributes are now detected and applied. ([#607](https://github.com/hashicorp/terraform-provider-tfe/pull/607))
- * r/tfe_workspace: Added attribute, `assessments_enabled`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
- * d/tfe_workspace: Added attribute, `assessments_enabled`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
- * r/tfe_organization: Added attribute, `assessments_enforced`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
- * d/tfe_organization: Added attribute, `assessments_enforced`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * r/tfe_workspace: (Available only in Terraform Cloud) Added attribute, `assessments_enabled`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * d/tfe_workspace: (Available only in Terraform Cloud) Added attribute, `assessments_enabled`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * r/tfe_organization: (Available only in Terraform Cloud) Added attribute, `assessments_enforced`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * d/tfe_organization: (Available only in Terraform Cloud) Added attribute, `assessments_enforced`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
 
 FEATURES:
 * r/tfe_workspace_run_task, d/tfe_workspace_run_task: Add `stage` attribute to workspace run tasks. ([#555](https://github.com/hashicorp/terraform-provider-tfe/pull/555))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## Unreleased
  * r/tfe_workspace: Changes in `agent_pool_id` and `execution_mode` attributes are now detected and applied. ([#607](https://github.com/hashicorp/terraform-provider-tfe/pull/607))
- * r/tfe_workspace: Added attribute for drift detection setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
- * d/tfe_workspace: Added attribute for drift detection setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
-
+ * r/tfe_workspace: Added attribute for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * d/tfe_workspace: Added attribute for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
 
 FEATURES:
 * r/tfe_workspace_run_task, d/tfe_workspace_run_task: Add `stage` attribute to workspace run tasks. ([#555](https://github.com/hashicorp/terraform-provider-tfe/pull/555))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## Unreleased
  * r/tfe_workspace: Changes in `agent_pool_id` and `execution_mode` attributes are now detected and applied. ([#607](https://github.com/hashicorp/terraform-provider-tfe/pull/607))
- * r/tfe_workspace: (Available only in Terraform Cloud) Added attribute, `assessments_enabled`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
- * d/tfe_workspace: (Available only in Terraform Cloud) Added attribute, `assessments_enabled`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
- * r/tfe_organization: (Available only in Terraform Cloud) Added attribute, `assessments_enforced`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
- * d/tfe_organization: (Available only in Terraform Cloud) Added attribute, `assessments_enforced`, for health assessments (drift detection) setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+* Added attributes for health assessments (drift detection) - available only in Terraform Cloud ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550)):
+  * r/tfe_workspace: Added attribute, `assessments_enabled`, for health assessments (drift detection) setting
+  * d/tfe_workspace: Added attribute, `assessments_enabled`, for health assessments (drift detection) setting
+  * r/tfe_organization: Added attribute, `assessments_enforced`, for health assessments (drift detection) setting
+  * d/tfe_organization: Added attribute, `assessments_enforced`, for health assessments (drift detection) setting
 
 FEATURES:
 * r/tfe_workspace_run_task, d/tfe_workspace_run_task: Add `stage` attribute to workspace run tasks. ([#555](https://github.com/hashicorp/terraform-provider-tfe/pull/555))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
  * r/tfe_workspace: Changes in `agent_pool_id` and `execution_mode` attributes are now detected and applied. ([#607](https://github.com/hashicorp/terraform-provider-tfe/pull/607))
+ * r/tfe_workspace: Added attribute for drift detection setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+ * d/tfe_workspace: Added attribute for drift detection setting ([550](https://github.com/hashicorp/terraform-provider-tfe/pull/550))
+
 
 FEATURES:
 * r/tfe_workspace_run_task, d/tfe_workspace_run_task: Add `stage` attribute to workspace run tasks. ([#555](https://github.com/hashicorp/terraform-provider-tfe/pull/555))

--- a/tfe/data_source_organization.go
+++ b/tfe/data_source_organization.go
@@ -52,6 +52,11 @@ func dataSourceTFEOrganization() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+
+			"assessments_enforced": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -79,6 +84,7 @@ func dataSourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("owners_team_saml_role_id", org.OwnersTeamSAMLRoleID)
 	d.Set("two_factor_conformant", org.TwoFactorConformant)
 	d.Set("send_passing_statuses_for_untriggered_speculative_plans", org.SendPassingStatusesForUntriggeredSpeculativePlans)
+	d.Set("assessments_enforced", org.AssessmentsEnforced)
 
 	return nil
 }

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -54,7 +54,7 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"drift_detection": {
+			"assessments_enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
@@ -188,7 +188,7 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("allow_destroy_plan", workspace.AllowDestroyPlan)
 	d.Set("auto_apply", workspace.AutoApply)
 	d.Set("description", workspace.Description)
-	d.Set("drift_detection", workspace.DriftDetection)
+	d.Set("assessments_enabled", workspace.AssessmentsEnabled)
 	d.Set("file_triggers_enabled", workspace.FileTriggersEnabled)
 	d.Set("operations", workspace.Operations)
 	d.Set("policy_check_failures", workspace.PolicyCheckFailures)

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -54,6 +54,11 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"drift_detection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"operations": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -183,6 +188,7 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("allow_destroy_plan", workspace.AllowDestroyPlan)
 	d.Set("auto_apply", workspace.AutoApply)
 	d.Set("description", workspace.Description)
+	d.Set("drift_detection", workspace.DriftDetection)
 	d.Set("file_triggers_enabled", workspace.FileTriggersEnabled)
 	d.Set("operations", workspace.Operations)
 	d.Set("policy_check_failures", workspace.PolicyCheckFailures)

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -92,7 +92,7 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "speculative_enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"data.tfe_workspace.foobar", "drift_detection", "false"),
+						"data.tfe_workspace.foobar", "assessments_enabled", "false"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "structured_run_output_enabled", "true"),
 					resource.TestCheckResourceAttr(
@@ -176,7 +176,7 @@ resource "tfe_workspace" "foobar" {
   file_triggers_enabled = true
   queue_all_runs        = false
   speculative_enabled   = true
-	drift_detection       = false
+	assessments_enabled       = false
   tag_names             = ["modules", "shared"]
   terraform_version     = "0.11.1"
   trigger_prefixes      = ["/modules", "/shared"]

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -92,6 +92,8 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "speculative_enabled", "true"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "drift_detection", "false"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "structured_run_output_enabled", "true"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "tag_names.0", "modules"),
@@ -174,6 +176,7 @@ resource "tfe_workspace" "foobar" {
   file_triggers_enabled = true
   queue_all_runs        = false
   speculative_enabled   = true
+	drift_detection       = false
   tag_names             = ["modules", "shared"]
   terraform_version     = "0.11.1"
   trigger_prefixes      = ["/modules", "/shared"]

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -77,7 +77,6 @@ func resourceTFEOrganization() *schema.Resource {
 			"assessments_enforced": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 			},
 		},
 	}
@@ -129,7 +128,11 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("owners_team_saml_role_id", org.OwnersTeamSAMLRoleID)
 	d.Set("cost_estimation_enabled", org.CostEstimationEnabled)
 	d.Set("send_passing_statuses_for_untriggered_speculative_plans", org.SendPassingStatusesForUntriggeredSpeculativePlans)
-	d.Set("assessments_enforced", org.AssessmentsEnforced)
+
+	//TFE (onprem) does not have access to this feature yet and cannot be expected to return this attribute
+	if org.AssessmentsEnforced != nil {
+		d.Set("assessments_enforced", org.AssessmentsEnforced)
+	}
 
 	return nil
 }

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -73,6 +73,12 @@ func resourceTFEOrganization() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"assessments_enforced": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -123,6 +129,7 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("owners_team_saml_role_id", org.OwnersTeamSAMLRoleID)
 	d.Set("cost_estimation_enabled", org.CostEstimationEnabled)
 	d.Set("send_passing_statuses_for_untriggered_speculative_plans", org.SendPassingStatusesForUntriggeredSpeculativePlans)
+	d.Set("assessments_enforced", org.AssessmentsEnforced)
 
 	return nil
 }
@@ -164,6 +171,11 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 	// If send_passing_statuses_for_untriggered_speculative_plans is supplied, set it using the options struct.
 	if sendPassingStatusesForUntriggeredSpeculativePlans, ok := d.GetOk("send_passing_statuses_for_untriggered_speculative_plans"); ok {
 		options.SendPassingStatusesForUntriggeredSpeculativePlans = tfe.Bool(sendPassingStatusesForUntriggeredSpeculativePlans.(bool))
+	}
+
+	// If cost_estimation_enabled is supplied, set it using the options struct.
+	if assessmentsEnforced, ok := d.GetOkExists("assessments_enforced"); ok {
+		options.assessmentsEnforced = tfe.Bool(assessmentsEnforced.(bool))
 	}
 
 	log.Printf("[DEBUG] Update configuration of organization: %s", d.Id())

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -175,7 +175,7 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 
 	// If cost_estimation_enabled is supplied, set it using the options struct.
 	if assessmentsEnforced, ok := d.GetOkExists("assessments_enforced"); ok {
-		options.assessmentsEnforced = tfe.Bool(assessmentsEnforced.(bool))
+		options.AssessmentsEnforced = tfe.Bool(assessmentsEnforced.(bool))
 	}
 
 	log.Printf("[DEBUG] Update configuration of organization: %s", d.Id())

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -128,11 +128,9 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("owners_team_saml_role_id", org.OwnersTeamSAMLRoleID)
 	d.Set("cost_estimation_enabled", org.CostEstimationEnabled)
 	d.Set("send_passing_statuses_for_untriggered_speculative_plans", org.SendPassingStatusesForUntriggeredSpeculativePlans)
-
-	//TFE (onprem) does not have access to this feature yet and cannot be expected to return this attribute
-	if org.AssessmentsEnforced != nil {
-		d.Set("assessments_enforced", org.AssessmentsEnforced)
-	}
+	// TFE (onprem) does not currently have this feature and this value won't be returned in those cases.
+	// org.AssessmentsEnforced will default to false
+	d.Set("assessments_enforced", org.AssessmentsEnforced)
 
 	return nil
 }

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -72,6 +72,8 @@ func TestAccTFEOrganization_full(t *testing.T) {
 						"tfe_organization.foobar", "cost_estimation_enabled", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "send_passing_statuses_for_untriggered_speculative_plans", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "assessments_enforced", "false"),
 				),
 			},
 		},
@@ -91,9 +93,11 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 
 	// First update
 	costEstimationEnabled1 := true
+	assessmentsEnforced1 := true
 
 	// Second update
 	costEstimationEnabled2 := false
+	assessmentsEnforced2 := false
 	updatedName := org.Name + "_foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -102,7 +106,7 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganization_update(org.Name, org.Email, costEstimationEnabled1),
+				Config: testAccTFEOrganization_update(org.Name, org.Email, costEstimationEnabled1, assessmentsEnforced1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
@@ -123,11 +127,13 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 						"tfe_organization.foobar", "cost_estimation_enabled", strconv.FormatBool(costEstimationEnabled1)),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "send_passing_statuses_for_untriggered_speculative_plans", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "assessments_enforced", strconv.FormatBool(assessmentsEnforced1)),
 				),
 			},
 
 			{
-				Config: testAccTFEOrganization_update(updatedName, org.Email, costEstimationEnabled2),
+				Config: testAccTFEOrganization_update(updatedName, org.Email, costEstimationEnabled2, assessmentsEnforced2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
@@ -146,6 +152,8 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 						"tfe_organization.foobar", "owners_team_saml_role_id", "owners"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "cost_estimation_enabled", strconv.FormatBool(costEstimationEnabled2)),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "assessments_enforced", strconv.FormatBool(assessmentsEnforced2)),
 				),
 			},
 		},
@@ -370,10 +378,11 @@ resource "tfe_organization" "foobar" {
   collaborator_auth_policy = "password"
   owners_team_saml_role_id = "owners"
   cost_estimation_enabled  = false
+  assessments_enforced     = false
 }`, rInt)
 }
 
-func testAccTFEOrganization_update(orgName string, orgEmail string, costEstimationEnabled bool) string {
+func testAccTFEOrganization_update(orgName string, orgEmail string, costEstimationEnabled bool, assessmentsEnforced bool) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name                     = "%s"
@@ -382,5 +391,6 @@ resource "tfe_organization" "foobar" {
   session_remember_minutes = 3600
   owners_team_saml_role_id = "owners"
   cost_estimation_enabled  = %t
-}`, orgName, orgEmail, costEstimationEnabled)
+	assessments_enforced     = %t
+}`, orgName, orgEmail, costEstimationEnabled, assessmentsEnforced)
 }

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -123,7 +123,7 @@ func resourceTFEWorkspace() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"drift_detection": {
+			"assessments_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -247,7 +247,7 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		AllowDestroyPlan:           tfe.Bool(d.Get("allow_destroy_plan").(bool)),
 		AutoApply:                  tfe.Bool(d.Get("auto_apply").(bool)),
 		Description:                tfe.String(d.Get("description").(string)),
-		DriftDetection:             tfe.Bool(d.Get("drift_detection").(bool)),
+		AssessmentsEnabled:         tfe.Bool(d.Get("assessments_enabled").(bool)),
 		FileTriggersEnabled:        tfe.Bool(d.Get("file_triggers_enabled").(bool)),
 		QueueAllRuns:               tfe.Bool(d.Get("queue_all_runs").(bool)),
 		SpeculativeEnabled:         tfe.Bool(d.Get("speculative_enabled").(bool)),
@@ -446,14 +446,14 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		d.HasChange("operations") || d.HasChange("execution_mode") ||
 		d.HasChange("description") || d.HasChange("agent_pool_id") ||
 		d.HasChange("global_remote_state") || d.HasChange("structured_run_output_enabled") ||
-		d.HasChange("drift_detection") {
+		d.HasChange("assessments_enabled") {
 		// Create a new options struct.
 		options := tfe.WorkspaceUpdateOptions{
 			Name:                       tfe.String(d.Get("name").(string)),
 			AllowDestroyPlan:           tfe.Bool(d.Get("allow_destroy_plan").(bool)),
 			AutoApply:                  tfe.Bool(d.Get("auto_apply").(bool)),
 			Description:                tfe.String(d.Get("description").(string)),
-			DriftDetection:             tfe.Bool(d.Get("drift_detection").(bool)),
+			AssessmentsEnabled:         tfe.Bool(d.Get("assessments_enabled").(bool)),
 			FileTriggersEnabled:        tfe.Bool(d.Get("file_triggers_enabled").(bool)),
 			GlobalRemoteState:          tfe.Bool(d.Get("global_remote_state").(bool)),
 			QueueAllRuns:               tfe.Bool(d.Get("queue_all_runs").(bool)),

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -372,10 +372,9 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", workspace.Name)
 	d.Set("allow_destroy_plan", workspace.AllowDestroyPlan)
 
-	//TFE (onprem) does not currently have this feature and this value won't be returned in those cases
-	if workspace.AssessmentsEnabled != nil {
-		d.Set("assessments_enabled", workspace.AssessmentsEnabled)
-	}
+	// TFE (onprem) does not currently have this feature and this value won't be returned in those cases.
+	// workspace.AssessmentsEnabled will default to false
+	d.Set("assessments_enabled", workspace.AssessmentsEnabled)
 
 	d.Set("auto_apply", workspace.AutoApply)
 	d.Set("description", workspace.Description)
@@ -467,7 +466,7 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		if d.HasChange("assessments_enabled") {
 			if v, ok := d.GetOkExists("assessments_enabled"); ok {
-				options.AssessmentsEnabled = tfe.Bool(d.Get("assessments_enabled").(bool))
+				options.AssessmentsEnabled = tfe.Bool(v.(bool))
 			}
 		}
 

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -123,6 +123,12 @@ func resourceTFEWorkspace() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"drift_detection": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"operations": {
 				Type:          schema.TypeBool,
 				Optional:      true,
@@ -241,6 +247,7 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		AllowDestroyPlan:           tfe.Bool(d.Get("allow_destroy_plan").(bool)),
 		AutoApply:                  tfe.Bool(d.Get("auto_apply").(bool)),
 		Description:                tfe.String(d.Get("description").(string)),
+		DriftDetection:             tfe.Bool(d.Get("drift_detection").(bool)),
 		FileTriggersEnabled:        tfe.Bool(d.Get("file_triggers_enabled").(bool)),
 		QueueAllRuns:               tfe.Bool(d.Get("queue_all_runs").(bool)),
 		SpeculativeEnabled:         tfe.Bool(d.Get("speculative_enabled").(bool)),
@@ -438,13 +445,15 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		d.HasChange("allow_destroy_plan") || d.HasChange("speculative_enabled") ||
 		d.HasChange("operations") || d.HasChange("execution_mode") ||
 		d.HasChange("description") || d.HasChange("agent_pool_id") ||
-		d.HasChange("global_remote_state") || d.HasChange("structured_run_output_enabled") {
+		d.HasChange("global_remote_state") || d.HasChange("structured_run_output_enabled") ||
+		d.HasChange("drift_detection") {
 		// Create a new options struct.
 		options := tfe.WorkspaceUpdateOptions{
 			Name:                       tfe.String(d.Get("name").(string)),
 			AllowDestroyPlan:           tfe.Bool(d.Get("allow_destroy_plan").(bool)),
 			AutoApply:                  tfe.Bool(d.Get("auto_apply").(bool)),
 			Description:                tfe.String(d.Get("description").(string)),
+			DriftDetection:             tfe.Bool(d.Get("drift_detection").(bool)),
 			FileTriggersEnabled:        tfe.Bool(d.Get("file_triggers_enabled").(bool)),
 			GlobalRemoteState:          tfe.Bool(d.Get("global_remote_state").(bool)),
 			QueueAllRuns:               tfe.Bool(d.Get("queue_all_runs").(bool)),

--- a/tfe/resource_tfe_workspace_migrate.go
+++ b/tfe/resource_tfe_workspace_migrate.go
@@ -20,6 +20,11 @@ func resourceTfeWorkspaceResourceV0() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"assessments_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true
+			},
+
 			"auto_apply": {
 				Type:     schema.TypeBool,
 				Optional: true,

--- a/tfe/resource_tfe_workspace_migrate.go
+++ b/tfe/resource_tfe_workspace_migrate.go
@@ -22,7 +22,7 @@ func resourceTfeWorkspaceResourceV0() *schema.Resource {
 
 			"assessments_enabled": {
 				Type:     schema.TypeBool,
-				Optional: true
+				Optional: true,
 			},
 
 			"auto_apply": {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -2157,7 +2157,6 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 }
 
 func TestAccTFEWorkspace_basicAssessmentsEnabled(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfEnterprise(t)
 
 	workspace := &tfe.Workspace{}

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -48,7 +48,7 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "speculative_enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"tfe_workspace.foobar", "drift_detection", "false"),
+						"tfe_workspace.foobar", "assessments_enabled", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "structured_run_output_enabled", "true"),
 					resource.TestCheckResourceAttr(
@@ -2156,7 +2156,7 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func TestAccTFEWorkspace_basicDriftDetection(t *testing.T) {
+func TestAccTFEWorkspace_basicAssessmentsEnabled(t *testing.T) {
 	skipIfFreeOnly(t)
 	skipIfEnterprise(t)
 
@@ -2177,18 +2177,18 @@ func TestAccTFEWorkspace_basicDriftDetection(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
 					resource.TestCheckResourceAttr(
-						"tfe_workspace.foobar", "drift_detection", "false"),
+						"tfe_workspace.foobar", "assessments_enabled", "false"),
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_updateDriftDetection(rInt),
+				Config: testAccTFEWorkspace_updateAssessmentsEnabled(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-updated"),
 					resource.TestCheckResourceAttr(
-						"tfe_workspace.foobar", "drift_detection", "true"),
+						"tfe_workspace.foobar", "assessments_enabled", "true"),
 				),
 			},
 		},
@@ -2422,7 +2422,7 @@ resource "tfe_workspace" "foobar" {
 }`, rInt)
 }
 
-func testAccTFEWorkspace_updateDriftDetection(rInt int) string {
+func testAccTFEWorkspace_updateAssessmentsEnabled(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
@@ -2433,7 +2433,7 @@ resource "tfe_workspace" "foobar" {
   name                  = "workspace-updated"
   organization          = tfe_organization.foobar.id
   description           = "My favorite workspace!"
-	drift_detection       = true
+	assessments_enabled       = true
   allow_destroy_plan    = false
   auto_apply            = true
   tag_names             = ["fav", "test"]

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -30,7 +30,7 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Name of the organization.
 * `email` - Admin email address.
 * `external_id` - An identifier for the organization.
-* `assessments_enforced` - (TFC only) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
+* `assessments_enforced` - (Available only in Terraform Cloud) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
 * `collaborator_auth_policy` - Authentication policy (`password` or `two_factor_mandatory`). Defaults to `password`.
 * `cost_estimation_enabled` - Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `owners_team_saml_role_id` - The name of the "owners" team.

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -30,6 +30,7 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Name of the organization.
 * `email` - Admin email address.
 * `external_id` - An identifier for the organization.
+* `assessments_enforced` - (TFC only) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
 * `collaborator_auth_policy` - Authentication policy (`password` or `two_factor_mandatory`). Defaults to `password`.
 * `cost_estimation_enabled` - Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `owners_team_saml_role_id` - The name of the "owners" team.

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -35,7 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The workspace ID.
 * `allow_destroy_plan` - Indicates whether destroy plans can be queued on the workspace.
 * `auto_apply` - Indicates whether to automatically apply changes when a Terraform plan is successful.
-  `drift_detection` - Indicates whether drift detection is enabled for the workspace.
+  `assessments_enabled` - Indicates whether health assessments such as drift detection are enabled for the workspace.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument).
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` is set to `true`.

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -35,6 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The workspace ID.
 * `allow_destroy_plan` - Indicates whether destroy plans can be queued on the workspace.
 * `auto_apply` - Indicates whether to automatically apply changes when a Terraform plan is successful.
+  `drift_detection` - Indicates whether drift detection is enabled for the workspace.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument).
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` is set to `true`.

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -35,7 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The workspace ID.
 * `allow_destroy_plan` - Indicates whether destroy plans can be queued on the workspace.
 * `auto_apply` - Indicates whether to automatically apply changes when a Terraform plan is successful.
-  `assessments_enabled` - Indicates whether health assessments such as drift detection are enabled for the workspace.
+  `assessments_enabled` - (Available only in Terraform Cloud) Indicates whether health assessments such as drift detection are enabled for the workspace.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument).
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` is set to `true`.

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
 * `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `send_passing_statuses_for_untriggered_speculative_plans` - (Optional) Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.
+* `assessments_enforced` - (Optional) (TFC only) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
 
 ## Attributes Reference
 

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
 * `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `send_passing_statuses_for_untriggered_speculative_plans` - (Optional) Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.
-* `assessments_enforced` - (Optional) (TFC only) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
+* `assessments_enforced` - (Optional) (Available only in Terraform Cloud) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
 
 ## Attributes Reference
 

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
   execution modes are valid.  When set to `local`, the workspace will be used
   for state storage only. This value _must not_ be provided if `operations`
   is provided.
-* `drift_detection` - (Optional) Whether to regularly run drift detection assessments on the workspace. Defaults to `false`.
+* `assessments_enabled` - (Optional) Whether to regularly run health assessments such as drift detection on the workspace. Defaults to `false`.
 * `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files
   in a VCS push. Defaults to `false`. If enabled, the working directory and
   trigger prefixes describe a set of paths which must contain changes for a

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -69,6 +69,7 @@ The following arguments are supported:
   execution modes are valid.  When set to `local`, the workspace will be used
   for state storage only. This value _must not_ be provided if `operations`
   is provided.
+* `drift_detection` - (Optional) Whether to regularly run drift detection assessments on the workspace. Defaults to `false`.
 * `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files
   in a VCS push. Defaults to `false`. If enabled, the working directory and
   trigger prefixes describe a set of paths which must contain changes for a


### PR DESCRIPTION
## Description

This Change is to allow operators to manage the drift detection setting for workspaces.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation]() <= not available until the go-tfe PR lands.
- [API documentation](https://www.terraform.io/cloud-docs/api-docs/workspaces#request-body)
Relies on:
- [Related PR](https://github.com/hashicorp/go-tfe/pull/462)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace_basicDriftDetection" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspace_basicDriftDetection -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEWorkspace_basicDriftDetection
--- PASS: TestAccTFEWorkspace_basicDriftDetection (11.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	11.978s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
...
```

```
$ TESTARGS="-run TestAccTFEWorkspaceDataSource_basic" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceDataSource_basic -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (6.30s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	6.667s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```
