### PR TITLE
docs: clarify the attribute type of the run_tasks team_access permission

### DIFF
--- a/website/docs/d/team_access.html.markdown
+++ b/website/docs/d/team_access.html.markdown
@@ -41,4 +41,4 @@ The `permissions` block contains:
 * `state_versions` - The permissions granted to state versions. Valid values are `none`, `read-outputs`, `read`, or `write`
 * `sentinel_mocks` - The permissions granted to Sentinel mocks. Valid values are `none` or `read`
 * `workspace_locking` - Whether permission is granted to manually lock the workspace or not.
-* `run_tasks` - Whether permission is granted to manage workspace run tasks or not.
+* `run_tasks` - (Required) Boolean determining whether or not to grant the team permission to manage workspace run tasks.

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -48,7 +48,7 @@ The `permissions` block supports:
 * `state_versions` - (Required) The permission to grant the team on the workspace's state versions. Valid values are `none`, `read`, `read-outputs`, or `write`.
 * `sentinel_mocks` - (Required) The permission to grant the team on the workspace's generated Sentinel mocks, Valid values are `none` or `read`.
 * `workspace_locking` - (Required) Boolean determining whether or not to grant the team permission to manually lock/unlock the workspace.
-* `run_tasks` - (Required) Whether permission is granted to manage workspace run tasks or not.
+* `run_tasks` - (Required) Boolean determining whether or not to grant the team permission to manage workspace run tasks.
 
 -> **Note:** At least one of `access` or `permissions` _must_ be provided, but not both. Whichever is omitted will automatically reflect the state of the other.
 


### PR DESCRIPTION
## Description

When modifying the [permissions](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/team_access#permissions) attribute on the `team_access` resource, I wasn't immediately sure what the type of `run_task` was and had to look at the `tfe` provider code to verify that it was a boolean. This PR updates the docs to specify that `run_task` is a boolean for this attribute.

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_
I didn't update the change log since this is just a documentation change. Please let me know if I should though!

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_
A screenshot of the fix is posted above.

## Testing plan

1.  _Describe how to replicate_
See the docs: https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/team_access#run_tasks
<img width="653" alt="image" src="https://user-images.githubusercontent.com/5590812/179571570-d547ca8b-eeef-425c-9f1c-aaec51a8721d.png">

1. _Updated docs_
<img width="643" alt="image" src="https://user-images.githubusercontent.com/5590812/179571706-ab940f8f-4617-468c-971e-0a26680a9fa5.png">
(from https://registry.terraform.io/tools/doc-preview)