### PR TITLE
Add workspace run task stage property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+FEATURES:
+* r/tfe_workspace_run_task, d/tfe_workspace_run_task: Add `stage` attribute to workspace run tasks. ([#555](https://github.com/hashicorp/terraform-provider-tfe/pull/555))
+
 ## v0.36.0 (August 16th, 2022)
 
 FEATURES:

--- a/tfe/data_source_workspace_run_task.go
+++ b/tfe/data_source_workspace_run_task.go
@@ -13,18 +13,27 @@ func dataSourceTFEWorkspaceRunTask() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"workspace_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "The id of the workspace.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"task_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "The id of the run task.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"enforcement_level": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The enforcement level of the task.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
+			"stage": {
+				Description: "Which stage the task will run in.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 		},
 	}
@@ -47,6 +56,7 @@ func dataSourceTFEWorkspaceRunTaskRead(d *schema.ResourceData, meta interface{})
 		for _, wstask := range list.Items {
 			if wstask.RunTask.ID == taskID {
 				d.Set("enforcement_level", string(wstask.EnforcementLevel))
+				d.Set("stage", string(wstask.Stage))
 				d.SetId(wstask.ID)
 				return nil
 			}

--- a/tfe/data_source_workspace_run_task_test.go
+++ b/tfe/data_source_workspace_run_task_test.go
@@ -25,6 +25,7 @@ func TestAccTFEWorkspaceRunTaskDataSource_basic(t *testing.T) {
 				Config: testAccTFEWorkspaceRunTaskDataSourceConfig(orgName, rInt, runTasksURL()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.tfe_workspace_run_task.foobar", "enforcement_level", "advisory"),
+					resource.TestCheckResourceAttrSet("data.tfe_workspace_run_task.foobar", "stage"),
 					resource.TestCheckResourceAttrSet("data.tfe_workspace_run_task.foobar", "id"),
 					resource.TestCheckResourceAttrSet("data.tfe_workspace_run_task.foobar", "task_id"),
 					resource.TestCheckResourceAttrSet("data.tfe_workspace_run_task.foobar", "workspace_id"),

--- a/tfe/resource_tfe_workspace_run_task.go
+++ b/tfe/resource_tfe_workspace_run_task.go
@@ -10,6 +10,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+func workspaceRunTaskEnforcementLevels() []string {
+	return []string{
+		string(tfe.Advisory),
+		string(tfe.Mandatory),
+	}
+}
+
+func workspaceRunTaskStages() []string {
+	return []string{
+		string(tfe.PrePlan),
+		string(tfe.PostPlan),
+	}
+}
+
+// Helper function to turn a slice of strings into an english sentence for documentation
+func sentenceList(items []string, prefix string, suffix string, conjunction string) string {
+	var b strings.Builder
+	for i, v := range items {
+		fmt.Fprint(&b, prefix, v, suffix)
+		if i < len(items)-1 {
+			if i < len(items)-2 {
+				fmt.Fprint(&b, ", ")
+			} else {
+				fmt.Fprintf(&b, " %s ", conjunction)
+			}
+		}
+	}
+	return b.String()
+}
+
 func resourceTFEWorkspaceRunTask() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTFEWorkspaceRunTaskCreate,
@@ -22,25 +52,47 @@ func resourceTFEWorkspaceRunTask() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"workspace_id": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
+				Description: "The id of the workspace to associate the Run task to.",
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
 			},
 
 			"task_id": {
+				Description: "The id of the Run task to associate to the Workspace.",
+
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
 			},
 
 			"enforcement_level": {
+				Description: fmt.Sprintf("The enforcement level of the task. Valid values are %s.", sentenceList(
+					workspaceRunTaskEnforcementLevels(),
+					"`",
+					"`",
+					"and",
+				)),
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice(
-					[]string{
-						string(tfe.Advisory),
-						string(tfe.Mandatory),
-					},
+					workspaceRunTaskEnforcementLevels(),
+					false,
+				),
+			},
+
+			"stage": {
+				Description: fmt.Sprintf("This is currently in BETA. The stage to run the task in. Valid values are %s.", sentenceList(
+					workspaceRunTaskStages(),
+					"`",
+					"`",
+					"and",
+				)),
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  tfe.PostPlan,
+				ValidateFunc: validation.StringInSlice(
+					workspaceRunTaskStages(),
 					false,
 				),
 			},
@@ -65,10 +117,12 @@ func resourceTFEWorkspaceRunTaskCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf(
 			"Error retrieving workspace %s: %w", workspaceID, err)
 	}
+	stage := tfe.Stage(d.Get("stage").(string))
 
 	options := tfe.WorkspaceRunTaskCreateOptions{
 		RunTask:          task,
 		EnforcementLevel: tfe.TaskEnforcementLevel(d.Get("enforcement_level").(string)),
+		Stage:            &stage,
 	}
 
 	log.Printf("[DEBUG] Create task %s in workspace %s", task.ID, ws.ID)
@@ -108,6 +162,10 @@ func resourceTFEWorkspaceRunTaskUpdate(d *schema.ResourceData, meta interface{})
 	if d.HasChange("enforcement_level") {
 		options.EnforcementLevel = tfe.TaskEnforcementLevel(d.Get("enforcement_level").(string))
 	}
+	if d.HasChange("stage") {
+		stage := tfe.Stage(d.Get("stage").(string))
+		options.Stage = &stage
+	}
 
 	log.Printf("[DEBUG] Update configuration of task %s in workspace %s", d.Id(), workspaceID)
 	_, err := tfeClient.WorkspaceRunTasks.Update(ctx, workspaceID, d.Id(), options)
@@ -138,6 +196,7 @@ func resourceTFEWorkspaceRunTaskRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("workspace_id", wstask.Workspace.ID)
 	d.Set("task_id", wstask.RunTask.ID)
 	d.Set("enforcement_level", string(wstask.EnforcementLevel))
+	d.Set("stage", string(wstask.Stage))
 
 	return nil
 }

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -67,6 +67,12 @@ func skipUnlessRunTasksDefined(t *testing.T) {
 	}
 }
 
+func skipUnlessBeta(t *testing.T) {
+	if !betaFeaturesEnabled() {
+		t.Skip("Skipping test related to a Terraform Cloud/Enterprise beta feature. Set ENABLE_BETA=1 to run.")
+	}
+}
+
 func enterpriseEnabled() bool {
 	return os.Getenv("ENABLE_TFE") == "1"
 }
@@ -77,6 +83,11 @@ func isAcceptanceTest() bool {
 
 func runTasksURL() string {
 	return os.Getenv(RunTasksURLEnvName)
+}
+
+// Checks to see if ENABLE_BETA is set to 1, thereby enabling tests for beta features.
+func betaFeaturesEnabled() bool {
+	return os.Getenv("ENABLE_BETA") == "1"
 }
 
 // Most tests rely on terraform-plugin-sdk/helper/resource.Test to run.  That test helper ensures

--- a/website/docs/d/workspace_run_task.html.markdown
+++ b/website/docs/d/workspace_run_task.html.markdown
@@ -25,7 +25,7 @@ data "tfe_workspace_run_task" "foobar" {
 
 The following arguments are supported:
 
-* `task_id` - (Required) The id of the Run task.
+* `task_id` - (Required) The id of the run task.
 * `workspace_id` - (Required) The id of the workspace.
 
 ## Attributes Reference
@@ -34,3 +34,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `enforcement_level` - The enforcement level of the task.
 * `id` - The ID of the Workspace Run task.
+* `stage` - Which stage the task will run in.

--- a/website/docs/r/workspace_run_task.html.markdown
+++ b/website/docs/r/workspace_run_task.html.markdown
@@ -31,6 +31,7 @@ The following arguments are supported:
 * `enforcement_level` - (Required) The enforcement level of the task. Valid values are `advisory` and `mandatory`.
 * `task_id` - (Required) The id of the Run task to associate to the Workspace.
 * `workspace_id` - (Required) The id of the workspace to associate the Run task to.
+* `stage` - (Optional) This is currently in BETA. The stage to run the task in. Valid values are `pre-plan` and `post-plan`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This commit adds the stage attribute to the Workspace Run Task
Resource and Data Source. Note that this is in beta for the
Resource.  This commit adds acceptance tests, and optionally
test the Beta features.

This commit also adds descriptions for the Workspace Run Task
attributes.

## Testing plan

1. Acceptance tests cover the testing plan.  Beta features require a feature flag to be enabled on TFC.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://github.com/hashicorp/go-tfe/pull/469x)
- [API documentation](https://github.com/hashicorp/go-tfe/pull/469)

## Output from acceptance tests

With beta tests enabled

```text
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEWorkspaceRunTask_create
--- PASS: TestAccTFEWorkspaceRunTask_create (38.84s)
=== RUN   TestAccTFEWorkspaceRunTask_beta_create
--- PASS: TestAccTFEWorkspaceRunTask_beta_create (34.31s)
=== RUN   TestAccTFEWorkspaceRunTask_import
--- PASS: TestAccTFEWorkspaceRunTask_import (27.11s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 100.750s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
