### PR TITLE
Allow agent pools to be imported by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 * d/agent_pool: Improve efficiency of reading agent pool data when the target organization has more than 20 agent pools ([#508](https://github.com/hashicorp/terraform-provider-tfe/pull/508))
+* r/agent_pool: Agent Pools can now be imported using `<ORGANIZATION NAME>/<AGENT POOL NAME>`
 * Added warning logs for 404 error responses ([#538](https://github.com/hashicorp/terraform-provider-tfe/pull/538))
 
 ## 0.33.0 (July 8th, 2022)

--- a/tfe/agent_pool_helpers.go
+++ b/tfe/agent_pool_helpers.go
@@ -6,7 +6,7 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 )
 
-func fetchtAgentPoolId(orgName string, poolName string, client *tfe.Client) (string, error) {
+func fetchtAgentPoolID(orgName string, poolName string, client *tfe.Client) (string, error) {
 	// to reduce the number of pages returned, search based on the name. TFE instances which
 	// do not support agent pool search will just ignore the query parameter
 	options := tfe.AgentPoolListOptions{

--- a/tfe/agent_pool_helpers.go
+++ b/tfe/agent_pool_helpers.go
@@ -6,7 +6,7 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 )
 
-func fetchtAgentPoolID(orgName string, poolName string, client *tfe.Client) (string, error) {
+func fetchAgentPoolID(orgName string, poolName string, client *tfe.Client) (string, error) {
 	// to reduce the number of pages returned, search based on the name. TFE instances which
 	// do not support agent pool search will just ignore the query parameter
 	options := tfe.AgentPoolListOptions{

--- a/tfe/agent_pool_helpers.go
+++ b/tfe/agent_pool_helpers.go
@@ -34,5 +34,5 @@ func fetchtAgentPoolID(orgName string, poolName string, client *tfe.Client) (str
 		options.PageNumber = l.NextPage
 	}
 
-	return "", fmt.Errorf("Could not find agent pool %s/%s", orgName, poolName)
+	return "", tfe.ErrResourceNotFound
 }

--- a/tfe/agent_pool_helpers.go
+++ b/tfe/agent_pool_helpers.go
@@ -1,0 +1,38 @@
+package tfe
+
+import (
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+func fetchtAgentPoolId(orgName string, poolName string, client *tfe.Client) (string, error) {
+	// to reduce the number of pages returned, search based on the name. TFE instances which
+	// do not support agent pool search will just ignore the query parameter
+	options := tfe.AgentPoolListOptions{
+		Query: poolName,
+	}
+
+	for {
+		l, err := client.AgentPools.List(ctx, orgName, &options)
+		if err != nil {
+			return "", fmt.Errorf("Error retrieving agent pools: %w", err)
+		}
+
+		for _, k := range l.Items {
+			if k.Name == poolName {
+				return k.ID, nil
+			}
+		}
+
+		// Exit the loop when we've seen all pages.
+		if l.CurrentPage >= l.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		options.PageNumber = l.NextPage
+	}
+
+	return "", fmt.Errorf("Could not find agent pool %s/%s", orgName, poolName)
+}

--- a/tfe/data_source_agent_pool.go
+++ b/tfe/data_source_agent_pool.go
@@ -30,7 +30,7 @@ func dataSourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error 
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
 
-	id, err := fetchtAgentPoolID(organization, name, tfeClient)
+	id, err := fetchAgentPoolID(organization, name, tfeClient)
 	if err != nil {
 		return err
 	}

--- a/tfe/data_source_agent_pool.go
+++ b/tfe/data_source_agent_pool.go
@@ -30,7 +30,7 @@ func dataSourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error 
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
 
-	id, err := fetchtAgentPoolId(organization, name, tfeClient)
+	id, err := fetchtAgentPoolID(organization, name, tfeClient)
 	if err != nil {
 		return err
 	}

--- a/tfe/data_source_agent_pool.go
+++ b/tfe/data_source_agent_pool.go
@@ -1,8 +1,6 @@
 package tfe
 
 import (
-	"fmt"
-
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -32,34 +30,10 @@ func dataSourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error 
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
 
-	// Create an options struct.
-	// to reduce the number of pages returned, search based on the name. TFE instances which
-	// do not support agent pool search will just ignore the query parameter
-	options := tfe.AgentPoolListOptions{
-		Query: name,
+	id, err := fetchtAgentPoolId(organization, name, tfeClient)
+	if err != nil {
+		return err
 	}
-
-	for {
-		l, err := tfeClient.AgentPools.List(ctx, organization, &options)
-		if err != nil {
-			return fmt.Errorf("Error retrieving agent pools: %w", err)
-		}
-
-		for _, k := range l.Items {
-			if k.Name == name {
-				d.SetId(k.ID)
-				return nil
-			}
-		}
-
-		// Exit the loop when we've seen all pages.
-		if l.CurrentPage >= l.TotalPages {
-			break
-		}
-
-		// Update the page number to get the next page.
-		options.PageNumber = l.NextPage
-	}
-
-	return fmt.Errorf("Could not find agent pool %s/%s", organization, name)
+	d.SetId(id)
+	return nil
 }

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -123,7 +123,7 @@ func resourceTFEAgentPoolImporter(d *schema.ResourceData, meta interface{}) ([]*
 	} else if len(s) == 2 {
 		org := s[0]
 		poolName := s[1]
-		poolID, err := fetchtAgentPoolID(org, poolName, tfeClient)
+		poolID, err := fetchAgentPoolID(org, poolName, tfeClient)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"error retrieving agent pool with name %s from organization %s %w", poolName, org, err)

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,7 +16,7 @@ func resourceTFEAgentPool() *schema.Resource {
 		Update: resourceTFEAgentPoolUpdate,
 		Delete: resourceTFEAgentPoolDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceTFEAgentPoolImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -108,4 +109,28 @@ func resourceTFEAgentPoolDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	return nil
+}
+
+func resourceTFEAgentPoolImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	tfeClient := meta.(*tfe.Client)
+
+	s := strings.Split(d.Id(), "/")
+	if len(s) >= 3 {
+		return nil, fmt.Errorf(
+			"invalid agent pool input format: %s (expected <ORGANIZATION>/<AGENT POOL NAME> or <AGENT POOL ID>)",
+			d.Id(),
+		)
+	} else if len(s) == 2 {
+		org := s[0]
+		poolName := s[1]
+		poolId, err := fetchtAgentPoolId(org, poolName, tfeClient)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error retrieving agent pool with name %s from organization %s %w", poolName, org, err)
+		}
+
+		d.SetId(poolId)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -123,13 +123,13 @@ func resourceTFEAgentPoolImporter(d *schema.ResourceData, meta interface{}) ([]*
 	} else if len(s) == 2 {
 		org := s[0]
 		poolName := s[1]
-		poolId, err := fetchtAgentPoolId(org, poolName, tfeClient)
+		poolID, err := fetchtAgentPoolID(org, poolName, tfeClient)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"error retrieving agent pool with name %s from organization %s %w", poolName, org, err)
 		}
 
-		d.SetId(poolId)
+		d.SetId(poolID)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/tfe/resource_tfe_agent_pool_test.go
+++ b/tfe/resource_tfe_agent_pool_test.go
@@ -94,6 +94,12 @@ func TestAccTFEAgentPool_import(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				ResourceName:      "tfe_agent_pool.foobar",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("tst-terraform-%d/agent-pool-test", rInt),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -47,8 +47,12 @@ The following arguments are supported:
 
 ## Import
 
-Agent pools can be imported; use `<AGENT POOL ID>` as the import ID. For example:
+Agent pools can be imported; use `<AGENT POOL ID>` or `<ORGANIZATION NAME>/<AGENT POOL NAME>` as the import ID. For example:
 
 ```shell
 terraform import tfe_agent_pool.test apool-rW0KoLSlnuNb5adB
+```
+
+```shell
+terraform import tfe_workspace.test my-org-name/my-agent-pool-name
 ```


### PR DESCRIPTION
## Description

Allow agent pools to be imported by `org name/agent pool name`


## Testing plan

1.  Check that agent pool data sources still works
2. Check that agent pools can still be imported by ID
3. 2. Check that agent pools can  be imported by org/name
4. Check that invalid import ID formats fail (eg a/b/c)
5. Check for error if org name is not found
6. Check for error if pool name is not found

## External links


- [Related Earlier PR](https://github.com/hashicorp/terraform-provider-tfe/pull/508)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-414)

## Output from acceptance tests

```
❯ go test github.com/hashicorp/terraform-provider-tfe/tfe  -run TestAccTFEAgentPool_import -v
=== RUN   TestAccTFEAgentPool_import
--- PASS: TestAccTFEAgentPool_import (104.15s)
PASS
ok
...
```
