### PR TITLE
Remove example because it does not work

### DIFF
--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -85,32 +85,6 @@ resource "tfe_variable" "test-b" {
 }
 ```
 
-Creating a variable set that is applied based on workspace tags:
-
-```hcl
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-data "tfe_workspace_ids" "prod-apps" {
-  tag_names    = ["prod", "app", "aws"]
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_variable_set" "test" {
-  name          = "Tag Based Varset"
-  description   = "Variable set applied to workspaces based on tag."
-  organization  = tfe_organization.test.name
-}
-
-resource "tfe_workspace_variable_set" "test" {
-  for_each        = toset(values(data.tfe_workspace_ids.prod-apps.ids))
-  workspace_id    = each.key
-  variable_set_id = tfe_variable_set.test.id
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
## Description

This [issue](https://github.com/hashicorp/terraform-provider-tfe/issues/559) reported the non-working example.

One workaround is to create workspaces in one pass, and then assign variable sets based on tags in a second terraform config. But this example could potentially be used to work around the security model of variable sets, so that does not seem ideal to include.

