### PR TITLE
Fix: read workspace state version outputs for sensitive values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES:
 * r/tfe_organization_run_task, d/tfe_organization_run_task: Add `description` attribute to organization run tasks. ([#585](https://github.com/hashicorp/terraform-provider-tfe/pull/585))
 
+BUG FIXES:
+* d/tfe_outputs: Fix referencing sensitive values in tfe_outputs ([#565](https://github.com/hashicorp/terraform-provider-tfe/pull/565))
+
 ## 0.35.0 (July 27th, 2022)
 
 BREAKING CHANGES:

--- a/tfe/data_source_outputs.go
+++ b/tfe/data_source_outputs.go
@@ -172,6 +172,14 @@ func (d dataSourceOutputs) readStateOutput(ctx context.Context, tfeClient *tfe.C
 	}
 
 	for _, op := range ws.Outputs {
+		if op.Sensitive {
+			sensitiveOutput, err := tfeClient.StateVersionOutputs.Read(ctx, op.ID)
+			if err != nil {
+				return nil, fmt.Errorf("Could not read sensitive output: %w", err)
+			}
+			op.Value = sensitiveOutput.Value
+		}
+
 		buf, err := json.Marshal(op.Value)
 		if err != nil {
 			return nil, fmt.Errorf("Could not marshal output value: %w", err)

--- a/tfe/data_source_outputs_test.go
+++ b/tfe/data_source_outputs_test.go
@@ -86,7 +86,7 @@ func TestAccTFEOutputs_emptyOutputs(t *testing.T) {
 						"data.tfe_outputs.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
 						"data.tfe_outputs.foobar", "workspace", wsName),
-					// This is relies on test-fixtures/state-versions/terraform-empty-outputs.tfstate
+					// This relies on test-fixtures/state-versions/terraform-empty-outputs.tfstate
 					testCheckOutputState("state_output", &terraform.OutputState{
 						Value: map[string]interface{}{},
 					}),

--- a/tfe/test-fixtures/state-versions/terraform.tfstate
+++ b/tfe/test-fixtures/state-versions/terraform.tfstate
@@ -15,7 +15,8 @@
     },
     "test_output_string": {
       "value": "9023256633839603543",
-      "type": "string"
+      "type": "string",
+      "sensitive": true
     },
     "test_output_tuple_number": {
       "value": [


### PR DESCRIPTION
## Description

It was [reported](https://github.com/hashicorp/terraform-provider-tfe/issues/557) (thank you!) that a sensitive value in an output was not being read via tfe_outputs. Investigating the issue, we were originally getting state version outputs via reading a workspace and including outputs. This [API](https://www.terraform.io/cloud-docs/api-docs/workspaces#show-workspace) call does not include sensitive values.

The fix is to instead read the outputs from the state version itself.

🤔 Question for reviewers: I noticed that in the go-tfe test for StateVersion.ListOutputs, we have a [call](https://github.com/hashicorp/go-tfe/blob/ce0f146febc7a8ad6aef26d56a0d0ebc9f242991/state_version_integration_test.go#L484) to wait for the state version outputs. I'm wondering if we need to do something similar here? Any thoughts?

## Testing plan

I created a simple example to show the error (based on what was reported in the two issues). Replace `YOUR_ORG_NAME` with the name of the organization you wish to use to test this out. I'm also using tfcdev to run a local tfc to make sure I'm using the version of `terraform-provider-tfe` built from this branch.

The first workspace, `uno_workspace` has the following config:

```
terraform {
  required_version = ">= 1.1.0"
  cloud {
    hostname     = "app.terraform.io"
    organization = "YOUR_ORG_NAME"

    workspaces {
      name = "uno-workspace"
    }
  }

required_providers {
  tfe = {
    version = "~> 0.33.0"
  }
  random = {
    source  = "hashicorp/random"
    version = "~> 3.3.1"
  }
}
}

resource "random_password" "uno_password" {
  length  = 32
  special = true
}

output "uno_password" {
  value     = random_password.uno_password.result
  sensitive = true
}
```

The second workspace, `dos_workspace` has the following terraform config:

```
terraform {
  cloud {
    hostname     = "app.terraform.io"
    organization = "YOUR_ORG_NAME"

    workspaces {
      name = "dos-workspace"
    }
  }
  required_providers {
    tfe = {
      version = "~> 0.33.0"
    }
    random = {
      source  = "hashicorp/random"
      version = "~> 3.3.1"
    }
  }
}

data "tfe_outputs" "remote_state" {
  organization = "YOUR_ORG_NAME"
  workspace = "uno-workspace"
}

output "dos_password" {
  sensitive = true
  value = data.tfe_outputs.remote_state.values.uno_password
}
```

1. Run `terraform apply` for `uno-workspace`
2. Run `terraform plan` for `dos-workspace` and you'll see an error:

```
│ Error: Unsupported attribute
│
│   on main.tf line 29, in output "dos_password":
│   29:   value = data.tfe_outputs.remote_state.values.uno_password
│     ├────────────────
│     │ data.tfe_outputs.remote_state.values has a sensitive value
│
│ This object does not have an attribute named "uno_password".
```

3. Check out this branch, run `make build`. Update your `.terraformrc` to point `"hashicorp/tfe"` to the newly-built `terraform-provider-tfe` binary (if it's not in the tfe provider directory, it might be in `~/go/bin`).

```
provider_installation {
  dev_overrides {
    "hashicorp/tfe" = "/Users/YOURNAME/dev/terraform-provider-tfe"
  }

  # For all other providers, install them directly from their origin provider
  # registries as normal. If you omit this, Terraform will _only_ use
  # the dev_overrides block, and so no other providers will be available.
  direct {}
}
```

4. Then run `terraform apply` in `dos_worskpace` and it should work.

## External links

- [Reported issue](https://github.com/hashicorp/terraform-provider-tfe/issues/557)
- [Related issue](https://github.com/hashicorp/terraform/issues/31234)
- [Docs on permissions](https://www.terraform.io/cloud-docs/users-teams-organizations/permissions)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEOutputs" make testacc

--- PASS: TestAccTFEOutputs_emptyOutputs (11.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	22.432s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```
