### PR TITLE
Remove force new modifier on name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 * Removed nonworking example from `tfe_variable_set` docs ([#562](https://github.com/hashicorp/terraform-provider-tfe/pull/562))
+* Removed `ForceNew` modifier from `name` attribute in `r/tfe_team` ([#566](https://github.com/hashicorp/terraform-provider-tfe/pull/566))
 
 FEATURES:
 * d/agent_pool: Improve efficiency of reading agent pool data when the target organization has more than 20 agent pools ([#508](https://github.com/hashicorp/terraform-provider-tfe/pull/508))

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -25,7 +25,6 @@ func resourceTFETeam() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"organization": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## Description

The issue was reported [here](https://github.com/hashicorp/terraform-provider-tfe/issues/439).

Effectively, the `ForceNew` modifier was set in the `name` attribute of the `r/tfe_team` schema causing the recreation of the team resource whenever the name was updated.

This PR removes this as there isn't any API specific behavior that requires the team to be recreated upon a name change. 

## Testing plan

In order to smoke test this, we'll need a simple configuration that provisions a team (ensure your organization is not on the free tier):
```hcl
resource "tfe_team" "foo" {
  name = "the-foo-fighters"
  organization = "rocknroll"
}
```
Create the team first using `terraform apply` and then simply modify the name, running `terraform apply` again. Overriding the provider to a local build including my changes, you should see that the team is no longer recreated. 