### PR TITLE
Changes to prevent unnecessary tfe_registry_modules replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.35.0 (July 27th, 2022)
 
 BUG FIXES:
-* Added `Computed` modifier to attributes in `r/tfe_registry_modules` to prevent unnecessary registry modules update. ([#572](https://github.com/hashicorp/terraform-provider-tfe/pull/572))
+* r/tfe_registry_module: Added `Computed` modifier to attributes in order to prevent unnecessary resource replacement ([#572](https://github.com/hashicorp/terraform-provider-tfe/pull/572))
 
 ## 0.34.0 (July 26th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.35.0 (July 27th, 2022)
+
+BUG FIXES:
+* Added `Computed` modifier to attributes in `r/tfe_registry_modules` to prevent unnecessary registry modules update. ([#572](https://github.com/hashicorp/terraform-provider-tfe/pull/572))
+
 ## 0.34.0 (July 26th, 2022)
 
 BUG FIXES:

--- a/tfe/resource_tfe_registry_module.go
+++ b/tfe/resource_tfe_registry_module.go
@@ -25,11 +25,13 @@ func resourceTFERegistryModule() *schema.Resource {
 			"organization": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"module_provider": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
 				ExactlyOneOf: []string{"vcs_repo"},
 				RequiredWith: []string{"organization", "name"},
@@ -37,6 +39,7 @@ func resourceTFERegistryModule() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"vcs_repo": {
@@ -68,12 +71,14 @@ func resourceTFERegistryModule() *schema.Resource {
 			"namespace": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
 				RequiredWith: []string{"registry_name"},
 			},
 			"registry_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
 				RequiredWith: []string{"module_provider"},
 				ValidateFunc: validation.StringInSlice(

--- a/tfe/resource_tfe_registry_module_test.go
+++ b/tfe/resource_tfe_registry_module_test.go
@@ -35,8 +35,7 @@ func TestAccTFERegistryModule_vcs(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccTFERegistryModule_vcs(rInt),
-				ExpectNonEmptyPlan: true,
+				Config: testAccTFERegistryModule_vcs(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
 						"tfe_registry_module.foobar",
@@ -111,8 +110,7 @@ func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName(t *
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccTFERegistryModule_privateRMWithoutRegistryName(rInt),
-				ExpectNonEmptyPlan: true,
+				Config: testAccTFERegistryModule_privateRMWithoutRegistryName(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
 						"tfe_registry_module.foobar",
@@ -161,8 +159,7 @@ func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName(t *tes
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccTFERegistryModule_privateRMWithRegistryName(rInt),
-				ExpectNonEmptyPlan: true,
+				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFERegistryModuleExists(
 						"tfe_registry_module.foobar",
@@ -251,8 +248,7 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccTFERegistryModule_vcs(rInt),
-				ExpectNonEmptyPlan: true,
+				Config: testAccTFERegistryModule_vcs(rInt),
 			},
 			{
 				ResourceName:        "tfe_registry_module.foobar",
@@ -276,8 +272,7 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat(t *testing.T) 
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccTFERegistryModule_vcs(rInt),
-				ExpectNonEmptyPlan: true,
+				Config: testAccTFERegistryModule_vcs(rInt),
 			},
 			{
 				ResourceName:        "tfe_registry_module.foobar",
@@ -300,8 +295,7 @@ func TestAccTFERegistryModuleImport_nonVCSPrivateRM(t *testing.T) {
 		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccTFERegistryModule_privateRMWithRegistryName(rInt),
-				ExpectNonEmptyPlan: true,
+				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
 			},
 			{
 				ResourceName:        "tfe_registry_module.foobar",


### PR DESCRIPTION
## Description

_Describe why you're making this change._
After a registry module is created and consecutive apply is run, the registry modules get recreated even though there is no change in the params. This PR adds changes to prevent unnecessary tfe_registry_modules replacement.

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_

## Testing plan

1.  _Create config with resource "tfe_registry_module"_
1.  _Run an apply, it should be successful_
1.  _Run another apply. Before this PR, new changes will be applied even though the params did not change_
1.  _After this PR, no changes should be applied unless the params change._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._


## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFERegistryModule" make testacc

...
```
