### PR TITLE
Remove `admin_settings` from `tfe_organization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.35.0 (July 27th, 2022)
 
+BREAKING CHANGES:
+* `r/tfe_organization`: `admin_settings` attribute was removed after being released prematurely in 0.34.0, breaking existing configurations due to requiring a token with admin privileges ([#573](https://github.com/hashicorp/terraform-provider-tfe/pull/573))
+
 BUG FIXES:
 * r/tfe_registry_module: Added `Computed` modifier to attributes in order to prevent unnecessary resource replacement ([#572](https://github.com/hashicorp/terraform-provider-tfe/pull/572))
 

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -218,71 +218,6 @@ func TestAccTFEOrganization_import(t *testing.T) {
 	})
 }
 
-func TestAccTFEOrganization_update_workspaceLimit(t *testing.T) {
-	skipIfCloud(t)
-
-	org := &tfe.Organization{}
-
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	// First update
-	initialWorkspaceLimit := 42
-
-	// Second update
-	updatedWorkspaceLimit := 1337
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEOrganization_workspaceLimited(rInt, initialWorkspaceLimit),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEOrganizationExists(
-						"tfe_organization.foobar", org),
-					testAccCheckTFEOrganizationAttributesBasic(org, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "email", "admin@company.com"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "admin_settings.0.workspace_limit", "42"),
-				),
-			},
-			{
-				Config: testAccTFEOrganization_workspaceLimited(rInt, updatedWorkspaceLimit),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEOrganizationExists(
-						"tfe_organization.foobar", org),
-					testAccCheckTFEOrganizationAttributesBasic(org, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "email", "admin@company.com"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "admin_settings.0.workspace_limit", "1337"),
-				),
-			},
-			{
-				Config: testAccTFEOrganization_workspaceNil(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEOrganizationExists(
-						"tfe_organization.foobar", org),
-					testAccCheckTFEOrganizationAttributesBasic(org, orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "email", "admin@company.com"),
-					resource.TestCheckNoResourceAttr(
-						"tfe_organization.foobar", "admin_settings.0.workspace_limit"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckTFEOrganizationExists(
 	n string, org *tfe.Organization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -461,23 +396,4 @@ resource "tfe_organization" "foobar" {
   owners_team_saml_role_id = "owners"
   cost_estimation_enabled  = %t
 }`, rInt, costEstimationEnabled)
-}
-
-func testAccTFEOrganization_workspaceLimited(rInt int, workspaceLimit int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-  admin_settings {
-    workspace_limit = %d
-  }
-}`, rInt, workspaceLimit)
-}
-
-func testAccTFEOrganization_workspaceNil(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}`, rInt)
 }

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -36,11 +36,6 @@ The following arguments are supported:
 * `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
 * `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `send_passing_statuses_for_untriggered_speculative_plans` - (Optional) Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.
-* `admin_settings` - Settings that are only available in Terraform Enterprise.
-
-* The `admin_settings` block supports:
-
-* `workspace_limit` - (Optional) The maximum number of workspaces that can exist in this organization. If this number is set to a value lower than the number of workspaces the organization currently has, it will prevent additional workspaces from being created, but existing workspaces will not be affected. If set to 0, this limit will have no effect.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This PR stems from #570 where a user with lower privileges would encounter a `404` error when managing a `tfe_organization` resource. 

The reason for this error is that `tfe_organization` makes a call to the [Admin Organization API](https://www.terraform.io/cloud-docs/api-docs/admin/organizations) to read the admin settings without accounting for the possibility the client `token` has lower privileges. Regardless, it's generally a bad idea to manage two different APIs that require different privileges within one resource.

This attribute will be removed in favor of creating a new resource `r/tfe_admin_organization` which will solely manage the admin settings for a given organization. Thus separating the concerns between a site admin and a regular user. 