### PR TITLE
Small adjustment for flaky CI test

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ sweep:
 	go test ./tfe -v -timeout 60m -sweep=prod
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 15m
+	TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(TEST) -v $(TESTARGS) -timeout 15m
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION
## Description

Lately we have had a few recurrent flaky tests in CircleCi. For example these three:


=== Failed
=== FAIL: tfe TestAccTFEOutputs (2.44s)
    data_source_outputs_****.go:31: Step 1/1 error: Error running pre-apply refresh: exit status 1


=== FAIL: tfe TestAccTFEVariableSetsDataSource_full (3.18s)
    data_source_variable_set_****.go:42: Step 1/1 error: Check failed: 1 error occurred:
        	* Check 4/4 error: data.tfe_variable_set.foobar: Attribute 'variable_ids.#' expected "1", got "0"
  
=== Failed
=== RUN   TestAccTFEOrganizationRunTask_create
    resource_tfe_organization_run_task_test.go:44: Step 2/3 error: Error running apply: exit status 1


For this PR, I have focused on investigating just the first one because it has been failing consistently, much more than others, to the point where, these days, we are just merging PRs ignore this test failure.

INVESTIGATION DISCOVERIES

This test `TestAccTFEOutputs` started failing over 3 months ago in circle CI but not locally (the first failure can be found in app.circleci.com under workflow ID `2a63d148-5d92-4569-9bec-c427bd1c7e00`). 

I checked if any of the PRs/changes around that time could have directly affected `TestAccTFEOutputs` test but no changes seemed to correlated to this failure.

I also checked if updating the terraform-plugin-sdk dependency (where the main error is coming from) could have any effect (perhaps some subtle incompatibility between dependencies version could affected the performance of the test), but upgrading did not change behavior at all.

Tracking down the errors that get concatenated in this test failure can be a little disorienting because they come from multiple sources/libraries (plugin-sdk, terraform-exec, terraform and hcl)

Here is the full set of errors:

```
Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: Unsupported attribute
        
          on terraform_plugin_test.tf line 19, in output "test_output_list_string":
          19: output "test_output_list_string" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_list_string) }
            ├────────────────
            │ data.tfe_outputs.foobar.values has a sensitive value
        
        This object does not have an attribute named "test_output_list_string".
        
        Error: Unsupported attribute
        
          on terraform_plugin_test.tf line 20, in output "test_output_string":
          20: output "test_output_string" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_string) }
            ├────────────────
            │ data.tfe_outputs.foobar.values has a sensitive value
        
        This object does not have an attribute named "test_output_string".
        
        Error: Unsupported attribute
        
          on terraform_plugin_test.tf line 21, in output "test_output_tuple_number":
          21: output "test_output_tuple_number" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_tuple_number) }
            ├────────────────
            │ data.tfe_outputs.foobar.values has a sensitive value
        
        This object does not have an attribute named "test_output_tuple_number".
        
        Error: Unsupported attribute
        
          on terraform_plugin_test.tf line 22, in output "test_output_tuple_string":
          22: output "test_output_tuple_string" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_tuple_string) }
            ├────────────────
            │ data.tfe_outputs.foobar.values has a sensitive value
        
        This object does not have an attribute named "test_output_tuple_string".
        
        Error: Unsupported attribute
        
          on terraform_plugin_test.tf line 23, in output "test_output_object":
          23: output "test_output_object" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_object) }
            ├────────────────
            │ data.tfe_outputs.foobar.values has a sensitive value
        
        This object does not have an attribute named "test_output_object".
        
        Error: Unsupported attribute
        
          on terraform_plugin_test.tf line 24, in output "test_output_number":
          24: output "test_output_number" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_number) }
            ├────────────────
            │ data.tfe_outputs.foobar.values has a sensitive value
        
        This object does not have an attribute named "test_output_number".
        
        Error: Unsupported attribute
        
          on terraform_plugin_test.tf line 25, in output "test_output_bool":
          25: output "test_output_bool" { value = nonsensitive(data.tfe_outputs.foobar.values.test_output_bool) }
            ├────────────────
            │ data.tfe_outputs.foobar.values has a sensitive value
        
        This object does not have an attribute named "test_output_bool".
```

Here is a summary of how these errors got added:

- Test `TestAccTFEOutputs` is importing plugin-sdk to call `resource.Test(t, resource.TestCase{Steps: []resource.TestStep{},  and some other test steps....})`

- plugin sdk iterates through each of the steps invoking `func testStepNewConfig(ctx context.Context, t testing.T, c TestCase, wd *plugintest.WorkingDir, step TestStep, providers *providerFactories)`
which sets a terraform config for each step and requires a "terraform refresh" before applying (otherwise data sources will not be updated): `err = runProviderCommand(ctx, t, func() error {return wd.Refresh(ctx)}, wd, providers)`

- Is during this `wd.Refresh(ctx)` check that we get the `return fmt.Errorf("Error running pre-apply refresh: %w", err)` top error.

- Now to run "refresh", plugin sdk is using this library `github.com/hashicorp/terraform-exec`

- Looking closing at this library, it's usage does not seem to be interfering, but just surfacing an error coming from terraform directly when performing this operation `func (b *Local) opRefresh(stopCtx context.Context, cancelCtx context.Context, op *backend.Operation, runningOp *backend.RunningOperation)`

- Somewhere within this operation we are loading config files. We use the `github.com/hashicorp/hcl/v2` to validate the terraform language and also check that config files do not contain variables references that have not being declared.

- Is during one of these HCL validations that the hcl library throws the error: `Unsupported attribute [some code line reference] This object does not have an attribute named [some output key]`.

HCL library is looking at, say, this reference in our config file test:

```
data "tfe_outputs" "foobar" {
  organization = "%s"
  workspace = "%s"
}
output "test_output_list_string" {
	sensitive = true
	value = data.tfe_outputs.foobar.values.test_output_list_string
}
```

and noticing that our `data "tfe_outputs" "foobar"` does not have an attribute named `test_output_list_string`, which is true.

However the PR that implemented this test + feature (https://github.com/hashicorp/terraform-provider-tfe/pull/344) states that the value for that attribute is retrieve from the State outputs not the config. 
But if the state outputs is not available, HCL as a backup would look into the config and data object for reference to the attribute, hence throwing that error.

So what could cause state outputs not being available on time before we perform this validation?

Maybe this test helper function could explain:

```
func createOutputs(t *testing.T, client *tfe.Client, rInt int, fileName string) (string, string, func()) {
	var orgCleanup func()

	org, err := client.Organizations.Create(ctx, tfe.OrganizationCreateOptions{
		Name:  tfe.String(fmt.Sprintf("tst-terraform-%d", rInt)),
		Email: tfe.String(fmt.Sprintf("%d@tfe.local", rInt)),
	})
	if err != nil {
		t.Fatal(err)
	}
	orgCleanup = func() {
		if err := client.Organizations.Delete(ctx, org.Name); err != nil {
			t.Errorf("Error destroying organization! WARNING: Dangling resources\n"+
				"may exist! The full error is shown below.\n\n"+
				"Organization: %s\nError: %s", org.Name, err)
		}
	}

	ws, err := client.Workspaces.Create(ctx, org.Name, tfe.WorkspaceCreateOptions{
		Name: tfe.String(fmt.Sprintf("tst-workspace-test-%d", rInt)),
	})
	if err != nil {
		t.Fatal(err)
	}

	state, err := ioutil.ReadFile(fileName)
	if err != nil {
		t.Fatal(err)
	}

	_, err = client.Workspaces.Lock(ctx, ws.ID, tfe.WorkspaceLockOptions{})
	if err != nil {
		t.Fatal(err)
	}
	defer func() {
		_, err := client.Workspaces.Unlock(ctx, ws.ID)
		if err != nil {
			t.Fatal(err)
		}
	}()

	sv, err := client.StateVersions.Create(ctx, ws.ID, tfe.StateVersionCreateOptions{
		MD5:    tfe.String(fmt.Sprintf("%x", md5.Sum(state))),
		Serial: tfe.Int64(0),
		State:  tfe.String(base64.StdEncoding.EncodeToString(state)),
	})
	if err != nil {
		t.Fatal(err)
	}
	return org.Name, ws.Name, orgCleanup
}
```

It looks like at the end we are uploading the new state version which should include outputs. I would think by the time we validate the outputs reference, we already have properly stored the state version and have access to read the state outputs. However, could it possible that due to some performance deterioration around our TFC APIs, now we are not giving enough time to ensure state outputs has been stored. So just in case, I added this last extra step to our test helper function to ensure we can read the state prior to parsing state outputs:

```
_, err = client.StateVersions.Read(ctx, sv.ID)
if err != nil {
	t.Fatal(err)
}
```

To be honest, I am not 100% confident API calls performance changes are the reason this test started failing three months ago but it was not failing at the time of its implementation (a year ago). The change I am making is treating a symptom not a cause.

TEST PLAN for local environment:

This test failure does not happen when running tests in dev environment; however you can force your test to reproduce this error locally. All you have to do is comment out my changes + this segment https://github.com/hashicorp/terraform-provider-tfe/blob/v0.35.0/tfe/data_source_outputs_test.go#L154-L161 + this line https://github.com/hashicorp/terraform-provider-tfe/blob/v0.35.0/tfe/data_source_outputs_test.go#L138, and then run `TF_ACC=1 TFE_HOSTNAME=app.staging.terraform.io TFE_TOKEN=your-stg-token go test -run TestAccTFEOutputs` in the `tfe` directory for this repo. You should see that same error you are seeing in CircleCI.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202671879461297