### PR TITLE
Add Organization run task description field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+FEATURES:
+* r/tfe_organization_run_task, d/tfe_organization_run_task: Add `description` attribute to organization run tasks. ([#585](https://github.com/hashicorp/terraform-provider-tfe/pull/585))
+
 ## 0.35.0 (July 27th, 2022)
 
 BREAKING CHANGES:

--- a/tfe/data_source_organization_run_task.go
+++ b/tfe/data_source_organization_run_task.go
@@ -34,6 +34,11 @@ func dataSourceTFEOrganizationRunTask() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -51,6 +56,7 @@ func dataSourceTFEOrganizationRunTaskRead(d *schema.ResourceData, meta interface
 	d.Set("url", task.URL)
 	d.Set("category", task.Category)
 	d.Set("enabled", task.Enabled)
+	d.Set("description", task.Description)
 	d.SetId(task.ID)
 
 	return nil

--- a/tfe/data_source_organization_run_task_test.go
+++ b/tfe/data_source_organization_run_task_test.go
@@ -28,6 +28,7 @@ func TestAccTFEOrganizationRunTaskDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.tfe_organization_run_task.foobar", "url", runTasksURL()),
 					resource.TestCheckResourceAttr("data.tfe_organization_run_task.foobar", "category", "task"),
 					resource.TestCheckResourceAttr("data.tfe_organization_run_task.foobar", "enabled", "false"),
+					resource.TestCheckResourceAttr("data.tfe_organization_run_task.foobar", "description", "a description"),
 					resource.TestCheckResourceAttrSet("data.tfe_organization_run_task.foobar", "id"),
 					resource.TestCheckResourceAttrSet("data.tfe_organization_run_task.foobar", "organization"),
 				),
@@ -49,6 +50,7 @@ resource "tfe_organization_run_task" "foobar" {
 	name         = "foobar-task-%d"
 	hmac_key     = "Password1"
 	enabled      = false
+	description = "a description"
 }
 
 data "tfe_organization_run_task" "foobar" {

--- a/tfe/resource_tfe_organization_run_task.go
+++ b/tfe/resource_tfe_organization_run_task.go
@@ -56,6 +56,11 @@ func resourceTFEOrganizationRunTask() *schema.Resource {
 				Default:  true,
 				Optional: true,
 			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -69,11 +74,12 @@ func resourceTFEOrganizationRunTaskCreate(d *schema.ResourceData, meta interface
 
 	// Create a new options struct.
 	options := tfe.RunTaskCreateOptions{
-		Name:     name,
-		URL:      d.Get("url").(string),
-		Category: d.Get("category").(string),
-		HMACKey:  tfe.String(d.Get("hmac_key").(string)),
-		Enabled:  tfe.Bool(d.Get("enabled").(bool)),
+		Name:        name,
+		URL:         d.Get("url").(string),
+		Category:    d.Get("category").(string),
+		HMACKey:     tfe.String(d.Get("hmac_key").(string)),
+		Enabled:     tfe.Bool(d.Get("enabled").(bool)),
+		Description: tfe.String(d.Get("description").(string)),
 	}
 
 	log.Printf("[DEBUG] Create task %s for organization: %s", name, organization)
@@ -123,6 +129,9 @@ func resourceTFEOrganizationRunTaskUpdate(d *schema.ResourceData, meta interface
 	if d.HasChange("hmac_key") {
 		options.HMACKey = tfe.String(d.Get("hmac_key").(string))
 	}
+	if d.HasChange("description") {
+		options.Description = tfe.String(d.Get("description").(string))
+	}
 
 	log.Printf("[DEBUG] Update configuration of task: %s", d.Id())
 	task, err := tfeClient.RunTasks.Update(ctx, d.Id(), options)
@@ -158,7 +167,7 @@ func resourceTFEOrganizationRunTaskRead(d *schema.ResourceData, meta interface{}
 	// The HMAC Key is always empty from the API so all we can do is
 	// echo the request's key to the response
 	d.Set("hmac_key", tfe.String(d.Get("hmac_key").(string)))
-
+	d.Set("description", task.Description)
 	return nil
 }
 

--- a/tfe/resource_tfe_organization_run_task_test.go
+++ b/tfe/resource_tfe_organization_run_task_test.go
@@ -56,6 +56,7 @@ func TestAccTFEOrganizationRunTask_create(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_organization_run_task.foobar", "category", "task"),
 					resource.TestCheckResourceAttr("tfe_organization_run_task.foobar", "hmac_key", ""),
 					resource.TestCheckResourceAttr("tfe_organization_run_task.foobar", "enabled", "false"),
+					resource.TestCheckResourceAttr("tfe_organization_run_task.foobar", "description", ""),
 				),
 			},
 			{
@@ -66,6 +67,7 @@ func TestAccTFEOrganizationRunTask_create(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_organization_run_task.foobar", "category", "task"),
 					resource.TestCheckResourceAttr("tfe_organization_run_task.foobar", "hmac_key", "somepassword"),
 					resource.TestCheckResourceAttr("tfe_organization_run_task.foobar", "enabled", "true"),
+					resource.TestCheckResourceAttr("tfe_organization_run_task.foobar", "description", "a description"),
 				),
 			},
 		},
@@ -175,6 +177,7 @@ func testAccTFEOrganizationRunTask_update(orgName string, rInt int, runTaskURL s
 		name         = "foobar-task-%d-new"
 		enabled      = true
 		hmac_key     = "somepassword"
+		description  = "a description"
 	}
 `, orgName, runTaskURL, rInt)
 }

--- a/website/docs/d/organization_run_task.html.markdown
+++ b/website/docs/d/organization_run_task.html.markdown
@@ -33,6 +33,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `category` - The type of task.
+* `description` - A short description of the the task.
 * `enabled` - Whether the task will be run.
-* `id` - The ID of the Run task.
-* `url` - URL to send a run task payload.
+* `id` - The ID of the task.
+* `url` - URL to send a task payload.

--- a/website/docs/r/organization_run_task.html.markdown
+++ b/website/docs/r/organization_run_task.html.markdown
@@ -22,6 +22,7 @@ resource "tfe_organization_run_task" "example" {
   url          = "https://external.service.com"
   name         = "task-name"
   enabled      = true
+  description  = "An example task"
 }
 ```
 
@@ -31,6 +32,7 @@ The following arguments are supported:
 
 * `category` - (Optional) The type of task.
 * `enabled` - (Optional) Whether the task will be run.
+* `description` - (Optional) A short description of the the task.
 * `hmac_key` - (Optional) HMAC key to verify run task.
 * `name` - (Required) Name of the task.
 * `organization` - (Required) Name of the organization.


### PR DESCRIPTION
## Description

Organization level run tasks were recently updated to include an optional
description field.  This commit updates the Org. Run Tasks resource and
data source to read and modify the new attribute.

## Testing plan

N/A Acceptance tests were updated.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://github.com/hashicorp/go-tfe/pull/447)
- [API documentation](https://www.terraform.io/cloud-docs/api-docs/run-tasks/run-tasks#create-a-run-task)

## Output from acceptance tests

In CI
