### PR TITLE
Add ability to attach a workspace to an existing policy set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 * r/tfe_workspace_run_task, d/tfe_workspace_run_task: Add `stage` attribute to workspace run tasks. ([#555](https://github.com/hashicorp/terraform-provider-tfe/pull/555))
+* r/tfe_workspace_policy_set: Add ability to attach an existing `workspace` to an existing `policy set`. ([#589](https://github.com/hashicorp/terraform-provider-tfe/pull/589))
 
 ## v0.36.0 (August 16th, 2022)
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-slug v0.10.0
-	github.com/hashicorp/go-tfe v1.7.0
+	github.com/hashicorp/go-tfe v1.8.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl/v2 v2.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/hashicorp/go-slug v0.10.0 h1:mh4DDkBJTh9BuEjY/cv8PTo7k9OjT4PcW8PgZnJ4
 github.com/hashicorp/go-slug v0.10.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-tfe v1.6.0 h1:lRfyTVLBP1njo2wShE9FimALzVZBfOqMGNuBdsor38w=
 github.com/hashicorp/go-tfe v1.6.0/go.mod h1:E8a90lC4kjU5Lc2c0D+SnWhUuyuoCIVm4Ewzv3jCD3A=
-github.com/hashicorp/go-tfe v1.7.0 h1:GELRhS5dizF6giwjZBqUC/xPaSuNYB+hWRtUnf6i8K8=
-github.com/hashicorp/go-tfe v1.7.0/go.mod h1:E8a90lC4kjU5Lc2c0D+SnWhUuyuoCIVm4Ewzv3jCD3A=
+github.com/hashicorp/go-tfe v1.8.0 h1:VnVdHHPoyAByqJuHN0aTOxY2Svojn5fzh/RnVlqDRqE=
+github.com/hashicorp/go-tfe v1.8.0/go.mod h1:uSWi2sPw7tLrqNIiASid9j3SprbbkPSJ/2s3X0mMemg=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -123,6 +123,7 @@ func Provider() *schema.Provider {
 			"tfe_variable":                    resourceTFEVariable(),
 			"tfe_variable_set":                resourceTFEVariableSet(),
 			"tfe_workspace_variable_set":      resourceTFEWorkspaceVariableSet(),
+			"tfe_workspace_policy_set":        resourceTFEWorkspacePolicySet(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -102,6 +102,7 @@ func resourceTFEPolicySet() *schema.Resource {
 			"workspace_ids": {
 				Type:          schema.TypeSet,
 				Optional:      true,
+				Computed:      true,
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				ConflictsWith: []string{"global"},
 			},

--- a/tfe/resource_tfe_workspace_policy_set.go
+++ b/tfe/resource_tfe_workspace_policy_set.go
@@ -1,0 +1,169 @@
+package tfe
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceTFEWorkspacePolicySet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTFEWorkspacePolicySetCreate,
+		Read:   resourceTFEWorkspacePolicySetRead,
+		Delete: resourceTFEWorkspacePolicySetDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceTFEWorkspacePolicySetImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_set_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceTFEWorkspacePolicySetCreate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	policySetID := d.Get("policy_set_id").(string)
+	workspaceID := d.Get("workspace_id").(string)
+
+	policySetAddWorkspacesOptions := tfe.PolicySetAddWorkspacesOptions{}
+	policySetAddWorkspacesOptions.Workspaces = append(policySetAddWorkspacesOptions.Workspaces, &tfe.Workspace{ID: workspaceID})
+
+	err := tfeClient.PolicySets.AddWorkspaces(ctx, policySetID, policySetAddWorkspacesOptions)
+	if err != nil {
+		return fmt.Errorf(
+			"Error attaching policy set id %s to workspace %s: %w", policySetID, workspaceID, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s_%s", workspaceID, policySetID))
+
+	return resourceTFEWorkspacePolicySetRead(d, meta)
+}
+
+func resourceTFEWorkspacePolicySetRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	policySetID := d.Get("policy_set_id").(string)
+	workspaceID := d.Get("workspace_id").(string)
+
+	log.Printf("[DEBUG] Read configuration of workspace policy set: %s", policySetID)
+	policySet, err := tfeClient.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
+		Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaces},
+	})
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			log.Printf("[DEBUG] Policy set %s no longer exists", policySetID)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading configuration of policy set %s: %w", policySetID, err)
+	}
+
+	isWorkspaceAttached := false
+	for _, workspace := range policySet.Workspaces {
+		if workspace.ID == workspaceID {
+			isWorkspaceAttached = true
+			d.Set("workspace_id", workspaceID)
+			break
+		}
+	}
+
+	if !isWorkspaceAttached {
+		log.Printf("[DEBUG] Workspace %s not attached to policy set %s. Removing from state.", workspaceID, policySetID)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("policy_set_id", policySetID)
+	return nil
+}
+
+func resourceTFEWorkspacePolicySetDelete(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	policySetID := d.Get("policy_set_id").(string)
+	workspaceID := d.Get("workspace_id").(string)
+
+	log.Printf("[DEBUG] Detaching workspace (%s) from policy set (%s)", workspaceID, policySetID)
+	policySetRemoveWorkspacesOptions := tfe.PolicySetRemoveWorkspacesOptions{}
+	policySetRemoveWorkspacesOptions.Workspaces = append(policySetRemoveWorkspacesOptions.Workspaces, &tfe.Workspace{ID: workspaceID})
+
+	err := tfeClient.PolicySets.RemoveWorkspaces(ctx, policySetID, policySetRemoveWorkspacesOptions)
+	if err != nil {
+		return fmt.Errorf(
+			"Error detaching workspace %s from policy set %s: %w", workspaceID, policySetID, err)
+	}
+
+	return nil
+}
+
+func resourceTFEWorkspacePolicySetImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// The format of the import ID is <ORGANIZATION/WORKSPACE NAME/POLICYSET NAME>
+	splitID := strings.SplitN(d.Id(), "/", 3)
+	if len(splitID) != 3 {
+		return nil, fmt.Errorf(
+			"invalid workspace policy set input format: %s (expected <ORGANIZATION>/<WORKSPACE NAME>/<POLICYSET NAME>)",
+			splitID,
+		)
+	}
+
+	organization, wsName, pSName := splitID[0], splitID[1], splitID[2]
+
+	tfeClient := meta.(*tfe.Client)
+
+	// Ensure the named workspace exists before fetching all the policy sets in the org
+	_, err := tfeClient.Workspaces.Read(ctx, organization, wsName)
+	if err != nil {
+		return nil, fmt.Errorf("error reading configuration of workspace %s in organization %s: %w", wsName, organization, err)
+	}
+
+	options := &tfe.PolicySetListOptions{Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaces}}
+	for {
+		list, err := tfeClient.PolicySets.List(ctx, organization, options)
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving policy sets: %w", err)
+		}
+		for _, policySet := range list.Items {
+			if policySet.Name != pSName {
+				continue
+			}
+
+			for _, ws := range policySet.Workspaces {
+				if ws.Name != wsName {
+					continue
+				}
+
+				d.Set("workspace_id", ws.ID)
+				d.Set("policy_set_id", policySet.ID)
+				d.SetId(fmt.Sprintf("%s_%s", ws.ID, policySet.ID))
+
+				return []*schema.ResourceData{d}, nil
+			}
+		}
+
+		// Exit the loop when we've seen all pages.
+		if list.CurrentPage >= list.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		options.PageNumber = list.NextPage
+	}
+
+	return nil, fmt.Errorf("workspace %s has not been assigned to policy set %s", wsName, pSName)
+}

--- a/tfe/resource_tfe_workspace_policy_set_test.go
+++ b/tfe/resource_tfe_workspace_policy_set_test.go
@@ -1,0 +1,149 @@
+package tfe
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccTFEWorkspacePolicySet_basic(t *testing.T) {
+	skipIfFreeOnly(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspacePolicySetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspacePolicySet_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspacePolicySetExists(
+						"tfe_workspace_policy_set.test"),
+				),
+			},
+			{
+				ResourceName:      "tfe_workspace_policy_set.test",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("tst-terraform-%d/tst-terraform-%d/tst-policy-set-%d", rInt, rInt, rInt),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspacePolicySet_incorrectImportSyntax(t *testing.T) {
+	skipIfFreeOnly(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspacePolicySet_basic(rInt),
+			},
+			{
+				ResourceName:  "tfe_workspace_policy_set.test",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("tst-terraform-%d/tst-terraform-%d", rInt, rInt),
+				ExpectError:   regexp.MustCompile(`Error: invalid workspace policy set input format`),
+			},
+		},
+	})
+}
+
+func testAccCheckTFEWorkspacePolicySetExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		id := rs.Primary.ID
+		if id == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		policySetID := rs.Primary.Attributes["policy_set_id"]
+		if policySetID == "" {
+			return fmt.Errorf("No policy set id set")
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		if workspaceID == "" {
+			return fmt.Errorf("No workspace id set")
+		}
+
+		policySet, err := tfeClient.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
+			Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaces},
+		})
+		if err != nil {
+			return fmt.Errorf("error reading polciy set %s: %w", policySetID, err)
+		}
+		for _, workspace := range policySet.Workspaces {
+			if workspace.ID == workspaceID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Workspace (%s) is not attached to policy set (%s).", workspaceID, policySetID)
+	}
+}
+
+func testAccCheckTFEWorkspacePolicySetDestroy(s *terraform.State) error {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_policy_set" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := tfeClient.PolicySets.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Policy Set %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccTFEWorkspacePolicySet_basic(rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_organization" "test" {
+		name  = "tst-terraform-%d"
+		email = "admin@company.com"
+	}
+
+	resource "tfe_workspace" "test" {
+		name         = "tst-terraform-%d"
+		organization = tfe_organization.test.id
+		auto_apply   = true
+		tag_names    = ["test"]
+	}
+
+	resource "tfe_policy_set" "test" {
+		name         = "tst-policy-set-%d"
+		description  = "Policy Set"
+		organization = tfe_organization.test.id
+	}
+
+	resource "tfe_workspace_policy_set" "test" {
+		policy_set_id = tfe_policy_set.test.id
+		workspace_id  = tfe_workspace.test.id
+	}`, rInt, rInt, rInt)
+}

--- a/website/docs/r/workspace_policy_set.html.markdown
+++ b/website/docs/r/workspace_policy_set.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_workspace_policy_set"
+sidebar_current: "docs-resource-tfe-workspace-policy-set"
+description: |-
+  Add a policy set to a workspace
+---
+
+# tfe_workspace_policy_set
+
+Adds and removes policy sets from a workspace
+
+-> **Note:** `tfe_policy_set` has an argument `workspace_ids` that should not be used alongside this resource. They attempt to manage the same attachments.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_organization" "test" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "my-workspace-name"
+  organization = tfe_organization.test.name
+}
+
+resource "tfe_policy_set" "test" {
+  name          = "my-policy-set"
+  description   = "Some description."
+  organization  = tfe_organization.test.name
+}
+
+resource "tfe_workspace_policy_set" "test" {
+  policy_set_id = tfe_policy_set.test.id
+  workspace_id  = tfe_workspace.test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_set_id` - (Required) ID of the policy set.
+* `workspace_id` - (Required) Workspace ID to add the policy set to.
+
+## Attributes Reference
+
+* `id` - The ID of the policy set attachment. ID format: `<workspace-id>_<policy-set-id>`
+
+## Import
+
+Workspace Policy Sets can be imported; use `<ORGANIZATION>/<WORKSPACE NAME>/<POLICY SET NAME>`. For example:
+
+```shell
+terraform import tfe_workspace_policy_set.test 'my-org-name/workspace/policy-set-name'
+```


### PR DESCRIPTION
## Description
Currently the lifecycle of the tfe_policy_set requires that all tfe_workspace resources are created first and then assigned in one call to the tfe_policy_set during creation of the policy. For example:

```
resource "tfe_workspace" "test_ws" {
  name         = "test_ws"
  organization = "my-org"
  tag_names    = ["test", "app"]
}

resource "tfe_policy_set" "test_policy_set" {
  name          = "my-policy-set"
  description   = "A new policy set"
  organization  = "my-org"
  workspace_ids = [tfe_workspace.test_ws.id]
}
```

Consider the case where `tfe_workspace` resources are spread across multiple repositories. Where each team or repo wants to be able to create & attach workspaces to existing policy sets. For example,

`team-security` is in charge of creating policies and own security-repo having:
```
resource "tfe_policy_set" "test_policy_set" {
  name          = "my-policy-set"
  description   = "A new policy set"
  organization  = "my-org"
  workspace_ids = []
}

```

`team-dev` wants to create its workspaces in `dev-repo` but attach it to existing policies above:
```
resource "tfe_workspace" "test_ws" {
  name         = "test_ws"
  organization = "my-org"
  tag_names    = ["test", "app"]
}

***no way to attach to existing policy set except by duplicating the policy set creation
```

User pain point: This leads to each repo re-creating the same policy unnecessarily. 

This PR adds `tfe_workspace_policy_set` which allows workspaces to be attached to existing policy sets.

```
resource "tfe_workspace" "test_ws" {
  name         = "test_ws"
  organization = "my-org"
  tag_names    = ["test", "app"]
}


resource "tfe_workspace_policy_set" "attachable_policy" {
  policy_set_id = data.tfe_policy_set.test_policy_set.id
  workspace_id = tfe_workspace.test_ws.id
}

```

**Note**:
Since workspaces can be added across multiple repos to the same policy set, this means the policy-set state can be altered by various configs(repos). Similar behaviour with `tfe_workspace_variable_set`

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_

## Testing plan

1.  _Create a workspace and a policy set in a config_
1.  _Create a second config, created another workspace, and attempt to attach this new workspace to the existing policy set from previous config_
1.  _There is no way to attach new workspace to existing policy set,_
1.  _After PR changes, attachment can be created with:_

```
resource "tfe_workspace" "test_ws" {
  name         = "test_ws"
  organization = "my-org"
  tag_names    = ["test", "app"]
}

data "tfe_policy_set" "test_policy_set" {
  name = "my-policy-set"
  organization = "my-org"
}

resource "tfe_workspace_policy_set" "attachable_policy" {
  policy_set_id = data.tfe_policy_set.test_policy_set.id
  workspace_id = tfe_workspace.test_ws.id
}

```

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/policy-sets#list-policy-sets)
- [Depends on Related PR](https://github.com/hashicorp/go-tfe/pull/494) and dependent PR https://github.com/hashicorp/terraform-provider-tfe/pull/592

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspacePolicySet" make testacc

...
```
<img width="1156" alt="Screen Shot 2022-08-18 at 10 58 30 AM" src="https://user-images.githubusercontent.com/22062046/185427701-f4af30c4-17bb-4447-af0d-0c5a30493e3c.png">
<img width="975" alt="Screen Shot 2022-08-18 at 10 58 37 AM" src="https://user-images.githubusercontent.com/22062046/185427711-888514b8-3e2d-41ae-94bf-f00b5b70cc83.png">
