### PR TITLE
Fix issue with removing vcs_repo config from workspace with tags_regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 BUG FIXES:
 * d/tfe_outputs: Fix referencing sensitive values in tfe_outputs ([#565](https://github.com/hashicorp/terraform-provider-tfe/pull/565))
+* r/tfe_workspace: Fix error when removing `vcs_repo` attribute block after previously setting a `tags_regex` value. ([#594](https://github.com/hashicorp/terraform-provider-tfe/pull/594))
 
 ## 0.35.0 (July 27th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ FEATURES:
 
 BUG FIXES:
 * d/tfe_outputs: Fix referencing sensitive values in tfe_outputs ([#565](https://github.com/hashicorp/terraform-provider-tfe/pull/565))
-* r/tfe_workspace: Fix error when removing `vcs_repo` attribute block after previously setting a `tags_regex` value. ([#594](https://github.com/hashicorp/terraform-provider-tfe/pull/594))
 
 ## 0.35.0 (July 27th, 2022)
 

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -509,26 +509,26 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 		}
 
+		// Remove vcs_repo from the workspace
+		// if the value of vcs_repo has been changed
+		// by removing it from the config
+		if d.HasChange("vcs_repo") {
+			_, ok := d.GetOk("vcs_repo")
+			if !ok {
+				_, err := tfeClient.Workspaces.RemoveVCSConnectionByID(ctx, id)
+				if err != nil {
+					d.Partial(true)
+					return fmt.Errorf("Error removing VCS repo from workspace %s: %w", id, err)
+				}
+			}
+		}
+
 		log.Printf("[DEBUG] Update workspace %s", id)
 		_, err := tfeClient.Workspaces.UpdateByID(ctx, id, options)
 		if err != nil {
 			d.Partial(true)
 			return fmt.Errorf(
 				"Error updating workspace %s: %w", id, err)
-		}
-	}
-
-	// Remove vcs_repo from the workspace
-	// if the value of vcs_repo has been changed
-	// by removing it from the config
-	if d.HasChange("vcs_repo") {
-		_, ok := d.GetOk("vcs_repo")
-		if !ok {
-			_, err := tfeClient.Workspaces.RemoveVCSConnectionByID(ctx, id)
-			if err != nil {
-				d.Partial(true)
-				return fmt.Errorf("Error removing VCS repo from workspace %s: %w", id, err)
-			}
 		}
 	}
 

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -1388,6 +1388,50 @@ func TestAccTFEWorkspace_updateVCSRepoChangeTagRegexToTriggerPattern(t *testing.
 	})
 }
 
+func TestAccTFEWorkspace_updateRemoveVCSRepoWithTagsRegex(t *testing.T) {
+	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccGithubPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-tags-regex"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "file_triggers_enabled", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "vcs_repo.0.identifier", GITHUB_WORKSPACE_IDENTIFIER),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "vcs_repo.0.branch", GITHUB_WORKSPACE_BRANCH),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "vcs_repo.0.ingress_submodules", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "vcs_repo.0.tags_regex", `\d+.\d+.\d+`),
+				),
+			},
+			{
+				Config: testAccTFEWorkspace_updateRemoveVCSBlockFromTagsRegex(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-tags-regex"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "file_triggers_enabled", "true"),
+					resource.TestCheckNoResourceAttr("tfe_workspace.foobar", "vcs_repo"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFEWorkspace_sshKey(t *testing.T) {
 	workspace := &tfe.Workspace{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -2563,22 +2607,6 @@ resource "tfe_workspace" "foobar" {
 `, rInt)
 }
 
-func testAccTFEWorkspace_updateRemoveVCSTagsRegexRepo(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-tf-%d-git-tag-ff-on"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name         			= "workspace-test"
-  description  			= "workspace-test-update-vcs-repo-tags-regex"
-  organization = tfe_organization.foobar.id
-  auto_apply   = true
-}
-`, rInt)
-}
-
 func testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
@@ -2604,7 +2632,7 @@ resource "tfe_workspace" "foobar" {
     identifier     = "%s"
     oauth_token_id = tfe_oauth_client.test.oauth_token_id
     branch         = "%s"
-	tags_regex     = "\\d+.\\d+.\\d+"
+	  tags_regex     = "\\d+.\\d+.\\d+"
   }
 }
 `,
@@ -2640,7 +2668,7 @@ resource "tfe_workspace" "foobar" {
     identifier     = "%s"
     oauth_token_id = tfe_oauth_client.test.oauth_token_id
     branch         = "%s"
-	tags_regex     = ""
+	  tags_regex     = ""
   }
 }
 `,
@@ -2684,6 +2712,35 @@ func testAccTFEWorkspace_updateToTriggerPatternsFromTagsRegex(rInt int) string {
 		GITHUB_TOKEN,
 		GITHUB_WORKSPACE_IDENTIFIER,
 		GITHUB_WORKSPACE_BRANCH,
+	)
+}
+
+func testAccTFEWorkspace_updateRemoveVCSBlockFromTagsRegex(rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_organization" "foobar" {
+		name  = "tst-tf-%d-git-tag-ff-on"
+		email = "admin@company.com"
+	}
+	
+	resource "tfe_oauth_client" "test" {
+		organization     = tfe_organization.foobar.id
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+	
+	resource "tfe_workspace" "foobar" {
+		name         			= "workspace-test"
+		description  			= "workspace-test-update-vcs-repo-tags-regex"
+		organization 			= tfe_organization.foobar.id
+		auto_apply   			= true
+		file_triggers_enabled = true
+		trigger_patterns = ["foo/**/*"]
+	}
+	`,
+		rInt,
+		GITHUB_TOKEN,
 	)
 }
 


### PR DESCRIPTION
## Description

Fix for the scenario of removing `vcs_repo` configuration from a workspace resource when previously setup the workspace to be triggered by tagged release via `tags_regex` 

## Testing plan

* Configure tfe_workspace resource with `vcs_repo` & `tags_regex`
* Apply the terraform configuration
* Remove vcs_repo configuration
* Attempt a terraform apply, should succeed and remove the vcs_repo setting from the workspace

Without this fix, last step would result in an error.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/cloud-docs/workspaces/settings/vcs#trigger-runs-when-a-git-tag-is-published)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/549)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace_updateRemoveVCSRepoWithTagsRegex" make testacc
...
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202781099862818