### PR TITLE
Enable debug mode on provider, via `TF_REATTACH_PROVIDERS`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,6 @@ dlv exec \
 -- -debug
 ```
 
-*Current issue where you may need to manually kill the delve debugger session.*
-
 ##### Visual Studio Code
 
 Example taken from [here](https://www.terraform.io/plugin/debugging#visual-studio-code)
@@ -203,7 +201,7 @@ provider_installation {
 }
 ```
 
-Initialize terraform in the project you wish to debug from via `terraform init`
+Initialize Terraform in the project you wish to debug from via `terraform init`
 
 Should see the following output with the previous examples being used
 
@@ -214,10 +212,16 @@ Initializing provider plugins...
 - Installed hashicorp/tfe v9.9.9 (unauthenticated)
 ```
 
-Take the output from debugger session from terraform-provider-tfe project `TF_REATTACH_PROVIDERS` and either export into your env shell or lead your terraform commands setting this value
+Copy the value of `TF_REATTACH_PROVIDERS` outputted by the debugger session and either export into your shell or lead your Terraform commands setting this value:
 
 ```
 TF_REATTACH_PROVIDERS='{...}' terraform {command}
 ```
 
 The breakpoints you have set will halt execution and show you the current variable values.
+
+If using the Delve CLI, include the full qualifed path to set a breakpoint.
+
+```
+(delve) b /Users/{user}/path/to/terraform-provider-tfe/tfe/resource_example.go:35
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,3 +111,113 @@ markdown will display correctly on the Registry:
 - ENHANCEMENTS: Use this for smaller new features added.
 - BUG FIXES: Use this for any bugs that were fixed.
 - NOTES: Use this section if you need to include any additional notes on things like upgrading, upcoming deprecations, or any other information you might want to highlight.
+
+
+### Setup Provider to debug locally
+
+Find more information [here](https://www.terraform.io/plugin/debugging#starting-a-provider-in-debug-mode)
+
+Clone the repository and build the provider binary with the necessary Go compiler flags: `-gcflags=all=-N -l`, to disable compiler optimization in order for the debugger to work efficiently.
+
+```sh
+$ git clone git@github.com:hashicorp/terraform-provider-tfe
+$ cd terraform-provider-tfe
+$ go build -gcflags="all=-N -l" -o {where to place the binary}
+```
+
+example, replace {platform}. 
+```sh
+go build -gcflags="all=-N -l" -o bin/registry.terraform.io/hashicorp/tfe/9.9.9/{platform}/terraform-provider-tfe
+```
+
+You can activate the debugger via your editor such as [visual studio code](https://www.terraform.io/plugin/debugging#visual-studio-code) or the Delve CLI.
+
+
+#### Delve
+
+```sh
+dlv exec \
+--accept-multiclient \
+--continue \
+--headless {location of the binary} \
+-- -debug
+```
+
+example 
+```sh
+dlv exec \
+--accept-multiclient \
+--continue \
+--headless bin/registry.terraform.io/hashicorp/tfe/9.9.9/{platform}/terraform-provider-tfe \
+-- -debug
+```
+
+*Current issue where you may need to manually kill the delve debugger session.*
+
+##### Visual Studio Code
+
+Example taken from [here](https://www.terraform.io/plugin/debugging#visual-studio-code)
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Terraform Provider",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            // this assumes your workspace is the root of the repo
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": [
+                "-debug",
+            ]
+        }
+    ]
+}
+
+```
+
+You'll know you activated the debugger successfully if you see the following output. 
+
+*For vscode, the output will be located in the Debug Console tab.*
+
+```sh
+# Provider server started
+export TF_REATTACH_PROVIDERS='{...}'
+```
+
+In the other project make sure you're pointing to your local provider binary you created in the previous step.
+
+Can leverage `.terraformrc` file to override Terraform's default installation behaviors and use a local mirror for the providers you wish to use.
+
+example:
+
+```
+provider_installation {
+  filesystem_mirror {
+    path = "" # path to provider binary binary
+    # path = "/Users/{users}/projects/terraform-provider-tfe/bin/" macos example
+    include = ["registry.terraform.io/hashicorp/tfe"]
+  }
+}
+```
+
+Initialize terraform in the project you wish to debug from via `terraform init`
+
+Should see the following output with the previous examples being used
+
+```
+Initializing provider plugins...
+- Finding latest version of hashicorp/tfe...
+- Installing hashicorp/tfe v9.9.9...
+- Installed hashicorp/tfe v9.9.9 (unauthenticated)
+```
+
+Take the output from debugger session from terraform-provider-tfe project `TF_REATTACH_PROVIDERS` and either export into your env shell or lead your terraform commands setting this value
+
+```
+TF_REATTACH_PROVIDERS='{...}' terraform {command}
+```
+
+The breakpoints you have set will halt execution and show you the current variable values.

--- a/main.go
+++ b/main.go
@@ -2,9 +2,15 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
 	"log"
 	"os"
+	"time"
 
+	"github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 	tfmux "github.com/hashicorp/terraform-plugin-mux"
@@ -24,6 +30,8 @@ func main() {
 	logFlags &^= (log.Ldate | log.Ltime)
 	log.SetFlags(logFlags)
 
+	debugFlag := flag.Bool("debug", false, "Start provider in debug mode.")
+	flag.Parse()
 	// terraform-plugin-mux here is used to combine multiple Terraform providers
 	// built using different SDK and frameworks in order to combine them into a
 	// single logical provider for Terraform to work with.
@@ -43,9 +51,58 @@ func main() {
 
 	err = tf5server.Serve(tfeProviderName, func() tfprotov5.ProviderServer {
 		return mux.Server()
-	})
+	}, withServeOptions(ctx, debugFlag)...)
 	if err != nil {
 		log.Printf("[ERROR] Could not start serving the ProviderServer: %v", err)
 		os.Exit(1)
 	}
+}
+
+func withServeOptions(ctx context.Context, debugFlag *bool) []tf5server.ServeOpt {
+	serveOpts := []tf5server.ServeOpt{}
+	if *debugFlag {
+		reattachConfigCh := make(chan *plugin.ReattachConfig)
+		go func() {
+			reattachConfig, err := waitForReattachConfig(reattachConfigCh)
+			if err != nil {
+				fmt.Printf("Error getting reattach config: %s\n", err)
+				return
+			}
+			printReattachConfig(reattachConfig)
+		}()
+		serveOpts = append(serveOpts, tf5server.WithDebug(ctx, reattachConfigCh, nil))
+	}
+	return serveOpts
+}
+
+func waitForReattachConfig(ch chan *plugin.ReattachConfig) (*plugin.ReattachConfig, error) {
+	select {
+	case config := <-ch:
+		return config, nil
+	case <-time.After(2 * time.Second):
+		return nil, fmt.Errorf("timeout waiting on reattach configuration")
+	}
+}
+
+func convertReattachConfig(reattachConfig *plugin.ReattachConfig) tfexec.ReattachConfig {
+	return tfexec.ReattachConfig{
+		Protocol: string(reattachConfig.Protocol),
+		Pid:      reattachConfig.Pid,
+		Test:     true,
+		Addr: tfexec.ReattachConfigAddr{
+			Network: reattachConfig.Addr.Network(),
+			String:  reattachConfig.Addr.String(),
+		},
+	}
+}
+
+func printReattachConfig(config *plugin.ReattachConfig) {
+	reattachStr, err := json.Marshal(map[string]tfexec.ReattachConfig{
+		tfeProviderName: convertReattachConfig(config),
+	})
+	if err != nil {
+		fmt.Printf("Error building reattach string: %s", err)
+		return
+	}
+	fmt.Printf("# Provider server started\nexport TF_REATTACH_PROVIDERS='%s'\n", string(reattachStr))
 }

--- a/main.go
+++ b/main.go
@@ -51,13 +51,17 @@ func main() {
 
 	err = tf5server.Serve(tfeProviderName, func() tfprotov5.ProviderServer {
 		return mux.Server()
-	}, withServeOptions(ctx, debugFlag)...)
+	},
+		/* TO-DO: replace with `tf5server.WithManagedDebug()` when we upgrade terraform-plugin-go to v0.6.0 or newer */
+		withServeOptions(ctx, debugFlag)...,
+	)
 	if err != nil {
 		log.Printf("[ERROR] Could not start serving the ProviderServer: %v", err)
 		os.Exit(1)
 	}
 }
 
+/* TO-DO: remove when we upgrade terraform-plugin-go to v0.6.0 or newer */
 func withServeOptions(ctx context.Context, debugFlag *bool) []tf5server.ServeOpt {
 	serveOpts := []tf5server.ServeOpt{}
 	if *debugFlag {
@@ -106,3 +110,5 @@ func printReattachConfig(config *plugin.ReattachConfig) {
 	}
 	fmt.Printf("# Provider server started\nexport TF_REATTACH_PROVIDERS='%s'\n", string(reattachStr))
 }
+
+/* TO-DO: remove when we upgrade terraform-plugin-go to v0.6.0 or newer */


### PR DESCRIPTION
## Description

Enable provider to initialize in debug mode, allowing devs to start debuggers via terraform commands as explained [here](https://www.terraform.io/plugin/debugging)

e.g.

```
TF_REATTACH_PROVIDERS='{"registry.terraform.io/my-org/my-provider":{"Protocol":"grpc","Pid":3382870,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin713096927"}}}' terraform apply
```

Looks like a newer release of tf5server, offers a simpler implementation with [WithManagedDebug](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server#WithManagedDebug). But this could be a workaround until we upgrade the tf5server package version.

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/README.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
