### PR TITLE
Add upgrade organization test helper, remove `SKIP_PAID` flag. 

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -43,9 +43,10 @@ these values with the environment variables specified below:
 1. `GITHUB_REGISTRY_MODULE_IDENTIFIER` - GitHub registry module repository identifier in the format `username/repository`. Required for running registry module tests.
 1. `GITHUB_WORKSPACE_IDENTIFIER` - GitHub workspace repository identifier in the format `username/repository`. Required for running workspace tests.
 1. `GITHUB_WORKSPACE_BRANCH`: A GitHub branch for the repository specified by `GITHUB_WORKSPACE_IDENTIFIER`. Required for running workspace tests.
-1. `SKIP_PAID` - Some tests depend on paid only features. By setting `SKIP_PAID=1`, you will skip tests that access paid features.
 1. `ENABLE_TFE` - Some tests cover features available only in Terraform Cloud. To skip these tests when running against a Terraform Enterprise instance, set `ENABLE_TFE=1`.
 1. `RUN_TASKS_URL` - External URL to use for testing Run Tasks operations, for example `RUN_TASKS_URL=http://somewhere.local:8080/pass`. Required for running run tasks tests.
+
+**Note:** In order to run integration tests for **Paid** features you will need a token `TFE_TOKEN` with TFC/E administrator privileges, otherwise the attempt to upgrade an organization's feature set will fail.
 
 You can set your environment variables up however you prefer. The following are instructions for setting up environment variables using [envchain](https://github.com/sorah/envchain).
    1. Make sure you have envchain installed. [Instructions for this can be found in the envchain README](https://github.com/sorah/envchain#installation).

--- a/tfe/data_source_agent_pool_test.go
+++ b/tfe/data_source_agent_pool_test.go
@@ -6,14 +6,17 @@ import (
 	"testing"
 	"time"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccTFEAgentPoolDataSource_basic(t *testing.T) {
 	skipIfEnterprise(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/data_source_agent_pool_test.go
+++ b/tfe/data_source_agent_pool_test.go
@@ -6,12 +6,16 @@ import (
 	"testing"
 	"time"
 
+	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccTFEAgentPoolDataSource_basic(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfEnterprise(t)
+
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -20,33 +24,28 @@ func TestAccTFEAgentPoolDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEAgentPoolDataSourceConfig(rInt),
+				Config: testAccTFEAgentPoolDataSourceConfig(org.Name, rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.tfe_agent_pool.foobar", "id"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_agent_pool.foobar", "name", fmt.Sprintf("agent-pool-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_agent_pool.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"data.tfe_agent_pool.foobar", "organization", org.Name),
 				),
 			},
 		},
 	})
 }
 
-func testAccTFEAgentPoolDataSourceConfig(rInt int) string {
+func testAccTFEAgentPoolDataSourceConfig(organization string, rInt int) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "foobar" {
   name                  = "agent-pool-test-%d"
-  organization          = tfe_organization.foobar.id
+  organization          = "%s"
 }
 
 data "tfe_agent_pool" "foobar" {
   name         = tfe_agent_pool.foobar.name
-  organization = tfe_agent_pool.foobar.organization
-}`, rInt, rInt)
+  organization = "%s"
+}`, rInt, organization, organization)
 }

--- a/tfe/data_source_organization_run_task_test.go
+++ b/tfe/data_source_organization_run_task_test.go
@@ -6,14 +6,17 @@ import (
 	"testing"
 	"time"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccTFEOrganizationRunTaskDataSource_basic(t *testing.T) {
 	skipUnlessRunTasksDefined(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/data_source_organization_run_task_test.go
+++ b/tfe/data_source_organization_run_task_test.go
@@ -26,7 +26,6 @@ func TestAccTFEOrganizationRunTaskDataSource_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			testCheckCreateOrgWithRunTasks(org),
 			{
 				Config: testAccTFEOrganizationRunTaskDataSourceConfig(org.Name, rInt, runTasksURL()),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/tfe/data_source_outputs_test.go
+++ b/tfe/data_source_outputs_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestAccTFEOutputs(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfUnitTest(t)
 
 	client, err := getClientUsingEnv()
@@ -27,7 +26,7 @@ func TestAccTFEOutputs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	fileName := "test-fixtures/state-versions/terraform.tfstate"
 	orgName, wsName, orgCleanup := createStateVersion(t, client, rInt, fileName)
-	defer orgCleanup()
+	t.Cleanup(orgCleanup)
 
 	waitForOutputs(t, client, orgName, wsName)
 
@@ -61,7 +60,6 @@ func TestAccTFEOutputs(t *testing.T) {
 }
 
 func TestAccTFEOutputs_emptyOutputs(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfUnitTest(t)
 
 	client, err := getClientUsingEnv()
@@ -72,7 +70,7 @@ func TestAccTFEOutputs_emptyOutputs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	fileName := "test-fixtures/state-versions/terraform-empty-outputs.tfstate"
 	orgName, wsName, orgCleanup := createStateVersion(t, client, rInt, fileName)
-	defer orgCleanup()
+	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -124,6 +122,9 @@ func createStateVersion(t *testing.T, client *tfe.Client, rInt int, fileName str
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	upgradeOrganizationSubscription(t, client, org)
+
 	orgCleanup = func() {
 		if err := client.Organizations.Delete(ctx, org.Name); err != nil {
 			t.Errorf("Error destroying organization! WARNING: Dangling resources\n"+

--- a/tfe/data_source_team_access_test.go
+++ b/tfe/data_source_team_access_test.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccTFETeamAccessDataSource_basic(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/data_source_team_test.go
+++ b/tfe/data_source_team_test.go
@@ -6,12 +6,15 @@ import (
 	"testing"
 	"time"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccTFETeamDataSource_basic(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -36,7 +39,11 @@ func TestAccTFETeamDataSource_basic(t *testing.T) {
 }
 
 func TestAccTFETeamDataSource_ssoTeamId(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/data_source_team_test.go
+++ b/tfe/data_source_team_test.go
@@ -6,25 +6,28 @@ import (
 	"testing"
 	"time"
 
+	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccTFETeamDataSource_basic(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamDataSourceConfig_basic(rInt),
+				Config: testAccTFETeamDataSourceConfig_basic(rInt, org.Name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.tfe_team.foobar", "name", fmt.Sprintf("team-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_team.foobar", "organization", orgName),
+						"data.tfe_team.foobar", "organization", org.Name),
 					resource.TestCheckResourceAttrSet("data.tfe_team.foobar", "id"),
 				),
 			},
@@ -33,64 +36,56 @@ func TestAccTFETeamDataSource_basic(t *testing.T) {
 }
 
 func TestAccTFETeamDataSource_ssoTeamId(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-	testSsoTeamId := fmt.Sprintf("sso-team-id-%d", rInt)
+	testSsoTeamID := fmt.Sprintf("sso-team-id-%d", rInt)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamDataSourceConfig_ssoTeamId(rInt, testSsoTeamId),
+				Config: testAccTFETeamDataSourceConfig_ssoTeamId(rInt, org.Name, testSsoTeamID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.tfe_team.sso_team", "name", fmt.Sprintf("team-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_team.sso_team", "organization", orgName),
+						"data.tfe_team.sso_team", "organization", org.Name),
 					resource.TestCheckResourceAttrSet("data.tfe_team.sso_team", "id"),
 					resource.TestCheckResourceAttr(
-						"data.tfe_team.sso_team", "sso_team_id", testSsoTeamId),
+						"data.tfe_team.sso_team", "sso_team_id", testSsoTeamID),
 				),
 			},
 		},
 	})
 }
 
-func testAccTFETeamDataSourceConfig_basic(rInt int) string {
+func testAccTFETeamDataSourceConfig_basic(rInt int, organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_team" "foobar" {
   name         = "team-test-%d"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
 }
 
 data "tfe_team" "foobar" {
   name         = tfe_team.foobar.name
-  organization = tfe_team.foobar.organization
-}`, rInt, rInt)
+  organization = "%s"
+}`, rInt, organization, organization)
 }
 
-func testAccTFETeamDataSourceConfig_ssoTeamId(rInt int, ssoTeamId string) string {
+func testAccTFETeamDataSourceConfig_ssoTeamId(rInt int, organization string, ssoTeamID string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_team" "sso_team" {
   name         = "team-test-%d"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
   sso_team_id  = "%s"
 }
 
 data "tfe_team" "sso_team" {
   name         = tfe_team.sso_team.name
   organization = tfe_team.sso_team.organization
-}`, rInt, rInt, ssoTeamId)
+}`, rInt, organization, ssoTeamID)
 }

--- a/tfe/data_source_workspace_run_task_test.go
+++ b/tfe/data_source_workspace_run_task_test.go
@@ -26,7 +26,6 @@ func TestAccTFEWorkspaceRunTaskDataSource_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			testCheckCreateOrgWithRunTasks(org),
 			{
 				Config: testAccTFEWorkspaceRunTaskDataSourceConfig(org.Name, rInt, runTasksURL()),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/tfe/data_source_workspace_run_task_test.go
+++ b/tfe/data_source_workspace_run_task_test.go
@@ -6,14 +6,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccTFEWorkspaceRunTaskDataSource_basic(t *testing.T) {
 	skipUnlessRunTasksDefined(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/provider_test.go
+++ b/tfe/provider_test.go
@@ -308,24 +308,24 @@ var GITHUB_REGISTRY_MODULE_IDENTIFIER = os.Getenv("GITHUB_REGISTRY_MODULE_IDENTI
 var TFE_USER1 = os.Getenv("TFE_USER1")
 var TFE_USER2 = os.Getenv("TFE_USER2")
 
-func testCheckCreateOrgWithRunTasks(organizationName string) resource.TestStep {
+func testCheckCreateOrgWithRunTasks(org *tfe.Organization) resource.TestStep {
 	check := func(_ *terraform.State) error {
 		client, err := getClientUsingEnv()
 		if err != nil {
 			return err
 		}
-		entitlements, err := client.Organizations.ReadEntitlements(context.TODO(), organizationName)
+		entitlements, err := client.Organizations.ReadEntitlements(context.TODO(), org.Name)
 		if err != nil {
 			return fmt.Errorf("error reading entitlements: %w", err)
 		}
 		if entitlements == nil || !entitlements.RunTasks {
-			return fmt.Errorf("Organization %s is not entitled to use Run Tasks", organizationName)
+			return fmt.Errorf("Organization %s is not entitled to use Run Tasks", org.Name)
 		}
 		return nil
 	}
 
 	return resource.TestStep{
-		Config: fmt.Sprintf("resource \"tfe_organization\" \"foobar\" {\n name = %q\nemail = \"admin@company.com\"\n}", organizationName),
+		Config: fmt.Sprintf("resource \"tfe_organization\" \"foobar\" {\n name = %q\nemail = %q\n}", org.Name, org.Email),
 		Check:  check,
 	}
 }

--- a/tfe/provider_test.go
+++ b/tfe/provider_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	tfmux "github.com/hashicorp/terraform-plugin-mux"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-tfe/version"
@@ -307,25 +306,3 @@ var GITHUB_POLICY_SET_PATH = os.Getenv("GITHUB_POLICY_SET_PATH")
 var GITHUB_REGISTRY_MODULE_IDENTIFIER = os.Getenv("GITHUB_REGISTRY_MODULE_IDENTIFIER")
 var TFE_USER1 = os.Getenv("TFE_USER1")
 var TFE_USER2 = os.Getenv("TFE_USER2")
-
-func testCheckCreateOrgWithRunTasks(org *tfe.Organization) resource.TestStep {
-	check := func(_ *terraform.State) error {
-		client, err := getClientUsingEnv()
-		if err != nil {
-			return err
-		}
-		entitlements, err := client.Organizations.ReadEntitlements(context.TODO(), org.Name)
-		if err != nil {
-			return fmt.Errorf("error reading entitlements: %w", err)
-		}
-		if entitlements == nil || !entitlements.RunTasks {
-			return fmt.Errorf("Organization %s is not entitled to use Run Tasks", org.Name)
-		}
-		return nil
-	}
-
-	return resource.TestStep{
-		Config: fmt.Sprintf("resource \"tfe_organization\" \"foobar\" {\n name = %q\nemail = %q\n}", org.Name, org.Email),
-		Check:  check,
-	}
-}

--- a/tfe/resource_tfe_agent_pool_test.go
+++ b/tfe/resource_tfe_agent_pool_test.go
@@ -12,7 +12,11 @@ import (
 func TestAccTFEAgentPool_basic(t *testing.T) {
 	skipIfEnterprise(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -40,7 +44,11 @@ func TestAccTFEAgentPool_basic(t *testing.T) {
 func TestAccTFEAgentPool_update(t *testing.T) {
 	skipIfEnterprise(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -79,7 +87,11 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 func TestAccTFEAgentPool_import(t *testing.T) {
 	skipIfEnterprise(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/resource_tfe_agent_pool_test.go
+++ b/tfe/resource_tfe_agent_pool_test.go
@@ -2,9 +2,7 @@ package tfe
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -12,11 +10,13 @@ import (
 )
 
 func TestAccTFEAgentPool_basic(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfEnterprise(t)
 
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
 	agentPool := &tfe.AgentPool{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,7 +24,7 @@ func TestAccTFEAgentPool_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEAgentPool_basic(rInt),
+				Config: testAccTFEAgentPool_basic(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEAgentPoolExists(
 						"tfe_agent_pool.foobar", agentPool),
@@ -38,11 +38,13 @@ func TestAccTFEAgentPool_basic(t *testing.T) {
 }
 
 func TestAccTFEAgentPool_update(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfEnterprise(t)
 
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
 	agentPool := &tfe.AgentPool{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,7 +52,7 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEAgentPool_basic(rInt),
+				Config: testAccTFEAgentPool_basic(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEAgentPoolExists(
 						"tfe_agent_pool.foobar", agentPool),
@@ -61,7 +63,7 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEAgentPool_update(rInt),
+				Config: testAccTFEAgentPool_update(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEAgentPoolExists(
 						"tfe_agent_pool.foobar", agentPool),
@@ -75,10 +77,11 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 }
 
 func TestAccTFEAgentPool_import(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfEnterprise(t)
 
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -86,9 +89,8 @@ func TestAccTFEAgentPool_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEAgentPool_basic(rInt),
+				Config: testAccTFEAgentPool_basic(org.Name),
 			},
-
 			{
 				ResourceName:      "tfe_agent_pool.foobar",
 				ImportState:       true,
@@ -97,7 +99,7 @@ func TestAccTFEAgentPool_import(t *testing.T) {
 			{
 				ResourceName:      "tfe_agent_pool.foobar",
 				ImportState:       true,
-				ImportStateId:     fmt.Sprintf("tst-terraform-%d/agent-pool-test", rInt),
+				ImportStateId:     fmt.Sprintf("%s/agent-pool-test", org.Name),
 				ImportStateVerify: true,
 			},
 		},
@@ -174,28 +176,18 @@ func testAccCheckTFEAgentPoolDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccTFEAgentPool_basic(rInt int) string {
+func testAccTFEAgentPool_basic(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "foobar" {
   name         = "agent-pool-test"
-  organization = tfe_organization.foobar.id
-}`, rInt)
+  organization = "%s"
+}`, organization)
 }
 
-func testAccTFEAgentPool_update(rInt int) string {
+func testAccTFEAgentPool_update(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "foobar" {
   name         = "agent-pool-updated"
-  organization = tfe_organization.foobar.id
-}`, rInt)
+  organization = "%s"
+}`, organization)
 }

--- a/tfe/resource_tfe_agent_token_test.go
+++ b/tfe/resource_tfe_agent_token_test.go
@@ -12,7 +12,11 @@ import (
 func TestAccTFEAgentToken_basic(t *testing.T) {
 	skipIfEnterprise(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/resource_tfe_organization_module_sharing_test.go
+++ b/tfe/resource_tfe_organization_module_sharing_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestAccTFEOrganizationModuleSharing_basic(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfCloud(t)
 
 	rInt1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -47,7 +46,6 @@ func TestAccTFEOrganizationModuleSharing_basic(t *testing.T) {
 }
 
 func TestAccTFEOrganizationModuleSharing_emptyOrg(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfCloud(t)
 
 	rInt1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -80,7 +78,6 @@ func TestAccTFEOrganizationModuleSharing_emptyOrg(t *testing.T) {
 }
 
 func TestAccTFEOrganizationModuleSharing_stopSharing(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfCloud(t)
 
 	rInt1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()

--- a/tfe/resource_tfe_organization_run_task_test.go
+++ b/tfe/resource_tfe_organization_run_task_test.go
@@ -52,7 +52,6 @@ func TestAccTFEOrganizationRunTask_create(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEOrganizationRunTaskDestroy,
 		Steps: []resource.TestStep{
-			testCheckCreateOrgWithRunTasks(org),
 			{
 				Config: testAccTFEOrganizationRunTask_basic(org.Name, rInt, runTasksURL()),
 				Check: resource.ComposeTestCheckFunc(
@@ -98,7 +97,6 @@ func TestAccTFEOrganizationRunTask_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
-			testCheckCreateOrgWithRunTasks(org),
 			{
 				Config: testAccTFEOrganizationRunTask_basic(org.Name, rInt, runTasksURL()),
 			},

--- a/tfe/resource_tfe_organization_run_task_test.go
+++ b/tfe/resource_tfe_organization_run_task_test.go
@@ -36,7 +36,11 @@ func TestAccTFEOrganizationRunTask_validateSchemaAttributeUrl(t *testing.T) {
 func TestAccTFEOrganizationRunTask_create(t *testing.T) {
 	skipUnlessRunTasksDefined(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -79,7 +83,11 @@ func TestAccTFEOrganizationRunTask_create(t *testing.T) {
 func TestAccTFEOrganizationRunTask_import(t *testing.T) {
 	skipUnlessRunTasksDefined(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -79,6 +79,8 @@ func TestAccTFEOrganization_full(t *testing.T) {
 }
 
 func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
+	t.Skip("Skipping this test until the SDK can support importing resources before applying a configuration")
+
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -79,7 +79,11 @@ func TestAccTFEOrganization_full(t *testing.T) {
 }
 
 func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -79,20 +79,16 @@ func TestAccTFEOrganization_full(t *testing.T) {
 }
 
 func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
-	skipIfFreeOnly(t)
-
-	org := &tfe.Organization{}
-
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	// First update
-	rInt1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	costEstimationEnabled1 := true
 
 	// Second update
-	rInt2 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	costEstimationEnabled2 := false
+	updatedName := org.Name + "_foobar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -100,28 +96,13 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganization_basic(rInt),
+				Config: testAccTFEOrganization_update(org.Name, org.Email, costEstimationEnabled1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
-					testAccCheckTFEOrganizationAttributesBasic(org, orgName),
+					testAccCheckTFEOrganizationAttributesUpdated(org, org.Name, costEstimationEnabled1),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", orgName),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "email", "admin@company.com"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
-				),
-			},
-
-			{
-				Config: testAccTFEOrganization_update(rInt1, costEstimationEnabled1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEOrganizationExists(
-						"tfe_organization.foobar", org),
-					testAccCheckTFEOrganizationAttributesUpdated(org, fmt.Sprintf("tst-terraform-%d", rInt1), costEstimationEnabled1),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", fmt.Sprintf("tst-terraform-%d", rInt1)),
+						"tfe_organization.foobar", "name", org.Name),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin-updated@company.com"),
 					resource.TestCheckResourceAttr(
@@ -140,13 +121,13 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEOrganization_update(rInt2, costEstimationEnabled2),
+				Config: testAccTFEOrganization_update(updatedName, org.Email, costEstimationEnabled2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
-					testAccCheckTFEOrganizationAttributesUpdated(org, fmt.Sprintf("tst-terraform-%d", rInt2), costEstimationEnabled2),
+					testAccCheckTFEOrganizationAttributesUpdated(org, updatedName, costEstimationEnabled2),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", fmt.Sprintf("tst-terraform-%d", rInt2)),
+						"tfe_organization.foobar", "name", updatedName),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin-updated@company.com"),
 					resource.TestCheckResourceAttr(
@@ -386,14 +367,14 @@ resource "tfe_organization" "foobar" {
 }`, rInt)
 }
 
-func testAccTFEOrganization_update(rInt int, costEstimationEnabled bool) string {
+func testAccTFEOrganization_update(orgName string, orgEmail string, costEstimationEnabled bool) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name                     = "tst-terraform-%d"
-  email                    = "admin-updated@company.com"
+  name                     = "%s"
+  email                    = "%s"
   session_timeout_minutes  = 3600
   session_remember_minutes = 3600
   owners_team_saml_role_id = "owners"
   cost_estimation_enabled  = %t
-}`, rInt, costEstimationEnabled)
+}`, orgName, orgEmail, costEstimationEnabled)
 }

--- a/tfe/resource_tfe_policy_set_parameter_test.go
+++ b/tfe/resource_tfe_policy_set_parameter_test.go
@@ -10,7 +10,11 @@ import (
 )
 
 func TestAccTFEPolicySetParameter_basic(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -40,7 +44,11 @@ func TestAccTFEPolicySetParameter_basic(t *testing.T) {
 }
 
 func TestAccTFEPolicySetParameter_update(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -85,7 +93,11 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 }
 
 func TestAccTFEPolicySetParameter_import(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/resource_tfe_policy_set_parameter_test.go
+++ b/tfe/resource_tfe_policy_set_parameter_test.go
@@ -2,9 +2,7 @@ package tfe
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -12,10 +10,11 @@ import (
 )
 
 func TestAccTFEPolicySetParameter_basic(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	parameter := &tfe.PolicySetParameter{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,7 +22,7 @@ func TestAccTFEPolicySetParameter_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySetParameter_basic(rInt),
+				Config: testAccTFEPolicySetParameter_basic(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -41,10 +40,11 @@ func TestAccTFEPolicySetParameter_basic(t *testing.T) {
 }
 
 func TestAccTFEPolicySetParameter_update(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	parameter := &tfe.PolicySetParameter{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,7 +52,7 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySetParameter_basic(rInt),
+				Config: testAccTFEPolicySetParameter_basic(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -67,7 +67,7 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySetParameter_update(rInt),
+				Config: testAccTFEPolicySetParameter_update(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetParameterExists(
 						"tfe_policy_set_parameter.foobar", parameter),
@@ -85,9 +85,9 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 }
 
 func TestAccTFEPolicySetParameter_import(t *testing.T) {
-	skipIfFreeOnly(t)
-
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -95,7 +95,7 @@ func TestAccTFEPolicySetParameter_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySetParameter_basic(rInt),
+				Config: testAccTFEPolicySetParameter_basic(org.Name),
 			},
 
 			{
@@ -198,35 +198,25 @@ func testAccCheckTFEPolicySetParameterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccTFEPolicySetParameter_basic(rInt int) string {
+func testAccTFEPolicySetParameter_basic(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_policy_set" "foobar" {
   name         = "policy-set-test"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
 }
 
 resource "tfe_policy_set_parameter" "foobar" {
   key          = "key_test"
   value        = "value_test"
   policy_set_id = tfe_policy_set.foobar.id
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEPolicySetParameter_update(rInt int) string {
+func testAccTFEPolicySetParameter_update(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_policy_set" "foobar" {
   name         = "policy-set-test"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
 }
 
 resource "tfe_policy_set_parameter" "foobar" {
@@ -234,5 +224,5 @@ resource "tfe_policy_set_parameter" "foobar" {
   value        = "value_updated"
   sensitive    = true
   policy_set_id = tfe_policy_set.foobar.id
-}`, rInt)
+}`, organization)
 }

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -3,11 +3,9 @@ package tfe
 import (
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"regexp"
 	"testing"
-	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,10 +13,11 @@ import (
 )
 
 func TestAccTFEPolicySet_basic(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -26,7 +25,7 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_basic(rInt),
+				Config: testAccTFEPolicySet_basic(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -45,11 +44,11 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_update(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -57,7 +56,7 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_basic(rInt),
+				Config: testAccTFEPolicySet_basic(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -73,10 +72,10 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_populated(rInt),
+				Config: testAccTFEPolicySet_populated(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
+					testAccCheckTFEPolicySetPopulated(policySet, org.Name),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -92,10 +91,11 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -103,7 +103,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_basic(rInt),
+				Config: testAccTFEPolicySet_basic(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -119,7 +119,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_empty(rInt),
+				Config: testAccTFEPolicySet_empty(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -138,11 +138,11 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -150,10 +150,10 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populated(rInt),
+				Config: testAccTFEPolicySet_populated(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
+					testAccCheckTFEPolicySetPopulated(policySet, org.Name),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -166,10 +166,10 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_updatePopulated(rInt),
+				Config: testAccTFEPolicySet_updatePopulated(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulatedUpdated(policySet, orgName),
+					testAccCheckTFEPolicySetPopulatedUpdated(policySet, org.Name),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated-updated"),
 					resource.TestCheckResourceAttr(
@@ -185,9 +185,11 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -195,10 +197,10 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populated(rInt),
+				Config: testAccTFEPolicySet_populated(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
+					testAccCheckTFEPolicySetPopulated(policySet, org.Name),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -211,7 +213,7 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_global(rInt),
+				Config: testAccTFEPolicySet_global(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -228,11 +230,11 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -240,7 +242,7 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_global(rInt),
+				Config: testAccTFEPolicySet_global(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetGlobal(policySet),
@@ -254,10 +256,10 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_populated(rInt),
+				Config: testAccTFEPolicySet_populated(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
-					testAccCheckTFEPolicySetPopulated(policySet, orgName),
+					testAccCheckTFEPolicySetPopulated(policySet, org.Name),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "name", "terraform-populated"),
 					resource.TestCheckResourceAttr(
@@ -273,10 +275,11 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_vcs(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -298,7 +301,7 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_vcs(rInt),
+				Config: testAccTFEPolicySet_vcs(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -323,10 +326,11 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
-	skipIfFreeOnly(t)
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -348,7 +352,7 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_vcs(rInt),
+				Config: testAccTFEPolicySet_vcs(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -370,7 +374,7 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEPolicySet_updateVCSBranch(rInt),
+				Config: testAccTFEPolicySet_updateVCSBranch(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -395,11 +399,13 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_versionedSlug(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfUnitTest(t)
 
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	checksum, err := hashPolicies(testFixtureVersionFiles)
 	if err != nil {
 		t.Fatalf("Unable to generate checksum for policies %v", err)
@@ -411,7 +417,7 @@ func TestAccTFEPolicySet_versionedSlug(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_versionSlug(rInt, testFixtureVersionFiles),
+				Config: testAccTFEPolicySet_versionSlug(org.Name, testFixtureVersionFiles),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -436,11 +442,13 @@ func TestAccTFEPolicySet_versionedSlug(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfUnitTest(t)
 
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
 	policySet := &tfe.PolicySet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	originalChecksum, err := hashPolicies(testFixtureVersionFiles)
 	if err != nil {
@@ -455,7 +463,7 @@ func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_versionSlug(rInt, testFixtureVersionFiles),
+				Config: testAccTFEPolicySet_versionSlug(org.Name, testFixtureVersionFiles),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
@@ -479,7 +487,7 @@ func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
 						os.Remove(newFile)
 					})
 				},
-				Config: testAccTFEPolicySet_versionSlug(rInt, testFixtureVersionFiles),
+				Config: testAccTFEPolicySet_versionSlug(org.Name, testFixtureVersionFiles),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					resource.TestCheckResourceAttr(
@@ -492,9 +500,9 @@ func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_versionedNoConflicts(t *testing.T) {
-	skipIfFreeOnly(t)
-
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -502,7 +510,7 @@ func TestAccTFEPolicySet_versionedNoConflicts(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFEPolicySet_versionsConflict(rInt, testFixtureVersionFiles),
+				Config:      testAccTFEPolicySet_versionsConflict(org.Name, testFixtureVersionFiles),
 				ExpectError: regexp.MustCompile(`Conflicting configuration`),
 			},
 		},
@@ -534,7 +542,9 @@ func testAccCheckTFEPolicySetVersionValidateChecksum(n string, sourcePath string
 }
 
 func TestAccTFEPolicySet_invalidName(t *testing.T) {
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -542,7 +552,7 @@ func TestAccTFEPolicySet_invalidName(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFEPolicySet_invalidName(rInt),
+				Config:      testAccTFEPolicySet_invalidName(org.Name),
 				ExpectError: regexp.MustCompile(`can only include letters, numbers, -, and _.`),
 			},
 		},
@@ -550,9 +560,9 @@ func TestAccTFEPolicySet_invalidName(t *testing.T) {
 }
 
 func TestAccTFEPolicySetImport(t *testing.T) {
-	skipIfFreeOnly(t)
-
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -560,7 +570,7 @@ func TestAccTFEPolicySetImport(t *testing.T) {
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEPolicySet_populated(rInt),
+				Config: testAccTFEPolicySet_populated(org.Name),
 			},
 
 			{
@@ -742,138 +752,125 @@ func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccTFEPolicySet_basic(rInt int) string {
+func testAccTFEPolicySet_basic(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_sentinel_policy" "foo" {
   name         = "policy-foo"
   policy       = "main = rule { true }"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
 }
 
 resource "tfe_policy_set" "foobar" {
   name         = "tst-terraform"
   description  = "Policy Set"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
   policy_ids   = [tfe_sentinel_policy.foo.id]
-}`, rInt)
+}`, organization, organization)
 }
 
-func testAccTFEPolicySet_empty(rInt int) string {
+func testAccTFEPolicySet_empty(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
  resource "tfe_policy_set" "foobar" {
   name         = "tst-terraform"
   description  = "Policy Set"
-  organization = tfe_organization.foobar.id
-}`, rInt)
+  organization = "%s"
+}`, organization)
 }
 
-func testAccTFEPolicySet_populated(rInt int) string {
+func testAccTFEPolicySet_populated(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
+locals {
+    organization_name = "%s"
 }
 
 resource "tfe_sentinel_policy" "foo" {
   name         = "policy-foo"
   policy       = "main = rule { true }"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_workspace" "foo" {
   name         = "workspace-foo"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_policy_set" "foobar" {
   name          = "terraform-populated"
-  organization  = tfe_organization.foobar.id
+  organization = local.organization_name
   policy_ids    = [tfe_sentinel_policy.foo.id]
   workspace_ids = [tfe_workspace.foo.id]
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEPolicySet_updatePopulated(rInt int) string {
+func testAccTFEPolicySet_updatePopulated(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
+locals {
+    organization_name = "%s"
 }
 
 resource "tfe_sentinel_policy" "foo" {
   name         = "policy-foo"
   policy       = "main = rule { true }"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_sentinel_policy" "bar" {
   name         = "policy-bar"
   policy       = "main = rule { false }"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_workspace" "foo" {
   name         = "workspace-foo"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_workspace" "bar" {
   name         = "workspace-bar"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_policy_set" "foobar" {
   name          = "terraform-populated-updated"
-  organization  = tfe_organization.foobar.id
+  organization = local.organization_name
   policy_ids    = [tfe_sentinel_policy.bar.id]
   workspace_ids = [tfe_workspace.bar.id]
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEPolicySet_global(rInt int) string {
+func testAccTFEPolicySet_global(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
+locals {
+    organization_name = "%s"
 }
 
 resource "tfe_sentinel_policy" "foo" {
   name         = "policy-foo"
   policy       = "main = rule { true }"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_workspace" "foo" {
   name         = "workspace-foo"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_policy_set" "foobar" {
   name         = "terraform-global"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
   global       = true
   policy_ids   = [tfe_sentinel_policy.foo.id]
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEPolicySet_vcs(rInt int) string {
+func testAccTFEPolicySet_vcs(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
+locals {
+    organization_name = "%s"
 }
 
 resource "tfe_oauth_client" "test" {
-  organization     = tfe_organization.foobar.id
+  organization     = local.organization_name
   api_url          = "https://api.github.com"
   http_url         = "https://github.com"
   oauth_token      = "%s"
@@ -883,7 +880,7 @@ resource "tfe_oauth_client" "test" {
 resource "tfe_policy_set" "foobar" {
   name         = "tst-terraform"
   description  = "Policy Set"
-  organization = tfe_organization.foobar.id
+  organization     = local.organization_name
   vcs_repo {
     identifier         = "%s"
     branch             = "main"
@@ -893,22 +890,21 @@ resource "tfe_policy_set" "foobar" {
 
   policies_path = "%s"
 }
-`, rInt,
+`, organization,
 		GITHUB_TOKEN,
 		GITHUB_POLICY_SET_IDENTIFIER,
 		GITHUB_POLICY_SET_PATH,
 	)
 }
 
-func testAccTFEPolicySet_updateVCSBranch(rInt int) string {
+func testAccTFEPolicySet_updateVCSBranch(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
+locals {
+    organization_name = "%s"
 }
 
 resource "tfe_oauth_client" "test" {
-  organization     = tfe_organization.foobar.id
+  organization     = local.organization_name
   api_url          = "https://api.github.com"
   http_url         = "https://github.com"
   oauth_token      = "%s"
@@ -918,7 +914,7 @@ resource "tfe_oauth_client" "test" {
 resource "tfe_policy_set" "foobar" {
   name         = "tst-terraform"
   description  = "Policy Set"
-  organization = tfe_organization.foobar.id
+  organization     = local.organization_name
   vcs_repo {
     identifier         = "%s"
     branch             = "%s"
@@ -928,7 +924,7 @@ resource "tfe_policy_set" "foobar" {
 
   policies_path = "%s"
 }
-`, rInt,
+`, organization,
 		GITHUB_TOKEN,
 		GITHUB_POLICY_SET_IDENTIFIER,
 		GITHUB_POLICY_SET_BRANCH,
@@ -936,34 +932,28 @@ resource "tfe_policy_set" "foobar" {
 	)
 }
 
-func testAccTFEPolicySet_invalidName(rInt int) string {
+func testAccTFEPolicySet_invalidName(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
+locals {
+    organization_name = "%s"
 }
 
 resource "tfe_sentinel_policy" "foo" {
   name         = "policy-foo"
   policy       = "main = rule { true }"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
 }
 
 resource "tfe_policy_set" "foobar" {
   name         = "not the right format"
   description  = "Policy Set"
-  organization = tfe_organization.foobar.id
+  organization = local.organization_name
   policy_ids   = [tfe_sentinel_policy.foo.id]
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEPolicySet_versionSlug(rInt int, sourcePath string) string {
+func testAccTFEPolicySet_versionSlug(organization string, sourcePath string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 data "tfe_slug" "policy" {
   source_path = "%s"
 }
@@ -971,18 +961,13 @@ data "tfe_slug" "policy" {
 resource "tfe_policy_set" "foobar" {
   name         = "tst-terraform"
   description  = "Policy Set"
-  organization = tfe_organization.foobar.id
-	slug = data.tfe_slug.policy
-}`, rInt, sourcePath)
+  organization = "%s"
+  slug         = data.tfe_slug.policy
+}`, sourcePath, organization)
 }
 
-func testAccTFEPolicySet_versionsConflict(rInt int, sourcePath string) string {
+func testAccTFEPolicySet_versionsConflict(organization string, sourcePath string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 data "tfe_slug" "policy" {
   source_path = "%s"
 }
@@ -990,7 +975,7 @@ data "tfe_slug" "policy" {
 resource "tfe_policy_set" "foobar" {
   name         = "tst-terraform"
   description  = "Policy Set"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
 	slug = data.tfe_slug.policy
   vcs_repo {
     identifier         = "foo"
@@ -998,5 +983,5 @@ resource "tfe_policy_set" "foobar" {
     ingress_submodules = true
     oauth_token_id     = "id"
   }
-} `, rInt, sourcePath)
+} `, sourcePath, organization)
 }

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -13,7 +13,11 @@ import (
 )
 
 func TestAccTFEPolicySet_basic(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -44,7 +48,11 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_update(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -91,7 +99,11 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -138,7 +150,11 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -185,7 +201,11 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -230,7 +250,11 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -275,7 +299,11 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_vcs(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -326,7 +354,11 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -401,7 +433,11 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 func TestAccTFEPolicySet_versionedSlug(t *testing.T) {
 	skipIfUnitTest(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -444,7 +480,11 @@ func TestAccTFEPolicySet_versionedSlug(t *testing.T) {
 func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
 	skipIfUnitTest(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -500,7 +540,11 @@ func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
 }
 
 func TestAccTFEPolicySet_versionedNoConflicts(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -542,7 +586,11 @@ func testAccCheckTFEPolicySetVersionValidateChecksum(n string, sourcePath string
 }
 
 func TestAccTFEPolicySet_invalidName(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
@@ -560,7 +608,11 @@ func TestAccTFEPolicySet_invalidName(t *testing.T) {
 }
 
 func TestAccTFEPolicySetImport(t *testing.T) {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/resource_tfe_terraform_version_test.go
+++ b/tfe/resource_tfe_terraform_version_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccTFETerraformVersion_basic(t *testing.T) {
-	skipIfFreeOnly(t)
+	skipIfCloud(t)
 
 	tfVersion := &tfe.AdminTerraformVersion{}
 	sha := genSha(t, "secret", "data")
@@ -44,6 +44,8 @@ func TestAccTFETerraformVersion_basic(t *testing.T) {
 }
 
 func TestAccTFETerraformVersion_import(t *testing.T) {
+	skipIfCloud(t)
+
 	sha := genSha(t, "secret", "data")
 	version := genSafeRandomTerraformVersion()
 
@@ -71,7 +73,7 @@ func TestAccTFETerraformVersion_import(t *testing.T) {
 }
 
 func TestAccTFETerraformVersion_full(t *testing.T) {
-	skipIfFreeOnly(t)
+	skipIfCloud(t)
 
 	tfVersion := &tfe.AdminTerraformVersion{}
 	sha := genSha(t, "secret", "data")

--- a/tfe/resource_tfe_workspace_run_task_test.go
+++ b/tfe/resource_tfe_workspace_run_task_test.go
@@ -27,7 +27,6 @@ func TestAccTFEWorkspaceRunTask_create(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEWorkspaceRunTaskDestroy,
 		Steps: []resource.TestStep{
-			testCheckCreateOrgWithRunTasks(org),
 			{
 				Config: testAccTFEWorkspaceRunTask_basic(org.Name, runTasksURL()),
 				Check: resource.ComposeTestCheckFunc(
@@ -99,7 +98,6 @@ func TestAccTFEWorkspaceRunTask_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
-			testCheckCreateOrgWithRunTasks(org),
 			{
 				Config: testAccTFEWorkspaceRunTask_basic(org.Name, runTasksURL()),
 			},

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -1540,7 +1540,11 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T) {
 	skipIfEnterprise(t)
 
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	org, orgCleanup := createBusinessOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -1538,11 +1538,13 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 }
 
 func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T) {
-	skipIfFreeOnly(t)
 	skipIfEnterprise(t)
 
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
 	workspace := &tfe.Workspace{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1550,7 +1552,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_operationsTrue(rInt),
+				Config: testAccTFEWorkspace_operationsTrue(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -1563,7 +1565,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_executionModeLocal(rInt),
+				Config: testAccTFEWorkspace_executionModeLocal(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -1576,7 +1578,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_operationsFalse(rInt),
+				Config: testAccTFEWorkspace_operationsFalse(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -1589,7 +1591,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_executionModeRemote(rInt),
+				Config: testAccTFEWorkspace_executionModeRemote(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -1602,7 +1604,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 				),
 			},
 			{
-				Config: testAccTFEWorkspace_executionModeAgent(rInt),
+				Config: testAccTFEWorkspace_executionModeAgent(org.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
@@ -2192,80 +2194,55 @@ resource "tfe_workspace" "foobar" {
 }`, rInt)
 }
 
-func testAccTFEWorkspace_operationsTrue(rInt int) string {
+func testAccTFEWorkspace_operationsTrue(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_workspace" "foobar" {
   name         = "workspace-test"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
   operations = true
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEWorkspace_operationsFalse(rInt int) string {
+func testAccTFEWorkspace_operationsFalse(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_workspace" "foobar" {
   name         = "workspace-test"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
   operations = false
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEWorkspace_executionModeRemote(rInt int) string {
+func testAccTFEWorkspace_executionModeRemote(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_workspace" "foobar" {
   name         = "workspace-test"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
   execution_mode = "remote"
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEWorkspace_executionModeLocal(rInt int) string {
+func testAccTFEWorkspace_executionModeLocal(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_workspace" "foobar" {
   name         = "workspace-test"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
   execution_mode = "local"
-}`, rInt)
+}`, organization)
 }
 
-func testAccTFEWorkspace_executionModeAgent(rInt int) string {
+func testAccTFEWorkspace_executionModeAgent(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "foobar" {
   name = "agent-pool-test"
-  organization = tfe_organization.foobar.name
+  organization = "%s"
 }
 
 resource "tfe_workspace" "foobar" {
   name         = "workspace-test"
-  organization = tfe_organization.foobar.id
+  organization = "%s"
   execution_mode = "agent"
   agent_pool_id = tfe_agent_pool.foobar.id
-}`, rInt)
+}`, organization, organization)
 }
 
 func testAccTFEWorkspace_basicSpeculativeOff(rInt int) string {
@@ -2685,7 +2662,7 @@ func testAccTFEWorkspace_updateToTriggerPatternsFromTagsRegex(rInt int) string {
 		name  = "tst-tf-%d-git-tag-ff-on"
 		email = "admin@company.com"
 	}
-	
+
 	resource "tfe_oauth_client" "test" {
 		organization     = tfe_organization.foobar.id
 		api_url          = "https://api.github.com"
@@ -2693,7 +2670,7 @@ func testAccTFEWorkspace_updateToTriggerPatternsFromTagsRegex(rInt int) string {
 		oauth_token      = "%s"
 		service_provider = "github"
 	}
-	
+
 	resource "tfe_workspace" "foobar" {
 		name         			= "workspace-test"
 		description  			= "workspace-test-update-vcs-repo-tags-regex"

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -114,14 +114,14 @@ func upgradeOrganizationSubscription(t *testing.T, client *tfe.Client, org *tfe.
 }
 
 func createBusinessOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
-    org, orgCleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
-        Name: tfe.String("tst-"+randomString(t)),
-        Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t)))
-    })
+	org, orgCleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
 
-    upgradeOrganizationSubscription(t, client, org)
+	upgradeOrganizationSubscription(t, client, org)
 
-    return org, orgCleanup
+	return org, orgCleanup
 }
 
 func createOrganization(t *testing.T, client *tfe.Client, options tfe.OrganizationCreateOptions) (*tfe.Organization, func()) {
@@ -194,11 +194,11 @@ func skipIfUnitTest(t *testing.T) {
 }
 
 func randomString(t *testing.T) string {
-    v, err := uuid.GenerateUUID()
-    if err != nil {
-        t.Fatal(err)
-    }
-    return v
+	v, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
 }
 
 type retryableFn func() (interface{}, error)

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -1,11 +1,15 @@
 package tfe
 
 import (
+	"context"
+	"fmt"
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-uuid"
 )
 
 const RunTasksURLEnvName = "RUN_TASKS_URL"
@@ -14,6 +18,29 @@ type testClientOptions struct {
 	defaultOrganization          string
 	defaultWorkspaceID           string
 	remoteStateConsumersResponse string
+}
+
+type featureSet struct {
+	ID string `jsonapi:"primary,feature-sets"`
+}
+
+type featureSetList struct {
+	Items []*featureSet
+	*tfe.Pagination
+}
+
+type featureSetListOptions struct {
+	Q string `url:"q,omitempty"`
+}
+
+type updateFeatureSetOptions struct {
+	Type               string    `jsonapi:"primary,subscription"`
+	RunsCeiling        int       `jsonapi:"attr,runs-ceiling"`
+	ContractStartAt    time.Time `jsonapi:"attr,contract-start-at,iso8601"`
+	ContractUserLimit  int       `jsonapi:"attr,contract-user-limit"`
+	ContractApplyLimit int       `jsonapi:"attr,contract-apply-limit"`
+
+	FeatureSet *featureSet `jsonapi:"relation,feature-set"`
 }
 
 // testTfeClient creates a mock client that creates workspaces with their ID
@@ -40,12 +67,76 @@ func testTfeClient(t *testing.T, options testClientOptions) *tfe.Client {
 	return client
 }
 
-// skips a test if the test requires a paid feature, and this flag
-// SKIP_PAID is set.
-func skipIfFreeOnly(t *testing.T) {
-	skip := os.Getenv("SKIP_PAID") == "1"
-	if skip {
-		t.Skip("Skipping test that requires a paid feature. Remove 'SKIP_PAID=1' if you want to run this test")
+func upgradeOrganizationSubscription(t *testing.T, client *tfe.Client, org *tfe.Organization) {
+	if enterpriseEnabled() {
+		t.Skip("Cannot upgrade an organization's subscription when enterprise is enabled. Set ENABLE_TFE=0 to run.")
+	}
+
+	req, err := client.NewRequest("GET", "admin/feature-sets", featureSetListOptions{
+		Q: "Business",
+	})
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	fsl := &featureSetList{}
+	err = req.Do(context.Background(), fsl)
+	if err != nil {
+		t.Fatalf("failed to enumerate feature sets: %v", err)
+		return
+	} else if len(fsl.Items) == 0 {
+		// this will serve as our catch all if enterprise is not enabled
+		// but the instance itself is enterprise
+		t.Fatalf("feature set response was empty")
+		return
+	}
+
+	opts := updateFeatureSetOptions{
+		RunsCeiling:        10,
+		ContractStartAt:    time.Now(),
+		ContractUserLimit:  1000,
+		ContractApplyLimit: 5000,
+		FeatureSet:         fsl.Items[0],
+	}
+
+	u := fmt.Sprintf("admin/organizations/%s/subscription", url.QueryEscape(org.Name))
+	req, err = client.NewRequest("POST", u, &opts)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+		return
+	}
+
+	err = req.Do(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Failed to upgrade subscription: %v", err)
+	}
+}
+
+func createBusinessOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
+    org, orgCleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
+        Name: tfe.String("tst-"+randomString(t)),
+        Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t)))
+    })
+
+    upgradeOrganizationSubscription(t, client, org)
+
+    return org, orgCleanup
+}
+
+func createOrganization(t *testing.T, client *tfe.Client, options tfe.OrganizationCreateOptions) (*tfe.Organization, func()) {
+	ctx := context.Background()
+	org, err := client.Organizations.Create(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return org, func() {
+		if err := client.Organizations.Delete(ctx, org.Name); err != nil {
+			t.Errorf("Error destroying organization! WARNING: Dangling resources\n"+
+				"may exist! The full error is show below:\n\n"+
+				"Organization:%s\nError: %s", org.Name, err)
+		}
 	}
 }
 
@@ -100,6 +191,14 @@ func skipIfUnitTest(t *testing.T) {
 	if !isAcceptanceTest() {
 		t.Skip("Skipping test because this test is an acceptance test, and is run as a unit test. Set 'TF_ACC=1' to run.")
 	}
+}
+
+func randomString(t *testing.T) string {
+    v, err := uuid.GenerateUUID()
+    if err != nil {
+        t.Fatal(err)
+    }
+    return v
 }
 
 type retryableFn func() (interface{}, error)


### PR DESCRIPTION
## Description

Adds a test helper `upgradeOrganizationSubscription()` that attempts to upgrade an organization's feature set if `TFE_HOSTNAME` is not enterprise. The helper will skip the test if it is running against an enterprise instance since all features are available in TFE unless otherwise specified. This PR also removes the `skipIfFree()` test helper for paid feature tests that were previously blocked from running in CI. 
