### PR TITLE
Add additional value to Workspace Task Stage

### DIFF
--- a/tfe/resource_tfe_workspace_run_task.go
+++ b/tfe/resource_tfe_workspace_run_task.go
@@ -21,6 +21,7 @@ func workspaceRunTaskStages() []string {
 	return []string{
 		string(tfe.PrePlan),
 		string(tfe.PostPlan),
+		string(tfe.PreApply),
 	}
 }
 

--- a/website/docs/r/workspace_run_task.html.markdown
+++ b/website/docs/r/workspace_run_task.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `enforcement_level` - (Required) The enforcement level of the task. Valid values are `advisory` and `mandatory`.
 * `task_id` - (Required) The id of the Run task to associate to the Workspace.
 * `workspace_id` - (Required) The id of the workspace to associate the Run task to.
-* `stage` - (Optional) This is currently in BETA. The stage to run the task in. Valid values are `pre-plan` and `post-plan`.
+* `stage` - (Optional) This is currently in BETA. The stage to run the task in. Valid values are `pre-plan`, `post-plan`, and `pre-apply`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This commit updates the go-tfe library to 1.10.0 which is necessary to add
the new task stage (pre-apply).

I did not add a changelog entry as this is too minor a change, and not worth noting.


## Testing plan

N/A

## External links

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/run-tasks/run-tasks#associate-a-run-task-to-a-workspace)
