### PR TITLE
Fix default in tfe_workspace documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 
 BUG FIXES:
 * Bump `terraform-plugin-go` to `v0.6.0`, due to a crash when `tfe_outputs` had null values. ([#611](https://github.com/hashicorp/terraform-provider-tfe/pull/611))
+* r/tfe_workspace: Fix documentation of file_triggers_enabled default. 
 
 ## v0.36.0 (August 16th, 2022)
 

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
   for state storage only. This value _must not_ be provided if `operations`
   is provided.
 * `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files
-  in a VCS push. Defaults to `false`. If enabled, the working directory and
+  in a VCS push. Defaults to `true`. If enabled, the working directory and
   trigger prefixes describe a set of paths which must contain changes for a
   VCS push to trigger a run. If disabled, any push will trigger a run.
 * `global_remote_state` - (Optional) Whether the workspace allows all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (`remote_state_consumer_ids`).


### PR DESCRIPTION
## Description

Current documentation states that the default for file_triggers_enabled is false when the actual default is true 

## External links

[Default value in code](https://github.com/hashicorp/terraform-provider-tfe/blob/0f04f5566d26ffb5a9f4d5e0b37f0dd12b5c277a/tfe/resource_tfe_workspace.go#L110)
