### PR TITLE
Fix panic when applying variable set to workspaces fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 BUG FIXES:
 * Bump `terraform-plugin-go` to `v0.6.0`, due to a crash when `tfe_outputs` had null values. ([#611](https://github.com/hashicorp/terraform-provider-tfe/pull/611))
 * r/tfe_workspace: Fix documentation of file_triggers_enabled default. ([#627](https://github.com/hashicorp/terraform-provider-tfe/pull/627))
+* r/tfe_variable_set: Fix panic when applying variable set to workspaces fails ([#628](https://github.com/hashicorp/terraform-provider-tfe/pull/628))
 
 ## v0.36.0 (August 16th, 2022)
 


### PR DESCRIPTION
## Description

This PR fixes a panic that occurs when setting the `workspace_ids` attribute to `[""]`, thus causing `tfeClient.VariableSets.UpdateWorkspaces()` to return an error. That error message in turn would reference a `nil` variable:

https://github.com/hashicorp/terraform-provider-tfe/blob/2a1b060e828ed33d2ab81f35ab81240284e4331e/tfe/resource_tfe_variable_set.go#L90-L94

See the issue? If that method returns an error, `variableSet.ID` in L93 will cause a panic. 

**Furthermore**, I noticed some weird behavior where the variable set would be created successfully, applying to a workspace would fail, and Terraform would then try to recreate the resource since it thinks it doesn't exist (both operations occur during the creation phase). I updated the provider to write to state when the variable set is created successfully _before_ we apply the variable set to a workspace. What this will do is if applying the variable set fails, Terraform will taint the resource to be recreated instead of attempting to create a new variable set!

## Testing plan

### To Reproduce
1.  Simply `terraform apply` this TF configuration:

```hcl
provider "tfe" {}

resource "tfe_variable_set" "foo" {
  name = "foo"
  organization = "my-org"
  workspace_ids = [""]
}
```
2. To reproduce the odd behavior I mentioned, simply run `terraform apply` again! You will get a bad request error stating the variable set name is already taken. This is because the variable set was already created but Terraform has no record of it (you can view the statefile to double check).

### The Fix
1. Pull these changes, `go install . `, and ensure you have an CLI overrides file pointing `hashicorp/tfe` to your locally built provider. 
2. We'll reuse the configuration above (make sure the original varset is deleted through the UI) and run `TF_CLI_CONFIG_FILE=/path/to/your/overrides.tfrc terraform apply`
3. This time you will get an error: `Insufficient identification for workspace assignment. no workspace id provided`. Perfect! No more panic and we get an error message letting us know we've provided an invalid or empty ID.
4. If you `terraform apply` again, you'll notice Terraform has now tainted the variable set resource. Don't apply the plan just yet!
5. Replace the workspace ID in your config with a valid value and run `terraform apply`. The resource will still be marked for replacement instead of creating a new variable set. Type yes to confirm, and the apply should succeed!

