### PR TITLE
Remove deprecated `workspace_ids` argument from `r/tfe_variable_set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
- * r/tfe_workspace: Changes in `agent_pool_id` and `execution_mode` attributes are now detected and applied. ([#607](https://github.com/hashicorp/terraform-provider-tfe/pull/607))
+
+BREAKING CHANGES:
+* `r/tfe_variable_set`: Removed deprecated argument `workspace_ids` for applying a variable set to workspace, use `r/tfe_workspace_variable_set` instead. ([#629](https://github.com/hashicorp/terraform-provider-tfe/pull/629))
 
 FEATURES:
 * r/tfe_workspace_run_task, d/tfe_workspace_run_task: Add `stage` attribute to workspace run tasks. ([#555](https://github.com/hashicorp/terraform-provider-tfe/pull/555))
@@ -8,6 +10,7 @@ FEATURES:
 BUG FIXES:
 * Bump `terraform-plugin-go` to `v0.6.0`, due to a crash when `tfe_outputs` had null values. ([#611](https://github.com/hashicorp/terraform-provider-tfe/pull/611))
 * r/tfe_workspace: Fix documentation of file_triggers_enabled default. ([#627](https://github.com/hashicorp/terraform-provider-tfe/pull/627))
+* r/tfe_workspace: Changes in `agent_pool_id` and `execution_mode` attributes are now detected and applied. ([#607](https://github.com/hashicorp/terraform-provider-tfe/pull/607))
 
 ## v0.36.0 (August 16th, 2022)
 

--- a/tfe/resource_tfe_variable_set_test.go
+++ b/tfe/resource_tfe_variable_set_test.go
@@ -11,33 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccTFEVariableSet_basic(t *testing.T) {
-	variableSet := &tfe.VariableSet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableSetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEVariableSet_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEVariableSetExists(
-						"tfe_variable_set.foobar", variableSet),
-					testAccCheckTFEVariableSetAttributes(variableSet),
-					resource.TestCheckResourceAttr(
-						"tfe_variable_set.foobar", "name", "variable_set_test"),
-					resource.TestCheckResourceAttr(
-						"tfe_variable_set.foobar", "description", "a test variable set"),
-					resource.TestCheckResourceAttr(
-						"tfe_variable_set.foobar", "global", "false"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccTFEVariableSet_full(t *testing.T) {
 	variableSet := &tfe.VariableSet{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -48,36 +21,6 @@ func TestAccTFEVariableSet_full(t *testing.T) {
 		CheckDestroy: testAccCheckTFEVariableSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEVariableSet_full(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEVariableSetExists(
-						"tfe_variable_set.foobar", variableSet),
-					testAccCheckTFEVariableSetAttributes(variableSet),
-					resource.TestCheckResourceAttr(
-						"tfe_variable_set.foobar", "name", "variable_set_test"),
-					resource.TestCheckResourceAttr(
-						"tfe_variable_set.foobar", "description", "a test variable set"),
-					resource.TestCheckResourceAttr(
-						"tfe_variable_set.foobar", "global", "false"),
-					testAccCheckTFEVariableSetExists(
-						"tfe_variable_set.applied", variableSet),
-					testAccCheckTFEVariableSetApplication(variableSet),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFEVariableSet_update(t *testing.T) {
-	variableSet := &tfe.VariableSet{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableSetDestroy,
-		Steps: []resource.TestStep{
-			{
 				Config: testAccTFEVariableSet_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEVariableSetExists(
@@ -89,10 +32,8 @@ func TestAccTFEVariableSet_update(t *testing.T) {
 						"tfe_variable_set.foobar", "description", "a test variable set"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable_set.foobar", "global", "false"),
-					testAccCheckTFEVariableSetApplicationUpdate(variableSet),
 				),
 			},
-
 			{
 				Config: testAccTFEVariableSet_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -196,26 +137,6 @@ func testAccCheckTFEVariableSetAttributesUpdate(
 	}
 }
 
-func testAccCheckTFEVariableSetApplication(variableSet *tfe.VariableSet) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(variableSet.Workspaces) != 1 {
-			return fmt.Errorf("Bad workspace apply: %v", variableSet.Workspaces)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckTFEVariableSetApplicationUpdate(variableSet *tfe.VariableSet) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(variableSet.Workspaces) != 0 {
-			return fmt.Errorf("Bad workspace apply: %v", variableSet.Workspaces)
-		}
-
-		return nil
-	}
-}
-
 func testAccCheckTFEVariableSetDestroy(s *terraform.State) error {
 	tfeClient := testAccProvider.Meta().(*tfe.Client)
 
@@ -241,67 +162,28 @@ func testAccTFEVariableSet_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name = "tst-terraform-%d"
-	email = "admin@company.com"
+  email = "admin@company.com"
 }
 
 resource "tfe_variable_set" "foobar" {
   name         = "variable_set_test"
-	description  = "a test variable set"
-	global       = false
-	organization = tfe_organization.foobar.id
-}`, rInt)
-}
-
-func testAccTFEVariableSet_full(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name = "tst-terraform-%d"
-	email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name = "foobar"
-	organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable_set" "foobar" {
-  name         = "variable_set_test"
-	description  = "a test variable set"
-	global       = false
-	organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable_set" "applied" {
-  name         = "variable_set_applied"
-	description  = "a test variable set"
-	workspace_ids   = [tfe_workspace.foobar.id]
-	organization = tfe_organization.foobar.id
+  description  = "a test variable set"
+  global       = false
+  organization = tfe_organization.foobar.id
 }`, rInt)
 }
 
 func testAccTFEVariableSet_update(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
+  name = "tst-terraform-%d"
   email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name = "foobar"
-	organization = tfe_organization.foobar.id
 }
 
 resource "tfe_variable_set" "foobar" {
   name         = "variable_set_test_updated"
-	description  = "another description"
-	global       = true
-	organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable_set" "applied" {
-  name         = "variable_set_applied"
-	description  = "a test variable set"
-	workspace_ids   = []
-	organization = tfe_organization.foobar.id
+  description  = "another description"
+  global       = true
+  organization = tfe_organization.foobar.id
 }`, rInt)
 }

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -90,17 +90,14 @@ resource "tfe_variable" "test-b" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the variable set.
+* `organization` - (Required) Name of the organization.
 * `description` - (Optional) Description of the variable set.
 * `global` - (Optional) Whether or not the variable set applies to all workspaces in the organization. Defaults to `false`.
-* `organization` - (Required) Name of the organization.
-* `workspace_ids` - **Deprecated** (Optional) IDs of the workspaces that use the variable set.
-  Must not be set if `global` is set. This argument is mutually exclusive with using the resource
-  [tfe_workspace_variable_set](workspace_variable_set.html) which is the preferred method of associating a workspace
-  with a variable set.
 
 ## Attributes Reference
 
 * `id` - The ID of the variable set.
+* `workspace_ids` - The IDs of the workspaces that use the variable set.
 
 ## Import
 

--- a/website/docs/r/workspace_variable_set.html.markdown
+++ b/website/docs/r/workspace_variable_set.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Adds and removes variable sets from a workspace
 
--> **Note:** `tfe_variable_set` has a deprecated argument `workspace_ids` that should not be used alongside this resource. They attempt to manage the same attachments and are mutually exclusive.
-
 ## Example Usage
 
 Basic usage:


### PR DESCRIPTION
## Description

`workspace_ids` has been marked as a deprecated argument since v0.33.0. This PR omits the fix #628 in favor of fully removing the "apply to a workspace" logic from this resource. The reasoning for removing this attribute as an argument is two-fold:
* Using the `workspace_ids` argument would override any existing workspaces that used this variable set. 
* The logic for creating a variable set was tightly coupled with applying it to a workspace(s) leading to some wonky behavior as noted in #628 . For ease of mind, these two operations should be separate to avoid any weird behavior. You can also read more in #537 

`workspace_ids` will remain as a computed property in the resource. The recommended method to apply a variable set to a workspace remains `r/tfe_workspace_variable_set`.