### PR TITLE
add datasource tfe_organization_members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Unreleased
 
-BUG FIXES:
+FEATURES:
+* d/tfe_organization_members: Add datasource for organization_members that returns a list of active members and members with pending invite in an organization. ([#635](https://github.com/hashicorp/terraform-provider-tfe/pull/635))
 
+BUG FIXES:
 * r/tfe_workspace: When assessments_enabled was the only change in to the resource the workspace was not being updated ([#641](https://github.com/hashicorp/terraform-provider-tfe/pull/641))
 
 ## v0.37.0 (September 28, 2022)

--- a/tfe/data_source_organization_members.go
+++ b/tfe/data_source_organization_members.go
@@ -58,9 +58,8 @@ func dataSourceTFEOrganizationMembersRead(d *schema.ResourceData, meta interface
 	tfeClient := meta.(*tfe.Client)
 
 	organizationName := d.Get("organization").(string)
-	options := tfe.OrganizationMembershipListOptions{Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser}}
 
-	members, membersWaiting, err := fetchOrganizationMembers(tfeClient, organizationName, options)
+	members, membersWaiting, err := fetchOrganizationMembers(tfeClient, organizationName)
 	if err != nil {
 		return err
 	}

--- a/tfe/data_source_organization_members.go
+++ b/tfe/data_source_organization_members.go
@@ -25,7 +25,7 @@ func dataSourceTFEOrganizationMembers() *schema.Resource {
 							Computed: true,
 						},
 
-						"membership_id": {
+						"organization_membership_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -43,7 +43,7 @@ func dataSourceTFEOrganizationMembers() *schema.Resource {
 							Computed: true,
 						},
 
-						"membership_id": {
+						"organization_membership_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -58,7 +58,7 @@ func dataSourceTFEOrganizationMembersRead(d *schema.ResourceData, meta interface
 	tfeClient := meta.(*tfe.Client)
 
 	organizationName := d.Get("organization").(string)
-	options := &tfe.OrganizationMembershipListOptions{Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser}}
+	options := tfe.OrganizationMembershipListOptions{Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser}}
 
 	members, membersWaiting, err := fetchOrganizationMembers(tfeClient, organizationName, options)
 	if err != nil {

--- a/tfe/data_source_organization_members.go
+++ b/tfe/data_source_organization_members.go
@@ -1,0 +1,73 @@
+package tfe
+
+import (
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceTFEOrganizationMembers() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTFEOrganizationMembersRead,
+
+		Schema: map[string]*schema.Schema{
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"members": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"membership_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"members_waiting": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"membership_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceTFEOrganizationMembersRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	organizationName := d.Get("organization").(string)
+	options := &tfe.OrganizationMembershipListOptions{Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser}}
+
+	members, membersWaiting, err := fetchOrganizationMembers(tfeClient, organizationName, options)
+	if err != nil {
+		return err
+	}
+
+	d.Set("members", members)
+	d.Set("members_waiting", membersWaiting)
+	d.SetId(organizationName)
+
+	return nil
+}

--- a/tfe/data_source_organization_members_test.go
+++ b/tfe/data_source_organization_members_test.go
@@ -1,0 +1,62 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFEOrganizationMembersDataSource_basic(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	options := tfe.OrganizationMembershipCreateOptions{
+		Email: tfe.String("invited_user@company.com"),
+	}
+	membership, membershipCleanup := createOrganizationMembership(t, tfeClient, org.Name, options)
+	t.Cleanup(membershipCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEOrganizationMembersDataSourceConfig(org.Name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_members.all_members", "organization", org.Name),
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_members.all_members", "id", org.Name),
+
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_members.all_members", "members.#", "1"),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_organization_members.all_members", "members.0.membership_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_organization_members.all_members", "members.0.user_id"),
+
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_members.all_members", "members_waiting.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_members.all_members", "members_waiting.0.membership_id", membership.ID),
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_members.all_members", "members_waiting.0.user_id", membership.User.ID),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFEOrganizationMembersDataSourceConfig(orgName string) string {
+	return fmt.Sprintf(`
+data "tfe_organization_members" "all_members" {
+  organization = "%s"
+}`, orgName)
+}

--- a/tfe/data_source_organization_members_test.go
+++ b/tfe/data_source_organization_members_test.go
@@ -20,8 +20,7 @@ func TestAccTFEOrganizationMembersDataSource_basic(t *testing.T) {
 	options := tfe.OrganizationMembershipCreateOptions{
 		Email: tfe.String("invited_user@company.com"),
 	}
-	membership, membershipCleanup := createOrganizationMembership(t, tfeClient, org.Name, options)
-	t.Cleanup(membershipCleanup)
+	membership := createOrganizationMembership(t, tfeClient, org.Name, options)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -38,14 +37,14 @@ func TestAccTFEOrganizationMembersDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_organization_members.all_members", "members.#", "1"),
 					resource.TestCheckResourceAttrSet(
-						"data.tfe_organization_members.all_members", "members.0.membership_id"),
+						"data.tfe_organization_members.all_members", "members.0.organization_membership_id"),
 					resource.TestCheckResourceAttrSet(
 						"data.tfe_organization_members.all_members", "members.0.user_id"),
 
 					resource.TestCheckResourceAttr(
 						"data.tfe_organization_members.all_members", "members_waiting.#", "1"),
 					resource.TestCheckResourceAttr(
-						"data.tfe_organization_members.all_members", "members_waiting.0.membership_id", membership.ID),
+						"data.tfe_organization_members.all_members", "members_waiting.0.organization_membership_id", membership.ID),
 					resource.TestCheckResourceAttr(
 						"data.tfe_organization_members.all_members", "members_waiting.0.user_id", membership.User.ID),
 				),

--- a/tfe/organization_members_helpers.go
+++ b/tfe/organization_members_helpers.go
@@ -7,10 +7,11 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 )
 
-func fetchOrganizationMembers(client *tfe.Client, orgName string, options tfe.OrganizationMembershipListOptions) ([]map[string]string, []map[string]string, error) {
+func fetchOrganizationMembers(client *tfe.Client, orgName string) ([]map[string]string, []map[string]string, error) {
 	var members []map[string]string
 	var membersWaiting []map[string]string
 
+	options := tfe.OrganizationMembershipListOptions{}
 	for {
 		organizationMembershipList, err := client.OrganizationMemberships.List(ctx, orgName, &options)
 		if err != nil {

--- a/tfe/organization_members_helpers.go
+++ b/tfe/organization_members_helpers.go
@@ -1,0 +1,41 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+func fetchOrganizationMembers(client *tfe.Client, orgName string, options *tfe.OrganizationMembershipListOptions) ([]map[string]string, []map[string]string, error) {
+	var members []map[string]string
+	var membersWaiting []map[string]string
+
+	for {
+		organizationMembershipList, err := client.OrganizationMemberships.List(ctx, orgName, options)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error retrieving organization members: %w", err)
+		}
+
+		for _, orgMembership := range organizationMembershipList.Items {
+			if orgMembership.Status == tfe.OrganizationMembershipActive {
+				member := map[string]string{"user_id": orgMembership.User.ID, "membership_id": orgMembership.ID}
+				members = append(members, member)
+			} else if orgMembership.Status == tfe.OrganizationMembershipInvited {
+				member := map[string]string{"user_id": orgMembership.User.ID, "membership_id": orgMembership.ID}
+				membersWaiting = append(membersWaiting, member)
+			} else {
+				log.Printf("Organization member with unknown status found: %s", orgMembership.Status)
+			}
+		}
+		// Exit the loop when we've seen all pages.
+		if organizationMembershipList.CurrentPage >= organizationMembershipList.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		options.PageNumber = organizationMembershipList.NextPage
+	}
+
+	return members, membersWaiting, nil
+}

--- a/tfe/organization_members_helpers.go
+++ b/tfe/organization_members_helpers.go
@@ -7,22 +7,22 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 )
 
-func fetchOrganizationMembers(client *tfe.Client, orgName string, options *tfe.OrganizationMembershipListOptions) ([]map[string]string, []map[string]string, error) {
+func fetchOrganizationMembers(client *tfe.Client, orgName string, options tfe.OrganizationMembershipListOptions) ([]map[string]string, []map[string]string, error) {
 	var members []map[string]string
 	var membersWaiting []map[string]string
 
 	for {
-		organizationMembershipList, err := client.OrganizationMemberships.List(ctx, orgName, options)
+		organizationMembershipList, err := client.OrganizationMemberships.List(ctx, orgName, &options)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Error retrieving organization members: %w", err)
 		}
 
 		for _, orgMembership := range organizationMembershipList.Items {
 			if orgMembership.Status == tfe.OrganizationMembershipActive {
-				member := map[string]string{"user_id": orgMembership.User.ID, "membership_id": orgMembership.ID}
+				member := map[string]string{"user_id": orgMembership.User.ID, "organization_membership_id": orgMembership.ID}
 				members = append(members, member)
 			} else if orgMembership.Status == tfe.OrganizationMembershipInvited {
-				member := map[string]string{"user_id": orgMembership.User.ID, "membership_id": orgMembership.ID}
+				member := map[string]string{"user_id": orgMembership.User.ID, "organization_membership_id": orgMembership.ID}
 				membersWaiting = append(membersWaiting, member)
 			} else {
 				log.Printf("Organization member with unknown status found: %s", orgMembership.Status)

--- a/tfe/organization_members_helpers_test.go
+++ b/tfe/organization_members_helpers_test.go
@@ -1,0 +1,125 @@
+package tfe
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	tfe "github.com/hashicorp/go-tfe"
+	tfemocks "github.com/hashicorp/go-tfe/mocks"
+)
+
+func MockOrganizationMemberships(t *testing.T, client *tfe.Client, orgName string, organizationMemberships []*tfe.OrganizationMembership) {
+	ctrl := gomock.NewController(t)
+	mockOrganizationMembershipAPI := tfemocks.NewMockOrganizationMemberships(ctrl)
+	organizationMembershipsList := tfe.OrganizationMembershipList{
+		Items: organizationMemberships,
+		Pagination: &tfe.Pagination{
+			CurrentPage: 1,
+			TotalPages:  1,
+			TotalCount:  len(organizationMemberships),
+		},
+	}
+
+	mockOrganizationMembershipAPI.
+		EXPECT().
+		List(gomock.Any(), orgName, gomock.Any()).
+		Return(&organizationMembershipsList, nil).
+		AnyTimes()
+
+	mockOrganizationMembershipAPI.
+		EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, tfe.ErrInvalidOrg).
+		AnyTimes()
+
+	client.OrganizationMemberships = mockOrganizationMembershipAPI
+}
+
+func TestFetchOrganizationMembers(t *testing.T) {
+	orgName := "hashicorp"
+
+	tests := map[string]struct {
+		members                []*tfe.OrganizationMembership
+		org                    string
+		err                    bool
+		expectedMembers        []map[string]string
+		expectedMembersWaiting []map[string]string
+	}{
+		"with non exisiting organization": {
+			[]*tfe.OrganizationMembership{},
+			"not-an-org",
+			true,
+			nil,
+			nil,
+		},
+		"with no members": {
+			[]*tfe.OrganizationMembership{},
+			orgName,
+			false,
+			nil,
+			nil,
+		},
+		"with both active and invited members": {
+			activeAndInvitedOrganizationMemberships(orgName),
+			orgName,
+			false,
+			[]map[string]string{{"user_id": "user-orgmember-1", "membership_id": "ou-orgmember-1"}},
+			[]map[string]string{{"user_id": "user-orgmember-2", "membership_id": "ou-orgmember-2"}},
+		},
+	}
+
+	client := testTfeClient(t, testClientOptions{defaultOrganization: orgName})
+
+	for name, test := range tests {
+		// Mock the Organization Membership
+		MockOrganizationMemberships(t, client, orgName, test.members)
+		t.Run(name, func(t *testing.T) {
+			receivedMembers, receivedMembersWaiting, err := fetchOrganizationMembers(client, test.org, &tfe.OrganizationMembershipListOptions{Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser}})
+
+			if (err != nil) != test.err {
+				t.Fatalf("expected error is %t, got %v", test.err, err)
+			}
+
+			checkIsEqualMembers(t, receivedMembers, test.expectedMembers)
+			checkIsEqualMembers(t, receivedMembersWaiting, test.expectedMembersWaiting)
+		})
+	}
+}
+
+func checkIsEqualMembers(t *testing.T, receivedMembers []map[string]string, expectedMembers []map[string]string) {
+	if expectedMembers != nil && receivedMembers != nil {
+		if len(expectedMembers) != len(receivedMembers) {
+			t.Fatalf("wrong result\ngot: %#v\nwant: %#v", receivedMembers, expectedMembers)
+		}
+
+		// the test case only have 1 active and invited member
+		if receivedMembers[0]["user_id"] != expectedMembers[0]["user_id"] || receivedMembers[0]["membership_id"] != expectedMembers[0]["membership_id"] {
+			t.Fatalf("wrong result\ngot: %#v\nwant: %#v", receivedMembers[0], expectedMembers[0])
+		}
+	} else if (expectedMembers == nil && receivedMembers != nil) || (expectedMembers != nil && receivedMembers == nil) {
+		t.Fatalf("wrong result\ngot: %#v\nwant: %#v", receivedMembers, expectedMembers)
+	}
+}
+
+func activeAndInvitedOrganizationMemberships(orgName string) []*tfe.OrganizationMembership {
+	return []*tfe.OrganizationMembership{
+		{
+			ID:           "ou-orgmember-1",
+			Status:       tfe.OrganizationMembershipActive,
+			Email:        "org_member_1@hashicorp.com",
+			Organization: &tfe.Organization{Name: orgName},
+			User: &tfe.User{
+				ID: "user-orgmember-1",
+			},
+		},
+		{
+			ID:           "ou-orgmember-2",
+			Status:       tfe.OrganizationMembershipInvited,
+			Email:        "org_member_2@hashicorp.com",
+			Organization: &tfe.Organization{Name: orgName},
+			User: &tfe.User{
+				ID: "user-orgmember-2",
+			},
+		},
+	}
+}

--- a/tfe/organization_members_helpers_test.go
+++ b/tfe/organization_members_helpers_test.go
@@ -74,7 +74,7 @@ func TestFetchOrganizationMembers(t *testing.T) {
 		// Mock the Organization Membership
 		MockOrganizationMemberships(t, client, orgName, test.members)
 		t.Run(name, func(t *testing.T) {
-			receivedMembers, receivedMembersWaiting, err := fetchOrganizationMembers(client, test.org, tfe.OrganizationMembershipListOptions{Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser}})
+			receivedMembers, receivedMembersWaiting, err := fetchOrganizationMembers(client, test.org)
 
 			if (err != nil) != test.err {
 				t.Fatalf("expected error is %t, got %v", test.err, err)

--- a/tfe/organization_members_helpers_test.go
+++ b/tfe/organization_members_helpers_test.go
@@ -63,8 +63,8 @@ func TestFetchOrganizationMembers(t *testing.T) {
 			activeAndInvitedOrganizationMemberships(orgName),
 			orgName,
 			false,
-			[]map[string]string{{"user_id": "user-orgmember-1", "membership_id": "ou-orgmember-1"}},
-			[]map[string]string{{"user_id": "user-orgmember-2", "membership_id": "ou-orgmember-2"}},
+			[]map[string]string{{"user_id": "user-orgmember-1", "organization_membership_id": "ou-orgmember-1"}},
+			[]map[string]string{{"user_id": "user-orgmember-2", "organization_membership_id": "ou-orgmember-2"}},
 		},
 	}
 
@@ -74,7 +74,7 @@ func TestFetchOrganizationMembers(t *testing.T) {
 		// Mock the Organization Membership
 		MockOrganizationMemberships(t, client, orgName, test.members)
 		t.Run(name, func(t *testing.T) {
-			receivedMembers, receivedMembersWaiting, err := fetchOrganizationMembers(client, test.org, &tfe.OrganizationMembershipListOptions{Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser}})
+			receivedMembers, receivedMembersWaiting, err := fetchOrganizationMembers(client, test.org, tfe.OrganizationMembershipListOptions{Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser}})
 
 			if (err != nil) != test.err {
 				t.Fatalf("expected error is %t, got %v", test.err, err)
@@ -93,7 +93,7 @@ func checkIsEqualMembers(t *testing.T, receivedMembers []map[string]string, expe
 		}
 
 		// the test case only have 1 active and invited member
-		if receivedMembers[0]["user_id"] != expectedMembers[0]["user_id"] || receivedMembers[0]["membership_id"] != expectedMembers[0]["membership_id"] {
+		if receivedMembers[0]["user_id"] != expectedMembers[0]["user_id"] || receivedMembers[0]["organization_membership_id"] != expectedMembers[0]["organization_membership_id"] {
 			t.Fatalf("wrong result\ngot: %#v\nwant: %#v", receivedMembers[0], expectedMembers[0])
 		}
 	} else if (expectedMembers == nil && receivedMembers != nil) || (expectedMembers != nil && receivedMembers == nil) {

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -92,6 +92,7 @@ func Provider() *schema.Provider {
 			"tfe_variables":               dataSourceTFEWorkspaceVariables(),
 			"tfe_variable_set":            dataSourceTFEVariableSet(),
 			"tfe_policy_set":              dataSourceTFEPolicySet(),
+			"tfe_organization_members":    dataSourceTFEOrganizationMembers(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -140,20 +140,22 @@ func createOrganization(t *testing.T, client *tfe.Client, options tfe.Organizati
 	}
 }
 
-func createOrganizationMembership(t *testing.T, client *tfe.Client, orgName string, options tfe.OrganizationMembershipCreateOptions) (*tfe.OrganizationMembership, func()) {
+func createOrganizationMembership(t *testing.T, client *tfe.Client, orgName string, options tfe.OrganizationMembershipCreateOptions) *tfe.OrganizationMembership {
 	ctx := context.Background()
 	orgMembership, err := client.OrganizationMemberships.Create(ctx, orgName, options)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return orgMembership, func() {
+	t.Cleanup(func() {
 		if err := client.OrganizationMemberships.Delete(ctx, orgMembership.ID); err != nil {
 			t.Errorf("Error destroying organization membership! WARNING: Dangling resources\n"+
 				"may exist! The full error is show below:\n\n"+
 				"Organization memberships:%s\nError: %s", orgMembership.ID, err)
 		}
-	}
+	})
+
+	return orgMembership
 }
 
 func skipIfCloud(t *testing.T) {

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -140,6 +140,22 @@ func createOrganization(t *testing.T, client *tfe.Client, options tfe.Organizati
 	}
 }
 
+func createOrganizationMembership(t *testing.T, client *tfe.Client, orgName string, options tfe.OrganizationMembershipCreateOptions) (*tfe.OrganizationMembership, func()) {
+	ctx := context.Background()
+	orgMembership, err := client.OrganizationMemberships.Create(ctx, orgName, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return orgMembership, func() {
+		if err := client.OrganizationMemberships.Delete(ctx, orgMembership.ID); err != nil {
+			t.Errorf("Error destroying organization membership! WARNING: Dangling resources\n"+
+				"may exist! The full error is show below:\n\n"+
+				"Organization memberships:%s\nError: %s", orgMembership.ID, err)
+		}
+	}
+}
+
 func skipIfCloud(t *testing.T) {
 	if !enterpriseEnabled() {
 		t.Skip("Skipping test for a feature unavailable in Terraform Cloud. Set 'ENABLE_TFE=1' to run.")

--- a/website/docs/d/organization_members.html.markdown
+++ b/website/docs/d/organization_members.html.markdown
@@ -13,8 +13,13 @@ Use this data source to get information about members of an organization.
 ## Example Usage
 
 ```hcl
+resource "tfe_organization" "bar" {
+   name = "org-bar"
+   email = "user@hashicorp.com"
+}
+
 data "tfe_organization_members" "foo" {
-  organization = "organization-name"
+  organization = tfe_organization.bar.name
 }
 ```
 
@@ -34,4 +39,4 @@ In addition to all arguments above, the following attributes are exported:
 The `member` block contains:
 
 * `user_id` - The ID of the user.
-* `membership_id` - The ID of the membership.
+* `organization_membership_id` - The ID of the organization membership.

--- a/website/docs/d/organization_members.html.markdown
+++ b/website/docs/d/organization_members.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_organization_members"
+sidebar_current: "docs-datasource-tfe-organization-members"
+description: |-
+  Get information on an Organization members.
+---
+
+# Data Source: tfe_organization_members
+
+Use this data source to get information about members of an organization.
+
+## Example Usage
+
+```hcl
+data "tfe_organization_members" "foo" {
+  organization = "organization-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `organization` - (Required) Name of the organization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Name of the organization.
+* `members` - A list of active members of the organization.
+* `members_waiting` - A list of members with pending invite to organization.
+
+The `member` block contains:
+
+* `user_id` - The ID of the user.
+* `membership_id` - The ID of the membership.


### PR DESCRIPTION
## Description

Add datasource `tfe_organization_members` which returns a list of active members and members with pending invite in an organization.

## Testing plan

1.  _Use config with:_
``` 
resource "tfe_organization" "bar" {
   name = "org-bar"
   email = "user@hashicorp.com"
}

data "tfe_organization_members" "foo" {
  organization = tfe_organization.bar.name
}

 ```
1.  _a list of members and members_waiting in the org should be returned_
```
{
  "id" = "my-org"
  "members" = tolist([
    {
      "organization_membership_id" = "ou-id"
      "user_id" = "user-id"
    },
  ])
  "members_waiting" = tolist([
    {
      "organization_membership_id" = "ou-id"
      "user_id" = "user-id"
    }
  ])
  "organization" = "my-org"
}

```

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe#OrganizationMembership)
- [API documentation](https://www.terraform.io/cloud-docs/api-docs/organization-memberships)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```

<img width="1261" alt="Screen Shot 2022-10-05 at 10 35 03 AM" src="https://user-images.githubusercontent.com/22062046/194087720-5a2b7f97-ea22-466b-9444-616a8c0df5bb.png">


