### PR TITLE
io/ioutil is deprecated, removed

### DIFF
--- a/tfe/data_source_outputs_test.go
+++ b/tfe/data_source_outputs_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -140,7 +140,7 @@ func createStateVersion(t *testing.T, client *tfe.Client, rInt int, fileName str
 		t.Fatal(err)
 	}
 
-	state, err := ioutil.ReadFile(fileName)
+	state, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfe/logging.go
+++ b/tfe/logging.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -77,7 +77,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 func hasSensitiveValues(req *http.Request) bool {
 	foundSensitiveVal := false
 	if req.Body != nil {
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		if err != nil {
 			return true // just to be safe, let's assume there could be a sensitive value
 		}
@@ -86,7 +86,7 @@ func hasSensitiveValues(req *http.Request) bool {
 			foundSensitiveVal = true
 		}
 		// after done inspecting the body, place back same data we read
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+		req.Body = io.NopCloser(bytes.NewBuffer(b))
 	}
 	return foundSensitiveVal
 }

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -365,7 +364,7 @@ func readCliConfigFile(configFilePath string) *Config {
 	config := &Config{}
 
 	// Read the CLI config file content.
-	content, err := ioutil.ReadFile(configFilePath)
+	content, err := os.ReadFile(configFilePath)
 	if err != nil {
 		log.Printf("[ERROR] Error reading CLI config or credentials file %s: %v", configFilePath, err)
 		return config

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -2,7 +2,6 @@ package tfe
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"testing"
@@ -519,7 +518,7 @@ func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					err = ioutil.WriteFile(newFile, []byte("main = rule { true }"), 0755)
+					err = os.WriteFile(newFile, []byte("main = rule { true }"), 0755)
 					if err != nil {
 						t.Fatalf("error writing to file %s", newFile)
 					}


### PR DESCRIPTION
## Description

"io/ioutil" has been [deprecated](https://pkg.go.dev/io/ioutil) since Go 1.16.

## Testing plan

1.  See referenced documentation

## External links

N/A

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
