### PR TITLE
Workspace not updated when assessments_enabled is the only change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+BUG FIXES:
+
+* r/tfe_workspace: When assessments_enabled was the only change in to the resource the workspace was not being updated ([#641](https://github.com/hashicorp/terraform-provider-tfe/pull/641))
+
 ## v0.37.0 (September 28, 2022)
 
 FEATURES:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ After creating new schema, it's important to test your changes beyond the automa
 - Are mutually exclusive config arguments constrained by an error?
 - If adding a new argument to an existing resource: is it required? (This would be a breaking change)
 - If adding a new attribute to an existing resource: is new or unexpected API authorization required?
+- Is the new resource argument updated when it is the _only_ change in a plan?
 
 ### Updating the Changelog
 
@@ -125,7 +126,7 @@ $ cd terraform-provider-tfe
 $ go build -gcflags="all=-N -l" -o {where to place the binary}
 ```
 
-example, replace {platform}. 
+example, replace {platform}.
 ```sh
 go build -gcflags="all=-N -l" -o bin/registry.terraform.io/hashicorp/tfe/9.9.9/{platform}/terraform-provider-tfe
 ```
@@ -143,7 +144,7 @@ dlv exec \
 -- -debug
 ```
 
-example 
+example
 ```sh
 dlv exec \
 --accept-multiclient \
@@ -176,7 +177,7 @@ Example taken from [here](https://www.terraform.io/plugin/debugging#visual-studi
 
 ```
 
-You'll know you activated the debugger successfully if you see the following output. 
+You'll know you activated the debugger successfully if you see the following output.
 
 *For vscode, the output will be located in the Debug Console tab.*
 

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -449,7 +449,8 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		d.HasChange("allow_destroy_plan") || d.HasChange("speculative_enabled") ||
 		d.HasChange("operations") || d.HasChange("execution_mode") ||
 		d.HasChange("description") || d.HasChange("agent_pool_id") ||
-		d.HasChange("global_remote_state") || d.HasChange("structured_run_output_enabled") {
+		d.HasChange("global_remote_state") || d.HasChange("structured_run_output_enabled") ||
+		d.HasChange("assessments_enabled") {
 		// Create a new options struct.
 		options := tfe.WorkspaceUpdateOptions{
 			Name:                       tfe.String(d.Get("name").(string)),


### PR DESCRIPTION
## Description

We neglected to add this argument to the list of changes to probe for when updating a workspace. If assessments_enabled is the only change in a workspace, the workspace will not be updated at all.

## Testing plan

Change assessments_enabled on a tfe_workspace resource (and no other argument) and apply the change. It should now be updated.

