### PR TITLE
⬆️ Use go 1.18 when building/testing in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ test_results_dir: &test_results_dir /tmp/test_results
 jobs:
   run-tests:
     docker:
-      - image: docker.mirror.hashicorp.services/cimg/go:1.17.1
+      - image: docker.mirror.hashicorp.services/cimg/go:1.18
         environment:
           TF_ACC_TERRAFORM_VERSION: 1.0.0
           TEST_RESULTS_DIR: *test_results_dir


### PR DESCRIPTION
## Description

Other 3rd party libraries are using 1.18 so let's get our build system also using 1.18.

## Testing plan

1. The circle ci tests should still run.

## External links

N/A

## Output from acceptance tests

N/A