### PR TITLE
Use golangci-lint 1.50.0 (latest)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45
+          version: v1.50.0
           args: "--out-${NO_FUTURE}format colored-line-number"


### PR DESCRIPTION
## Description

I'm seeing these 2 issues with the older version of the linter:
- https://github.com/golangci/golangci-lint/issues/2374
- https://github.com/golangci/golangci-lint/issues/2649

So bumping the version to the latest (1.50.0) to resolve issues with go1.18.

## Testing plan

1. Linting passes

### Feels gif
![](https://media.giphy.com/media/ZcKDWNzkQ9tOsV9LXp/giphy.gif)