### PR TITLE
fix flaky test by adding depends_on meta-arg

### DIFF
--- a/tfe/data_source_variable_set_test.go
+++ b/tfe/data_source_variable_set_test.go
@@ -108,5 +108,6 @@ resource "tfe_variable" "envfoo" {
 data "tfe_variable_set" "foobar" {
   name = tfe_variable_set.foobar.name
 	organization = tfe_variable_set.foobar.organization
+	depends_on = [tfe_variable.envfoo]
 }`, rInt, rInt, rInt)
 }


### PR DESCRIPTION
## Description

This PR adds the [depends_on](https://www.terraform.io/language/meta-arguments/depends_on) meta-argument to ensure `variable_ids` is processed before the resource is read.

## Testing plan

1. Run the test 100 times.

## External links

N/A

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
