### PR TITLE
ResourceImporter.State has deprecated funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## Unreleased
-* `ResourceImporter.State` has deprecated functions and those functions have been replaced. ([#654](https://github.com/hashicorp/terraform-provider-tfe/pull/654))
-
 ## v0.38.0 (October 24, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* `ResourceImporter.State` has deprecated functions and those functions have been replaced. ([#654](https://github.com/hashicorp/terraform-provider-tfe/pull/654))
+
 ## v0.38.0 (October 24, 2022)
 
 FEATURES:

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -16,7 +17,7 @@ func resourceTFEAgentPool() *schema.Resource {
 		Update: resourceTFEAgentPoolUpdate,
 		Delete: resourceTFEAgentPoolDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEAgentPoolImporter,
+			StateContext: resourceTFEAgentPoolImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -111,7 +112,7 @@ func resourceTFEAgentPoolDelete(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceTFEAgentPoolImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEAgentPoolImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	tfeClient := meta.(*tfe.Client)
 
 	s := strings.Split(d.Id(), "/")

--- a/tfe/resource_tfe_notification_configuration.go
+++ b/tfe/resource_tfe_notification_configuration.go
@@ -16,7 +16,7 @@ func resourceTFENotificationConfiguration() *schema.Resource {
 		Update: resourceTFENotificationConfigurationUpdate,
 		Delete: resourceTFENotificationConfigurationDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -17,7 +17,7 @@ func resourceTFEOrganization() *schema.Resource {
 		Update: resourceTFEOrganizationUpdate,
 		Delete: resourceTFEOrganizationDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -14,7 +14,7 @@ func resourceTFEOrganizationMembership() *schema.Resource {
 		Read:   resourceTFEOrganizationMembershipRead,
 		Delete: resourceTFEOrganizationMembershipDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tfe/resource_tfe_organization_run_task.go
+++ b/tfe/resource_tfe_organization_run_task.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -17,7 +18,7 @@ func resourceTFEOrganizationRunTask() *schema.Resource {
 		Delete: resourceTFEOrganizationRunTaskDelete,
 		Update: resourceTFEOrganizationRunTaskUpdate,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEOrganizationRunTaskImporter,
+			StateContext: resourceTFEOrganizationRunTaskImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -171,7 +172,7 @@ func resourceTFEOrganizationRunTaskRead(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceTFEOrganizationRunTaskImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEOrganizationRunTaskImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	tfeClient := meta.(*tfe.Client)
 
 	s := strings.Split(d.Id(), "/")

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -14,7 +15,7 @@ func resourceTFEOrganizationToken() *schema.Resource {
 		Read:   resourceTFEOrganizationTokenRead,
 		Delete: resourceTFEOrganizationTokenDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEOrganizationTokenImporter,
+			StateContext: resourceTFEOrganizationTokenImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -109,7 +110,7 @@ func resourceTFEOrganizationTokenDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceTFEOrganizationTokenImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEOrganizationTokenImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// Set the organization field.
 	d.Set("organization", d.Id())
 

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -17,7 +17,7 @@ func resourceTFEPolicySet() *schema.Resource {
 		Update: resourceTFEPolicySetUpdate,
 		Delete: resourceTFEPolicySetDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tfe/resource_tfe_policy_set_parameter.go
+++ b/tfe/resource_tfe_policy_set_parameter.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -16,7 +17,7 @@ func resourceTFEPolicySetParameter() *schema.Resource {
 		Update: resourceTFEPolicySetParameterUpdate,
 		Delete: resourceTFEPolicySetParameterDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEPolicySetParameterImporter,
+			StateContext: resourceTFEPolicySetParameterImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -156,7 +157,7 @@ func resourceTFEPolicySetParameterDelete(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func resourceTFEPolicySetParameterImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEPolicySetParameterImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 2)
 	if len(s) != 2 {
 		return nil, fmt.Errorf(

--- a/tfe/resource_tfe_registry_module.go
+++ b/tfe/resource_tfe_registry_module.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -18,7 +19,7 @@ func resourceTFERegistryModule() *schema.Resource {
 		Read:   resourceTFERegistryModuleRead,
 		Delete: resourceTFERegistryModuleDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFERegistryModuleImporter,
+			StateContext: resourceTFERegistryModuleImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -254,7 +255,7 @@ func resourceTFERegistryModuleDelete(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceTFERegistryModuleImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFERegistryModuleImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	registryModuleInfo := strings.SplitN(d.Id(), "/", 6)
 	if len(registryModuleInfo) == 4 {
 		// for format: <ORGANIZATION>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>

--- a/tfe/resource_tfe_run_trigger.go
+++ b/tfe/resource_tfe_run_trigger.go
@@ -17,7 +17,7 @@ func resourceTFERunTrigger() *schema.Resource {
 		Read:   resourceTFERunTriggerRead,
 		Delete: resourceTFERunTriggerDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -17,7 +18,7 @@ func resourceTFESentinelPolicy() *schema.Resource {
 		Update: resourceTFESentinelPolicyUpdate,
 		Delete: resourceTFESentinelPolicyDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFESentinelPolicyImporter,
+			StateContext: resourceTFESentinelPolicyImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -187,7 +188,7 @@ func resourceTFESentinelPolicyDelete(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceTFESentinelPolicyImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFESentinelPolicyImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 2)
 	if len(s) != 2 {
 		return nil, fmt.Errorf(

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -18,7 +19,7 @@ func resourceTFETeam() *schema.Resource {
 		Update: resourceTFETeamUpdate,
 		Delete: resourceTFETeamDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFETeamImporter,
+			StateContext: resourceTFETeamImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -243,7 +244,7 @@ func resourceTFETeamDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceTFETeamImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFETeamImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 2)
 	if len(s) != 2 {
 		return nil, fmt.Errorf(

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -18,7 +18,7 @@ func resourceTFETeamAccess() *schema.Resource {
 		Update: resourceTFETeamAccessUpdate,
 		Delete: resourceTFETeamAccessDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFETeamAccessImporter,
+			StateContext: resourceTFETeamAccessImporter,
 		},
 
 		CustomizeDiff: setCustomOrComputedPermissions,
@@ -337,7 +337,7 @@ func resourceTFETeamAccessDelete(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceTFETeamAccessImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFETeamAccessImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	tfeClient := meta.(*tfe.Client)
 
 	s := strings.SplitN(d.Id(), "/", 3)

--- a/tfe/resource_tfe_team_member.go
+++ b/tfe/resource_tfe_team_member.go
@@ -15,7 +15,7 @@ func resourceTFETeamMember() *schema.Resource {
 		Read:   resourceTFETeamMemberRead,
 		Delete: resourceTFETeamMemberDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tfe/resource_tfe_team_members.go
+++ b/tfe/resource_tfe_team_members.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -15,7 +16,7 @@ func resourceTFETeamMembers() *schema.Resource {
 		Update: resourceTFETeamMembersUpdate,
 		Delete: resourceTFETeamMembersDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFETeamMembersImporter,
+			StateContext: resourceTFETeamMembersImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -163,7 +164,7 @@ func resourceTFETeamMembersDelete(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceTFETeamMembersImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFETeamMembersImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// Set the team ID field.
 	d.Set("team_id", d.Id())
 

--- a/tfe/resource_tfe_team_organization_member.go
+++ b/tfe/resource_tfe_team_organization_member.go
@@ -15,7 +15,7 @@ func resourceTFETeamOrganizationMember() *schema.Resource {
 		Read:   resourceTFETeamOrganizationMemberRead,
 		Delete: resourceTFETeamOrganizationMemberDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tfe/resource_tfe_team_token.go
+++ b/tfe/resource_tfe_team_token.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -14,7 +15,7 @@ func resourceTFETeamToken() *schema.Resource {
 		Read:   resourceTFETeamTokenRead,
 		Delete: resourceTFETeamTokenDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFETeamTokenImporter,
+			StateContext: resourceTFETeamTokenImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -107,7 +108,7 @@ func resourceTFETeamTokenDelete(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func resourceTFETeamTokenImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFETeamTokenImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// Set the team ID field.
 	d.Set("team_id", d.Id())
 

--- a/tfe/resource_tfe_terraform_version.go
+++ b/tfe/resource_tfe_terraform_version.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -16,7 +17,7 @@ func resourceTFETerraformVersion() *schema.Resource {
 		Update: resourceTFETerraformVersionUpdate,
 		Delete: resourceTFETerraformVersionDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFETerraformVersionImporter,
+			StateContext: resourceTFETerraformVersionImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -152,7 +153,7 @@ func resourceTFETerraformVersionDelete(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceTFETerraformVersionImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFETerraformVersionImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	tfeClient := meta.(*tfe.Client)
 
 	// Splitting by '-' and checking if the first elem is equal to tool

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -18,7 +18,7 @@ func resourceTFEVariable() *schema.Resource {
 		Update: resourceTFEVariableUpdate,
 		Delete: resourceTFEVariableDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEVariableImporter,
+			StateContext: resourceTFEVariableImporter,
 		},
 
 		SchemaVersion: 1,
@@ -404,7 +404,7 @@ func resourceTFEVariableSetVariableDelete(d *schema.ResourceData, meta interface
 	return nil
 }
 
-func resourceTFEVariableImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEVariableImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	tfeClient := meta.(*tfe.Client)
 
 	s := strings.SplitN(d.Id(), "/", 3)

--- a/tfe/resource_tfe_variable_set.go
+++ b/tfe/resource_tfe_variable_set.go
@@ -18,7 +18,7 @@ func resourceTFEVariableSet() *schema.Resource {
 		Update: resourceTFEVariableSetUpdate,
 		Delete: resourceTFEVariableSetDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -21,7 +21,7 @@ func resourceTFEWorkspace() *schema.Resource {
 		Update: resourceTFEWorkspaceUpdate,
 		Delete: resourceTFEWorkspaceDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEWorkspaceImporter,
+			StateContext: resourceTFEWorkspaceImporter,
 		},
 
 		SchemaVersion: 1,
@@ -741,7 +741,7 @@ func validateRemoteState(_ context.Context, d *schema.ResourceDiff) error {
 	return nil
 }
 
-func resourceTFEWorkspaceImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEWorkspaceImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	tfeClient := meta.(*tfe.Client)
 
 	s := strings.Split(d.Id(), "/")

--- a/tfe/resource_tfe_workspace_policy_set.go
+++ b/tfe/resource_tfe_workspace_policy_set.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -16,7 +17,7 @@ func resourceTFEWorkspacePolicySet() *schema.Resource {
 		Read:   resourceTFEWorkspacePolicySetRead,
 		Delete: resourceTFEWorkspacePolicySetDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEWorkspacePolicySetImporter,
+			StateContext: resourceTFEWorkspacePolicySetImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -112,7 +113,7 @@ func resourceTFEWorkspacePolicySetDelete(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func resourceTFEWorkspacePolicySetImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEWorkspacePolicySetImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// The format of the import ID is <ORGANIZATION/WORKSPACE NAME/POLICYSET NAME>
 	splitID := strings.SplitN(d.Id(), "/", 3)
 	if len(splitID) != 3 {

--- a/tfe/resource_tfe_workspace_run_task.go
+++ b/tfe/resource_tfe_workspace_run_task.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -48,7 +49,7 @@ func resourceTFEWorkspaceRunTask() *schema.Resource {
 		Delete: resourceTFEWorkspaceRunTaskDelete,
 		Update: resourceTFEWorkspaceRunTaskUpdate,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEWorkspaceRunTaskImporter,
+			StateContext: resourceTFEWorkspaceRunTaskImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -202,7 +203,7 @@ func resourceTFEWorkspaceRunTaskRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceTFEWorkspaceRunTaskImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEWorkspaceRunTaskImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	tfeClient := meta.(*tfe.Client)
 
 	s := strings.Split(d.Id(), "/")

--- a/tfe/resource_tfe_workspace_variable_set.go
+++ b/tfe/resource_tfe_workspace_variable_set.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -16,7 +17,7 @@ func resourceTFEWorkspaceVariableSet() *schema.Resource {
 		Read:   resourceTFEWorkspaceVariableSetRead,
 		Delete: resourceTFEWorkspaceVariableSetDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceTFEWorkspaceVariableSetImporter,
+			StateContext: resourceTFEWorkspaceVariableSetImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -116,7 +117,7 @@ func encodeVariableSetWorkspaceAttachment(wID, vSID string) string {
 	return fmt.Sprintf("%s_%s", wID, vSID)
 }
 
-func resourceTFEWorkspaceVariableSetImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTFEWorkspaceVariableSetImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// The format of the import ID is <ORGANIZATION/WORKSPACE NAME/VARSET NAME> but be aware
 	// that variable set names can contain forward slash characters but organization/workspace
 	// names cannot. Therefore, we split the import ID into at most 3 substrings.


### PR DESCRIPTION
## Description

`ResourceImporter.State` has deprecated functions.

## Testing plan

N/A

## External links

See docs on [ImportStatePassthrough](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ImportStatePassthrough)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
