### PR TITLE
docs: mention non-support for `credential_helper`

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -63,6 +63,8 @@ Terraform on your local command line, it can automatically discover the credenti
 the [CLI Configuration File documentation](/docs/commands/cli-config.html).
 If you used the `TF_CLI_CONFIG_FILE` environment variable to specify a
 non-default location for .terraformrc, the provider will also use that location.
+Using a `credentials_helper` block is not supported.
+
 
 ## Versions
 


### PR DESCRIPTION
## Description

Adds documentation that a `credentials_helper` in the user's Terraform configuration is not a supported authentication mechanism. While it's supported by the package used for fetching authn (`terraform-svchost`), only static tokens are implemented currently by this provider.

https://github.com/hashicorp/terraform-svchost/blob/master/auth/helper_program.go

Adding support for credentials helpers is non-trivial. The package handles the protocol for calling these helpers (args) but not things like the directory where helper executables are found. Given the effort involved in implementing this and the fact that it would only work in workspaces in local execution mode, documenting the limitation rather than addressing it seems like the best course.

## External links

* #637 
* https://github.com/bendrucker/terraform-credentials-keychain/issues/38#issuecomment-1277030030