### PR TITLE
[#TF-720] Add allow_force_delete_workspaces organization setting to the tfe provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+FEATURES:
+* r/tfe_organization: Add `allow_force_delete_workspaces` attribute to set whether admins are permitted to delete workspaces with resource under management. ([#661](https://github.com/hashicorp/terraform-provider-tfe/pull/661))
+
 ## v0.38.0 (October 24, 2022)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-slug v0.10.0
-	github.com/hashicorp/go-tfe v1.11.0
+	github.com/hashicorp/go-tfe v1.12.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl/v2 v2.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/hashicorp/go-slug v0.10.0 h1:mh4DDkBJTh9BuEjY/cv8PTo7k9OjT4PcW8PgZnJ4
 github.com/hashicorp/go-slug v0.10.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-tfe v1.11.0 h1:rubJ4Jfqg8luMc8znl4kzZHYcr9sIMZ4SI/m6uXuhZw=
 github.com/hashicorp/go-tfe v1.11.0/go.mod h1:W9x3IWVZD3RWJ0EhsaZZfYBzJrWwdwjJn0HfeDvh6yU=
+github.com/hashicorp/go-tfe v1.12.0 h1:2l7emKW8rNTTbnxYHNVj6b46iJzOEp2G/3xIHfGSDnc=
+github.com/hashicorp/go-tfe v1.12.0/go.mod h1:thYtIxtgBpDDNdf/2yYPdBJ94Fz5yT5XCNZvGtTGHAU=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/tfe/client_mock_workspaces.go
+++ b/tfe/client_mock_workspaces.go
@@ -146,3 +146,11 @@ func (m *mockWorkspaces) AddTags(ctx context.Context, workspaceID string, option
 func (m *mockWorkspaces) RemoveTags(ctx context.Context, workspaceID string, options tfe.WorkspaceRemoveTagsOptions) error {
 	panic("not implemented")
 }
+
+func (m *mockWorkspaces) SafeDelete(ctx context.Context, organization string, workspace string) error {
+	panic("not implemented")
+}
+
+func (m *mockWorkspaces) SafeDeleteByID(ctx context.Context, workspaceID string) error {
+	panic("not implemented")
+}

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -78,6 +78,11 @@ func resourceTFEOrganization() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"allow_force_delete_workspaces": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -131,6 +136,7 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	// TFE (onprem) does not currently have this feature and this value won't be returned in those cases.
 	// org.AssessmentsEnforced will default to false
 	d.Set("assessments_enforced", org.AssessmentsEnforced)
+	d.Set("allow_force_delete_workspaces", org.AllowForceDeleteWorkspaces)
 
 	return nil
 }
@@ -174,9 +180,14 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 		options.SendPassingStatusesForUntriggeredSpeculativePlans = tfe.Bool(sendPassingStatusesForUntriggeredSpeculativePlans.(bool))
 	}
 
-	// If cost_estimation_enabled is supplied, set it using the options struct.
+	// If assessments_enforced is supplied, set it using the options struct.
 	if assessmentsEnforced, ok := d.GetOkExists("assessments_enforced"); ok {
 		options.AssessmentsEnforced = tfe.Bool(assessmentsEnforced.(bool))
+	}
+
+	// If allow_force_delete_workspaces is supplied, set it using the options struct.
+	if allowForceDeleteWorkspaces, ok := d.GetOkExists("allow_force_delete_workspaces"); ok {
+		options.AllowForceDeleteWorkspaces = tfe.Bool(allowForceDeleteWorkspaces.(bool))
 	}
 
 	log.Printf("[DEBUG] Update configuration of organization: %s", d.Id())

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -74,6 +74,8 @@ func TestAccTFEOrganization_full(t *testing.T) {
 						"tfe_organization.foobar", "send_passing_statuses_for_untriggered_speculative_plans", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "assessments_enforced", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "allow_force_delete_workspaces", "false"),
 				),
 			},
 		},
@@ -94,10 +96,12 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 	// First update
 	costEstimationEnabled1 := true
 	assessmentsEnforced1 := true
+	allowForceDeleteWorkspaces1 := true
 
 	// Second update
 	costEstimationEnabled2 := false
 	assessmentsEnforced2 := false
+	allowForceDeleteWorkspaces2 := false
 	updatedName := org.Name + "_foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -106,7 +110,7 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganization_update(org.Name, org.Email, costEstimationEnabled1, assessmentsEnforced1),
+				Config: testAccTFEOrganization_update(org.Name, org.Email, costEstimationEnabled1, assessmentsEnforced1, allowForceDeleteWorkspaces1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
@@ -129,11 +133,13 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 						"tfe_organization.foobar", "send_passing_statuses_for_untriggered_speculative_plans", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "assessments_enforced", strconv.FormatBool(assessmentsEnforced1)),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "allow_force_delete_workspaces", strconv.FormatBool(allowForceDeleteWorkspaces1)),
 				),
 			},
 
 			{
-				Config: testAccTFEOrganization_update(updatedName, org.Email, costEstimationEnabled2, assessmentsEnforced2),
+				Config: testAccTFEOrganization_update(updatedName, org.Email, costEstimationEnabled2, assessmentsEnforced2, allowForceDeleteWorkspaces2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", org),
@@ -154,6 +160,8 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 						"tfe_organization.foobar", "cost_estimation_enabled", strconv.FormatBool(costEstimationEnabled2)),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "assessments_enforced", strconv.FormatBool(assessmentsEnforced2)),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "allow_force_delete_workspaces", strconv.FormatBool(allowForceDeleteWorkspaces2)),
 				),
 			},
 		},
@@ -371,26 +379,28 @@ resource "tfe_organization" "foobar" {
 func testAccTFEOrganization_full(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name                     = "tst-terraform-%d"
-  email                    = "admin@company.com"
-  session_timeout_minutes  = 30
-  session_remember_minutes = 30
-  collaborator_auth_policy = "password"
-  owners_team_saml_role_id = "owners"
-  cost_estimation_enabled  = false
-  assessments_enforced     = false
+  name                     		= "tst-terraform-%d"
+  email                    		= "admin@company.com"
+  session_timeout_minutes  		= 30
+  session_remember_minutes 		= 30
+  collaborator_auth_policy 		= "password"
+  owners_team_saml_role_id 		= "owners"
+  cost_estimation_enabled  		= false
+  assessments_enforced     		= false
+  allow_force_delete_workspaces	= false
 }`, rInt)
 }
 
-func testAccTFEOrganization_update(orgName string, orgEmail string, costEstimationEnabled bool, assessmentsEnforced bool) string {
+func testAccTFEOrganization_update(orgName string, orgEmail string, costEstimationEnabled bool, assessmentsEnforced bool, allowForceDeleteWorkspaces bool) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name                     = "%s"
-  email                    = "%s"
-  session_timeout_minutes  = 3600
-  session_remember_minutes = 3600
-  owners_team_saml_role_id = "owners"
-  cost_estimation_enabled  = %t
-	assessments_enforced     = %t
-}`, orgName, orgEmail, costEstimationEnabled, assessmentsEnforced)
+  name                     		= "%s"
+  email                    		= "%s"
+  session_timeout_minutes  		= 3600
+  session_remember_minutes 		= 3600
+  owners_team_saml_role_id 		= "owners"
+  cost_estimation_enabled  		= %t
+  assessments_enforced     		= %t
+  allow_force_delete_workspaces = %t
+}`, orgName, orgEmail, costEstimationEnabled, assessmentsEnforced, allowForceDeleteWorkspaces)
 }

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -379,28 +379,28 @@ resource "tfe_organization" "foobar" {
 func testAccTFEOrganization_full(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name                     		= "tst-terraform-%d"
-  email                    		= "admin@company.com"
-  session_timeout_minutes  		= 30
-  session_remember_minutes 		= 30
-  collaborator_auth_policy 		= "password"
-  owners_team_saml_role_id 		= "owners"
-  cost_estimation_enabled  		= false
-  assessments_enforced     		= false
-  allow_force_delete_workspaces	= false
+  name                              = "tst-terraform-%d"
+  email                             = "admin@company.com"
+  session_timeout_minutes           = 30
+  session_remember_minutes          = 30
+  collaborator_auth_policy          = "password"
+  owners_team_saml_role_id          = "owners"
+  cost_estimation_enabled           = false
+  assessments_enforced              = false
+  allow_force_delete_workspaces     = false
 }`, rInt)
 }
 
 func testAccTFEOrganization_update(orgName string, orgEmail string, costEstimationEnabled bool, assessmentsEnforced bool, allowForceDeleteWorkspaces bool) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name                     		= "%s"
-  email                    		= "%s"
-  session_timeout_minutes  		= 3600
-  session_remember_minutes 		= 3600
-  owners_team_saml_role_id 		= "owners"
-  cost_estimation_enabled  		= %t
-  assessments_enforced     		= %t
-  allow_force_delete_workspaces = %t
+  name                              = "%s"
+  email                             = "%s"
+  session_timeout_minutes           = 3600
+  session_remember_minutes          = 3600
+  owners_team_saml_role_id          = "owners"
+  cost_estimation_enabled           = %t
+  assessments_enforced              = %t
+  allow_force_delete_workspaces     = %t
 }`, orgName, orgEmail, costEstimationEnabled, assessmentsEnforced, allowForceDeleteWorkspaces)
 }

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `send_passing_statuses_for_untriggered_speculative_plans` - (Optional) Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.
 * `assessments_enforced` - (Optional) (Available only in Terraform Cloud) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
+* `allow_force_delete_workspaces` - (Optional) Whether workspace administrators are permitted to delete workspaces with resources under management. If false, only organization owners may delete these workspaces. Defaults to false
 
 ## Attributes Reference
 

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 * `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a Terraform Cloud organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `send_passing_statuses_for_untriggered_speculative_plans` - (Optional) Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.
 * `assessments_enforced` - (Optional) (Available only in Terraform Cloud) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
-* `allow_force_delete_workspaces` - (Optional) Whether workspace administrators are permitted to delete workspaces with resources under management. If false, only organization owners may delete these workspaces. Defaults to false
+* `allow_force_delete_workspaces` - (Optional) Whether workspace administrators are permitted to delete workspaces with resources under management. If false, only organization owners may delete these workspaces. Defaults to false.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This change adds the `allow_force_delete_workspaces` setting to the TFE provider.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Related PR](https://github.com/hashicorp/atlas/pull/13244)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
/opt/homebrew/Cellar/go/1.19.2/libexec/bin/go tool test2json -t /private/var/folders/2z/33zp571x44v_ndv_hk8cyy1w0000gp/T/GoLand/___1TestAccTFEOrganization_basic_in_github_com_hashicorp_terraform_provider_tfe_tfe.test -test.v -test.paniconexit0 -test.run ^\QTestAccTFEOrganization_basic\E$
=== RUN   TestAccTFEOrganization_basic
--- PASS: TestAccTFEOrganization_basic (8.08s)
PASS

Process finished with the exit code 0



/opt/homebrew/Cellar/go/1.19.2/libexec/bin/go tool test2json -t /private/var/folders/2z/33zp571x44v_ndv_hk8cyy1w0000gp/T/GoLand/___1TestAccTFEOrganization_full_in_github_com_hashicorp_terraform_provider_tfe_tfe.test -test.v -test.paniconexit0 -test.run ^\QTestAccTFEOrganization_full\E$
=== RUN   TestAccTFEOrganization_full
--- PASS: TestAccTFEOrganization_full (7.31s)
PASS

Process finished with the exit code 0

```
