### PR TITLE
Fixing markdown syntax to fix ADO identifier example

### DIFF
--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -118,7 +118,7 @@ The `vcs_repo` block supports:
 
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization and repository
-  in your VCS provider. The format for Azure DevOps is <organization>/<project>/_git/<repository>.
+  in your VCS provider. The format for Azure DevOps is `<organization>/<project>/_git/<repository>`.
 * `branch` - (Optional) The repository branch that Terraform will execute from.
   This defaults to the repository's default branch (e.g. main).
 * `ingress_submodules` - (Optional) Whether submodules should be fetched when


### PR DESCRIPTION
## Description

Fixing markdown syntax to fix ADO `identifier` example

![Screen Shot 2022-10-17 at 4 33 29 PM](https://user-images.githubusercontent.com/10444994/196288650-9b86b374-adee-481a-96b3-11ac53c094e6.png)
