### PR TITLE
Update tflocal module to v0.8, remove token/password vars

### DIFF
--- a/tflocal/main.tf
+++ b/tflocal/main.tf
@@ -1,9 +1,7 @@
 module "tflocal" {
   source                       = "app.terraform.io/hashicorp-v2/tflocal-cloud/aws"
-  version                      = "0.3.0"
+  version                      = "0.8.0"
   tflocal_cloud                = "true"
-  tflocal_cloud_admin_password = var.tflocal_cloud_admin_password
-  tflocal_cloud_admin_token    = var.tflocal_cloud_admin_token
   git_branch                   = var.git_branch
   tfe_ref                      = var.tfe_ref
   ngrok_domain                 = var.ngrok_domain

--- a/tflocal/variables.tf
+++ b/tflocal/variables.tf
@@ -2,17 +2,6 @@ variable "aws_region" {
   type = string
 }
 
-variable "tflocal_cloud_admin_password" {
-  description = "The password for logging into this tfe:local's TFC instance; stored in 1Password under Engineering Service's 'TFLOCAL_CLOUD tfe instance login and ngrok'"
-  type        = string
-}
-
-variable "tflocal_cloud_admin_token" {
-  description = "The token for accessing this instance's API as admin"
-  type        = string
-  sensitive   = true
-}
-
 variable "env" {
   description = "Environment variables that will be present during startup. These may be propagated into services through the Docker Compose definitions"
   type        = map(string)


### PR DESCRIPTION
## Description

PR says it all, the latest version of tflocal-cloud is v0.8. I've also removed the token/password variables to let the module seed these values. 