### PR TITLE
Remove Run Task beta notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ FEATURES:
 * d/tfe_organization_membership: Add new argument `username` to enable fetching an organization membership by username. ([#660](https://github.com/hashicorp/terraform-provider-tfe/pull/660))
 * r/tfe_organization_membership: Add new computed attribute `username`. ([#660](https://github.com/hashicorp/terraform-provider-tfe/pull/660))
 * r/tfe_team_organization_members: Add resource for managing team members via organization membership IDs ([#617](https://github.com/hashicorp/terraform-provider-tfe/pull/617))
+* d/tfe_oauth_client: Adds `name`, `service_provider`, `service_provider_display_name`, `organization`, `callback_url`, and `created_at` fields, and enables searching for an OAuth client with `organization`, `name`, and `service_provider`. ([#599](https://github.com/hashicorp/terraform-provider-tfe/pull/599))
+* r/tfe_workspace_run_task: Removed beta notices on the `stage` attribute for workspace run tasks. ([#669](https://github.com/hashicorp/terraform-provider-tfe/pull/669))
 
 BUG FIXES:
 * r/tfe_workspace: When assessments_enabled was the only change in to the resource the workspace was not being updated ([#641](https://github.com/hashicorp/terraform-provider-tfe/pull/641))

--- a/tfe/resource_tfe_workspace_run_task.go
+++ b/tfe/resource_tfe_workspace_run_task.go
@@ -83,7 +83,7 @@ func resourceTFEWorkspaceRunTask() *schema.Resource {
 			},
 
 			"stage": {
-				Description: fmt.Sprintf("This is currently in BETA. The stage to run the task in. Valid values are %s.", sentenceList(
+				Description: fmt.Sprintf("The stage to run the task in. Valid values are %s.", sentenceList(
 					workspaceRunTaskStages(),
 					"`",
 					"`",

--- a/website/docs/r/terraform_version.html.markdown
+++ b/website/docs/r/terraform_version.html.markdown
@@ -44,11 +44,11 @@ The following arguments are supported:
 Terraform versions can be imported; use `<TERRAFORM VERSION ID>` or `<TERRAFORM VERSION NUMBER>` as the import ID. For example:
 
 ```shell
-terraform import tfe_terraform_version.test tool-L4oe7rNwn7J4E5Yr 
+terraform import tfe_terraform_version.test tool-L4oe7rNwn7J4E5Yr
 ```
 
 ```shell
-terraform import tfe_terraform_version.test 1.1.2 
+terraform import tfe_terraform_version.test 1.1.2
 ```
 
--> **Note:** You can fetch a Terraform version ID from the URL of an exisiting version in the Terraform Cloud UI. The ID is in the format `tool-<RANDOM STRING>` 
+-> **Note:** You can fetch a Terraform version ID from the URL of an existing version in the Terraform Cloud UI. The ID is in the format `tool-<RANDOM STRING>`

--- a/website/docs/r/workspace_run_task.html.markdown
+++ b/website/docs/r/workspace_run_task.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `enforcement_level` - (Required) The enforcement level of the task. Valid values are `advisory` and `mandatory`.
 * `task_id` - (Required) The id of the Run task to associate to the Workspace.
 * `workspace_id` - (Required) The id of the workspace to associate the Run task to.
-* `stage` - (Optional) This is currently in BETA. The stage to run the task in. Valid values are `pre-plan`, `post-plan`, and `pre-apply`.
+* `stage` - (Optional) The stage to run the task in. Valid values are `pre-plan`, `post-plan`, and `pre-apply`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Pre-plan and Pre-Apply Run Tasks are now generally available. This commit removes the beta notices. Note that the tests cannot be modified yet as the integration environment has been updated.

## Testing plan

Not applicable
