### PR TITLE
[#TF-722] Allow safe and force delete through the tfe provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 * r/tfe_organization: Add `allow_force_delete_workspaces` attribute to set whether admins are permitted to delete workspaces with resource under management. ([#661](https://github.com/hashicorp/terraform-provider-tfe/pull/661))
+* r/tfe_workspace: Add `force_delete` attribute to set whether workspaces will be force deleted when removed through the provider. Otherwise, they will be safe deleted. ([#675](https://github.com/hashicorp/terraform-provider-tfe/pull/675))
 
 ## v0.38.0 (October 24, 2022)
 

--- a/tfe/client_mock_workspaces.go
+++ b/tfe/client_mock_workspaces.go
@@ -73,7 +73,7 @@ func (m *mockWorkspaces) ReadByID(ctx context.Context, workspaceID string) (*tfe
 			return workspace, nil
 		}
 	}
-	return nil, fmt.Errorf("no workspace found with id %s", workspaceID)
+	return nil, tfe.ErrResourceNotFound
 }
 
 func (m *mockWorkspaces) Update(ctx context.Context, organization, workspace string, options tfe.WorkspaceUpdateOptions) (*tfe.Workspace, error) {

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -688,14 +688,26 @@ func resourceTFEWorkspaceDelete(d *schema.ResourceData, meta interface{}) error 
 
 	forceDelete := d.Get("force_delete").(bool)
 
-	if ws.Permissions.CanForceDelete == nil && !forceDelete {
-		return fmt.Errorf(
-			"Error deleting workspace %s: This workspace must be force deleted by setting force_delete=true", id)
-	}
-
-	if forceDelete {
-		err = tfeClient.Workspaces.DeleteByID(ctx, id)
+	// presence of Permissions.CanForceDelete will determine if current version of TFE supports safe deletes
+	if ws.Permissions.CanForceDelete == nil {
+		if forceDelete {
+			err = tfeClient.Workspaces.DeleteByID(ctx, id)
+		} else {
+			return fmt.Errorf(
+				"Error deleting workspace %s: This workspace must be force deleted by setting force_delete=true", id)
+		}
+	} else if *ws.Permissions.CanForceDelete {
+		if forceDelete {
+			err = tfeClient.Workspaces.DeleteByID(ctx, id)
+		} else {
+			err = tfeClient.Workspaces.SafeDeleteByID(ctx, id)
+			return errWorkspaceSafeDeleteWithPermission(id, err)
+		}
 	} else {
+		if forceDelete {
+			return fmt.Errorf(
+				"Error deleting workspace %s: missing required permissions to set force delete workspaces in the organization.", id)
+		}
 		err = tfeClient.Workspaces.SafeDeleteByID(ctx, id)
 	}
 
@@ -706,7 +718,6 @@ func resourceTFEWorkspaceDelete(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf(
 			"Error deleting workspace %s: %w", id, err)
 	}
-
 	return nil
 }
 
@@ -793,4 +804,13 @@ func resourceTFEWorkspaceImporter(ctx context.Context, d *schema.ResourceData, m
 // Warns the user that a workspace tag containing uppercase characters will be downcased.
 func warnWorkspaceTagsCasing(ctx context.Context, tag string) {
 	log.Printf("[WARN] The tag \"%s\" contains uppercase characters that will be transformed by the API. Please update your configuration to lowercase tags in order to avoid conflicts with state.", tag)
+}
+
+func errWorkspaceSafeDeleteWithPermission(workspaceID string, err error) error {
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "conflict") {
+			return fmt.Errorf("Error deleting workspace %s: %w\nTo delete this workspace without destroying the managed resources, add force_delete = true to the resource config.", workspaceID, err)
+		}
+	}
+	return nil
 }

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -1907,7 +1907,7 @@ func TestTFEWorkspace_delete_withoutCanForceDeletePermission(t *testing.T) {
 	// workspace resource delete function directly, rather than use the usual resource.
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("test-orgnaization-%d", rInt)
+	orgName := fmt.Sprintf("test-organization-%d", rInt)
 
 	client := testTfeClient(t, testClientOptions{defaultOrganization: orgName})
 	workspace, err := client.Workspaces.Create(ctx, orgName, tfe.WorkspaceCreateOptions{
@@ -1926,9 +1926,8 @@ func TestTFEWorkspace_delete_withoutCanForceDeletePermission(t *testing.T) {
 	}
 
 	err = resourceTFEWorkspaceDelete(rd, client)
-
 	if err == nil {
-		t.Fatalf("Expected an error deleting workspace with CanForceDelete=nil and force_delete=true")
+		t.Fatalf("Expected an error deleting workspace with CanForceDelete=nil and force_delete=false")
 	}
 	expectedErrSubstring := "workspace must be force deleted by setting force_delete=true"
 	if !strings.Contains(err.Error(), expectedErrSubstring) {

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -113,6 +113,7 @@ The following arguments are supported:
 * `vcs_repo` - (Optional) Settings for the workspace's VCS repository, enabling the [UI/VCS-driven run workflow](https://www.terraform.io/docs/cloud/run/ui.html).
   Omit this argument to utilize the [CLI-driven](https://www.terraform.io/docs/cloud/run/cli.html) and [API-driven](https://www.terraform.io/docs/cloud/run/api.html)
   workflows, where runs are not driven by webhooks on your VCS provider.
+* `force_delete` - (Optional) If this attribute is present on a workspace that is being deleted through the provider, it will use the existing force delete API. If this attribute is not present or false it will safe delete the workspace.
 
 The `vcs_repo` block supports:
 


### PR DESCRIPTION
## Description

Adds the `force_delete` attribute to a workspace provider resource. 

## External links

- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/661)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
/opt/homebrew/Cellar/go/1.19.2/libexec/bin/go tool test2json -t /private/var/folders/2z/33zp571x44v_ndv_hk8cyy1w0000gp/T/GoLand/___TestTFEWorkspace_delete_withoutCanForceDeletePermission_in_github_com_hashicorp_terraform_provider_tfe_tfe.test -test.v -test.paniconexit0 -test.run ^\QTestTFEWorkspace_delete_withoutCanForceDeletePermission\E$
=== RUN   TestTFEWorkspace_delete_withoutCanForceDeletePermission
2022/11/08 09:43:52 [DEBUG] Delete workspace ws-testing
2022/11/08 09:43:52 [DEBUG] Delete workspace ws-testing
--- PASS: TestTFEWorkspace_delete_withoutCanForceDeletePermission (0.37s)
PASS

Process finished with the exit code 0

...


```
