### PR TITLE
Add OPA support to the provider

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,7 +27,7 @@ To run all tests, you will need to set the following environment variables:
 
 ##### Required:
 A hostname and token must be provided in order to run the acceptance tests. By
-default, these are loaded from the the `credentials` in the [CLI config
+default, these are loaded from the `credentials` in the [CLI config
 file](https://www.terraform.io/docs/commands/cli-config.html). You can override
 these values with the environment variables specified below:
 

--- a/go.mod
+++ b/go.mod
@@ -66,3 +66,5 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 )
+
+replace github.com/hashicorp/go-tfe => ../go-tfe

--- a/go.mod
+++ b/go.mod
@@ -67,4 +67,5 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 )
 
+// TODO DEBUG ONLY. REMOVE ME
 replace github.com/hashicorp/go-tfe => ../go-tfe

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -105,6 +105,7 @@ func Provider() *schema.Provider {
 			"tfe_organization_module_sharing": resourceTFEOrganizationModuleSharing(),
 			"tfe_organization_run_task":       resourceTFEOrganizationRunTask(),
 			"tfe_organization_token":          resourceTFEOrganizationToken(),
+			"tfe_policy":                      resourceTFEPolicy(),
 			"tfe_policy_set":                  resourceTFEPolicySet(),
 			"tfe_policy_set_parameter":        resourceTFEPolicySetParameter(),
 			"tfe_registry_module":             resourceTFERegistryModule(),

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -46,6 +46,17 @@ func resourceTFEPolicySet() *schema.Resource {
 				ConflictsWith: []string{"workspace_ids"},
 			},
 
+			"kind": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "sentinel",
+			},
+
+			"overridable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"policies_path": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -121,6 +132,13 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 		Name:   tfe.String(name),
 		Global: tfe.Bool(d.Get("global").(bool)),
 	}
+	if vKind, ok := d.GetOk("kind"); ok {
+		options.Kind = tfe.PolicyKind(vKind.(string))
+	}
+
+	if vOverridable, ok := d.GetOk("overridable"); ok {
+		options.Overridable = tfe.Bool(vOverridable.(bool))
+	}
 
 	// Process all configured options.
 	if desc, ok := d.GetOk("description"); ok {
@@ -193,10 +211,15 @@ func resourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", policySet.Name)
 	d.Set("description", policySet.Description)
 	d.Set("global", policySet.Global)
+	d.Set("kind", policySet.Kind)
 	d.Set("policies_path", policySet.PoliciesPath)
 
 	if policySet.Organization != nil {
 		d.Set("organization", policySet.Organization.Name)
+	}
+
+	if policySet.Overridable != nil {
+		d.Set("overridable", policySet.Overridable)
 	}
 
 	// Set VCS policy set options.

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -49,12 +49,18 @@ func resourceTFEPolicySet() *schema.Resource {
 			"kind": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "sentinel",
+				Default:  string(tfe.Sentinel),
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(tfe.OPA),
+						string(tfe.Sentinel),
+					}, false),
 			},
 
 			"overridable": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  false,
 			},
 
 			"policies_path": {

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -38,8 +38,6 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 						"tfe_policy_set.foobar", "description", "Policy Set"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
 				),
 			},
 		},
@@ -75,8 +73,6 @@ func TestAccTFEPolicySetOPA_basic(t *testing.T) {
 						"tfe_policy_set.foobar", "description", "Policy Set"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "global", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "policy_ids.#", "1"),
 				),
 			},
 		},
@@ -858,20 +854,12 @@ resource "tfe_policy_set" "foobar" {
 
 func testAccTFEPolicySetOPA_basic(organization string) string {
 	return fmt.Sprintf(`
-resource "tfe_sentinel_policy" "foo" {
-  name         = "policy-foo"
-  policy       = "package example rule["not allowed"] { false }"
-  organization = "%s"
-  kind         = "opa"
-}
-
 resource "tfe_policy_set" "foobar" {
   name         = "tst-terraform"
   description  = "Policy Set"
   organization = "%s"
   kind         = "opa"
-  policy_ids   = [tfe_sentinel_policy.foo.id]
-}`, organization, organization)
+}`, organization)
 }
 
 func testAccTFEPolicySet_empty(organization string) string {

--- a/tfe/resource_tfe_policy_test.go
+++ b/tfe/resource_tfe_policy_test.go
@@ -1,0 +1,389 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccTFEPolicy_basic(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	policy := &tfe.Policy{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicy_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEPolicyAttributes(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "sentinel"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "main = rule { true }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "hard-mandatory"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicyOPA_basic(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	policy := &tfe.Policy{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicyOPA_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEOPAPolicyAttributes(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "opa"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "package example rule[\"not allowed\"] { false }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "query", "data.example.rule"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "mandatory"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicy_update(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	policy := &tfe.Policy{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicy_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEPolicyAttributes(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "sentinel"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "main = rule { true }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "hard-mandatory"),
+				),
+			},
+
+			{
+				Config: testAccTFEPolicy_update(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEPolicyAttributesUpdated(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "An updated test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "main = rule { false }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "soft-mandatory"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicyOPA_update(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	policy := &tfe.Policy{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicyOPA_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEOPAPolicyAttributes(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "opa"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "package example rule[\"not allowed\"] { false }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "query", "data.example.rule"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "mandatory"),
+				),
+			},
+
+			{
+				Config: testAccTFEPolicyOPA_update(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEOPAPolicyAttributesUpdated(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "An updated test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "package example rule[\"not allowed\"] { true }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "query", "data.example.rule"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "advisory"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicy_import(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicy_basic(org.Name),
+			},
+
+			{
+				ResourceName:        "tfe_policy.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", org.Name),
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func testAccCheckTFEPolicyExists(
+	n string, policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		p, err := tfeClient.Policies.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if p.ID != rs.Primary.ID {
+			return fmt.Errorf("Policy not found")
+		}
+
+		*policy = *p
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicyAttributes(
+	policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policy.Name != "policy-test" {
+			return fmt.Errorf("Bad name: %s", policy.Name)
+		}
+
+		if policy.Enforce[0].Mode != "hard-mandatory" {
+			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEOPAPolicyAttributes(
+	policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policy.Name != "policy-test" {
+			return fmt.Errorf("Bad name: %s", policy.Name)
+		}
+
+		if policy.Enforce[0].Mode != "mandatory" {
+			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicyAttributesUpdated(
+	policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policy.Name != "policy-test" {
+			return fmt.Errorf("Bad name: %s", policy.Name)
+		}
+
+		if policy.Enforce[0].Mode != "soft-mandatory" {
+			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEOPAPolicyAttributesUpdated(
+	policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policy.Name != "policy-test" {
+			return fmt.Errorf("Bad name: %s", policy.Name)
+		}
+
+		if policy.Enforce[0].Mode != "advisory" {
+			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicyDestroy(s *terraform.State) error {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_policy" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := tfeClient.Policies.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf(" policy %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccTFEPolicy_basic(organization string) string {
+	return fmt.Sprintf(`
+
+resource "tfe_policy" "foobar" {
+  name         = "policy-test"
+  description  = "A test policy"
+  organization = "%s"
+  policy       = "main = rule { true }"
+  enforce_mode = "hard-mandatory"
+}`, organization)
+}
+
+func testAccTFEPolicyOPA_basic(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_policy" "foobar" {
+  name         = "policy-test"
+  description  = "A test policy"
+  organization = "%s"
+  kind         = "opa"
+  policy       = "package example rule[\"not allowed\"] { false }"
+  query        = "data.example.rule"
+  enforce_mode = "mandatory"
+}`, organization)
+}
+
+func testAccTFEPolicy_update(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_policy" "foobar" {
+  name         = "policy-test"
+  description  = "An updated test policy"
+  organization = "%s"
+  policy       = "main = rule { false }"
+  enforce_mode = "soft-mandatory"
+}`, organization)
+}
+
+func testAccTFEPolicyOPA_update(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_policy" "foobar" {
+  name         = "policy-test"
+  description  = "An updated test policy"
+  organization = "%s"
+  kind         = "opa"
+  policy       = "package example rule[\"not allowed\"] { true }"
+  query        = "data.example.rule"
+  enforce_mode = "advisory"
+}`, organization)
+}


### PR DESCRIPTION
## Description

Spike to add OPA support to the tfe provider. 

## Testing plan

Acceptance tests added

## External links

- [go-tfe documentation]()
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/policies)

## Output from acceptance tests

