### PR TITLE
Add OPA support to the provider for Policies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-slug v0.10.0
-	github.com/hashicorp/go-tfe v1.12.0
+	github.com/hashicorp/go-tfe v1.13.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl/v2 v2.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-slug v0.10.0 h1:mh4DDkBJTh9BuEjY/cv8PTo7k9OjT4PcW8PgZnJ4jTY=
 github.com/hashicorp/go-slug v0.10.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
-github.com/hashicorp/go-tfe v1.12.0 h1:2l7emKW8rNTTbnxYHNVj6b46iJzOEp2G/3xIHfGSDnc=
-github.com/hashicorp/go-tfe v1.12.0/go.mod h1:thYtIxtgBpDDNdf/2yYPdBJ94Fz5yT5XCNZvGtTGHAU=
+github.com/hashicorp/go-tfe v1.13.0 h1:Z8pJrmN9BV5EncnFRmQmLjhP7pHMNXkC2VkCQXWxKjM=
+github.com/hashicorp/go-tfe v1.13.0/go.mod h1:thYtIxtgBpDDNdf/2yYPdBJ94Fz5yT5XCNZvGtTGHAU=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -105,6 +105,7 @@ func Provider() *schema.Provider {
 			"tfe_organization_module_sharing": resourceTFEOrganizationModuleSharing(),
 			"tfe_organization_run_task":       resourceTFEOrganizationRunTask(),
 			"tfe_organization_token":          resourceTFEOrganizationToken(),
+			"tfe_policy":                      resourceTFEPolicy(),
 			"tfe_policy_set":                  resourceTFEPolicySet(),
 			"tfe_policy_set_parameter":        resourceTFEPolicySetParameter(),
 			"tfe_registry_module":             resourceTFERegistryModule(),

--- a/tfe/resource_tfe_policy.go
+++ b/tfe/resource_tfe_policy.go
@@ -1,0 +1,272 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceTFEPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTFEPolicyCreate,
+		Read:   resourceTFEPolicyRead,
+		Update: resourceTFEPolicyUpdate,
+		Delete: resourceTFEPolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceTFEPolicyImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"kind": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(tfe.Sentinel),
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(tfe.OPA),
+						string(tfe.Sentinel),
+					}, false),
+			},
+
+			"query": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"policy": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"enforce_mode": {
+				Type: schema.TypeString,
+				Description: fmt.Sprintf(
+					"The enforce_mode of the policy. For Sentinel, valid values are `%s`, `%s`, and `%s`. For OPA, Valid values are `%s`and `%s`",
+					tfe.EnforcementHard, tfe.EnforcementSoft, tfe.EnforcementAdvisory,
+					tfe.EnforcementMandatory, tfe.EnforcementAdvisory),
+				Optional: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(tfe.EnforcementAdvisory),
+						string(tfe.EnforcementHard),
+						string(tfe.EnforcementSoft),
+						string(tfe.EnforcementMandatory),
+					},
+					false,
+				),
+			},
+		},
+	}
+}
+
+func resourceTFEPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// Get the name and organization.
+	name := d.Get("name").(string)
+	organization := d.Get("organization").(string)
+
+	var kind string
+	if vKind, ok := d.GetOk("kind"); ok {
+		kind = vKind.(string)
+	}
+
+	// Setup common policy options
+	options := &tfe.PolicyCreateOptions{
+		Name: tfe.String(name),
+		Kind: tfe.PolicyKind(kind),
+	}
+
+	if desc, ok := d.GetOk("description"); ok {
+		options.Description = tfe.String(desc.(string))
+	}
+
+	//  Setup per-kind policy options
+	switch tfe.PolicyKind(kind) {
+	case tfe.Sentinel:
+		options = createSentinelPolicyOptions(options, d, meta)
+	case tfe.OPA:
+		options = createOPAPolicyOptions(options, d, meta)
+	default:
+		return fmt.Errorf(
+			"Unsupported policy kind %s: has to be one of [%s, %s]", kind, string(tfe.Sentinel), string(tfe.OPA))
+	}
+
+	log.Printf("[DEBUG] Create %s policy %s for organization: %s", kind, name, organization)
+	policy, err := tfeClient.Policies.Create(ctx, organization, *options)
+	if err != nil {
+		return fmt.Errorf(
+			"Error creating %s policy %s for organization %s: %w", kind, name, organization, err)
+	}
+
+	d.SetId(policy.ID)
+
+	log.Printf("[DEBUG] Upload %s policy %s for organization: %s", kind, name, organization)
+	err = tfeClient.Policies.Upload(ctx, policy.ID, []byte(d.Get("policy").(string)))
+	if err != nil {
+		return fmt.Errorf(
+			"Error uploading %s policy %s for organization %s: %w", kind, name, organization, err)
+	}
+
+	return resourceTFEPolicyRead(d, meta)
+}
+
+func createOPAPolicyOptions(options *tfe.PolicyCreateOptions, d *schema.ResourceData, meta interface{}) *tfe.PolicyCreateOptions {
+	name := d.Get("name").(string)
+	path := name + ".rego"
+	options.Enforce = []*tfe.EnforcementOptions{
+		{
+			Path: tfe.String(path),
+			Mode: tfe.EnforcementMode(tfe.EnforcementLevel(d.Get("enforce_mode").(string))),
+		},
+	}
+	if vQuery, ok := d.GetOk("query"); ok {
+		options.Query = tfe.String(vQuery.(string))
+	}
+	return options
+}
+
+func createSentinelPolicyOptions(options *tfe.PolicyCreateOptions, d *schema.ResourceData, meta interface{}) *tfe.PolicyCreateOptions {
+	name := d.Get("name").(string)
+	path := name + ".rego"
+	options.Enforce = []*tfe.EnforcementOptions{
+		{
+			Path: tfe.String(path),
+			Mode: tfe.EnforcementMode(tfe.EnforcementLevel(d.Get("enforce_mode").(string))),
+		},
+	}
+	return options
+}
+
+func resourceTFEPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Read policy: %s", d.Id())
+	policy, err := tfeClient.Policies.Read(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			log.Printf("[DEBUG] Policy %s does no longer exist", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Policy %s: %w", d.Id(), err)
+	}
+
+	// Update the config.
+	d.Set("name", policy.Name)
+	d.Set("description", policy.Description)
+	d.Set("kind", policy.Kind)
+
+	if len(policy.Enforce) == 1 {
+		d.Set("enforce_mode", string(policy.Enforce[0].Mode))
+	}
+
+	content, err := tfeClient.Policies.Download(ctx, policy.ID)
+	if err != nil {
+		return fmt.Errorf("Error downloading policy %s: %w", d.Id(), err)
+	}
+	d.Set("policy", string(content))
+
+	return nil
+}
+
+func resourceTFEPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	if d.HasChange("description") || d.HasChange("enforce_mode") {
+		// Create a new options struct.
+		options := tfe.PolicyUpdateOptions{}
+
+		if desc, ok := d.GetOk("description"); ok {
+			options.Description = tfe.String(desc.(string))
+		}
+
+		path := d.Get("name").(string) + ".sentinel"
+		vKind, ok := d.GetOk("kind")
+		if ok {
+			if vKind == tfe.OPA {
+				path = d.Get("name").(string) + ".rego"
+			}
+		}
+		if d.HasChange("enforce_mode") {
+			options.Enforce = []*tfe.EnforcementOptions{
+				{
+					Path: tfe.String(path),
+					Mode: tfe.EnforcementMode(tfe.EnforcementLevel(d.Get("enforce_mode").(string))),
+				},
+			}
+		}
+
+		log.Printf("[DEBUG] Update configuration for %s policy: %s", vKind, d.Id())
+		_, err := tfeClient.Policies.Update(ctx, d.Id(), options)
+		if err != nil {
+			return fmt.Errorf(
+				"Error updating configuration for %s policy %s: %w", vKind, d.Id(), err)
+		}
+	}
+
+	if d.HasChange("policy") {
+		vKind := d.Get("kind").(string)
+		log.Printf("[DEBUG] Update %s policy: %s", vKind, d.Id())
+		err := tfeClient.Policies.Upload(ctx, d.Id(), []byte(d.Get("policy").(string)))
+		if err != nil {
+			return fmt.Errorf("Error updating %s policy %s: %w", vKind, d.Id(), err)
+		}
+	}
+
+	return resourceTFEPolicyRead(d, meta)
+}
+
+func resourceTFEPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Delete policy: %s", d.Id())
+	err := tfeClient.Policies.Delete(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			return nil
+		}
+		return fmt.Errorf("Error deleting policy %s: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceTFEPolicyImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	s := strings.SplitN(d.Id(), "/", 2)
+	if len(s) != 2 {
+		return nil, fmt.Errorf(
+			"invalid policy import format: %s (expected <ORGANIZATION>/<POLICY ID>)",
+			d.Id(),
+		)
+	}
+
+	// Set the fields that are part of the import ID.
+	d.Set("organization", s[0])
+	d.SetId(s[1])
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/tfe/resource_tfe_policy_test.go
+++ b/tfe/resource_tfe_policy_test.go
@@ -1,0 +1,388 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccTFEPolicy_basic(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	policy := &tfe.Policy{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicy_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEPolicyAttributes(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "sentinel"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "main = rule { true }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "hard-mandatory"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicyOPA_basic(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	policy := &tfe.Policy{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicyOPA_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEOPAPolicyAttributes(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "opa"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "package example rule[\"not allowed\"] { false }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "query", "data.example.rule"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "mandatory"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicy_update(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	policy := &tfe.Policy{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicy_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEPolicyAttributes(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "sentinel"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "main = rule { true }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "hard-mandatory"),
+				),
+			},
+
+			{
+				Config: testAccTFEPolicy_update(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEPolicyAttributesUpdated(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "An updated test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "main = rule { false }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "soft-mandatory"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicyOPA_update(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	policy := &tfe.Policy{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicyOPA_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEOPAPolicyAttributes(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "opa"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "package example rule[\"not allowed\"] { false }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "query", "data.example.rule"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "mandatory"),
+				),
+			},
+
+			{
+				Config: testAccTFEPolicyOPA_update(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEOPAPolicyAttributesUpdated(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "An updated test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "package example rule[\"not allowed\"] { true }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "query", "data.example.rule"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "advisory"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicy_import(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicy_basic(org.Name),
+			},
+
+			{
+				ResourceName:        "tfe_policy.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: fmt.Sprintf("%s/", org.Name),
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func testAccCheckTFEPolicyExists(
+	n string, policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		p, err := tfeClient.Policies.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if p.ID != rs.Primary.ID {
+			return fmt.Errorf("Policy not found")
+		}
+
+		*policy = *p
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicyAttributes(
+	policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policy.Name != "policy-test" {
+			return fmt.Errorf("Bad name: %s", policy.Name)
+		}
+
+		if policy.Enforce[0].Mode != "hard-mandatory" {
+			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEOPAPolicyAttributes(
+	policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policy.Name != "policy-test" {
+			return fmt.Errorf("Bad name: %s", policy.Name)
+		}
+
+		if policy.Enforce[0].Mode != "mandatory" {
+			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicyAttributesUpdated(
+	policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policy.Name != "policy-test" {
+			return fmt.Errorf("Bad name: %s", policy.Name)
+		}
+
+		if policy.Enforce[0].Mode != "soft-mandatory" {
+			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEOPAPolicyAttributesUpdated(
+	policy *tfe.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policy.Name != "policy-test" {
+			return fmt.Errorf("Bad name: %s", policy.Name)
+		}
+
+		if policy.Enforce[0].Mode != "advisory" {
+			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicyDestroy(s *terraform.State) error {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_policy" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := tfeClient.Policies.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf(" policy %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccTFEPolicy_basic(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_policy" "foobar" {
+  name         = "policy-test"
+  description  = "A test policy"
+  organization = "%s"
+  policy       = "main = rule { true }"
+  enforce_mode = "hard-mandatory"
+}`, organization)
+}
+
+func testAccTFEPolicyOPA_basic(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_policy" "foobar" {
+  name         = "policy-test"
+  description  = "A test policy"
+  organization = "%s"
+  kind         = "opa"
+  policy       = "package example rule[\"not allowed\"] { false }"
+  query        = "data.example.rule"
+  enforce_mode = "mandatory"
+}`, organization)
+}
+
+func testAccTFEPolicy_update(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_policy" "foobar" {
+  name         = "policy-test"
+  description  = "An updated test policy"
+  organization = "%s"
+  policy       = "main = rule { false }"
+  enforce_mode = "soft-mandatory"
+}`, organization)
+}
+
+func testAccTFEPolicyOPA_update(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_policy" "foobar" {
+  name         = "policy-test"
+  description  = "An updated test policy"
+  organization = "%s"
+  kind         = "opa"
+  policy       = "package example rule[\"not allowed\"] { true }"
+  query        = "data.example.rule"
+  enforce_mode = "advisory"
+}`, organization)
+}

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -13,10 +13,11 @@ import (
 
 func resourceTFESentinelPolicy() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceTFESentinelPolicyCreate,
-		Read:   resourceTFESentinelPolicyRead,
-		Update: resourceTFESentinelPolicyUpdate,
-		Delete: resourceTFESentinelPolicyDelete,
+		DeprecationMessage: "tfe_sentinel_policy is being deprecated, please use tfe_policy instead",
+		Create:             resourceTFESentinelPolicyCreate,
+		Read:               resourceTFESentinelPolicyRead,
+		Update:             resourceTFESentinelPolicyUpdate,
+		Delete:             resourceTFESentinelPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceTFESentinelPolicyImporter,
 		},


### PR DESCRIPTION
## Description

Add OPA support to the tfe-provider for policies. OPA is still in beta phase.
The existing `tfe_sentinel_policy` will be deprecated in favour of `tfe_policy` which will allow for creation of both sentinel as well as OPA policies in the provider.

This is the first of the 3 PRs for adding OPA support:
Upcoming PRs
- Add OPA support for policy sets
- Update documentation

## Testing plan

Added acceptance tests

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://github.com/hashicorp/go-tfe/blob/main/policy.go#L103)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/policies)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-1451)

## Output from acceptance tests

$  TESTARGS="-run TestAccTFEPolicy_basic" envchain staging make testacc
```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEPolicy_basic -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEPolicy_basic
2022/11/16 09:46:32 [DEBUG] Configuring client for host "app.staging.terraform.io"
2022/11/16 09:46:32 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
--- PASS: TestAccTFEPolicy_basic (13.44s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe (cached)
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
$  TESTARGS="-run TestAccTFEPolicyOPA_basic" envchain staging make testacc

```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEPolicyOPA_basic -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEPolicyOPA_basic
2022/11/16 09:59:59 [DEBUG] Configuring client for host "app.staging.terraform.io"
2022/11/16 09:59:59 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
--- PASS: TestAccTFEPolicyOPA_basic (12.62s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 13.051s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

$  TESTARGS="-run TestAccTFEPolicy_update" envchain staging make testacc

```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEPolicy_update -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEPolicy_update
2022/11/16 10:01:01 [DEBUG] Configuring client for host "app.staging.terraform.io"
2022/11/16 10:01:01 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
--- PASS: TestAccTFEPolicy_update (21.59s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 21.824s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

$  TESTARGS="-run TestAccTFEPolicyOPA_update" envchain staging make testacc

```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEPolicyOPA_update -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEPolicyOPA_update
2022/11/16 10:01:58 [DEBUG] Configuring client for host "app.staging.terraform.io"
2022/11/16 10:01:58 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
--- PASS: TestAccTFEPolicyOPA_update (21.65s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 21.902s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

$  TESTARGS="-run TestAccTFEPolicy_import" envchain staging make testacc

```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEPolicy_import -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEPolicy_import
2022/11/16 10:02:56 [DEBUG] Configuring client for host "app.staging.terraform.io"
2022/11/16 10:02:56 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
--- PASS: TestAccTFEPolicy_import (14.39s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 14.636s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

