### PR TITLE
refactor how workspace names resource arg filters for matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 FEATURES:
+* d/tfe_workspace_ids: Add support for filtering workspace names with partial matching using `*` ([#698](https://github.com/hashicorp/terraform-provider-tfe/pull/698))
 * r/tfe_workspace: Add preemptive check for resources under management when `force_delete` attribute is false ([#699](https://github.com/hashicorp/terraform-provider-tfe/pull/699))
 * r/tfe_policy: Add OPA support for policies. `tfe_policy` is a new resource that supports both Sentinel as well as OPA policies. `tfe_sentinel_policy` now includes a deprecation warning. ([#690](https://github.com/hashicorp/terraform-provider-tfe/pull/690))
 * r/tfe_policy_set: Add OPA support for policy sets. ([#691](https://github.com/hashicorp/terraform-provider-tfe/pull/691))

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -73,7 +73,7 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt),
+				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, "*"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// names attribute
 					resource.TestCheckResourceAttr(
@@ -113,6 +113,144 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-bar-%d", rInt)),
 					resource.TestCheckResourceAttrSet(
 						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-dummy-%d", rInt)),
+
+					// id attribute
+					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspaceIDsDataSource_prefixWildcard(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	fooWorkspaceName := fmt.Sprintf("*-foo-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, fooWorkspaceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "names.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "names.0", fooWorkspaceName),
+
+					// organization attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "organization", orgName),
+
+					// full_names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "full_names.%", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar",
+						fmt.Sprintf("full_names.workspace-foo-%d", rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-foo-%d", rInt, rInt),
+					),
+
+					// ids attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "ids.%", "1"),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-foo-%d", rInt)),
+
+					// id attribute
+					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspaceIDsDataSource_suffixWildcard(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	fooWorkspaceName := "workspace-foo-*"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, fooWorkspaceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "names.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "names.0", fooWorkspaceName),
+
+					// organization attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "organization", orgName),
+
+					// full_names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "full_names.%", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar",
+						fmt.Sprintf("full_names.workspace-foo-%d", rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-foo-%d", rInt, rInt),
+					),
+
+					// ids attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "ids.%", "1"),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-foo-%d", rInt)),
+
+					// id attribute
+					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspaceIDsDataSource_substringWildcard(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	fooWorkspaceName := "*-foo-*"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, fooWorkspaceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "names.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "names.0", fooWorkspaceName),
+
+					// organization attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "organization", orgName),
+
+					// full_names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "full_names.%", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar",
+						fmt.Sprintf("full_names.workspace-foo-%d", rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-foo-%d", rInt, rInt),
+					),
+
+					// ids attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "ids.%", "1"),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_workspace_ids.foobar", fmt.Sprintf("ids.workspace-foo-%d", rInt)),
 
 					// id attribute
 					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),
@@ -357,7 +495,7 @@ data "tfe_workspace_ids" "foobar" {
 }`, rInt, rInt, rInt, rInt)
 }
 
-func testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt int) string {
+func testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt int, wildcardName string) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform-%d"
@@ -380,14 +518,14 @@ resource "tfe_workspace" "dummy" {
 }
 
 data "tfe_workspace_ids" "foobar" {
-  names        = ["*"]
+  names        = ["%s"]
   organization = tfe_workspace.dummy.organization
   depends_on = [
     tfe_workspace.foo,
     tfe_workspace.bar,
     tfe_workspace.dummy
   ]
-}`, rInt, rInt, rInt, rInt)
+}`, rInt, rInt, rInt, rInt, wildcardName)
 }
 
 func testAccTFEWorkspaceIDsDataSourceConfig_tags(rInt int) string {

--- a/website/docs/d/workspace_ids.html.markdown
+++ b/website/docs/d/workspace_ids.html.markdown
@@ -40,10 +40,10 @@ data "tfe_workspace_ids" "prod-only" {
 The following arguments are supported. At least one of `names` or `tag_names` must be present. Both can be used together.
 
 * `names` - (Optional) A list of workspace names to search for. Names that don't
-  match a real workspace will be omitted from the results, but are not an error.
+  match a valid workspace will be omitted from the results, but are not an error.
 
     To select _all_ workspaces for an organization, provide a list with a single
-    asterisk, like `["*"]`. No other use of wildcards is supported.
+    asterisk, like `["*"]`. The asterisk also supports partial matching on prefix and/or suffix, like `[*-prod]`, `[test-*]`, `[*dev*]`.
 * `tag_names` - (Optional) A list of tag names to search for.
 * `exclude_tags` - (Optional) A list of tag names to exclude when searching.
 * `organization` - (Required) Name of the organization.


### PR DESCRIPTION
## Description

There was a [feature request](https://github.com/hashicorp/terraform-provider-tfe/issues/274) to pass partial matching to `names` arg using the `*` char.

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-documentation)_

## Testing plan

1.  See [docs](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/workspace_ids) on how to use `names` arg

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
