### PR TITLE
fix doc to remove enforce_mode is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ FEATURES:
 * r/tfe_policy: Add OPA support for policies. `tfe_policy` is a new resource that supports both Sentinel as well as OPA policies. `tfe_sentinel_policy` now includes a deprecation warning. ([#690](https://github.com/hashicorp/terraform-provider-tfe/pull/690))
 * r/tfe_policy_set: Add OPA support for policy sets. ([#691](https://github.com/hashicorp/terraform-provider-tfe/pull/691))
 * d/tfe_policy_set: Add optional `kind` and `overridable` fields for OPA policy sets ([#691](https://github.com/hashicorp/terraform-provider-tfe/pull/691))
+* r/tfe_policy: Fix documentation to make enforce_mode not a required property ([#705](https://github.com/hashicorp/terraform-provider-tfe/pull/705))
+* r/tfe_sentinel_policy: Fix documentation to make enforce_mode not a required property ([#705](https://github.com/hashicorp/terraform-provider-tfe/pull/705))
 
 ## v0.39.0 (November 18, 2022)
 

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `query` - (Optional) The OPA query to identify a specific policy rule that 
    needs to run within your Rego code. Required for all OPA policies. 
 * `policy` - (Required) The actual policy itself.
-* `enforce_mode` - The enforcement level of the policy. Valid
+* `enforce_mode` - (Optional) The enforcement level of the policy. Valid
   values for Sentinel are `advisory`, `hard-mandatory` and `soft-mandatory`. Defaults
   to `soft-mandatory`. Valid values for OPA are `advisory` and `mandatory`. Defaults
   to `advisory`.

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `query` - (Optional) The OPA query to identify a specific policy rule that 
    needs to run within your Rego code. Required for all OPA policies. 
 * `policy` - (Required) The actual policy itself.
-* `enforce_mode` - (Required) The enforcement level of the policy. Valid
+* `enforce_mode` - The enforcement level of the policy. Valid
   values for Sentinel are `advisory`, `hard-mandatory` and `soft-mandatory`. Defaults
   to `soft-mandatory`. Valid values for OPA are `advisory` and `mandatory`. Defaults
   to `advisory`.

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `description` - (Optional) A description of the policy's purpose.
 * `organization` - (Required) Name of the organization.
 * `policy` - (Required) The actual policy itself.
-* `enforce_mode` - The enforcement level of the policy. Valid
+* `enforce_mode` - (Optional) The enforcement level of the policy. Valid
   values are `advisory`, `hard-mandatory` and `soft-mandatory`. Defaults
   to `soft-mandatory`.
 

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 * `description` - (Optional) A description of the policy's purpose.
 * `organization` - (Required) Name of the organization.
 * `policy` - (Required) The actual policy itself.
-* `enforce_mode` - (Required) The enforcement level of the policy. Valid
+* `enforce_mode` - The enforcement level of the policy. Valid
   values are `advisory`, `hard-mandatory` and `soft-mandatory`. Defaults
   to `soft-mandatory`.
 


### PR DESCRIPTION
## Description

Fix documentation to say the enforce_mode is not required while creating policies

![registry terraform io_tools_doc-preview (5)](https://user-images.githubusercontent.com/17270065/204401360-6f0e5dcd-9f15-489e-ab4e-daf33af83063.png)

![registry terraform io_tools_doc-preview (6)](https://user-images.githubusercontent.com/17270065/204401362-8f0f0687-3cd0-4a05-89eb-b79c6a2e3251.png)

