### PR TITLE
add nonsensitive_values field to tfe_outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 FEATURES:
+* d/tfe_outputs: Add `nonsensitive_values` attribute to expose current non-sensitive outputs of a given workspace ([#711](https://github.com/hashicorp/terraform-provider-tfe/pull/711))
 
 ## v0.40.0 (December 6, 2022)
 

--- a/tfe/plugin_provider.go
+++ b/tfe/plugin_provider.go
@@ -211,6 +211,12 @@ func PluginProviderServer() tfprotov5.ProviderServer {
 							Computed:  true,
 							Sensitive: true,
 						},
+						{
+							Name:      "nonsensitive_values",
+							Type:      tftypes.DynamicPseudoType,
+							Computed:  true,
+							Sensitive: false,
+						},
 					},
 				},
 			},

--- a/website/docs/d/outputs.html.markdown
+++ b/website/docs/d/outputs.html.markdown
@@ -10,10 +10,10 @@ description: |-
 This data source is used to retrieve the state outputs for a given workspace.
 It enables output values in one Terraform configuration to be used in another.
 
-As the outputs retrieved from a different workspace may contain sensitive
-information in the context of that workspace, the `values` attribute of this
-data source is statically marked as
-[sensitive](https://www.terraform.io/docs/language/values/outputs.html#sensitive-suppressing-values-in-cli-output).
+The `values` attribute has been defined as sensitive because the workspace
+outputs may contain sensitive values and the provider protocol does not support
+marking values as [sensitive](https://www.terraform.io/docs/language/values/outputs.html#sensitive-suppressing-values-in-cli-output) after this information is known. You can access
+the subset of non-sensitive outputs using the `nonsensitive_values` attribute.
 
 ## Example Usage
 
@@ -49,4 +49,4 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `values` - The current output values for the specified workspace.
-* `nonsensitive_values` - The current non-sensitive output values for the specified workspace.
+* `nonsensitive_values` - The current non-sensitive output values for the specified workspace, this is a subset of all output values.

--- a/website/docs/d/outputs.html.markdown
+++ b/website/docs/d/outputs.html.markdown
@@ -49,3 +49,4 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `values` - The current output values for the specified workspace.
+* `nonsensitive_values` - The current non-sensitive output values for the specified workspace.


### PR DESCRIPTION
## Description

Added `nonsensitive_values` attribute to `tfe_outputs` datasource to allow retrieving the current non-sensitive outputs of a given workspace. 

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-documentation)_

## Testing plan

1.  _Create a workspace that has both sensitive and non-sensitive outputs_
2.  _Use tfe_outputs datasource like below to attempt to retrieve outputs_

```
data "tfe_outputs" "example" {
  organization = "org"
  workspace = "prod-app"
}

output "example" {
  value = data.tfe_outputs.example.values.foo
}
```

3.  _Retrieval should error unless you use the `nonsensitive` function_
4.  _After these changes, use `nonsensitive_values` to retrieve all non-sensitive values. For instance if a workspace has non-sensitive output value `foo`_
```
data "tfe_outputs" "example" {
  organization = "org"
  workspace = "prod-app"
}

output "example" {
  value = data.tfe_outputs.example.nonsensitive_values.foo
}
```

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Related issue](https://github.com/hashicorp/terraform-provider-tfe/issues/666)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEOutputs" make testacc

=== RUN   TestAccTFEOutputs
--- PASS: TestAccTFEOutputs (18.51s)
=== RUN   TestAccTFEOutputs_ReadAllNonSensitiveValues
--- PASS: TestAccTFEOutputs_ReadAllNonSensitiveValues (17.74s)
=== RUN   TestAccTFEOutputs_emptyOutputs
--- PASS: TestAccTFEOutputs_emptyOutputs (13.29s)
PASS
ok  
```

Doc Preview:

<img width="1128" alt="Screen Shot 2022-12-07 at 12 19 12 PM" src="https://user-images.githubusercontent.com/22062046/206247048-b69587ef-84e5-4bd3-9fc2-27d9d60276b4.png">
<img width="1104" alt="Screen Shot 2022-12-07 at 12 19 20 PM" src="https://user-images.githubusercontent.com/22062046/206247057-1396014a-6709-4883-9715-4a2459866323.png">
