### PR TITLE
Adding support for the resource_count attribute on tfe_workspace 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 FEATURES:
+* r/tfe_workspace: Add attribute `resource_count` to `tfe_workspace` by @rhughes1 ([#682](https://github.com/hashicorp/terraform-provider-tfe/pull/682))
 
 ## v0.40.0 (December 6, 2022)
 

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -240,6 +240,10 @@ func resourceTFEWorkspace() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"resource_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -406,6 +410,7 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("trigger_patterns", workspace.TriggerPatterns)
 	d.Set("working_directory", workspace.WorkingDirectory)
 	d.Set("organization", workspace.Organization.Name)
+	d.Set("resource_count", workspace.ResourceCount)
 
 	// Project will be nil for versions of TFE that predate projects
 	if workspace.Project != nil {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -60,6 +60,8 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 						"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "working_directory", ""),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "resource_count", "0"),
 				),
 			},
 		},
@@ -2180,6 +2182,10 @@ func testAccCheckTFEWorkspaceAttributes(
 
 		if len(workspace.TriggerPrefixes) != 0 {
 			return fmt.Errorf("Bad trigger prefixes: %s", workspace.TriggerPrefixes)
+		}
+
+		if workspace.ResourceCount > 0 {
+			return fmt.Errorf("Bad resource count: %d", workspace.ResourceCount)
 		}
 
 		return nil

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -134,6 +134,7 @@ The `vcs_repo` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The workspace ID.
+* `resource_count` - The number of resources managed by the workspace.
 
 ## Import
 


### PR DESCRIPTION
## Description

This PR exposes the `resource_count` attribute on the `tfe_workspace` resource. This is to make it easier for users writing a Sentinel policy to prevent workspaces from being deleted prior to deleting all of the resources that belong to the given workspace. This attribute is already exposed as part of the data source call.

Below is a screenshot of the documentation update on the `tfe_workspace` resource:

![image](https://user-images.githubusercontent.com/15823106/200732043-0098900b-8da5-484b-99ba-f9294e5f4c22.png)

## Testing plan

1. Create a new workspace using the configuration below

```hcl
resource "tfe_organization" "test-organization" {
  name  = "my-org-name"
  email = "admin@company.com"
}

resource "tfe_workspace" "test" {
  name         = "my-workspace-name"
  organization = tfe_organization.test-organization.name
  tag_names    = ["test", "app"]
}

output "workspace_resource_count" {
  value = tfe_workspace.test.resource_count
}
```

This should yield a result like this:

```bash
$ terraform refresh
...
Outputs:

workspace_resource_count = 0
```
2. Inside the new workspace (ie `my-workspace-name`), use the following configuration (or similar) to add resources under the control of the workspace:

```hcl
resource "tfe_team" "test" {
  name         = "my-team-name"
  organization = "my-org-name"
}
```

3. Back on the original workspace, re-run a `terraform refresh` so we can now see that the `resource_count` has changed from `0` to `1`:

```
$ terraform refresh
...
Outputs:

workspace_resource_count = 1
```

## External links
- [Related Issue](https://github.com/hashicorp/terraform-provider-tfe/issues/448)

## Output from acceptance tests

```
$ TF_ACC=1 TF_LOG_SDK_PROTO=OFF envchain tfe-staging go test ./... -v -run TestAccTFEWorkspace

```