### PR TITLE
Disable the no_code registry module test in TFE

### DIFF
--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -61,11 +61,6 @@ jobs:
         with:
           index: ${{ matrix.index }}
           total: ${{ matrix.parallel }}
-          
-      - name: Wait for test infra
-        # replace this with a real status check
-        run: |
-          sleep 10
 
       - name: Fetch Outputs
         env:

--- a/tfe/resource_tfe_registry_module_test.go
+++ b/tfe/resource_tfe_registry_module_test.go
@@ -237,6 +237,8 @@ func TestAccTFERegistryModule_publicRegistryModule(t *testing.T) {
 }
 
 func TestAccTFERegistryModule_noCodeModule(t *testing.T) {
+	skipIfEnterprise(t)
+
 	registryModule := &tfe.RegistryModule{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)


### PR DESCRIPTION
This is breaking the nightly. I checked with the registry team and this is the new expected behavior.