### PR TITLE
Allow tfe_organization_membership import by org name and user email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 ENHANCEMENTS:
+* r/tfe_organization_membership: Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>` ([#715](https://github.com/hashicorp/terraform-provider-tfe/pull/715))
 
 BUG FIXES:
 

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -119,7 +119,7 @@ func resourceTFEOrganizationMembershipDelete(d *schema.ResourceData, meta interf
 }
 
 func resourceTFEOrganizationMembershipImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Import formats:
 	//  - <ORGANIZATION MEMBERSHIP ID>
@@ -133,7 +133,7 @@ func resourceTFEOrganizationMembershipImporter(ctx context.Context, d *schema.Re
 	} else if len(s) == 2 {
 		org := s[0]
 		email := s[1]
-		orgMembership, err := fetchOrganizationMemberByNameOrEmail(ctx, tfeClient, org, "", email)
+		orgMembership, err := fetchOrganizationMemberByNameOrEmail(ctx, config.Client, org, "", email)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"error retrieving user with email %s from organization %s: %w", email, org, err)

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -4,8 +4,10 @@
 package tfe
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,7 +19,7 @@ func resourceTFEOrganizationMembership() *schema.Resource {
 		Read:   resourceTFEOrganizationMembershipRead,
 		Delete: resourceTFEOrganizationMembershipDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceTFEOrganizationMembershipImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -114,4 +116,31 @@ func resourceTFEOrganizationMembershipDelete(d *schema.ResourceData, meta interf
 	}
 
 	return nil
+}
+
+func resourceTFEOrganizationMembershipImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	tfeClient := meta.(*tfe.Client)
+
+	// Import formats:
+	//  - <ORGANIZATION MEMBERSHIP ID>
+	//  - <organization name>/<user email>
+	s := strings.Split(d.Id(), "/")
+	if len(s) >= 3 {
+		return nil, fmt.Errorf(
+			"invalid organization membership input format: %s (expected <ORGANIZATION>/<USER EMAIL> or <ORGANIZATION MEMBERSHIP ID>)",
+			d.Id(),
+		)
+	} else if len(s) == 2 {
+		org := s[0]
+		email := s[1]
+		orgMembership, err := fetchOrganizationMemberByNameOrEmail(ctx, tfeClient, org, "", email)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error retrieving user with email %s from organization %s: %w", email, org, err)
+		}
+
+		d.SetId(orgMembership.ID)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -124,13 +124,8 @@ func resourceTFEOrganizationMembershipImporter(ctx context.Context, d *schema.Re
 	// Import formats:
 	//  - <ORGANIZATION MEMBERSHIP ID>
 	//  - <organization name>/<user email>
-	s := strings.Split(d.Id(), "/")
-	if len(s) >= 3 {
-		return nil, fmt.Errorf(
-			"invalid organization membership input format: %s (expected <ORGANIZATION>/<USER EMAIL> or <ORGANIZATION MEMBERSHIP ID>)",
-			d.Id(),
-		)
-	} else if len(s) == 2 {
+	s := strings.SplitN(d.Id(), "/", 2)
+	if len(s) == 2 {
 		org := s[0]
 		email := s[1]
 		orgMembership, err := fetchOrganizationMemberByNameOrEmail(ctx, config.Client, org, "", email)

--- a/tfe/resource_tfe_organization_membership_test.go
+++ b/tfe/resource_tfe_organization_membership_test.go
@@ -106,7 +106,7 @@ func TestAccTFEOrganizationMembershipImport_invalidImportId(t *testing.T) {
 				ResourceName:  "tfe_organization_membership.foobar",
 				ImportState:   true,
 				ImportStateId: fmt.Sprintf("%s/%s/someOtherString", orgName, email),
-				ExpectError:   regexp.MustCompile("invalid organization membership input format"),
+				ExpectError:   regexp.MustCompile(fmt.Sprintf("error retrieving user with email %s/someOtherString from organization %s", email, orgName)),
 			},
 			{
 				ResourceName:  "tfe_organization_membership.foobar",

--- a/website/docs/r/organization_membership.html.markdown
+++ b/website/docs/r/organization_membership.html.markdown
@@ -43,8 +43,14 @@ In addition to all arguments above, the following attributes are exported:
 * `user_id` - The ID of the user associated with the organization membership.
 * `username` - The username of the user associated with the organization membership.
 
-Organization memberships can be imported; use `<ORGANIZATION MEMBERSHIP ID>` as the import ID. For
+## Import 
+
+Organization memberships can be imported using `<ORGANIZATION>/<USER EMAIL>` or `<ORGANIZATION MEMBERSHIP ID>` as the import ID. For
 example:
+
+```shell
+terraform import tfe_organization_membership.test my-org-name/user@example.com
+```
 
 ```shell
 terraform import tfe_organization_membership.test ou-wAs3zYmWAhYK7peR


### PR DESCRIPTION
## Description

Allow tfe_organization_membership resource to also be imported by org-name/user-email

Presently, the resource can only be imported through its ID, which is not presented to the user in the TFE UI. This makes it very difficult to import.

## Testing plan

1.  Test that import by ID still works
1.  Test that importing by org/email works
2. Test that importing by an invalid format errors
3. Test that importing a non existent org name or email errors

## External links

- [internal JIRA](https://hashicorp.atlassian.net/browse/TF-3336)
- [resource documentation](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/organization_membership)

## Output from acceptance tests


```
❯ TF_ACC=1 go test ./...  -run TestAccTFEOrganizationMembership -tags=integration -v
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEOrganizationMembershipDataSource_basic
--- PASS: TestAccTFEOrganizationMembershipDataSource_basic (17.87s)
=== RUN   TestAccTFEOrganizationMembershipDataSource_findByName
    data_source_organization_membership_test.go:47: Please set TFE_USER1 to run this test
--- SKIP: TestAccTFEOrganizationMembershipDataSource_findByName (0.36s)
=== RUN   TestAccTFEOrganizationMembershipDataSource_missingParams
--- PASS: TestAccTFEOrganizationMembershipDataSource_missingParams (4.41s)
=== RUN   TestAccTFEOrganizationMembership_basic
--- PASS: TestAccTFEOrganizationMembership_basic (6.66s)
=== RUN   TestAccTFEOrganizationMembershipImport_ByID
--- PASS: TestAccTFEOrganizationMembershipImport_ByID (6.94s)
=== RUN   TestAccTFEOrganizationMembershipImport_ByEmail
--- PASS: TestAccTFEOrganizationMembershipImport_ByEmail (7.05s)
=== RUN   TestAccTFEOrganizationMembershipImport_invalidImportId
--- PASS: TestAccTFEOrganizationMembershipImport_invalidImportId (7.72s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 51.182s


...
```
