### PR TITLE
Update acceptance test to reflect Project rename bugfix with go-tfe v1.16.0 upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210622215436-a8dc77f794b6 // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.4.0 // indirect
-	golang.org/x/time v0.1.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.1.0 h1:xYY+Bajn2a7VBmTM5GikTmnK8ZuX8YgnQCqZpbBNtmA=
 golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/tfe/resource_tfe_project_test.go
+++ b/tfe/resource_tfe_project_test.go
@@ -2,10 +2,11 @@ package tfe
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -66,7 +67,7 @@ func TestAccTFEProject_update(t *testing.T) {
 						"tfe_project.foobar", project),
 					testAccCheckTFEProjectAttributesUpdated(project),
 					resource.TestCheckResourceAttr(
-						"tfe_project.foobar", "name", "projectupdated"),
+						"tfe_project.foobar", "name", "project updated"),
 				),
 			},
 		},
@@ -113,7 +114,7 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_project" "foobar" {
   organization = tfe_organization.foobar.name
-  name = "projectupdated"
+  name = "project updated"
 }`, rInt)
 }
 
@@ -189,7 +190,7 @@ func testAccCheckTFEProjectAttributes(
 func testAccCheckTFEProjectAttributesUpdated(
 	project *tfe.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if project.Name != "projectupdated" {
+		if project.Name != "project updated" {
 			return fmt.Errorf("Bad name: %s", project.Name)
 		}
 


### PR DESCRIPTION
## Description

The title is a concise summary :book: and this PR closes #714 

The fix was actually implemented in our go-tfe dependency [here]( https://github.com/hashicorp/go-tfe/pull/608
) (released in v1.16).

The go-tfe library was validating project names as external IDs, of which inner spaces would result in a validation error.  `go-tfe` was upgraded [here](https://github.com/hashicorp/terraform-provider-tfe/commit/49a77efcc05d1fe6de475c373a530f80b9e109c4).  

I've updated the `tfe_project` resource `Update` test and changed the `name` attribute to include an inner space to reflect the fix :smile: 

## Testing plan
### Acceptance Test
```sh
ENABLE_BETA=1 TESTARGS="-run TestAccTFEProject_update" make testacc
```
### Smoke Test
1. Apply this config:
```hcl
resource "tfe_project" "foo" {
  name = "a project name with spaces"
  organization = "<my_org_name>"
}
```
  

