### PR TITLE
Debug step failure

### DIFF
--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           TFE_TOKEN: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
         run: |
+          set -euo pipefail
           go run .github/scripts/fetch_outputs/main.go hashicorp-v2 tflocal-terraform-provider-tfe-nightly
 
       - name: Run Tests

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -87,7 +87,6 @@ jobs:
           gotestsum --format short-verbose -- $MOD_PROVIDER $MOD_TFE $MOD_VERSION -timeout=30m -run "${{ steps.test_split.outputs.run }}"
 
   tests-summarize:
-    name: Summarize Tests
     needs: [tests]
     runs-on: ubuntu-latest
     if: ${{ always() }}


### PR DESCRIPTION
## Description

Fetch outputs steps within the nightly TFE tests is failing from time to time with the same `unauthorized` error: https://github.com/hashicorp/terraform-provider-tfe/actions/runs/3661717920/jobs/6190255505

We are not completely sure what is causing it, though there is some speculations. Please read the latest slack conversation on this for more information.

Changes that we are making to either fix the issue or help with the troubleshooting of the issue:
1)We are removing the name field `name: Summarize Tests` in case is conflicting with the job id called `tests-summarize`.
2)We are also adding some additional context to some errors in the go program for fetch outputs to help debug in the future.
3)Finally, adding some additional options to the workflow bash that runs with only -e option by default. I will remove this after we see the step no longer fails with the unauthorized error.

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
