### PR TITLE
tfe hostname clarification for users

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -100,7 +100,7 @@ For more information on provider installation and constraining provider versions
 
 ```hcl
 provider "tfe" {
-  hostname = var.hostname
+  hostname = var.hostname # Optional, it defaults to Terraform Cloud `app.terraform.io` if not setup
   token    = var.token
   version  = "~> 0.41.0"
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -100,7 +100,7 @@ For more information on provider installation and constraining provider versions
 
 ```hcl
 provider "tfe" {
-  hostname = var.hostname # Optional, it defaults to Terraform Cloud `app.terraform.io` if not setup
+  hostname = var.hostname # Optional, defaults to Terraform Cloud `app.terraform.io`
   token    = var.token
   version  = "~> 0.41.0"
 }


### PR DESCRIPTION
The tfe hostname needs to have a clear description that needs to be setup for the Terraform Enterprise, otherwise it sends the request to the Terraform Cloud hostname