### PR TITLE
Remove `sidebar_current:` from all docs yaml frontmatter

### DIFF
--- a/website/docs/d/agent_pool.html.markdown
+++ b/website/docs/d/agent_pool.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_agent_pool"
-sidebar_current: "docs-datasource-tfe-agent-pool"
 description: |-
   Get information on an agent pool.
 ---

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_ip_ranges"
-sidebar_current: "docs-datasource-tfe-ip-ranges"
 description: |-
   Get Terraform Cloud/Enterprise's IP ranges of its services
 ---

--- a/website/docs/d/oauth_client.html.markdown
+++ b/website/docs/d/oauth_client.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_oauth_client"
-sidebar_current: "docs-datasource-tfe-oauth-client-x"
 description: |-
   Get information on an OAuth client.
 ---

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization"
-sidebar_current: "docs-datasource-tfe-organization"
 description: |-
   Get information on an Organization.
 ---

--- a/website/docs/d/organization_members.html.markdown
+++ b/website/docs/d/organization_members.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization_members"
-sidebar_current: "docs-datasource-tfe-organization-members"
 description: |-
   Get information on an Organization members.
 ---

--- a/website/docs/d/organization_membership.html.markdown
+++ b/website/docs/d/organization_membership.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization_membership"
-sidebar_current: "docs-datasource-tfe-organization-membership"
 description: |-
   Get information on an organization membership.
 ---

--- a/website/docs/d/organization_run_task.html.markdown
+++ b/website/docs/d/organization_run_task.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization_run_task"
-sidebar_current: "docs-datasource-tfe-organization-run-task"
 description: |-
   Get information on a Run task.
 ---

--- a/website/docs/d/organizations.html.markdown
+++ b/website/docs/d/organizations.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organizations"
-sidebar_current: "docs-datasource-tfe-organizations"
 description: |-
   Get information on Organizations.
 ---

--- a/website/docs/d/outputs.html.markdown
+++ b/website/docs/d/outputs.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_outputs"
-sidebar_current: "docs-datasource-tfe-state-outputs"
 description: |-
   Get output values from another organization/workspace.
 ---

--- a/website/docs/d/policy_set.html.markdown
+++ b/website/docs/d/policy_set.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_policy_set"
-sidebar_current: "docs-datasource-tfe-policy-set"
 description: |-
   Get information on organization policy sets.
 ---

--- a/website/docs/d/slug.html.markdown
+++ b/website/docs/d/slug.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_slug"
-sidebar_current: "docs-datasource-tfe-slug"
 description: |-
   Manages files.
 ---

--- a/website/docs/d/ssh_key.html.markdown
+++ b/website/docs/d/ssh_key.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_ssh_key"
-sidebar_current: "docs-datasource-tfe-ssh-key"
 description: |-
   Get information on a SSH key.
 ---

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team"
-sidebar_current: "docs-datasource-tfe-team-x"
 description: |-
   Get information on a team.
 ---

--- a/website/docs/d/team_access.html.markdown
+++ b/website/docs/d/team_access.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team_access"
-sidebar_current: "docs-datasource-tfe-team-access"
 description: |-
   Get information on team permissions on a workspace.
 ---

--- a/website/docs/d/variable_set.html.markdown
+++ b/website/docs/d/variable_set.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_variable_set"
-sidebar_current: "docs-datasource-tfe-variable-set"
 description: |-
   Get information on organization variable sets.
 ---

--- a/website/docs/d/variables.html.markdown
+++ b/website/docs/d/variables.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_variables"
-sidebar_current: "docs-datasource-tfe-variables-x"
 description: |-
   Get information on a workspace variables.
 ---

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_workspace"
-sidebar_current: "docs-datasource-tfe-workspace-x"
 description: |-
   Get information on a workspace.
 ---

--- a/website/docs/d/workspace_ids.html.markdown
+++ b/website/docs/d/workspace_ids.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_workspace_ids"
-sidebar_current: "docs-datasource-tfe-workspace-ids"
 description: |-
   Get information on workspace IDs.
 ---

--- a/website/docs/d/workspace_run_task.html.markdown
+++ b/website/docs/d/workspace_run_task.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_workspace_task"
-sidebar_current: "docs-datasource-tfe-workspace-task"
 description: |-
   Get information on a Workspace Run task.
 ---

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Provider: Terraform Cloud/Enterprise"
-sidebar_current: "docs-tfe-index"
 description: |-
   Provision Terraform Cloud or Terraform Enterprise - with Terraform! Management of organizations, workspaces, teams, variables, run triggers, policy sets, and more. Maintained by the Terraform Cloud team at HashiCorp.
 ---

--- a/website/docs/r/admin_organization_settings.markdown
+++ b/website/docs/r/admin_organization_settings.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_admin_organization_settings"
-sidebar_current: "docs-resource-tfe-organization-x"
 description: |-
   Manages admin settings for an organization (Terraform Enterprise Only).
 ---

--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_agent_pool"
-sidebar_current: "docs-resource-tfe-agent-pool"
 description: |-
   Manages agent pools
 ---

--- a/website/docs/r/agent_token.html.markdown
+++ b/website/docs/r/agent_token.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_agent_token"
-sidebar_current: "docs-resource-tfe-agent-token"
 description: |-
   Manages agent tokens
 ---

--- a/website/docs/r/notification_configuration.html.markdown
+++ b/website/docs/r/notification_configuration.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_notification_configuration"
-sidebar_current: "docs-resource-tfe-notification-configuration"
 description: |-
   Manages notifications configurations.
 ---

--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_oauth_client"
-sidebar_current: "docs-resource-tfe-oauth-client"
 description: |-
   Manages OAuth clients.
 ---

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization"
-sidebar_current: "docs-resource-tfe-organization-x"
 description: |-
   Manages organizations.
 ---

--- a/website/docs/r/organization_membership.html.markdown
+++ b/website/docs/r/organization_membership.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization_membership"
-sidebar_current: "docs-resource-tfe-organization-membership"
 description: |-
   Add or remove a user from an organization.
 ---

--- a/website/docs/r/organization_module_sharing.html.markdown
+++ b/website/docs/r/organization_module_sharing.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization_module_sharing"
-sidebar_current: "docs-resource-tfe-organization-module-sharing"
 description: |-
   Manage module sharing for an organization.
 ---

--- a/website/docs/r/organization_run_task.html.markdown
+++ b/website/docs/r/organization_run_task.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization_run_task"
-sidebar_current: "docs-resource-tfe-organization-run-task"
 description: |-
   Manages Run tasks.
 ---

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_organization_token"
-sidebar_current: "docs-resource-tfe-organization-token"
 description: |-
   Generates a new organization token, replacing any existing token.
 ---

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_policy"
-sidebar_current: "docs-resource-tfe-policy"
 description: |-
   Manages policies.
 ---

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_policy_set"
-sidebar_current: "docs-resource-tfe-tfe_policy_set"
 description: |-
   Manages policy sets.
 ---

--- a/website/docs/r/policy_set_parameter.html.markdown
+++ b/website/docs/r/policy_set_parameter.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_policy_set_parameter"
-sidebar_current: "docs-resource-tfe-policy-set-parameter"
 description: |-
   Manages policy set parameters.
 ---

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_project"
-sidebar_current: "docs-resource-tfe-project"
 description: |-
 Manages projects.
 ---

--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_registry_module"
-sidebar_current: "docs-resource-tfe-registry-module"
 description: |-
   Manages registry modules
 ---

--- a/website/docs/r/run_trigger.html.markdown
+++ b/website/docs/r/run_trigger.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_run_trigger"
-sidebar_current: "docs-resource-tfe-run-trigger"
 description: |-
   Manages run triggers
 ---

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_sentinel_policy"
-sidebar_current: "docs-resource-tfe-sentinel-policy"
 description: |-
   Manages Sentinel policies.
 ---

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_ssh_key"
-sidebar_current: "docs-resource-tfe-ssh-key"
 description: |-
   Manages SSH keys.
 ---

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team"
-sidebar_current: "docs-resource-tfe-team-x"
 description: |-
   Manages teams.
 ---

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team_access"
-sidebar_current: "docs-resource-tfe-team-access"
 description: |-
   Associate a team to permissions on a workspace.
 ---

--- a/website/docs/r/team_member.html.markdown
+++ b/website/docs/r/team_member.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team_member"
-sidebar_current: "docs-resource-tfe-team-member-x"
 description: |-
   Add or remove a user from a team.
 ---

--- a/website/docs/r/team_members.html.markdown
+++ b/website/docs/r/team_members.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team_members"
-sidebar_current: "docs-resource-tfe-team-members"
 description: |-
   Manages users in a team.
 ---

--- a/website/docs/r/team_organization_member.html.markdown
+++ b/website/docs/r/team_organization_member.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team_organization_member"
-sidebar_current: "docs-resource-tfe-team-organization_member"
 description: |-
   Add or remove a user from a team.
 ---

--- a/website/docs/r/team_organization_members.html.markdown
+++ b/website/docs/r/team_organization_members.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team_organization_members"
-sidebar_current: "docs-resource-tfe-team-organization_members"
 description: |-
   Add or remove users from a team based on their organization memberships.
 ---

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_team_token"
-sidebar_current: "docs-resource-tfe-team-token"
 description: |-
   Generates a new team token and overrides existing token if one exists.
 ---

--- a/website/docs/r/terraform_version.html.markdown
+++ b/website/docs/r/terraform_version.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_terraform_version"
-sidebar_current: "docs-resource-tfe-terraform-version-x"
 description: |-
   Manages Terraform versions
 ---

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_variable"
-sidebar_current: "docs-resource-tfe-variable"
 description: |-
   Manages variables.
 ---

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_variable_set"
-sidebar_current: "docs-resource-tfe-variable-set"
 description: |-
   Manages variable sets.
 ---

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_workspace"
-sidebar_current: "docs-resource-tfe-workspace"
 description: |-
   Manages workspaces.
 ---

--- a/website/docs/r/workspace_policy_set.html.markdown
+++ b/website/docs/r/workspace_policy_set.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_workspace_policy_set"
-sidebar_current: "docs-resource-tfe-workspace-policy-set"
 description: |-
   Add a policy set to a workspace
 ---

--- a/website/docs/r/workspace_run_task.html.markdown
+++ b/website/docs/r/workspace_run_task.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_workspace_run_task"
-sidebar_current: "docs-resource-tfe_workspace_run_task"
 description: |-
   Manages Workspace Run tasks.
 ---

--- a/website/docs/r/workspace_variable_set.html.markdown
+++ b/website/docs/r/workspace_variable_set.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_workspace_variable_set"
-sidebar_current: "docs-resource-tfe-workspace-variable-set"
 description: |-
   Add a variable set to a workspace
 ---


### PR DESCRIPTION
## Description

For reference: [the current frontmatter keys supported by the Terraform Registry's docs formatter.](https://developer.hashicorp.com/terraform/registry/providers/docs#yaml-frontmatter)

This old sidebar_current frontmatter key does nothing, and any effort spent adding it to new files or keeping it up to date is tragic. Let's yank it so newer contributors aren't tempted to mess with it!

Background story: This used to be a hack to make the sidebar navs work properly on the old Middleman-based Terraform.io website. I eventually replaced that hack with a better hack, later we stopped hosting provider docs on terraform.io at all, and then some years later we moved that site off Middleman entirely anyway.

## Testing plan

1. This is a docs-only PR.