### PR TITLE
Validate tag_names for lowercase and other api validation rules

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,7 +40,7 @@ vet:
 	fi
 
 lint:
-	@golangci-lint run ; if [ $$? -ne 1 ]; then \
+	@golangci-lint run ; if [ $$? -ne 0 ]; then \
 		echo ""; \
 		echo "golangci-lint found some code style issues." \
 		exit 1; \

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -35,18 +35,19 @@ func resourceTFEWorkspace() *schema.Resource {
 
 		CustomizeDiff: func(c context.Context, d *schema.ResourceDiff, meta interface{}) error {
 			// NOTE: execution mode must be set to default first before calling the validation functions
-			err := setExecutionModeDefault(c, d)
-			if err != nil {
+			if err := setExecutionModeDefault(c, d); err != nil {
 				return err
 			}
 
-			err = validateAgentExecution(c, d)
-			if err != nil {
+			if err := validateAgentExecution(c, d); err != nil {
 				return err
 			}
 
-			err = validateRemoteState(c, d)
-			if err != nil {
+			if err := validateRemoteState(c, d); err != nil {
+				return err
+			}
+
+			if err := validateTagNames(c, d); err != nil {
 				return err
 			}
 
@@ -333,12 +334,7 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 
 	for _, tagName := range d.Get("tag_names").(*schema.Set).List() {
 		name := tagName.(string)
-		if len(strings.TrimSpace(name)) != 0 {
-			if tagContainsUppercase(name) {
-				warnWorkspaceTagsCasing(ctx, name)
-			}
-			options.Tags = append(options.Tags, &tfe.Tag{Name: name})
-		}
+		options.Tags = append(options.Tags, &tfe.Tag{Name: name})
 	}
 
 	log.Printf("[DEBUG] Create workspace %s for organization: %s", name, organization)
@@ -627,9 +623,6 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 
 			for _, tagName := range newTagNames.List() {
 				name := tagName.(string)
-				if tagContainsUppercase(name) {
-					warnWorkspaceTagsCasing(ctx, name)
-				}
 				addTags = append(addTags, &tfe.Tag{Name: name})
 			}
 
@@ -798,6 +791,36 @@ func validateAgentExecution(_ context.Context, d *schema.ResourceDiff) error {
 	return nil
 }
 
+func validTagName(tag string) bool {
+	// Tags are re-validated here because the API will accept uppercase letters and automatically
+	// downcase them, causing resource drift. It's better to catch this issue during the plan phase
+	//
+	//     \A            match beginning of string
+	//     [a-z0-9]      match a letter or number for the first char; case insensitive
+	//     (?:           start non-capture group; used to group sub-expressions; will not capture/store, interally
+	//       [\w:-]*     match 0 or more letter, number, colon, or hyphen
+	//       [a-z0-9]    match a letter or number as the final character when this group is present
+	//     )?            end non-capture group; ? is quantifier; matches 0 or 1 instances of the non-capture group in preceding set
+	//     \z            match end of string; requires last char to match preceding subset; in this case, an alphanumeric char
+	tagPattern := regexp.MustCompile(`\A[a-z0-9](?:[\w:-]*[a-z0-9])?\z`)
+	return tagPattern.MatchString(tag)
+}
+
+func validateTagNames(_ context.Context, d *schema.ResourceDiff) error {
+	names, ok := d.GetOk("tag_names")
+	if !ok {
+		return nil
+	}
+
+	for _, t := range names.(*schema.Set).List() {
+		tagName := t.(string)
+		if !validTagName(tagName) {
+			return fmt.Errorf("%q is not a valid tag name. Tag must be one or more characters; can include letters, numbers, colons, hyphens, and underscores; and must begin and end with a letter or number", tagName)
+		}
+	}
+	return nil
+}
+
 func validateRemoteState(_ context.Context, d *schema.ResourceDiff) error {
 	// If remote state consumers aren't set, the global setting can be either value and it
 	// doesn't matter.
@@ -807,7 +830,7 @@ func validateRemoteState(_ context.Context, d *schema.ResourceDiff) error {
 	}
 
 	if globalRemoteState, ok := d.GetOk("global_remote_state"); ok {
-		if globalRemoteState.(bool) == true {
+		if globalRemoteState.(bool) {
 			return fmt.Errorf("global_remote_state must be 'false' when setting remote_state_consumer_ids")
 		}
 	}
@@ -837,15 +860,10 @@ func resourceTFEWorkspaceImporter(ctx context.Context, d *schema.ResourceData, m
 	return []*schema.ResourceData{d}, nil
 }
 
-// Warns the user that a workspace tag containing uppercase characters will be downcased.
-func warnWorkspaceTagsCasing(ctx context.Context, tag string) {
-	log.Printf("[WARN] The tag \"%s\" contains uppercase characters that will be transformed by the API. Please update your configuration to lowercase tags in order to avoid conflicts with state.", tag)
-}
-
 func errWorkspaceSafeDeleteWithPermission(workspaceID string, err error) error {
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "conflict") {
-			return fmt.Errorf("Error deleting workspace %s: %w\nTo delete this workspace without destroying the managed resources, add force_delete = true to the resource config.", workspaceID, err)
+			return fmt.Errorf("error deleting workspace %s: %w\nTo delete this workspace without destroying the managed resources, add force_delete = true to the resource config", workspaceID, err)
 		}
 	}
 	return nil
@@ -854,7 +872,7 @@ func errWorkspaceSafeDeleteWithPermission(workspaceID string, err error) error {
 func errWorkspaceResourceCountCheck(workspaceID string, resourceCount int) error {
 	if resourceCount > 0 {
 		return fmt.Errorf(
-			"Error deleting workspace %s: This workspace has %v resources under management and must be force deleted by setting force_delete = true", workspaceID, resourceCount)
+			"error deleting workspace %s: This workspace has %v resources under management and must be force deleted by setting force_delete = true", workspaceID, resourceCount)
 	}
 	return nil
 }

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -798,11 +798,11 @@ func validTagName(tag string) bool {
 	//     \A            match beginning of string
 	//     [a-z0-9]      match a letter or number for the first char; case insensitive
 	//     (?:           start non-capture group; used to group sub-expressions; will not capture/store, interally
-	//       [\w:-]*     match 0 or more letter, number, colon, or hyphen
+	//       [a-z0-9_:-]*     match 0 or more letter, number, colon, or hyphen
 	//       [a-z0-9]    match a letter or number as the final character when this group is present
 	//     )?            end non-capture group; ? is quantifier; matches 0 or 1 instances of the non-capture group in preceding set
 	//     \z            match end of string; requires last char to match preceding subset; in this case, an alphanumeric char
-	tagPattern := regexp.MustCompile(`\A[a-z0-9](?:[\w:-]*[a-z0-9])?\z`)
+	tagPattern := regexp.MustCompile(`\A[a-z0-9](?:[a-z0-9_:-]*[a-z0-9])?\z`)
 	return tagPattern.MatchString(tag)
 }
 
@@ -815,7 +815,7 @@ func validateTagNames(_ context.Context, d *schema.ResourceDiff) error {
 	for _, t := range names.(*schema.Set).List() {
 		tagName := t.(string)
 		if !validTagName(tagName) {
-			return fmt.Errorf("%q is not a valid tag name. Tag must be one or more characters; can include letters, numbers, colons, hyphens, and underscores; and must begin and end with a letter or number", tagName)
+			return fmt.Errorf("%q is not a valid tag name. Tag must be one or more characters; can include lowercase letters, numbers, colons, hyphens, and underscores; and must begin and end with a letter or number", tagName)
 		}
 	}
 	return nil

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -125,6 +125,9 @@ func TestTagValidation(t *testing.T) {
 		{"h1", true},
 		{"1h", true},
 		{"1H", false},
+		{"aStater", false},
+		{"new_Cap", false},
+		{"new_cap-laugh", true},
 	}
 
 	for _, c := range testCases {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -114,6 +114,30 @@ func TestAccTFEWorkspace_customProject(t *testing.T) {
 	})
 }
 
+func TestTagValidation(t *testing.T) {
+	testCases := []struct {
+		tag   string
+		valid bool
+	}{
+		{"hello-world", true},
+		{"-helloworld", false},
+		{"H1", false},
+		{"h1", true},
+		{"1h", true},
+		{"1H", false},
+	}
+
+	for _, c := range testCases {
+		if validTagName(c.tag) != c.valid {
+			explain := "an invalid"
+			if c.valid {
+				explain = "a valid"
+			}
+			t.Errorf("expected %q to be %s tag", c.tag, explain)
+		}
+	}
+}
+
 func TestAccTFEWorkspace_panic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -1216,6 +1240,11 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.1", "test"),
 				),
+			},
+			{
+				// bad tags
+				Config:      testAccTFEWorkspace_basicBadTag(rInt),
+				ExpectError: regexp.MustCompile(`"-Hello" is not a valid tag name.`),
 			},
 		},
 	})
@@ -2532,6 +2561,21 @@ resource "tfe_workspace" "foobar" {
   organization       = tfe_organization.foobar.id
   auto_apply         = true
   tag_names          = []
+}`, rInt)
+}
+
+func testAccTFEWorkspace_basicBadTag(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name               = "workspace-test"
+  organization       = tfe_organization.foobar.id
+  auto_apply         = true
+  tag_names          = ["-Hello"]
 }`, rInt)
 }
 

--- a/tfe/workspace_helpers.go
+++ b/tfe/workspace_helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"unicode"
 
 	tfe "github.com/hashicorp/go-tfe"
 )
@@ -104,13 +103,4 @@ func readWorkspaceStateConsumers(id string, client *tfe.Client) (bool, []interfa
 	}
 
 	return false, remoteStateConsumerIDs, nil
-}
-
-func tagContainsUppercase(tag string) bool {
-	for _, c := range tag {
-		if unicode.IsUpper(c) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Today, we print a warning if you use upcase letters in your tfe_workspace tag_names. Trouble is, you don't see these warnings until after you've already created the offending tag name and only if you have TF_LOG level set to warn.

The API will accept uppercase tag names, but will silently downcase them, which introduces a problem for uppercase config tag names, because from that time on, the case change is detected as drift. This proactive enforcement will protect users from unexpected drift on the next apply:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tfe_workspace.deleteme will be created
  + resource "tfe_workspace" "deleteme" {
      + allow_destroy_plan            = true
      + auto_apply                    = false
      + execution_mode                = "remote"
      + file_triggers_enabled         = true
      + force_delete                  = false
      + global_remote_state           = (known after apply)
      + id                            = (known after apply)
      + name                          = "deleteme"
      + operations                    = (known after apply)
      + organization                  = "hashicorp"
      + project_id                    = (known after apply)
      + queue_all_runs                = true
      + remote_state_consumer_ids     = (known after apply)
      + speculative_enabled           = true
      + structured_run_output_enabled = true
      + tag_names                     = [
          + "Hello-World",
        ]
      + terraform_version             = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tfe_workspace.deleteme: Creating...
tfe_workspace.deleteme: Creation complete after 1s [id=ws-WJipFZUjydzfwvPw]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
~/hashicorp/example-tfe-workspace
$ terraform apply
tfe_workspace.deleteme: Refreshing state... [id=ws-WJipFZUjydzfwvPw]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # tfe_workspace.deleteme will be updated in-place
  ~ resource "tfe_workspace" "deleteme" {
        id                            = "ws-WJipFZUjydzfwvPw"
        name                          = "deleteme"
      ~ tag_names                     = [
          + "Hello-World",
          - "hello-world",
        ]
        # (17 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value:
```

Closes #529

## Description

_Describe why you're making this change._

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-documentation)_

## Testing plan

1. Create workspace config. Try adding invalid tags (containing uppercase characters for instance)
2. See tests to show examples of invalid tags

Example config:

```hcl
resource "tfe_workspace" "deleteme" {
  name = "deleteme"
  organization = "hashicorp"
  tag_names = ["Hello"]
}
```