### PR TITLE
d/workspace_ids: Require exact match when no wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 BUG FIXES:
-* d/tfe_workspace_ids: When no wildcard matchers were used in the names argument a substring match was being performed anyway
+* d/tfe_workspace_ids: When no wildcard matchers were used in the names argument a substring match was being performed anyway @brandonc ([#752](https://github.com/hashicorp/terraform-provider-tfe/pull/752))
 
 FEATURES:
 * r/tfe_workspace: Add attribute `resource_count` to `tfe_workspace` by @rhughes1 ([#682](https://github.com/hashicorp/terraform-provider-tfe/pull/682))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUG FIXES:
+* d/tfe_workspace_ids: When no wildcard matchers were used in the names argument a substring match was being performed anyway
+
 FEATURES:
 * r/tfe_workspace: Add attribute `resource_count` to `tfe_workspace` by @rhughes1 ([#682](https://github.com/hashicorp/terraform-provider-tfe/pull/682))
 * d/tfe_outputs: Add `nonsensitive_values` attribute to expose current non-sensitive outputs of a given workspace ([#711](https://github.com/hashicorp/terraform-provider-tfe/pull/711))

--- a/tfe/data_source_workspace_ids.go
+++ b/tfe/data_source_workspace_ids.go
@@ -56,7 +56,7 @@ func includedByName(names map[string]bool, workspaceName string) bool {
 		case len(name) == 0:
 			continue
 		case !strings.HasPrefix(name, "*") && !strings.HasSuffix(name, "*"):
-			if strings.Contains(workspaceName, name) {
+			if name == workspaceName {
 				return true
 			}
 		case strings.HasPrefix(name, "*") && strings.HasSuffix(name, "*"):

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -214,6 +214,43 @@ func TestAccTFEWorkspaceIDsDataSource_suffixWildcard(t *testing.T) {
 	})
 }
 
+func TestAccTFEWorkspaceIDsDataSource_noMatch(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	fooWorkspaceName := "workspace-foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, fooWorkspaceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "names.#", "1"),
+
+					// organization attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "organization", orgName),
+
+					// full_names attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "full_names.%", "0"),
+
+					// ids attribute
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace_ids.foobar", "ids.%", "0"),
+
+					// id attribute
+					resource.TestCheckResourceAttrSet("data.tfe_workspace_ids.foobar", "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFEWorkspaceIDsDataSource_substringWildcard(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)


### PR DESCRIPTION
## Description

There was a bug in the new d/tfe_workspace_ids wildcard logic that performed a substring match even when no wildcards were present

## External links

Closes #747 

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEWorkspaceIDsDataSource_noMatch" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceIDsDataSource_noMatch -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEWorkspaceIDsDataSource_noMatch
--- PASS: TestAccTFEWorkspaceIDsDataSource_noMatch (25.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	26.388s
```
