### PR TITLE
Add provider config organization, making all resource organization fields optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 * Update API doc links from terraform.io to developer.hashicorp domain by @uk1288 [#764](https://github.com/hashicorp/terraform-provider-tfe/pull/764)
 
 FEATURES:
+* **New Provider Config**: `organization` defines a default organization for all resources, making all resource-specific organization arguments optional.
 * r/tfe_team: Teams can now be imported using `<ORGANIZATION NAME>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
 * r/tfe_team_organization_member: Team Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
 

--- a/tfe/data_source_agent_pool.go
+++ b/tfe/data_source_agent_pool.go
@@ -16,7 +16,7 @@ func dataSourceTFEAgentPool() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 		},
 	}
@@ -27,7 +27,10 @@ func dataSourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error 
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	id, err := fetchAgentPoolID(organization, name, config.Client)
 	if err != nil {

--- a/tfe/data_source_agent_pool.go
+++ b/tfe/data_source_agent_pool.go
@@ -1,7 +1,6 @@
 package tfe
 
 import (
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -24,13 +23,13 @@ func dataSourceTFEAgentPool() *schema.Resource {
 }
 
 func dataSourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
 
-	id, err := fetchAgentPoolID(organization, name, tfeClient)
+	id, err := fetchAgentPoolID(organization, name, config.Client)
 	if err != nil {
 		return err
 	}

--- a/tfe/data_source_ip_ranges.go
+++ b/tfe/data_source_ip_ranges.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -38,10 +37,10 @@ func dataSourceTFEIPRanges() *schema.Resource {
 }
 
 func dataSourceTFEIPRangesRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Reading IP Ranges")
-	ipRanges, err := tfeClient.Meta.IPRanges.Read(ctx, "")
+	ipRanges, err := config.Client.Meta.IPRanges.Read(ctx, "")
 	if err != nil {
 		return fmt.Errorf("Error retrieving IP ranges: %w", err)
 	}

--- a/tfe/data_source_oauth_client.go
+++ b/tfe/data_source_oauth_client.go
@@ -78,14 +78,14 @@ func dataSourceTFEOAuthClient() *schema.Resource {
 
 func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := context.TODO()
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	var oc *tfe.OAuthClient
 	var err error
 
 	switch v, ok := d.GetOk("oauth_client_id"); {
 	case ok:
-		oc, err = tfeClient.OAuthClients.Read(ctx, v.(string))
+		oc, err = config.Client.OAuthClients.Read(ctx, v.(string))
 		if err != nil {
 			return fmt.Errorf("Error retrieving OAuth client: %w", err)
 		}
@@ -104,7 +104,7 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 			serviceProvider = tfe.ServiceProviderType(vServiceProvider.(string))
 		}
 
-		oc, err = fetchOAuthClientByNameOrServiceProvider(ctx, tfeClient, organization, name, serviceProvider)
+		oc, err = fetchOAuthClientByNameOrServiceProvider(ctx, config.Client, organization, name, serviceProvider)
 		if err != nil {
 			return err
 		}

--- a/tfe/data_source_oauth_client.go
+++ b/tfe/data_source_oauth_client.go
@@ -91,7 +91,10 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	default:
 		// search by name or service provider within a specific organization instead
-		organization := d.Get("organization").(string)
+		organization, err := config.schemaOrDefaultOrganization(d)
+		if err != nil {
+			return err
+		}
 
 		var name string
 		var serviceProvider tfe.ServiceProviderType
@@ -119,7 +122,6 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 	if oc.Name != nil {
 		d.Set("name", *oc.Name)
 	}
-	d.Set("organization", oc.Organization.Name)
 	d.Set("service_provider", oc.ServiceProvider)
 	d.Set("service_provider_display_name", oc.ServiceProviderName)
 

--- a/tfe/data_source_organization.go
+++ b/tfe/data_source_organization.go
@@ -69,7 +69,11 @@ func dataSourceTFEOrganization() *schema.Resource {
 func dataSourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
 
-	name := d.Get("name").(string)
+	name, err := config.schemaOrDefaultOrganizationKey(d, "name")
+	if err != nil {
+		return err
+	}
+
 	log.Printf("[DEBUG] Read configuration for Organization: %s", name)
 	org, err := config.Client.Organizations.Read(ctx, name)
 	if err != nil {
@@ -81,7 +85,6 @@ func dataSourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Setting Organization Attributes")
 	d.SetId(org.ExternalID)
-	d.Set("name", org.Name)
 	d.Set("external_id", org.ExternalID)
 	d.Set("collaborator_auth_policy", org.CollaboratorAuthPolicy)
 	d.Set("cost_estimation_enabled", org.CostEstimationEnabled)

--- a/tfe/data_source_organization.go
+++ b/tfe/data_source_organization.go
@@ -67,11 +67,11 @@ func dataSourceTFEOrganization() *schema.Resource {
 }
 
 func dataSourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	name := d.Get("name").(string)
 	log.Printf("[DEBUG] Read configuration for Organization: %s", name)
-	org, err := tfeClient.Organizations.Read(ctx, name)
+	org, err := config.Client.Organizations.Read(ctx, name)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return fmt.Errorf("could not read organization '%s'", name)

--- a/tfe/data_source_organization_members.go
+++ b/tfe/data_source_organization_members.go
@@ -11,7 +11,7 @@ func dataSourceTFEOrganizationMembers() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"members": {
@@ -56,7 +56,10 @@ func dataSourceTFEOrganizationMembers() *schema.Resource {
 func dataSourceTFEOrganizationMembersRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
 
-	organizationName := d.Get("organization").(string)
+	organizationName, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	members, membersWaiting, err := fetchOrganizationMembers(config.Client, organizationName)
 	if err != nil {

--- a/tfe/data_source_organization_members.go
+++ b/tfe/data_source_organization_members.go
@@ -1,7 +1,6 @@
 package tfe
 
 import (
-	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -55,11 +54,11 @@ func dataSourceTFEOrganizationMembers() *schema.Resource {
 }
 
 func dataSourceTFEOrganizationMembersRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	organizationName := d.Get("organization").(string)
 
-	members, membersWaiting, err := fetchOrganizationMembers(tfeClient, organizationName)
+	members, membersWaiting, err := fetchOrganizationMembers(config.Client, organizationName)
 	if err != nil {
 		return err
 	}

--- a/tfe/data_source_organization_membership.go
+++ b/tfe/data_source_organization_membership.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -38,14 +37,14 @@ func dataSourceTFEOrganizationMembership() *schema.Resource {
 }
 
 func dataSourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the user email and organization.
 	email := d.Get("email").(string)
 	username := d.Get("username").(string)
 	organization := d.Get("organization").(string)
 
-	orgMember, err := fetchOrganizationMemberByNameOrEmail(context.Background(), tfeClient, organization, username, email)
+	orgMember, err := fetchOrganizationMemberByNameOrEmail(context.Background(), config.Client, organization, username, email)
 	if err != nil {
 		return fmt.Errorf("could not find organization membership for organization %s: %w", organization, err)
 	}

--- a/tfe/data_source_organization_membership.go
+++ b/tfe/data_source_organization_membership.go
@@ -25,7 +25,7 @@ func dataSourceTFEOrganizationMembership() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"user_id": {
@@ -42,7 +42,11 @@ func dataSourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interf
 	// Get the user email and organization.
 	email := d.Get("email").(string)
 	username := d.Get("username").(string)
-	organization := d.Get("organization").(string)
+
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	orgMember, err := fetchOrganizationMemberByNameOrEmail(context.Background(), config.Client, organization, username, email)
 	if err != nil {

--- a/tfe/data_source_organization_run_task.go
+++ b/tfe/data_source_organization_run_task.go
@@ -1,7 +1,6 @@
 package tfe
 
 import (
-	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -44,11 +43,11 @@ func dataSourceTFEOrganizationRunTask() *schema.Resource {
 }
 
 func dataSourceTFEOrganizationRunTaskRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
 
-	task, err := fetchOrganizationRunTask(name, organization, tfeClient)
+	task, err := fetchOrganizationRunTask(name, organization, config.Client)
 	if err != nil {
 		return err
 	}

--- a/tfe/data_source_organization_run_task.go
+++ b/tfe/data_source_organization_run_task.go
@@ -16,7 +16,7 @@ func dataSourceTFEOrganizationRunTask() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"url": {
@@ -45,7 +45,10 @@ func dataSourceTFEOrganizationRunTask() *schema.Resource {
 func dataSourceTFEOrganizationRunTaskRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	task, err := fetchOrganizationRunTask(name, organization, config.Client)
 	if err != nil {

--- a/tfe/data_source_organizations.go
+++ b/tfe/data_source_organizations.go
@@ -34,16 +34,16 @@ func dataSourceTFEOrganizations() *schema.Resource {
 }
 
 func dataSourceTFEOrganizationList(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	var names []string
 	var ids map[string]string
 	var err error
 
 	if isAdmin(d) {
-		names, ids, err = adminOrgsPopulateFields(tfeClient)
+		names, ids, err = adminOrgsPopulateFields(config.Client)
 	} else {
-		names, ids, err = orgsPopulateFields(tfeClient)
+		names, ids, err = orgsPopulateFields(config.Client)
 	}
 
 	if err != nil {

--- a/tfe/data_source_outputs.go
+++ b/tfe/data_source_outputs.go
@@ -14,14 +14,14 @@ import (
 )
 
 type dataSourceOutputs struct {
-	tfeClient           *tfe.Client
-	defaultOrganization string
+	tfeClient    *tfe.Client
+	organization string
 }
 
 func newDataSourceOutputs(config ConfiguredClient) tfprotov5.DataSourceServer {
 	return dataSourceOutputs{
-		tfeClient:           config.Client,
-		defaultOrganization: config.DefaultOrganization,
+		tfeClient:    config.Client,
+		organization: config.Organization,
 	}
 }
 
@@ -130,11 +130,11 @@ func (d dataSourceOutputs) readConfigValues(req *tfprotov5.ReadDataSourceRequest
 	}
 
 	err = valMap["organization"].As(&orgName)
-	if err != nil {
-		if d.defaultOrganization == "" {
-			return "", "", fmt.Errorf("error assigning 'organization' value to string: %w", err)
+	if err != nil || orgName == "" {
+		if d.organization == "" {
+			return "", "", errMissingOrganization
 		}
-		orgName = d.defaultOrganization
+		orgName = d.organization
 	}
 
 	if valMap["workspace"].IsNull() {

--- a/tfe/data_source_outputs_test.go
+++ b/tfe/data_source_outputs_test.go
@@ -18,17 +18,17 @@ import (
 func TestAccTFEOutputs(t *testing.T) {
 	skipIfUnitTest(t)
 
-	client, err := getClientUsingEnv()
+	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatalf("error getting client %v", err)
 	}
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	fileName := "test-fixtures/state-versions/terraform.tfstate"
-	orgName, wsName, orgCleanup := createStateVersion(t, client, rInt, fileName)
+	orgName, wsName, orgCleanup := createStateVersion(t, tfeClient, rInt, fileName)
 	t.Cleanup(orgCleanup)
 
-	waitForOutputs(t, client, orgName, wsName)
+	waitForOutputs(t, tfeClient, orgName, wsName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -62,17 +62,17 @@ func TestAccTFEOutputs(t *testing.T) {
 func TestAccTFEOutputs_ReadAllNonSensitiveValues(t *testing.T) {
 	skipIfUnitTest(t)
 
-	client, err := getClientUsingEnv()
+	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatalf("error getting client %v", err)
 	}
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	fileName := "test-fixtures/state-versions/terraform.tfstate"
-	orgName, wsName, orgCleanup := createStateVersion(t, client, rInt, fileName)
+	orgName, wsName, orgCleanup := createStateVersion(t, tfeClient, rInt, fileName)
 	t.Cleanup(orgCleanup)
 
-	waitForOutputs(t, client, orgName, wsName)
+	waitForOutputs(t, tfeClient, orgName, wsName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -107,14 +107,14 @@ func TestAccTFEOutputs_ReadAllNonSensitiveValues(t *testing.T) {
 func TestAccTFEOutputs_emptyOutputs(t *testing.T) {
 	skipIfUnitTest(t)
 
-	client, err := getClientUsingEnv()
+	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatalf("error getting client %v", err)
 	}
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	fileName := "test-fixtures/state-versions/terraform-empty-outputs.tfstate"
-	orgName, wsName, orgCleanup := createStateVersion(t, client, rInt, fileName)
+	orgName, wsName, orgCleanup := createStateVersion(t, tfeClient, rInt, fileName)
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{

--- a/tfe/data_source_policy_set.go
+++ b/tfe/data_source_policy_set.go
@@ -20,7 +20,7 @@ func dataSourceTFEPolicySet() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"description": {
@@ -97,7 +97,10 @@ func dataSourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error 
 	config := meta.(ConfiguredClient)
 
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	listOptions := tfe.PolicySetListOptions{}
 
@@ -118,10 +121,6 @@ func dataSourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error 
 				d.Set("description", policySet.Description)
 				d.Set("global", policySet.Global)
 				d.Set("policies_path", policySet.PoliciesPath)
-
-				if policySet.Organization != nil {
-					d.Set("organization", policySet.Organization.Name)
-				}
 
 				if policySet.Kind != "" {
 					d.Set("kind", policySet.Kind)

--- a/tfe/data_source_policy_set.go
+++ b/tfe/data_source_policy_set.go
@@ -94,7 +94,7 @@ func dataSourceTFEPolicySet() *schema.Resource {
 }
 
 func dataSourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
@@ -102,7 +102,7 @@ func dataSourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error 
 	listOptions := tfe.PolicySetListOptions{}
 
 	for {
-		policySetList, err := tfeClient.PolicySets.List(ctx, organization, &listOptions)
+		policySetList, err := config.Client.PolicySets.List(ctx, organization, &listOptions)
 
 		if err != nil {
 			if errors.Is(err, tfe.ErrResourceNotFound) {

--- a/tfe/data_source_ssh_key.go
+++ b/tfe/data_source_ssh_key.go
@@ -19,7 +19,7 @@ func dataSourceTFESSHKey() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 		},
 	}
@@ -30,7 +30,10 @@ func dataSourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create an options struct.
 	options := &tfe.SSHKeyListOptions{}

--- a/tfe/data_source_ssh_key.go
+++ b/tfe/data_source_ssh_key.go
@@ -26,7 +26,7 @@ func dataSourceTFESSHKey() *schema.Resource {
 }
 
 func dataSourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
@@ -36,7 +36,7 @@ func dataSourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 	options := &tfe.SSHKeyListOptions{}
 
 	for {
-		l, err := tfeClient.SSHKeys.List(ctx, organization, options)
+		l, err := config.Client.SSHKeys.List(ctx, organization, options)
 		if err != nil {
 			return fmt.Errorf("Error retrieving SSH keys: %w", err)
 		}

--- a/tfe/data_source_team.go
+++ b/tfe/data_source_team.go
@@ -30,13 +30,13 @@ func dataSourceTFETeam() *schema.Resource {
 }
 
 func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
 
-	tl, err := tfeClient.Teams.List(ctx, organization, &tfe.TeamListOptions{
+	tl, err := config.Client.Teams.List(ctx, organization, &tfe.TeamListOptions{
 		Names: []string{name},
 	})
 	if err != nil {
@@ -75,7 +75,7 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 
 			options.PageNumber = tl.NextPage
 
-			tl, err = tfeClient.Teams.List(ctx, organization, options)
+			tl, err = config.Client.Teams.List(ctx, organization, options)
 			if err != nil {
 				return fmt.Errorf("Error retrieving teams: %w", err)
 			}

--- a/tfe/data_source_team.go
+++ b/tfe/data_source_team.go
@@ -19,7 +19,7 @@ func dataSourceTFETeam() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"sso_team_id": {
 				Type:     schema.TypeString,
@@ -34,7 +34,10 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	tl, err := config.Client.Teams.List(ctx, organization, &tfe.TeamListOptions{
 		Names: []string{name},

--- a/tfe/data_source_team_access.go
+++ b/tfe/data_source_team_access.go
@@ -69,14 +69,14 @@ func dataSourceTFETeamAccess() *schema.Resource {
 }
 
 func dataSourceTFETeamAccessRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the team ID.
 	teamID := d.Get("team_id").(string)
 
 	// Get the workspace
 	workspaceID := d.Get("workspace_id").(string)
-	ws, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+	ws, err := config.Client.Workspaces.ReadByID(ctx, workspaceID)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving workspace %s: %w", workspaceID, err)
@@ -88,7 +88,7 @@ func dataSourceTFETeamAccessRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	for {
-		l, err := tfeClient.TeamAccess.List(ctx, options)
+		l, err := config.Client.TeamAccess.List(ctx, options)
 		if err != nil {
 			return fmt.Errorf("Error retrieving team access list: %w", err)
 		}

--- a/tfe/data_source_variable_set.go
+++ b/tfe/data_source_variable_set.go
@@ -19,7 +19,7 @@ func dataSourceTFEVariableSet() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"description": {
@@ -54,7 +54,10 @@ func dataSourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) erro
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create an options struct.
 	options := tfe.VariableSetListOptions{}

--- a/tfe/data_source_variable_set.go
+++ b/tfe/data_source_variable_set.go
@@ -50,7 +50,7 @@ func dataSourceTFEVariableSet() *schema.Resource {
 }
 
 func dataSourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
@@ -62,7 +62,7 @@ func dataSourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) erro
 	for {
 		// Variable Set relations, vars and workspaces, are omitted from the querying until
 		// we find the desired variable set.
-		l, err := tfeClient.VariableSets.List(ctx, organization, &options)
+		l, err := config.Client.VariableSets.List(ctx, organization, &options)
 		if err != nil {
 			if err == tfe.ErrResourceNotFound {
 				return fmt.Errorf("could not find variable set%s/%s", organization, name)
@@ -81,7 +81,7 @@ func dataSourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) erro
 					Include: &[]tfe.VariableSetIncludeOpt{tfe.VariableSetWorkspaces, tfe.VariableSetVars},
 				}
 
-				vs, err = tfeClient.VariableSets.Read(ctx, vs.ID, &readOptions)
+				vs, err = config.Client.VariableSets.Read(ctx, vs.ID, &readOptions)
 				if err != nil {
 					return fmt.Errorf("Error retrieving variable set relations: %w", err)
 				}

--- a/tfe/data_source_variables.go
+++ b/tfe/data_source_variables.go
@@ -82,7 +82,7 @@ func dataSourceVariableRead(d *schema.ResourceData, meta interface{}) error {
 		return dataSourceVariableSetVariableRead(d, meta)
 	}
 
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	workspaceID := d.Get("workspace_id").(string)
@@ -95,7 +95,7 @@ func dataSourceVariableRead(d *schema.ResourceData, meta interface{}) error {
 	options := &tfe.VariableListOptions{}
 
 	for {
-		variableList, err := tfeClient.Variables.List(ctx, workspaceID, options)
+		variableList, err := config.Client.Variables.List(ctx, workspaceID, options)
 		if err != nil {
 			return fmt.Errorf("Error retrieving variable list: %w", err)
 		}
@@ -136,7 +136,7 @@ func dataSourceVariableRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func dataSourceVariableSetVariableRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the id.
 	variableSetID := d.Get("variable_set_id").(string)
@@ -149,7 +149,7 @@ func dataSourceVariableSetVariableRead(d *schema.ResourceData, meta interface{})
 	options := tfe.VariableSetVariableListOptions{}
 
 	for {
-		variableList, err := tfeClient.VariableSetVariables.List(ctx, variableSetID, &options)
+		variableList, err := config.Client.VariableSetVariables.List(ctx, variableSetID, &options)
 		if err != nil {
 			return fmt.Errorf("Error retrieving variable list: %w", err)
 		}

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -20,7 +20,7 @@ func dataSourceTFEWorkspace() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"description": {
@@ -179,7 +179,10 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[DEBUG] Read configuration of workspace: %s", name)
 	workspace, err := config.Client.Workspaces.Read(ctx, organization, name)

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -175,14 +175,14 @@ func dataSourceTFEWorkspace() *schema.Resource {
 }
 
 func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
 
 	log.Printf("[DEBUG] Read configuration of workspace: %s", name)
-	workspace, err := tfeClient.Workspaces.Read(ctx, organization, name)
+	workspace, err := config.Client.Workspaces.Read(ctx, organization, name)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return fmt.Errorf("could not find workspace %s/%s", organization, name)
@@ -221,7 +221,7 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 			return err
 		}
 	} else {
-		legacyGlobalState, remoteStateConsumerIDs, err := readWorkspaceStateConsumers(workspace.ID, tfeClient)
+		legacyGlobalState, remoteStateConsumerIDs, err := readWorkspaceStateConsumers(workspace.ID, config.Client)
 
 		if err != nil {
 			return fmt.Errorf(

--- a/tfe/data_source_workspace_ids.go
+++ b/tfe/data_source_workspace_ids.go
@@ -34,7 +34,7 @@ func dataSourceTFEWorkspaceIDs() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"ids": {
@@ -86,7 +86,10 @@ func dataSourceTFEWorkspaceIDsRead(d *schema.ResourceData, meta interface{}) err
 	config := meta.(ConfiguredClient)
 
 	// Get the organization.
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a map with all the names we are looking for.
 	var id string

--- a/tfe/data_source_workspace_ids.go
+++ b/tfe/data_source_workspace_ids.go
@@ -83,7 +83,7 @@ func includedByName(names map[string]bool, workspaceName string) bool {
 }
 
 func dataSourceTFEWorkspaceIDsRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the organization.
 	organization := d.Get("organization").(string)
@@ -140,7 +140,7 @@ func dataSourceTFEWorkspaceIDsRead(d *schema.ResourceData, meta interface{}) err
 	hasOnlyTags := len(tagSearchParts) > 0 && len(names) == 0
 
 	for {
-		wl, err := tfeClient.Workspaces.List(ctx, organization, options)
+		wl, err := config.Client.Workspaces.List(ctx, organization, options)
 		if err != nil {
 			return fmt.Errorf("Error retrieving workspaces: %w", err)
 		}

--- a/tfe/data_source_workspace_run_task.go
+++ b/tfe/data_source_workspace_run_task.go
@@ -40,7 +40,7 @@ func dataSourceTFEWorkspaceRunTask() *schema.Resource {
 }
 
 func dataSourceTFEWorkspaceRunTaskRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	workspaceID := d.Get("workspace_id").(string)
 	taskID := d.Get("task_id").(string)
@@ -48,7 +48,7 @@ func dataSourceTFEWorkspaceRunTaskRead(d *schema.ResourceData, meta interface{})
 	// Create an options struct.
 	options := &tfe.WorkspaceRunTaskListOptions{}
 	for {
-		list, err := tfeClient.WorkspaceRunTasks.List(ctx, workspaceID, options)
+		list, err := config.Client.WorkspaceRunTasks.List(ctx, workspaceID, options)
 		if err != nil {
 			return fmt.Errorf("Error retrieving tasks for workspace %s: %w", workspaceID, err)
 		}

--- a/tfe/plugin_provider.go
+++ b/tfe/plugin_provider.go
@@ -33,9 +33,10 @@ func (e errUnsupportedResource) Error() string {
 }
 
 type providerMeta struct {
-	token         string
-	hostname      string
-	sslSkipVerify bool
+	token               string
+	hostname            string
+	sslSkipVerify       bool
+	defaultOrganization string
 }
 
 func (p *pluginProviderServer) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProviderSchemaRequest) (*tfprotov5.GetProviderSchemaResponse, error) {
@@ -176,6 +177,12 @@ func PluginProviderServer() tfprotov5.ProviderServer {
 						Description: descriptions["ssl_skip_verify"],
 						Optional:    true,
 					},
+					{
+						Name:        "default_organization",
+						Type:        tftypes.String,
+						Description: descriptions["default_organization"],
+						Optional:    true,
+					},
 				},
 			},
 		},
@@ -232,9 +239,10 @@ func retrieveProviderMeta(req *tfprotov5.ConfigureProviderRequest) (providerMeta
 	config := req.Config
 	val, err := config.Unmarshal(tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
-			"hostname":        tftypes.String,
-			"token":           tftypes.String,
-			"ssl_skip_verify": tftypes.Bool,
+			"hostname":             tftypes.String,
+			"token":                tftypes.String,
+			"ssl_skip_verify":      tftypes.Bool,
+			"default_organization": tftypes.String,
 		}})
 
 	if err != nil {
@@ -243,6 +251,7 @@ func retrieveProviderMeta(req *tfprotov5.ConfigureProviderRequest) (providerMeta
 	var hostname string
 	var token string
 	var sslSkipVerify bool
+	var defaultOrganization string
 	var valMap map[string]tftypes.Value
 	err = val.As(&valMap)
 	if err != nil {
@@ -268,10 +277,17 @@ func retrieveProviderMeta(req *tfprotov5.ConfigureProviderRequest) (providerMeta
 	} else {
 		sslSkipVerify = defaultSSLSkipVerify
 	}
+	if !valMap["default_organization"].IsNull() {
+		err = valMap["default_organization"].As(&defaultOrganization)
+		if err != nil {
+			return meta, fmt.Errorf("failed to set the default_organization value to string: %w", err)
+		}
+	}
 
 	meta.hostname = hostname
 	meta.token = token
 	meta.sslSkipVerify = sslSkipVerify
+	meta.defaultOrganization = defaultOrganization
 
 	return meta, nil
 }

--- a/tfe/plugin_provider.go
+++ b/tfe/plugin_provider.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"context"
 	"fmt"
+	"os"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -75,6 +76,10 @@ func (p *pluginProviderServer) ConfigureProvider(ctx context.Context, req *tfpro
 			Detail:   fmt.Sprintf("Error getting client: %v", err),
 		})
 		return resp, nil
+	}
+
+	if meta.organization == "" {
+		meta.organization = os.Getenv("TFE_ORGANIZATION")
 	}
 
 	p.tfeClient = client

--- a/tfe/plugin_provider.go
+++ b/tfe/plugin_provider.go
@@ -211,7 +211,7 @@ func PluginProviderServer() tfprotov5.ProviderServer {
 							Type:            tftypes.String,
 							Description:     "The organization to fetch the remote state from.",
 							DescriptionKind: tfprotov5.StringKindPlain,
-							Required:        true,
+							Optional:        true,
 						},
 						{
 							Name:      "values",

--- a/tfe/plugin_provider_test.go
+++ b/tfe/plugin_provider_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestPluginProvider_providerMeta(t *testing.T) {
 	cases := map[string]struct {
-		hostname            string
-		token               string
-		sslSkipVerify       bool
-		defaultOrganization string
-		err                 error
+		hostname      string
+		token         string
+		sslSkipVerify bool
+		organization  string
+		err           error
 	}{
 		"has none": {},
 		"has only hostname": {
@@ -38,31 +38,31 @@ func TestPluginProvider_providerMeta(t *testing.T) {
 			token:         "secret",
 			sslSkipVerify: true,
 		},
-		"has default_organization": {
-			defaultOrganization: "hashicorp",
+		"has organization": {
+			organization: "hashicorp",
 		},
 	}
 
 	for name, tc := range cases {
 		config, err := tfprotov5.NewDynamicValue(tftypes.Object{
 			AttributeTypes: map[string]tftypes.Type{
-				"hostname":             tftypes.String,
-				"token":                tftypes.String,
-				"ssl_skip_verify":      tftypes.Bool,
-				"default_organization": tftypes.String,
+				"hostname":        tftypes.String,
+				"token":           tftypes.String,
+				"ssl_skip_verify": tftypes.Bool,
+				"organization":    tftypes.String,
 			},
 		}, tftypes.NewValue(tftypes.Object{
 			AttributeTypes: map[string]tftypes.Type{
-				"hostname":             tftypes.String,
-				"token":                tftypes.String,
-				"ssl_skip_verify":      tftypes.Bool,
-				"default_organization": tftypes.String,
+				"hostname":        tftypes.String,
+				"token":           tftypes.String,
+				"ssl_skip_verify": tftypes.Bool,
+				"organization":    tftypes.String,
 			},
 		}, map[string]tftypes.Value{
-			"hostname":             tftypes.NewValue(tftypes.String, tc.hostname),
-			"token":                tftypes.NewValue(tftypes.String, tc.token),
-			"ssl_skip_verify":      tftypes.NewValue(tftypes.Bool, tc.sslSkipVerify),
-			"default_organization": tftypes.NewValue(tftypes.String, tc.defaultOrganization),
+			"hostname":        tftypes.NewValue(tftypes.String, tc.hostname),
+			"token":           tftypes.NewValue(tftypes.String, tc.token),
+			"ssl_skip_verify": tftypes.NewValue(tftypes.Bool, tc.sslSkipVerify),
+			"organization":    tftypes.NewValue(tftypes.String, tc.organization),
 		}))
 		if err != nil {
 			t.Fatal(err.Error())
@@ -97,7 +97,7 @@ func TestPluginProvider_providerMeta(t *testing.T) {
 			t.Fatalf("Test %s: ssl_skip_verify was not set in config and has not been set to default", name)
 		}
 
-		if tc.defaultOrganization != meta.defaultOrganization {
+		if tc.organization != meta.organization {
 			t.Fatalf("Test %s: default organization was set in config and input default organization %s does not have the same value in meta %s", name, tc.token, meta.token)
 		}
 

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -72,6 +72,12 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: descriptions["ssl_skip_verify"],
 			},
+
+			"default_organization": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["default_organization"],
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -521,6 +527,8 @@ var descriptions = map[string]string{
 	"token": "The token used to authenticate with Terraform Enterprise. We recommend omitting\n" +
 		"the token which can be set as credentials in the CLI config file.",
 	"ssl_skip_verify": "Whether or not to skip certificate verifications.",
+	"default_organization": "The organization to apply to a resource if one is not defined on\n" +
+		"the resource itself",
 }
 
 // A commonly used helper method to check if the error

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -164,6 +164,9 @@ func Provider() *schema.Provider {
 func configure() schema.ConfigureContextFunc {
 	return func(ctx context.Context, rd *schema.ResourceData) (any, diag.Diagnostics) {
 		providerOrganization := rd.Get("organization").(string)
+		if providerOrganization == "" {
+			providerOrganization = os.Getenv("TFE_ORGANIZATION")
+		}
 
 		client, err := configureClient(rd)
 		if err != nil {

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -47,8 +47,8 @@ type ConfigHost struct {
 }
 
 type ConfiguredClient struct {
-	Client              *tfe.Client
-	DefaultOrganization string
+	Client       *tfe.Client
+	Organization string
 }
 
 func (c ConfiguredClient) schemaOrDefaultOrganization(resource *schema.ResourceData) (string, error) {
@@ -60,10 +60,10 @@ func (c ConfiguredClient) schemaOrDefaultOrganizationKey(resource *schema.Resour
 	if got {
 		return schemaOrg.(string), nil
 	}
-	if c.DefaultOrganization == "" {
+	if c.Organization == "" {
 		return "", errMissingOrganization
 	}
-	return c.DefaultOrganization, nil
+	return c.Organization, nil
 }
 
 // ctx is used as default context.Context when making TFE calls.
@@ -95,10 +95,10 @@ func Provider() *schema.Provider {
 				Description: descriptions["ssl_skip_verify"],
 			},
 
-			"default_organization": {
+			"organization": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: descriptions["default_organization"],
+				Description: descriptions["organization"],
 			},
 		},
 
@@ -163,7 +163,7 @@ func Provider() *schema.Provider {
 
 func configure() schema.ConfigureContextFunc {
 	return func(ctx context.Context, rd *schema.ResourceData) (any, diag.Diagnostics) {
-		defaultOrganization := rd.Get("default_organization").(string)
+		providerOrganization := rd.Get("organization").(string)
 
 		client, err := configureClient(rd)
 		if err != nil {
@@ -172,7 +172,7 @@ func configure() schema.ConfigureContextFunc {
 
 		return ConfiguredClient{
 			client,
-			defaultOrganization,
+			providerOrganization,
 		}, nil
 	}
 }
@@ -565,7 +565,7 @@ var descriptions = map[string]string{
 	"token": "The token used to authenticate with Terraform Enterprise. We recommend omitting\n" +
 		"the token which can be set as credentials in the CLI config file.",
 	"ssl_skip_verify": "Whether or not to skip certificate verifications.",
-	"default_organization": "The organization to apply to a resource if one is not defined on\n" +
+	"organization": "The organization to apply to a resource if one is not defined on\n" +
 		"the resource itself",
 }
 

--- a/tfe/provider_test.go
+++ b/tfe/provider_test.go
@@ -320,6 +320,38 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func TestConfigureEnvOrganization(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	originalTFEOrganization := os.Getenv("TFE_ORGANIZATION")
+	reset := func() {
+		if originalTFEOrganization != "" {
+			os.Setenv("TFE_ORGANIZATION", originalTFEOrganization)
+		} else {
+			os.Unsetenv("TFE_ORGANIZATION")
+		}
+	}
+	defer reset()
+
+	expectedOrganization := fmt.Sprintf("tst-organization-%d", rInt)
+	os.Setenv("TFE_ORGANIZATION", expectedOrganization)
+
+	provider := Provider()
+
+	// The credentials must be provided by the CLI config file for testing.
+	if diags := provider.Configure(context.Background(), &terraform.ResourceConfig{}); diags.HasError() {
+		for _, d := range diags {
+			if d.Severity == diag.Error {
+				t.Fatalf("err: %s", d.Summary)
+			}
+		}
+	}
+
+	config := provider.Meta().(ConfiguredClient)
+	if config.Organization != expectedOrganization {
+		t.Fatalf("unexpected organization configuration: got %s, wanted %s", config.Organization, expectedOrganization)
+	}
+}
+
 func testAccGithubPreCheck(t *testing.T) {
 	if envGithubToken == "" {
 		t.Skip("Please set GITHUB_TOKEN to run this test")

--- a/tfe/provider_test.go
+++ b/tfe/provider_test.go
@@ -49,8 +49,8 @@ func providerWithDefaultOrganization(defaultOrgName string) map[string]*schema.P
 	testAccProviderDefaultOrganization.ConfigureContextFunc = func(ctx context.Context, rd *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		client, err := getClientUsingEnv()
 		return ConfiguredClient{
-			Client:              client,
-			DefaultOrganization: defaultOrgName,
+			Client:       client,
+			Organization: defaultOrgName,
 		}, diag.FromErr(err)
 	}
 	return map[string]*schema.Provider{

--- a/tfe/provider_test.go
+++ b/tfe/provider_test.go
@@ -3,9 +3,11 @@ package tfe
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -23,6 +25,7 @@ var testAccMuxedProviders map[string]func() (tfprotov5.ProviderServer, error)
 
 func init() {
 	testAccProvider = Provider()
+
 	testAccProviders = map[string]*schema.Provider{
 		"tfe": testAccProvider,
 	}
@@ -39,6 +42,38 @@ func init() {
 			return mux.Server(), nil
 		},
 	}
+}
+
+func providerWithDefaultOrganization(defaultOrgName string) map[string]*schema.Provider {
+	testAccProviderDefaultOrganization := Provider()
+	testAccProviderDefaultOrganization.ConfigureContextFunc = func(ctx context.Context, rd *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		client, err := getClientUsingEnv()
+		return ConfiguredClient{
+			Client:              client,
+			DefaultOrganization: defaultOrgName,
+		}, diag.FromErr(err)
+	}
+	return map[string]*schema.Provider{
+		"tfe": testAccProviderDefaultOrganization,
+	}
+}
+
+func setupDefaultOrganization(t *testing.T) (string, int) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	defaultOrgName := fmt.Sprintf("tst-default-org-%d", rInt)
+
+	client, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, cleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
+		Name:  &defaultOrgName,
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+
+	t.Cleanup(cleanup)
+	return defaultOrgName, rInt
 }
 
 func getClientUsingEnv() (*tfe.Client, error) {

--- a/tfe/resource_tfe_admin_organization_settings.go
+++ b/tfe/resource_tfe_admin_organization_settings.go
@@ -51,13 +51,13 @@ func resourceTFEAdminOrganizationSettings() *schema.Resource {
 }
 
 func resourceTFEAdminOrganizationSettingsRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name.
 	name := d.Get("organization").(string)
 
 	log.Printf("[DEBUG] Read configuration of admin organization: %s", name)
-	org, err := tfeClient.Admin.Organizations.Read(ctx, name)
+	org, err := config.Client.Admin.Organizations.Read(ctx, name)
 	if err != nil {
 		return fmt.Errorf("failed to read admin organization %s: %w", name, err)
 	}
@@ -76,7 +76,7 @@ func resourceTFEAdminOrganizationSettingsRead(d *schema.ResourceData, meta inter
 
 		log.Printf("[DEBUG] Read configuration of module sharing for organization: %s", d.Id())
 		for {
-			consumerList, err := tfeClient.Admin.Organizations.ListModuleConsumers(ctx, d.Id(), options)
+			consumerList, err := config.Client.Admin.Organizations.ListModuleConsumers(ctx, d.Id(), options)
 			if err != nil {
 				if errors.Is(err, tfe.ErrResourceNotFound) {
 					log.Printf("[DEBUG] Organization %s does not longer exist", d.Id())
@@ -113,11 +113,11 @@ func resourceTFEAdminOrganizationSettingsDelete(d *schema.ResourceData, meta int
 }
 
 func resourceTFEAdminOrganizationSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 	name := d.Get("organization").(string)
 	globalModuleSharing := d.Get("global_module_sharing").(bool)
 
-	_, err := tfeClient.Admin.Organizations.Update(ctx, name, tfe.AdminOrganizationUpdateOptions{
+	_, err := config.Client.Admin.Organizations.Update(ctx, name, tfe.AdminOrganizationUpdateOptions{
 		AccessBetaTools:     tfe.Bool(d.Get("access_beta_tools").(bool)),
 		GlobalModuleSharing: tfe.Bool(globalModuleSharing),
 		WorkspaceLimit:      tfe.Int(d.Get("workspace_limit").(int)),
@@ -145,7 +145,7 @@ func resourceTFEAdminOrganizationSettingsUpdate(d *schema.ResourceData, meta int
 			consumerOrgNames[i] = v.(string)
 		}
 
-		err = tfeClient.Admin.Organizations.UpdateModuleConsumers(ctx, name, consumerOrgNames)
+		err = config.Client.Admin.Organizations.UpdateModuleConsumers(ctx, name, consumerOrgNames)
 		if err != nil {
 			return fmt.Errorf("failed to update organization module consumers: %w", err)
 		}

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -36,7 +36,7 @@ func resourceTFEAgentPool() *schema.Resource {
 }
 
 func resourceTFEAgentPoolCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
@@ -48,7 +48,7 @@ func resourceTFEAgentPoolCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] Create new agent pool for organization: %s", organization)
-	agentPool, err := tfeClient.AgentPools.Create(ctx, organization, options)
+	agentPool, err := config.Client.AgentPools.Create(ctx, organization, options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating agent pool %s for organization %s: %w", name, organization, err)
@@ -60,10 +60,10 @@ func resourceTFEAgentPoolCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of agent pool: %s", d.Id())
-	agentPool, err := tfeClient.AgentPools.Read(ctx, d.Id())
+	agentPool, err := config.Client.AgentPools.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] agent pool %s no longer exists", d.Id())
@@ -81,7 +81,7 @@ func resourceTFEAgentPoolRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFEAgentPoolUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Create a new options struct.
 	options := tfe.AgentPoolUpdateOptions{
@@ -89,7 +89,7 @@ func resourceTFEAgentPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] Update agent pool: %s", d.Id())
-	_, err := tfeClient.AgentPools.Update(ctx, d.Id(), options)
+	_, err := config.Client.AgentPools.Update(ctx, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error updating agent pool %s: %w", d.Id(), err)
 	}
@@ -98,10 +98,10 @@ func resourceTFEAgentPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFEAgentPoolDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete agent pool: %s", d.Id())
-	err := tfeClient.AgentPools.Delete(ctx, d.Id())
+	err := config.Client.AgentPools.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil
@@ -113,7 +113,7 @@ func resourceTFEAgentPoolDelete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFEAgentPoolImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	s := strings.Split(d.Id(), "/")
 	if len(s) >= 3 {
@@ -124,7 +124,7 @@ func resourceTFEAgentPoolImporter(ctx context.Context, d *schema.ResourceData, m
 	} else if len(s) == 2 {
 		org := s[0]
 		poolName := s[1]
-		poolID, err := fetchAgentPoolID(org, poolName, tfeClient)
+		poolID, err := fetchAgentPoolID(org, poolName, config.Client)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"error retrieving agent pool with name %s from organization %s %w", poolName, org, err)

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -28,7 +28,8 @@ func resourceTFEAgentPool() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -40,7 +41,10 @@ func resourceTFEAgentPoolCreate(d *schema.ResourceData, meta interface{}) error 
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.AgentPoolCreateOptions{

--- a/tfe/resource_tfe_agent_pool_test.go
+++ b/tfe/resource_tfe_agent_pool_test.go
@@ -121,7 +121,7 @@ func TestAccTFEAgentPool_import(t *testing.T) {
 func testAccCheckTFEAgentPoolExists(
 	n string, agentPool *tfe.AgentPool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -132,7 +132,7 @@ func testAccCheckTFEAgentPoolExists(
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		sk, err := tfeClient.AgentPools.Read(ctx, rs.Primary.ID)
+		sk, err := config.Client.AgentPools.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -168,7 +168,7 @@ func testAccCheckTFEAgentPoolAttributesUpdated(
 }
 
 func testAccCheckTFEAgentPoolDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_agent_pool" {
@@ -179,7 +179,7 @@ func testAccCheckTFEAgentPoolDestroy(s *terraform.State) error {
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		_, err := tfeClient.AgentPools.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.AgentPools.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("agent pool %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_agent_token.go
+++ b/tfe/resource_tfe_agent_token.go
@@ -35,7 +35,7 @@ func resourceTFEAgentToken() *schema.Resource {
 }
 
 func resourceTFEAgentTokenCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the agent pool ID
 	agentPoolID := d.Get("agent_pool_id").(string)
@@ -49,7 +49,7 @@ func resourceTFEAgentTokenCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] Create new agent token for agent pool ID: %s", agentPoolID)
-	agentToken, err := tfeClient.AgentTokens.Create(ctx, agentPoolID, options)
+	agentToken, err := config.Client.AgentTokens.Create(ctx, agentPoolID, options)
 	if err != nil {
 		return fmt.Errorf("Error creating agent token for agent pool ID %s: %w", agentPoolID, err)
 	}
@@ -64,10 +64,10 @@ func resourceTFEAgentTokenCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceTFEAgentTokenRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of agent token: %s", d.Id())
-	agentToken, err := tfeClient.AgentTokens.Read(ctx, d.Id())
+	agentToken, err := config.Client.AgentTokens.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] agent token %s no longer exists", d.Id())
@@ -84,10 +84,10 @@ func resourceTFEAgentTokenRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFEAgentTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete agent token: %s", d.Id())
-	err := tfeClient.AgentTokens.Delete(ctx, d.Id())
+	err := config.Client.AgentTokens.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_agent_token_test.go
+++ b/tfe/resource_tfe_agent_token_test.go
@@ -44,7 +44,7 @@ func TestAccTFEAgentToken_basic(t *testing.T) {
 func testAccCheckTFEAgentTokenExists(
 	n string, agentToken *tfe.AgentToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -55,7 +55,7 @@ func testAccCheckTFEAgentTokenExists(
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		sk, err := tfeClient.AgentTokens.Read(ctx, rs.Primary.ID)
+		sk, err := config.Client.AgentTokens.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -81,7 +81,7 @@ func testAccCheckTFEAgentTokenAttributes(
 }
 
 func testAccCheckTFEAgentTokenDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_agent_token" {
@@ -92,7 +92,7 @@ func testAccCheckTFEAgentTokenDestroy(s *terraform.State) error {
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		_, err := tfeClient.AgentTokens.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.AgentTokens.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("agent token %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_notification_configuration.go
+++ b/tfe/resource_tfe_notification_configuration.go
@@ -105,7 +105,7 @@ func resourceTFENotificationConfiguration() *schema.Resource {
 }
 
 func resourceTFENotificationConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get workspace
 	workspaceID := d.Get("workspace_id").(string)
@@ -180,7 +180,7 @@ func resourceTFENotificationConfigurationCreate(d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Create notification configuration: %s", name)
-	notificationConfiguration, err := tfeClient.NotificationConfigurations.Create(ctx, workspaceID, options)
+	notificationConfiguration, err := config.Client.NotificationConfigurations.Create(ctx, workspaceID, options)
 	if err != nil {
 		return fmt.Errorf("Error creating notification configuration %s: %w", name, err)
 	}
@@ -191,10 +191,10 @@ func resourceTFENotificationConfigurationCreate(d *schema.ResourceData, meta int
 }
 
 func resourceTFENotificationConfigurationRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read notification configuration: %s", d.Id())
-	notificationConfiguration, err := tfeClient.NotificationConfigurations.Read(ctx, d.Id())
+	notificationConfiguration, err := config.Client.NotificationConfigurations.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Notification configuration %s no longer exists", d.Id())
@@ -237,7 +237,7 @@ func resourceTFENotificationConfigurationRead(d *schema.ResourceData, meta inter
 }
 
 func resourceTFENotificationConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get attributes
 	enabled := d.Get("enabled").(bool)
@@ -308,7 +308,7 @@ func resourceTFENotificationConfigurationUpdate(d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Update notification configuration: %s", d.Id())
-	_, err := tfeClient.NotificationConfigurations.Update(ctx, d.Id(), options)
+	_, err := config.Client.NotificationConfigurations.Update(ctx, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error updating notification configuration %s: %w", d.Id(), err)
 	}
@@ -317,10 +317,10 @@ func resourceTFENotificationConfigurationUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceTFENotificationConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete notification configuration: %s", d.Id())
-	err := tfeClient.NotificationConfigurations.Delete(ctx, d.Id())
+	err := config.Client.NotificationConfigurations.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_notification_configuration_test.go
+++ b/tfe/resource_tfe_notification_configuration_test.go
@@ -546,7 +546,7 @@ func TestAccTFENotificationConfigurationImport_emptyEmailUserIDs(t *testing.T) {
 
 func testAccCheckTFENotificationConfigurationExists(n string, notificationConfiguration *tfe.NotificationConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -557,7 +557,7 @@ func testAccCheckTFENotificationConfigurationExists(n string, notificationConfig
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		nc, err := tfeClient.NotificationConfigurations.Read(ctx, rs.Primary.ID)
+		nc, err := config.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -763,7 +763,7 @@ func testAccCheckTFENotificationConfigurationAttributesDuplicateTriggers(notific
 }
 
 func testAccCheckTFENotificationConfigurationDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_notification_configuration" {
@@ -774,7 +774,7 @@ func testAccCheckTFENotificationConfigurationDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.NotificationConfigurations.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Notification configuration %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_oauth_client.go
+++ b/tfe/resource_tfe_oauth_client.go
@@ -105,7 +105,7 @@ func resourceTFEOAuthClient() *schema.Resource {
 }
 
 func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the organization and provider.
 	organization := d.Get("organization").(string)
@@ -144,7 +144,7 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Create an OAuth client for organization: %s", organization)
-	oc, err := tfeClient.OAuthClients.Create(ctx, organization, options)
+	oc, err := config.Client.OAuthClients.Create(ctx, organization, options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating OAuth client for organization %s: %w", organization, err)
@@ -156,10 +156,10 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of OAuth client: %s", d.Id())
-	oc, err := tfeClient.OAuthClients.Read(ctx, d.Id())
+	oc, err := config.Client.OAuthClients.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] OAuth client %s no longer exists", d.Id())
@@ -188,10 +188,10 @@ func resourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFEOAuthClientDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete OAuth client: %s", d.Id())
-	err := tfeClient.OAuthClients.Delete(ctx, d.Id())
+	err := config.Client.OAuthClients.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_oauth_client.go
+++ b/tfe/resource_tfe_oauth_client.go
@@ -24,7 +24,8 @@ func resourceTFEOAuthClient() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -108,7 +109,10 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 	config := meta.(ConfiguredClient)
 
 	// Get the organization and provider.
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 	name := d.Get("name").(string)
 	privateKey := d.Get("private_key").(string)
 	rsaPublicKey := d.Get("rsa_public_key").(string)
@@ -170,9 +174,9 @@ func resourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	// Update the config.
+	d.Set("organization", oc.Organization.Name)
 	d.Set("api_url", oc.APIURL)
 	d.Set("http_url", oc.HTTPURL)
-	d.Set("organization", oc.Organization.Name)
 	d.Set("service_provider", string(oc.ServiceProvider))
 
 	switch len(oc.OAuthTokens) {

--- a/tfe/resource_tfe_oauth_client_test.go
+++ b/tfe/resource_tfe_oauth_client_test.go
@@ -75,7 +75,7 @@ func TestAccTFEOAuthClient_rsaKeys(t *testing.T) {
 func testAccCheckTFEOAuthClientExists(
 	n string, oc *tfe.OAuthClient) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -86,7 +86,7 @@ func testAccCheckTFEOAuthClientExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		client, err := tfeClient.OAuthClients.Read(ctx, rs.Primary.ID)
+		client, err := config.Client.OAuthClients.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func testAccCheckTFEOAuthClientAttributes(
 }
 
 func testAccCheckTFEOAuthClientDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_oauth_client" {
@@ -128,7 +128,7 @@ func testAccCheckTFEOAuthClientDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.OAuthClients.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.OAuthClients.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("OAuth client %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -93,7 +93,7 @@ func resourceTFEOrganization() *schema.Resource {
 }
 
 func resourceTFEOrganizationCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the organization name.
 	name := d.Get("name").(string)
@@ -105,7 +105,7 @@ func resourceTFEOrganizationCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	log.Printf("[DEBUG] Create new organization: %s", name)
-	org, err := tfeClient.Organizations.Create(ctx, options)
+	org, err := config.Client.Organizations.Create(ctx, options)
 	if err != nil {
 		return fmt.Errorf("Error creating the new organization %s: %w", name, err)
 	}
@@ -116,10 +116,10 @@ func resourceTFEOrganizationCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of organization: %s", d.Id())
-	org, err := tfeClient.Organizations.Read(ctx, d.Id())
+	org, err := config.Client.Organizations.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Organization %s no longer exists", d.Id())
@@ -151,7 +151,7 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Create a new options struct.
 	options := tfe.OrganizationUpdateOptions{
@@ -200,7 +200,7 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	log.Printf("[DEBUG] Update configuration of organization: %s", d.Id())
-	org, err := tfeClient.Organizations.Update(ctx, d.Id(), options)
+	org, err := config.Client.Organizations.Update(ctx, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error updating organization %s: %w", d.Id(), err)
 	}
@@ -211,10 +211,10 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceTFEOrganizationDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete organization: %s", d.Id())
-	err := tfeClient.Organizations.Delete(ctx, d.Id())
+	err := config.Client.Organizations.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -44,7 +44,7 @@ func resourceTFEOrganizationMembership() *schema.Resource {
 }
 
 func resourceTFEOrganizationMembershipCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the email and organization.
 	email := d.Get("email").(string)
@@ -56,7 +56,7 @@ func resourceTFEOrganizationMembershipCreate(d *schema.ResourceData, meta interf
 	}
 
 	log.Printf("[DEBUG] Create membership %s for organization: %s", email, organization)
-	membership, err := tfeClient.OrganizationMemberships.Create(ctx, organization, options)
+	membership, err := config.Client.OrganizationMemberships.Create(ctx, organization, options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating membership %s for organization %s: %w", email, organization, err)
@@ -68,14 +68,14 @@ func resourceTFEOrganizationMembershipCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	options := tfe.OrganizationMembershipReadOptions{
 		Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser},
 	}
 
 	log.Printf("[DEBUG] Read configuration of membership: %s", d.Id())
-	membership, err := tfeClient.OrganizationMemberships.ReadWithOptions(ctx, d.Id(), options)
+	membership, err := config.Client.OrganizationMemberships.ReadWithOptions(ctx, d.Id(), options)
 
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
@@ -95,10 +95,10 @@ func resourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceTFEOrganizationMembershipDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete membership: %s", d.Id())
-	err := tfeClient.OrganizationMemberships.Delete(ctx, d.Id())
+	err := config.Client.OrganizationMemberships.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -26,7 +26,8 @@ func resourceTFEOrganizationMembership() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -48,7 +49,10 @@ func resourceTFEOrganizationMembershipCreate(d *schema.ResourceData, meta interf
 
 	// Get the email and organization.
 	email := d.Get("email").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.OrganizationMembershipCreateOptions{

--- a/tfe/resource_tfe_organization_membership_test.go
+++ b/tfe/resource_tfe_organization_membership_test.go
@@ -63,7 +63,7 @@ func TestAccTFEOrganizationMembershipImport(t *testing.T) {
 func testAccCheckTFEOrganizationMembershipExists(
 	n string, membership *tfe.OrganizationMembership) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -78,7 +78,7 @@ func testAccCheckTFEOrganizationMembershipExists(
 			Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser},
 		}
 
-		m, err := tfeClient.OrganizationMemberships.ReadWithOptions(ctx, rs.Primary.ID, options)
+		m, err := config.Client.OrganizationMemberships.ReadWithOptions(ctx, rs.Primary.ID, options)
 		if err != nil {
 			return err
 		}
@@ -111,7 +111,7 @@ func testAccCheckTFEOrganizationMembershipAttributes(
 }
 
 func testAccCheckTFEOrganizationMembershipDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_organization_membership" {
@@ -122,7 +122,7 @@ func testAccCheckTFEOrganizationMembershipDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.OrganizationMemberships.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.OrganizationMemberships.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Membership %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_organization_module_sharing.go
+++ b/tfe/resource_tfe_organization_module_sharing.go
@@ -19,7 +19,9 @@ func resourceTFEOrganizationModuleSharing() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 				DiffSuppressFunc: func(k, old, current string, d *schema.ResourceData) bool {
 					return strings.EqualFold(old, current)
 				},
@@ -36,7 +38,12 @@ func resourceTFEOrganizationModuleSharing() *schema.Resource {
 
 func resourceTFEOrganizationModuleSharingCreate(d *schema.ResourceData, meta interface{}) error {
 	// Get the organization name that will share "produce" modules
-	producer := d.Get("organization").(string)
+	config := meta.(ConfiguredClient)
+
+	producer, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[DEBUG] Create %s module consumers", producer)
 	d.SetId(producer)

--- a/tfe/resource_tfe_organization_module_sharing.go
+++ b/tfe/resource_tfe_organization_module_sharing.go
@@ -45,7 +45,7 @@ func resourceTFEOrganizationModuleSharingCreate(d *schema.ResourceData, meta int
 }
 
 func resourceTFEOrganizationModuleSharingUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	var consumers []string
 	for _, name := range d.Get("module_consumers").([]interface{}) {
@@ -57,7 +57,7 @@ func resourceTFEOrganizationModuleSharingUpdate(d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Update %s module consumers", d.Id())
-	err := tfeClient.Admin.Organizations.UpdateModuleConsumers(ctx, d.Id(), consumers)
+	err := config.Client.Admin.Organizations.UpdateModuleConsumers(ctx, d.Id(), consumers)
 	if err != nil {
 		return fmt.Errorf("error updating module consumers to %s: %w", d.Id(), err)
 	}
@@ -66,13 +66,13 @@ func resourceTFEOrganizationModuleSharingUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceTFEOrganizationModuleSharingRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	options := &tfe.AdminOrganizationListModuleConsumersOptions{}
 
 	log.Printf("[DEBUG] Read configuration of module sharing for organization: %s", d.Id())
 	for {
-		consumerList, err := tfeClient.Admin.Organizations.ListModuleConsumers(ctx, d.Id(), options)
+		consumerList, err := config.Client.Admin.Organizations.ListModuleConsumers(ctx, d.Id(), options)
 		if err != nil {
 			if err == tfe.ErrResourceNotFound {
 				log.Printf("[DEBUG] Organization %s does not longer exist", d.Id())
@@ -93,10 +93,10 @@ func resourceTFEOrganizationModuleSharingRead(d *schema.ResourceData, meta inter
 }
 
 func resourceTFEOrganizationModuleSharingDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Disable module sharing for organization: %s", d.Id())
-	err := tfeClient.Admin.Organizations.UpdateModuleConsumers(ctx, d.Id(), []string{})
+	err := config.Client.Admin.Organizations.UpdateModuleConsumers(ctx, d.Id(), []string{})
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_organization_run_task.go
+++ b/tfe/resource_tfe_organization_run_task.go
@@ -67,7 +67,7 @@ func resourceTFEOrganizationRunTask() *schema.Resource {
 }
 
 func resourceTFEOrganizationRunTaskCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	client := meta.(ConfiguredClient)
 
 	// Get the task name and organization.
 	name := d.Get("name").(string)
@@ -84,7 +84,7 @@ func resourceTFEOrganizationRunTaskCreate(d *schema.ResourceData, meta interface
 	}
 
 	log.Printf("[DEBUG] Create task %s for organization: %s", name, organization)
-	task, err := tfeClient.RunTasks.Create(ctx, organization, options)
+	task, err := client.Client.RunTasks.Create(ctx, organization, options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating task %s for organization %s: %w", name, organization, err)
@@ -96,10 +96,10 @@ func resourceTFEOrganizationRunTaskCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceTFEOrganizationRunTaskDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	client := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete task: %s", d.Id())
-	err := tfeClient.RunTasks.Delete(ctx, d.Id())
+	err := client.Client.RunTasks.Delete(ctx, d.Id())
 	if err != nil {
 		if isErrResourceNotFound(err) {
 			return nil
@@ -111,7 +111,7 @@ func resourceTFEOrganizationRunTaskDelete(d *schema.ResourceData, meta interface
 }
 
 func resourceTFEOrganizationRunTaskUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	client := meta.(ConfiguredClient)
 
 	// Setup the options struct
 	options := tfe.RunTaskUpdateOptions{}
@@ -135,7 +135,7 @@ func resourceTFEOrganizationRunTaskUpdate(d *schema.ResourceData, meta interface
 	}
 
 	log.Printf("[DEBUG] Update configuration of task: %s", d.Id())
-	task, err := tfeClient.RunTasks.Update(ctx, d.Id(), options)
+	task, err := client.Client.RunTasks.Update(ctx, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error updating task %s: %w", d.Id(), err)
 	}
@@ -146,10 +146,10 @@ func resourceTFEOrganizationRunTaskUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceTFEOrganizationRunTaskRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	client := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of task: %s", d.Id())
-	task, err := tfeClient.RunTasks.Read(ctx, d.Id())
+	task, err := client.Client.RunTasks.Read(ctx, d.Id())
 
 	if err != nil {
 		if isErrResourceNotFound(err) {
@@ -173,7 +173,7 @@ func resourceTFEOrganizationRunTaskRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceTFEOrganizationRunTaskImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	tfeClient := meta.(*tfe.Client)
+	client := meta.(ConfiguredClient)
 
 	s := strings.Split(d.Id(), "/")
 	if len(s) != 2 {
@@ -183,7 +183,7 @@ func resourceTFEOrganizationRunTaskImporter(ctx context.Context, d *schema.Resou
 		)
 	}
 
-	task, err := fetchOrganizationRunTask(s[1], s[0], tfeClient)
+	task, err := fetchOrganizationRunTask(s[1], s[0], client.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/tfe/resource_tfe_organization_run_task.go
+++ b/tfe/resource_tfe_organization_run_task.go
@@ -29,7 +29,8 @@ func resourceTFEOrganizationRunTask() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -67,11 +68,14 @@ func resourceTFEOrganizationRunTask() *schema.Resource {
 }
 
 func resourceTFEOrganizationRunTaskCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(ConfiguredClient)
+	config := meta.(ConfiguredClient)
 
 	// Get the task name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.RunTaskCreateOptions{
@@ -84,7 +88,7 @@ func resourceTFEOrganizationRunTaskCreate(d *schema.ResourceData, meta interface
 	}
 
 	log.Printf("[DEBUG] Create task %s for organization: %s", name, organization)
-	task, err := client.Client.RunTasks.Create(ctx, organization, options)
+	task, err := config.Client.RunTasks.Create(ctx, organization, options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating task %s for organization %s: %w", name, organization, err)

--- a/tfe/resource_tfe_organization_run_task_test.go
+++ b/tfe/resource_tfe_organization_run_task_test.go
@@ -112,7 +112,7 @@ func TestAccTFEOrganizationRunTask_import(t *testing.T) {
 
 func testAccCheckTFEOrganizationRunTaskExists(n string, runTask *tfe.RunTask) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -122,7 +122,7 @@ func testAccCheckTFEOrganizationRunTaskExists(n string, runTask *tfe.RunTask) re
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No instance ID is set")
 		}
-		rt, err := tfeClient.RunTasks.Read(ctx, rs.Primary.ID)
+		rt, err := config.Client.RunTasks.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error reading Run Task: %w", err)
 		}
@@ -138,7 +138,7 @@ func testAccCheckTFEOrganizationRunTaskExists(n string, runTask *tfe.RunTask) re
 }
 
 func testAccCheckTFEOrganizationRunTaskDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_organization_run_task" {
@@ -149,7 +149,7 @@ func testAccCheckTFEOrganizationRunTaskDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.RunTasks.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.RunTasks.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Organization Run Task %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -252,7 +252,7 @@ func TestAccTFEOrganization_import(t *testing.T) {
 func testAccCheckTFEOrganizationExists(
 	n string, org *tfe.Organization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -263,7 +263,7 @@ func testAccCheckTFEOrganizationExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		o, err := tfeClient.Organizations.Read(ctx, rs.Primary.ID)
+		o, err := config.Client.Organizations.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -368,7 +368,7 @@ func testAccCheckTFEOrganizationAttributesUpdated(
 }
 
 func testAccCheckTFEOrganizationDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_organization" {
@@ -379,7 +379,7 @@ func testAccCheckTFEOrganizationDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Organizations.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.Organizations.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Organization %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -42,13 +42,13 @@ func resourceTFEOrganizationToken() *schema.Resource {
 }
 
 func resourceTFEOrganizationTokenCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the organization name.
 	organization := d.Get("organization").(string)
 
 	log.Printf("[DEBUG] Check if a token already exists for organization: %s", organization)
-	_, err := tfeClient.OrganizationTokens.Read(ctx, organization)
+	_, err := config.Client.OrganizationTokens.Read(ctx, organization)
 	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 		return fmt.Errorf("error checking if a token exists for organization %s: %w", organization, err)
 	}
@@ -61,7 +61,7 @@ func resourceTFEOrganizationTokenCreate(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Regenerating existing token for organization: %s", organization)
 	}
 
-	token, err := tfeClient.OrganizationTokens.Create(ctx, organization)
+	token, err := config.Client.OrganizationTokens.Create(ctx, organization)
 	if err != nil {
 		return fmt.Errorf(
 			"error creating new token for organization %s: %w", organization, err)
@@ -77,10 +77,10 @@ func resourceTFEOrganizationTokenCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceTFEOrganizationTokenRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read the token from organization: %s", d.Id())
-	_, err := tfeClient.OrganizationTokens.Read(ctx, d.Id())
+	_, err := config.Client.OrganizationTokens.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Token for organization %s no longer exists", d.Id())
@@ -94,13 +94,13 @@ func resourceTFEOrganizationTokenRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceTFEOrganizationTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the organization name.
 	organization := d.Get("organization").(string)
 
 	log.Printf("[DEBUG] Delete token from organization: %s", organization)
-	err := tfeClient.OrganizationTokens.Delete(ctx, organization)
+	err := config.Client.OrganizationTokens.Delete(ctx, organization)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -121,7 +121,7 @@ func TestAccTFEOrganizationToken_import(t *testing.T) {
 func testAccCheckTFEOrganizationTokenExists(
 	n string, token *tfe.OrganizationToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -132,7 +132,7 @@ func testAccCheckTFEOrganizationTokenExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		ot, err := tfeClient.OrganizationTokens.Read(ctx, rs.Primary.ID)
+		ot, err := config.Client.OrganizationTokens.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -148,7 +148,7 @@ func testAccCheckTFEOrganizationTokenExists(
 }
 
 func testAccCheckTFEOrganizationTokenDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_organization_token" {
@@ -159,7 +159,7 @@ func testAccCheckTFEOrganizationTokenDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.OrganizationTokens.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.OrganizationTokens.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("OrganizationToken %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_policy.go
+++ b/tfe/resource_tfe_policy.go
@@ -40,7 +40,8 @@ func resourceTFEPolicy() *schema.Resource {
 			"organization": {
 				Description: "Name of the organization that this policy belongs to",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 			},
 
@@ -118,7 +119,10 @@ func resourceTFEPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	var kind string
 	if vKind, ok := d.GetOk("kind"); ok {
@@ -135,7 +139,6 @@ func resourceTFEPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 		options.Description = tfe.String(desc.(string))
 	}
 
-	var err error
 	//  Setup per-kind policy options
 	switch tfe.PolicyKind(kind) {
 	case tfe.Sentinel:

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -35,7 +35,8 @@ func resourceTFEPolicySet() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -132,7 +133,10 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 	config := meta.(ConfiguredClient)
 
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.PolicySetCreateOptions{

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -129,7 +129,7 @@ func resourceTFEPolicySet() *schema.Resource {
 }
 
 func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	name := d.Get("name").(string)
 	organization := d.Get("organization").(string)
@@ -182,7 +182,7 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] Create policy set %s for organization: %s", name, organization)
-	policySet, err := tfeClient.PolicySets.Create(ctx, organization, options)
+	policySet, err := config.Client.PolicySets.Create(ctx, organization, options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating policy set %s for organization %s: %w", name, organization, err)
@@ -190,7 +190,7 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 	_, hasVCSRepo := d.GetOk("vcs_repo")
 	_, hasSlug := d.GetOk("slug")
 	if hasSlug && !hasVCSRepo {
-		err := resourceTFEPolicySetUploadVersion(tfeClient, d, policySet.ID)
+		err := resourceTFEPolicySetUploadVersion(config.Client, d, policySet.ID)
 		if err != nil {
 			return err
 		}
@@ -202,10 +202,10 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read policy set: %s", d.Id())
-	policySet, err := tfeClient.PolicySets.Read(ctx, d.Id())
+	policySet, err := config.Client.PolicySets.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Policy set %s no longer exists", d.Id())
@@ -278,7 +278,7 @@ func resourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	name := d.Get("name").(string)
 	global := d.Get("global").(bool)
@@ -298,7 +298,7 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 
 			log.Printf("[DEBUG] Removing previous workspaces from now-global policy set: %s", d.Id())
-			err := tfeClient.PolicySets.RemoveWorkspaces(ctx, d.Id(), options)
+			err := config.Client.PolicySets.RemoveWorkspaces(ctx, d.Id(), options)
 			if err != nil {
 				return fmt.Errorf("Error detaching policy set %s from workspaces: %w", d.Id(), err)
 			}
@@ -334,7 +334,7 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		log.Printf("[DEBUG] Update configuration for policy set: %s", d.Id())
-		_, err := tfeClient.PolicySets.Update(ctx, d.Id(), options)
+		_, err := config.Client.PolicySets.Update(ctx, d.Id(), options)
 		if err != nil {
 			return fmt.Errorf(
 				"Error updating configuration for policy set %s: %w", d.Id(), err)
@@ -355,7 +355,7 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 
 			log.Printf("[DEBUG] Add policies to policy set: %s", d.Id())
-			err := tfeClient.PolicySets.AddPolicies(ctx, d.Id(), options)
+			err := config.Client.PolicySets.AddPolicies(ctx, d.Id(), options)
 			if err != nil {
 				return fmt.Errorf("Error adding policies to policy set %s: %w", d.Id(), err)
 			}
@@ -370,7 +370,7 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 
 			log.Printf("[DEBUG] Remove policies from policy set: %s", d.Id())
-			err := tfeClient.PolicySets.RemovePolicies(ctx, d.Id(), options)
+			err := config.Client.PolicySets.RemovePolicies(ctx, d.Id(), options)
 			if err != nil {
 				return fmt.Errorf("Error removing policies from policy set %s: %w", d.Id(), err)
 			}
@@ -379,7 +379,7 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	_, hasVCSRepo := d.GetOk("vcs_repo")
 	if d.HasChange("slug") && !hasVCSRepo {
-		err := resourceTFEPolicySetUploadVersion(tfeClient, d, d.Id())
+		err := resourceTFEPolicySetUploadVersion(config.Client, d, d.Id())
 		if err != nil {
 			return err
 		}
@@ -402,7 +402,7 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 
 			log.Printf("[DEBUG] Attach policy set to workspaces: %s", d.Id())
-			err := tfeClient.PolicySets.AddWorkspaces(ctx, d.Id(), options)
+			err := config.Client.PolicySets.AddWorkspaces(ctx, d.Id(), options)
 			if err != nil {
 				return fmt.Errorf("Error attaching policy set %s to workspaces: %w", d.Id(), err)
 			}
@@ -417,7 +417,7 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 
 			log.Printf("[DEBUG] Detach policy set from workspaces: %s", d.Id())
-			err := tfeClient.PolicySets.RemoveWorkspaces(ctx, d.Id(), options)
+			err := config.Client.PolicySets.RemoveWorkspaces(ctx, d.Id(), options)
 			if err != nil {
 				return fmt.Errorf("Error detaching policy set %s from workspaces: %w", d.Id(), err)
 			}
@@ -428,10 +428,10 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFEPolicySetDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete policy set: %s", d.Id())
-	err := tfeClient.PolicySets.Delete(ctx, d.Id())
+	err := config.Client.PolicySets.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_policy_set_parameter.go
+++ b/tfe/resource_tfe_policy_set_parameter.go
@@ -49,13 +49,13 @@ func resourceTFEPolicySetParameter() *schema.Resource {
 }
 
 func resourceTFEPolicySetParameterCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get key
 	key := d.Get("key").(string)
 
 	ps := d.Get("policy_set_id").(string)
-	policySet, err := tfeClient.PolicySets.Read(ctx, ps)
+	policySet, err := config.Client.PolicySets.Read(ctx, ps)
 	if err != nil {
 		return fmt.Errorf("Error retrieving policy set %s: %w", ps, err)
 	}
@@ -69,7 +69,7 @@ func resourceTFEPolicySetParameterCreate(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Create %s parameter: %s", tfe.CategoryPolicySet, key)
-	parameter, err := tfeClient.PolicySetParameters.Create(ctx, policySet.ID, options)
+	parameter, err := config.Client.PolicySetParameters.Create(ctx, policySet.ID, options)
 	if err != nil {
 		return fmt.Errorf("Error creating %s parameter %s %w", tfe.CategoryPolicySet, key, err)
 	}
@@ -80,16 +80,16 @@ func resourceTFEPolicySetParameterCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceTFEPolicySetParameterRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	ps := d.Get("policy_set_id").(string)
-	policySet, err := tfeClient.PolicySets.Read(ctx, ps)
+	policySet, err := config.Client.PolicySets.Read(ctx, ps)
 	if err != nil {
 		return fmt.Errorf("Error retrieving policy set %s: %w", ps, err)
 	}
 
 	log.Printf("[DEBUG] Read parameter: %s", d.Id())
-	parameter, err := tfeClient.PolicySetParameters.Read(ctx, policySet.ID, d.Id())
+	parameter, err := config.Client.PolicySetParameters.Read(ctx, policySet.ID, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] PolicySetParameter %s no longer exists", d.Id())
@@ -112,10 +112,10 @@ func resourceTFEPolicySetParameterRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceTFEPolicySetParameterUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	ps := d.Get("policy_set_id").(string)
-	policySet, err := tfeClient.PolicySets.Read(ctx, ps)
+	policySet, err := config.Client.PolicySets.Read(ctx, ps)
 	if err != nil {
 		return fmt.Errorf("Error retrieving policy set %s: %w", ps, err)
 	}
@@ -128,7 +128,7 @@ func resourceTFEPolicySetParameterUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Update parameter: %s", d.Id())
-	_, err = tfeClient.PolicySetParameters.Update(ctx, policySet.ID, d.Id(), options)
+	_, err = config.Client.PolicySetParameters.Update(ctx, policySet.ID, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error updating parameter %s: %w", d.Id(), err)
 	}
@@ -137,16 +137,16 @@ func resourceTFEPolicySetParameterUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceTFEPolicySetParameterDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	ps := d.Get("policy_set_id").(string)
-	policySet, err := tfeClient.PolicySets.Read(ctx, ps)
+	policySet, err := config.Client.PolicySets.Read(ctx, ps)
 	if err != nil {
 		return fmt.Errorf("Error retrieving policy set %s: %w", ps, err)
 	}
 
 	log.Printf("[DEBUG] Delete parameter: %s", d.Id())
-	err = tfeClient.PolicySetParameters.Delete(ctx, policySet.ID, d.Id())
+	err = config.Client.PolicySetParameters.Delete(ctx, policySet.ID, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_policy_set_parameter_test.go
+++ b/tfe/resource_tfe_policy_set_parameter_test.go
@@ -129,7 +129,7 @@ func TestAccTFEPolicySetParameter_import(t *testing.T) {
 func testAccCheckTFEPolicySetParameterExists(
 	n string, parameter *tfe.PolicySetParameter) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -140,7 +140,7 @@ func testAccCheckTFEPolicySetParameterExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		v, err := tfeClient.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
+		v, err := config.Client.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -190,7 +190,7 @@ func testAccCheckTFEPolicySetParameterAttributesUpdate(
 }
 
 func testAccCheckTFEPolicySetParameterDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy_set_parameter" {
@@ -201,7 +201,7 @@ func testAccCheckTFEPolicySetParameterDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
+		_, err := config.Client.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("PolicySetParameter %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -737,7 +737,7 @@ func TestAccTFEPolicySetImport(t *testing.T) {
 
 func testAccCheckTFEPolicySetExists(n string, policySet *tfe.PolicySet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -748,7 +748,7 @@ func testAccCheckTFEPolicySetExists(n string, policySet *tfe.PolicySet) resource
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		ps, err := tfeClient.PolicySets.Read(ctx, rs.Primary.ID)
+		ps, err := config.Client.PolicySets.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -783,7 +783,7 @@ func testAccCheckTFEPolicySetAttributes(policySet *tfe.PolicySet) resource.TestC
 
 func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		if policySet.Name != "terraform-populated" {
 			return fmt.Errorf("Bad name: %s", policySet.Name)
@@ -798,7 +798,7 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string)
 		}
 
 		policyID := policySet.Policies[0].ID
-		policy, _ := tfeClient.Policies.Read(ctx, policyID)
+		policy, _ := config.Client.Policies.Read(ctx, policyID)
 		if policy.Name != "policy-foo" {
 			return fmt.Errorf("Wrong member policy: %v", policy.Name)
 		}
@@ -808,7 +808,7 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string)
 		}
 
 		workspaceID := policySet.Workspaces[0].ID
-		workspace, _ := tfeClient.Workspaces.Read(ctx, orgName, "workspace-foo")
+		workspace, _ := config.Client.Workspaces.Read(ctx, orgName, "workspace-foo")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
 		}
@@ -819,7 +819,7 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string)
 
 func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		if policySet.Name != "terraform-populated-updated" {
 			return fmt.Errorf("Bad name: %s", policySet.Name)
@@ -834,7 +834,7 @@ func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName 
 		}
 
 		policyID := policySet.Policies[0].ID
-		policy, _ := tfeClient.Policies.Read(ctx, policyID)
+		policy, _ := config.Client.Policies.Read(ctx, policyID)
 		if policy.Name != "policy-bar" {
 			return fmt.Errorf("Wrong member policy: %v", policy.Name)
 		}
@@ -844,7 +844,7 @@ func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName 
 		}
 
 		workspaceID := policySet.Workspaces[0].ID
-		workspace, _ := tfeClient.Workspaces.Read(ctx, orgName, "workspace-bar")
+		workspace, _ := config.Client.Workspaces.Read(ctx, orgName, "workspace-bar")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
 		}
@@ -855,7 +855,7 @@ func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName 
 
 func testAccCheckTFEPolicySetGlobal(policySet *tfe.PolicySet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		if policySet.Name != "terraform-global" {
 			return fmt.Errorf("Bad name: %s", policySet.Name)
@@ -870,7 +870,7 @@ func testAccCheckTFEPolicySetGlobal(policySet *tfe.PolicySet) resource.TestCheck
 		}
 
 		policyID := policySet.Policies[0].ID
-		policy, _ := tfeClient.Policies.Read(ctx, policyID)
+		policy, _ := config.Client.Policies.Read(ctx, policyID)
 		if policy.Name != "policy-foo" {
 			return fmt.Errorf("Wrong member policy: %v", policy.Name)
 		}
@@ -885,7 +885,7 @@ func testAccCheckTFEPolicySetGlobal(policySet *tfe.PolicySet) resource.TestCheck
 }
 
 func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy_set" {
@@ -896,7 +896,7 @@ func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.PolicySets.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.PolicySets.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Sentinel policy %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_policy_test.go
+++ b/tfe/resource_tfe_policy_test.go
@@ -332,7 +332,7 @@ func TestAccTFEPolicy_import(t *testing.T) {
 func testAccCheckTFEPolicyExists(
 	n string, policy *tfe.Policy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -343,7 +343,7 @@ func testAccCheckTFEPolicyExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		p, err := tfeClient.Policies.Read(ctx, rs.Primary.ID)
+		p, err := config.Client.Policies.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			// nolint: wrapcheck
 			return err
@@ -440,7 +440,7 @@ func testAccCheckTFEOPAPolicyAttributesUpdated(
 }
 
 func testAccCheckTFEPolicyDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy" {
@@ -451,7 +451,7 @@ func testAccCheckTFEPolicyDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Policies.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.Policies.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf(" policy %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_project.go
+++ b/tfe/resource_tfe_project.go
@@ -28,7 +28,8 @@ func resourceTFEProject() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -38,7 +39,10 @@ func resourceTFEProject() *schema.Resource {
 func resourceTFEProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ConfiguredClient)
 
-	organizationName := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	name := d.Get("name").(string)
 
 	options := tfe.ProjectCreateOptions{
@@ -46,7 +50,7 @@ func resourceTFEProjectCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[DEBUG] Create new project: %s", name)
-	project, err := config.Client.Projects.Create(ctx, organizationName, options)
+	project, err := config.Client.Projects.Create(ctx, organization, options)
 	if err != nil {
 		return diag.Errorf("Error creating the new project %s: %v", name, err)
 	}

--- a/tfe/resource_tfe_project_test.go
+++ b/tfe/resource_tfe_project_test.go
@@ -132,7 +132,7 @@ resource "tfe_project" "foobar" {
 }
 
 func testAccCheckTFEProjectDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_project" {
@@ -143,7 +143,7 @@ func testAccCheckTFEProjectDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Projects.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.Projects.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Project %s still exists", rs.Primary.ID)
 		}
@@ -154,7 +154,7 @@ func testAccCheckTFEProjectDestroy(s *terraform.State) error {
 
 func testAccCheckTFEProjectExists(n string, project *tfe.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -165,7 +165,7 @@ func testAccCheckTFEProjectExists(n string, project *tfe.Project) resource.TestC
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		p, err := tfeClient.Projects.Read(ctx, rs.Primary.ID)
+		p, err := config.Client.Projects.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("unable to read project with ID %s", project.ID)
 		}

--- a/tfe/resource_tfe_registry_module_test.go
+++ b/tfe/resource_tfe_registry_module_test.go
@@ -475,7 +475,7 @@ func TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(t *test
 }
 func testAccCheckTFERegistryModuleExists(n string, rmID tfe.RegistryModuleID, registryModule *tfe.RegistryModule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -486,7 +486,7 @@ func testAccCheckTFERegistryModuleExists(n string, rmID tfe.RegistryModuleID, re
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		rm, err := tfeClient.RegistryModules.Read(ctx, rmID)
+		rm, err := config.Client.RegistryModules.Read(ctx, rmID)
 		if err != nil {
 			return err
 		}
@@ -550,7 +550,7 @@ func testAccCheckTFERegistryModuleVCSAttributes(registryModule *tfe.RegistryModu
 }
 
 func testAccCheckTFERegistryModuleDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_registry_module" {
@@ -594,7 +594,7 @@ func testAccCheckTFERegistryModuleDestroy(s *terraform.State) error {
 			Namespace:    rs.Primary.Attributes["namespace"],
 			RegistryName: tfe.RegistryName(rs.Primary.Attributes["registry_name"]),
 		}
-		_, err := tfeClient.RegistryModules.Read(ctx, rmID)
+		_, err := config.Client.RegistryModules.Read(ctx, rmID)
 		if err == nil {
 			return fmt.Errorf("Registry module %s still exists", id)
 		}

--- a/tfe/resource_tfe_run_trigger.go
+++ b/tfe/resource_tfe_run_trigger.go
@@ -36,7 +36,7 @@ func resourceTFERunTrigger() *schema.Resource {
 }
 
 func resourceTFERunTriggerCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get attributes
 	workspaceID := d.Get("workspace_id").(string)
@@ -51,7 +51,7 @@ func resourceTFERunTriggerCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Create run trigger on workspace %s with sourceable %s", workspaceID, sourceableID)
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		runTrigger, err := tfeClient.RunTriggers.Create(ctx, workspaceID, options)
+		runTrigger, err := config.Client.RunTriggers.Create(ctx, workspaceID, options)
 		if err == nil {
 			d.SetId(runTrigger.ID)
 			return nil
@@ -73,10 +73,10 @@ func resourceTFERunTriggerCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceTFERunTriggerRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read run trigger: %s", d.Id())
-	runTrigger, err := tfeClient.RunTriggers.Read(ctx, d.Id())
+	runTrigger, err := config.Client.RunTriggers.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] run trigger %s no longer exists", d.Id())
@@ -93,10 +93,10 @@ func resourceTFERunTriggerRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFERunTriggerDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete run trigger: %s", d.Id())
-	err := tfeClient.RunTriggers.Delete(ctx, d.Id())
+	err := config.Client.RunTriggers.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_run_trigger_test.go
+++ b/tfe/resource_tfe_run_trigger_test.go
@@ -75,7 +75,7 @@ func TestAccTFERunTriggerImport(t *testing.T) {
 
 func testAccCheckTFERunTriggerExists(n string, runTrigger *tfe.RunTrigger) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -86,7 +86,7 @@ func testAccCheckTFERunTriggerExists(n string, runTrigger *tfe.RunTrigger) resou
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		rt, err := tfeClient.RunTriggers.Read(ctx, rs.Primary.ID)
+		rt, err := config.Client.RunTriggers.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -99,16 +99,16 @@ func testAccCheckTFERunTriggerExists(n string, runTrigger *tfe.RunTrigger) resou
 
 func testAccCheckTFERunTriggerAttributes(runTrigger *tfe.RunTrigger, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		workspaceID := runTrigger.Workspace.ID
-		workspace, _ := tfeClient.Workspaces.Read(ctx, orgName, "workspace-test")
+		workspace, _ := config.Client.Workspaces.Read(ctx, orgName, "workspace-test")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong workspace: %v", workspace.ID)
 		}
 
 		sourceableID := runTrigger.Sourceable.ID
-		sourceable, _ := tfeClient.Workspaces.Read(ctx, orgName, "sourceable-test")
+		sourceable, _ := config.Client.Workspaces.Read(ctx, orgName, "sourceable-test")
 		if sourceable.ID != sourceableID {
 			return fmt.Errorf("Wrong sourceable: %v", sourceable.ID)
 		}
@@ -118,7 +118,7 @@ func testAccCheckTFERunTriggerAttributes(runTrigger *tfe.RunTrigger, orgName str
 }
 
 func testAccCheckTFERunTriggerDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_run_trigger" {
@@ -129,7 +129,7 @@ func testAccCheckTFERunTriggerDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.RunTriggers.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.RunTriggers.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Run trigger %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -37,7 +37,8 @@ func resourceTFESentinelPolicy() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -68,7 +69,10 @@ func resourceTFESentinelPolicyCreate(d *schema.ResourceData, meta interface{}) e
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.PolicyCreateOptions{

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -64,7 +64,7 @@ func resourceTFESentinelPolicy() *schema.Resource {
 }
 
 func resourceTFESentinelPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
@@ -86,7 +86,7 @@ func resourceTFESentinelPolicyCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[DEBUG] Create sentinel policy %s for organization: %s", name, organization)
-	policy, err := tfeClient.Policies.Create(ctx, organization, options)
+	policy, err := config.Client.Policies.Create(ctx, organization, options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating sentinel policy %s for organization %s: %w", name, organization, err)
@@ -95,7 +95,7 @@ func resourceTFESentinelPolicyCreate(d *schema.ResourceData, meta interface{}) e
 	d.SetId(policy.ID)
 
 	log.Printf("[DEBUG] Upload sentinel policy %s for organization: %s", name, organization)
-	err = tfeClient.Policies.Upload(ctx, policy.ID, []byte(d.Get("policy").(string)))
+	err = config.Client.Policies.Upload(ctx, policy.ID, []byte(d.Get("policy").(string)))
 	if err != nil {
 		return fmt.Errorf(
 			"Error uploading sentinel policy %s for organization %s: %w", name, organization, err)
@@ -105,10 +105,10 @@ func resourceTFESentinelPolicyCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceTFESentinelPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read sentinel policy: %s", d.Id())
-	policy, err := tfeClient.Policies.Read(ctx, d.Id())
+	policy, err := config.Client.Policies.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Sentinel policy %s no longer exists", d.Id())
@@ -126,7 +126,7 @@ func resourceTFESentinelPolicyRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("enforce_mode", string(policy.Enforce[0].Mode))
 	}
 
-	content, err := tfeClient.Policies.Download(ctx, policy.ID)
+	content, err := config.Client.Policies.Download(ctx, policy.ID)
 	if err != nil {
 		return fmt.Errorf("Error downloading sentinel policy %s: %w", d.Id(), err)
 	}
@@ -136,7 +136,7 @@ func resourceTFESentinelPolicyRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	if d.HasChange("description") || d.HasChange("enforce_mode") {
 		// Create a new options struct.
@@ -156,7 +156,7 @@ func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		log.Printf("[DEBUG] Update configuration for sentinel policy: %s", d.Id())
-		_, err := tfeClient.Policies.Update(ctx, d.Id(), options)
+		_, err := config.Client.Policies.Update(ctx, d.Id(), options)
 		if err != nil {
 			return fmt.Errorf(
 				"Error updating configuration for sentinel policy %s: %w", d.Id(), err)
@@ -165,7 +165,7 @@ func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) e
 
 	if d.HasChange("policy") {
 		log.Printf("[DEBUG] Update sentinel policy: %s", d.Id())
-		err := tfeClient.Policies.Upload(ctx, d.Id(), []byte(d.Get("policy").(string)))
+		err := config.Client.Policies.Upload(ctx, d.Id(), []byte(d.Get("policy").(string)))
 		if err != nil {
 			return fmt.Errorf("Error updating sentinel policy %s: %w", d.Id(), err)
 		}
@@ -175,10 +175,10 @@ func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceTFESentinelPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete sentinel policy: %s", d.Id())
-	err := tfeClient.Policies.Delete(ctx, d.Id())
+	err := config.Client.Policies.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_sentinel_policy_test.go
+++ b/tfe/resource_tfe_sentinel_policy_test.go
@@ -111,7 +111,7 @@ func TestAccTFESentinelPolicy_import(t *testing.T) {
 func testAccCheckTFESentinelPolicyExists(
 	n string, policy *tfe.Policy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -122,7 +122,7 @@ func testAccCheckTFESentinelPolicyExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		p, err := tfeClient.Policies.Read(ctx, rs.Primary.ID)
+		p, err := config.Client.Policies.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -168,7 +168,7 @@ func testAccCheckTFESentinelPolicyAttributesUpdated(
 }
 
 func testAccCheckTFESentinelPolicyDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_sentinel_policy" {
@@ -179,7 +179,7 @@ func testAccCheckTFESentinelPolicyDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Policies.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.Policies.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Sentinel policy %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_ssh_key.go
+++ b/tfe/resource_tfe_ssh_key.go
@@ -23,7 +23,8 @@ func resourceTFESSHKey() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -41,7 +42,10 @@ func resourceTFESSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.SSHKeyCreateOptions{

--- a/tfe/resource_tfe_ssh_key.go
+++ b/tfe/resource_tfe_ssh_key.go
@@ -37,7 +37,7 @@ func resourceTFESSHKey() *schema.Resource {
 }
 
 func resourceTFESSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
@@ -50,7 +50,7 @@ func resourceTFESSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Create new SSH key for organization: %s", organization)
-	sshKey, err := tfeClient.SSHKeys.Create(ctx, organization, options)
+	sshKey, err := config.Client.SSHKeys.Create(ctx, organization, options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating SSH key %s for organization %s: %w", name, organization, err)
@@ -62,10 +62,10 @@ func resourceTFESSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of SSH key: %s", d.Id())
-	sshKey, err := tfeClient.SSHKeys.Read(ctx, d.Id())
+	sshKey, err := config.Client.SSHKeys.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] SSH key %s no longer exists", d.Id())
@@ -82,7 +82,7 @@ func resourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFESSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Create a new options struct.
 	options := tfe.SSHKeyUpdateOptions{
@@ -90,7 +90,7 @@ func resourceTFESSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Update SSH key: %s", d.Id())
-	_, err := tfeClient.SSHKeys.Update(ctx, d.Id(), options)
+	_, err := config.Client.SSHKeys.Update(ctx, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error updating SSH key %s: %w", d.Id(), err)
 	}
@@ -99,10 +99,10 @@ func resourceTFESSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFESSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete SSH key: %s", d.Id())
-	err := tfeClient.SSHKeys.Delete(ctx, d.Id())
+	err := config.Client.SSHKeys.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_ssh_key_test.go
+++ b/tfe/resource_tfe_ssh_key_test.go
@@ -77,7 +77,7 @@ func TestAccTFESSHKey_update(t *testing.T) {
 func testAccCheckTFESSHKeyExists(
 	n string, sshKey *tfe.SSHKey) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -88,7 +88,7 @@ func testAccCheckTFESSHKeyExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		sk, err := tfeClient.SSHKeys.Read(ctx, rs.Primary.ID)
+		sk, err := config.Client.SSHKeys.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func testAccCheckTFESSHKeyAttributesUpdated(
 }
 
 func testAccCheckTFESSHKeyDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_ssh_key" {
@@ -135,7 +135,7 @@ func testAccCheckTFESSHKeyDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.SSHKeys.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.SSHKeys.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("SSH key %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -95,7 +95,7 @@ func resourceTFETeam() *schema.Resource {
 }
 
 func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get team attributes.
 	name := d.Get("name").(string)
@@ -129,10 +129,10 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Create team %s for organization: %s", name, organization)
-	team, err := tfeClient.Teams.Create(ctx, organization, options)
+	team, err := config.Client.Teams.Create(ctx, organization, options)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
-			entitlements, _ := tfeClient.Organizations.ReadEntitlements(ctx, organization)
+			entitlements, _ := config.Client.Organizations.ReadEntitlements(ctx, organization)
 			if entitlements == nil {
 				return fmt.Errorf("Error creating team %s for organization %s: %w", name, organization, err)
 			}
@@ -149,10 +149,10 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of team: %s", d.Id())
-	team, err := tfeClient.Teams.Read(ctx, d.Id())
+	team, err := config.Client.Teams.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Team %s no longer exists", d.Id())
@@ -185,7 +185,7 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
@@ -220,7 +220,7 @@ func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Update team: %s", d.Id())
-	_, err := tfeClient.Teams.Update(ctx, d.Id(), options)
+	_, err := config.Client.Teams.Update(ctx, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error updating team %s: %w", d.Id(), err)
@@ -230,10 +230,10 @@ func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFETeamDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete team: %s", d.Id())
-	err := tfeClient.Teams.Delete(ctx, d.Id())
+	err := config.Client.Teams.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil
@@ -266,9 +266,9 @@ func resourceTFETeamImporter(ctx context.Context, d *schema.ResourceData, meta i
 
 	// we don't know if the second piece of the import is an ID or a team name. If it is an ID we should be able to read
 	// the team by that ID
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 	if isResourceIDFormat("team", teamNameOrID) {
-		team, err := tfeClient.Teams.Read(ctx, teamNameOrID)
+		team, err := config.Client.Teams.Read(ctx, teamNameOrID)
 		if err == nil {
 			d.SetId(team.ID)
 			return []*schema.ResourceData{d}, nil
@@ -276,7 +276,7 @@ func resourceTFETeamImporter(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	// a team does not exist (or cannot be found) with the ID s[1]...check if it is the team name instead
-	team, err := fetchTeamByName(ctx, tfeClient, orgName, teamNameOrID)
+	team, err := fetchTeamByName(ctx, config.Client, orgName, teamNameOrID)
 	if err != nil {
 		return nil, fmt.Errorf("no team found with name or ID %s in organization %s: %w", teamNameOrID, orgName, err)
 	}

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -29,7 +29,8 @@ func resourceTFETeam() *schema.Resource {
 			},
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"organization_access": {
@@ -99,7 +100,10 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Get team attributes.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.TeamCreateOptions{

--- a/tfe/resource_tfe_team_access_migrate.go
+++ b/tfe/resource_tfe_team_access_migrate.go
@@ -43,10 +43,10 @@ func resourceTfeTeamAccessResourceV0() *schema.Resource {
 }
 
 func resourceTfeTeamAccessStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	humanID := rawState["workspace_id"].(string)
-	id, err := fetchWorkspaceExternalID(humanID, tfeClient)
+	id, err := fetchWorkspaceExternalID(humanID, config.Client)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading configuration of workspace %s: %w", humanID, err)
 	}

--- a/tfe/resource_tfe_team_access_migrate_test.go
+++ b/tfe/resource_tfe_team_access_migrate_test.go
@@ -28,7 +28,9 @@ func TestResourceTfeTeamAccessStateUpgradeV0(t *testing.T) {
 	})
 
 	expected := testResourceTfeTeamAccessStateDataV1()
-	actual, err := resourceTfeTeamAccessStateUpgradeV0(context.Background(), testResourceTfeTeamAccessStateDataV0(), client)
+	actual, err := resourceTfeTeamAccessStateUpgradeV0(context.Background(), testResourceTfeTeamAccessStateDataV0(), ConfiguredClient{
+		Client: client,
+	})
 	if err != nil {
 		t.Fatalf("error migrating state: %s", err)
 	}

--- a/tfe/resource_tfe_team_access_test.go
+++ b/tfe/resource_tfe_team_access_test.go
@@ -281,7 +281,7 @@ func TestAccTFETeamAccess_import(t *testing.T) {
 func testAccCheckTFETeamAccessExists(
 	n string, tmAccess *tfe.TeamAccess) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -292,7 +292,7 @@ func testAccCheckTFETeamAccessExists(
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		ta, err := tfeClient.TeamAccess.Read(ctx, rs.Primary.ID)
+		ta, err := config.Client.TeamAccess.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -341,7 +341,7 @@ func testAccCheckTFETeamAccessAttributesPermissionsAre(tmAccess *tfe.TeamAccess,
 }
 
 func testAccCheckTFETeamAccessDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_access" {
@@ -352,7 +352,7 @@ func testAccCheckTFETeamAccessDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.TeamAccess.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.TeamAccess.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Team access %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_team_member.go
+++ b/tfe/resource_tfe_team_member.go
@@ -35,7 +35,7 @@ func resourceTFETeamMember() *schema.Resource {
 }
 
 func resourceTFETeamMemberCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the team ID and username..
 	teamID := d.Get("team_id").(string)
@@ -47,7 +47,7 @@ func resourceTFETeamMemberCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] Add user %q to team: %s", username, teamID)
-	err := tfeClient.TeamMembers.Add(ctx, teamID, options)
+	err := config.Client.TeamMembers.Add(ctx, teamID, options)
 	if err != nil {
 		return fmt.Errorf("Error adding user %q to team %s: %w", username, teamID, err)
 	}
@@ -58,7 +58,7 @@ func resourceTFETeamMemberCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceTFETeamMemberRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the team ID and username.
 	teamID, username, err := unpackTeamMemberID(d.Id())
@@ -67,7 +67,7 @@ func resourceTFETeamMemberRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Read users from team: %s", teamID)
-	users, err := tfeClient.TeamMembers.List(ctx, teamID)
+	users, err := config.Client.TeamMembers.List(ctx, teamID)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] User %q no longer exists", d.Id())
@@ -100,7 +100,7 @@ func resourceTFETeamMemberRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFETeamMemberDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the team ID and username.
 	teamID, username, err := unpackTeamMemberID(d.Id())
@@ -114,7 +114,7 @@ func resourceTFETeamMemberDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] Remove user %q from team: %s", username, teamID)
-	err = tfeClient.TeamMembers.Remove(ctx, teamID, options)
+	err = config.Client.TeamMembers.Remove(ctx, teamID, options)
 	if err != nil {
 		return fmt.Errorf("Error removing user %q to team %s: %w", username, teamID, err)
 	}

--- a/tfe/resource_tfe_team_member_test.go
+++ b/tfe/resource_tfe_team_member_test.go
@@ -130,7 +130,7 @@ func TestAccTFETeamMember_import(t *testing.T) {
 func testAccCheckTFETeamMemberExists(
 	n string, user *tfe.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -147,7 +147,7 @@ func testAccCheckTFETeamMemberExists(
 			return fmt.Errorf("error unpacking team member ID: %w", err)
 		}
 
-		users, err := tfeClient.TeamMembers.List(ctx, teamID)
+		users, err := config.Client.TeamMembers.List(ctx, teamID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}
@@ -180,7 +180,7 @@ func testAccCheckTFETeamMemberAttributes(
 }
 
 func testAccCheckTFETeamMemberDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_member" {
@@ -197,7 +197,7 @@ func testAccCheckTFETeamMemberDestroy(s *terraform.State) error {
 			return fmt.Errorf("error unpacking team member ID: %w", err)
 		}
 
-		users, err := tfeClient.TeamMembers.List(ctx, teamID)
+		users, err := config.Client.TeamMembers.List(ctx, teamID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}

--- a/tfe/resource_tfe_team_members.go
+++ b/tfe/resource_tfe_team_members.go
@@ -36,7 +36,7 @@ func resourceTFETeamMembers() *schema.Resource {
 }
 
 func resourceTFETeamMembersCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the team ID.
 	teamID := d.Get("team_id").(string)
@@ -50,7 +50,7 @@ func resourceTFETeamMembersCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Add users to team: %s", teamID)
-	err := tfeClient.TeamMembers.Add(ctx, teamID, options)
+	err := config.Client.TeamMembers.Add(ctx, teamID, options)
 	if err != nil {
 		return fmt.Errorf("Error adding users to team %s: %w", teamID, err)
 	}
@@ -61,10 +61,10 @@ func resourceTFETeamMembersCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceTFETeamMembersRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read users from team: %s", d.Id())
-	users, err := tfeClient.TeamMembers.List(ctx, d.Id())
+	users, err := config.Client.TeamMembers.List(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Users do no longer exist")
@@ -90,7 +90,7 @@ func resourceTFETeamMembersRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFETeamMembersUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	if d.HasChange("usernames") {
 		oldUsernames, newUsernames := d.GetChange("usernames")
@@ -108,7 +108,7 @@ func resourceTFETeamMembersUpdate(d *schema.ResourceData, meta interface{}) erro
 			}
 
 			log.Printf("[DEBUG] Add users to team: %s", d.Id())
-			err := tfeClient.TeamMembers.Add(ctx, d.Id(), options)
+			err := config.Client.TeamMembers.Add(ctx, d.Id(), options)
 			if err != nil {
 				return fmt.Errorf("Error adding users to team %s: %w", d.Id(), err)
 			}
@@ -125,7 +125,7 @@ func resourceTFETeamMembersUpdate(d *schema.ResourceData, meta interface{}) erro
 			}
 
 			log.Printf("[DEBUG] Remove users from team: %s", d.Id())
-			err := tfeClient.TeamMembers.Remove(ctx, d.Id(), options)
+			err := config.Client.TeamMembers.Remove(ctx, d.Id(), options)
 			if err != nil {
 				return fmt.Errorf("Error removing users to team %s: %w", d.Id(), err)
 			}
@@ -136,10 +136,10 @@ func resourceTFETeamMembersUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceTFETeamMembersDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Retrieve users to remove from team: %s", d.Id())
-	users, err := tfeClient.TeamMembers.List(ctx, d.Id())
+	users, err := config.Client.TeamMembers.List(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil
@@ -156,7 +156,7 @@ func resourceTFETeamMembersDelete(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Remove users from team: %s", d.Id())
-	err = tfeClient.TeamMembers.Remove(ctx, d.Id(), options)
+	err = config.Client.TeamMembers.Remove(ctx, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error removing users to team %s: %w", d.Id(), err)
 	}

--- a/tfe/resource_tfe_team_members_test.go
+++ b/tfe/resource_tfe_team_members_test.go
@@ -134,7 +134,7 @@ func hashSchemaString(username string) int {
 func testAccCheckTFETeamMembersExists(
 	n string, users *[]*tfe.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -145,7 +145,7 @@ func testAccCheckTFETeamMembersExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		us, err := tfeClient.TeamMembers.List(ctx, rs.Primary.ID)
+		us, err := config.Client.TeamMembers.List(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}
@@ -182,7 +182,7 @@ func usernamesFromTFEUsers(users []*tfe.User) []string {
 }
 
 func testAccCheckTFETeamMembersDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_members" {
@@ -193,7 +193,7 @@ func testAccCheckTFETeamMembersDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		users, err := tfeClient.TeamMembers.List(ctx, rs.Primary.ID)
+		users, err := config.Client.TeamMembers.List(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}

--- a/tfe/resource_tfe_team_organization_member_test.go
+++ b/tfe/resource_tfe_team_organization_member_test.go
@@ -264,7 +264,7 @@ func TestAccTFETeamOrganizationMember_import_slashesInTeamName(t *testing.T) {
 func testAccCheckTFETeamOrganizationMemberExists(
 	n string, organizationMembership *tfe.OrganizationMembership) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -281,7 +281,7 @@ func testAccCheckTFETeamOrganizationMemberExists(
 			return fmt.Errorf("Error unpacking team organization member ID: %w", err)
 		}
 
-		organizationMemberships, err := tfeClient.TeamMembers.ListOrganizationMemberships(ctx, teamID)
+		organizationMemberships, err := config.Client.TeamMembers.ListOrganizationMemberships(ctx, teamID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}
@@ -314,7 +314,7 @@ func testAccCheckTFETeamOrganizationMemberAttributes(
 }
 
 func testAccCheckTFETeamOrganizationMemberDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_organization_member" {
@@ -331,7 +331,7 @@ func testAccCheckTFETeamOrganizationMemberDestroy(s *terraform.State) error {
 			return fmt.Errorf("Error unpacking team organization member ID: %w", err)
 		}
 
-		organizationMemberships, err := tfeClient.TeamMembers.ListOrganizationMemberships(ctx, teamID)
+		organizationMemberships, err := config.Client.TeamMembers.ListOrganizationMemberships(ctx, teamID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}

--- a/tfe/resource_tfe_team_organization_members_test.go
+++ b/tfe/resource_tfe_team_organization_members_test.go
@@ -64,7 +64,7 @@ func TestAccTFETeamOrganizationMembers_import(t *testing.T) {
 
 func testAccCheckTFETeamOrganizationMembersExists(resourceName string, organizationMemberships *[]tfe.OrganizationMembership) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 		*organizationMemberships = []tfe.OrganizationMembership{}
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -77,7 +77,7 @@ func testAccCheckTFETeamOrganizationMembersExists(resourceName string, organizat
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		orgMemberships, err := tfeClient.TeamMembers.ListOrganizationMemberships(ctx, rs.Primary.ID)
+		orgMemberships, err := config.Client.TeamMembers.ListOrganizationMemberships(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return fmt.Errorf("error while listing organization memberships: %w", err)
 		}
@@ -126,7 +126,7 @@ func testAccCheckTFETeamOrganizationMembersCount(expected int, organizationMembe
 }
 
 func testAccCheckTFETeamOrganizationMembersDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		// Continue if current resource is not a "tfe_team_organization_members" resource
@@ -139,7 +139,7 @@ func testAccCheckTFETeamOrganizationMembersDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		organizationMemberships, err := tfeClient.TeamMembers.ListOrganizationMemberships(ctx, rs.Primary.ID)
+		organizationMemberships, err := config.Client.TeamMembers.ListOrganizationMemberships(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return fmt.Errorf("error while listing organization memberships: %w", err)
 		}

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -349,7 +349,7 @@ func TestAccTFETeam_import_teamNameWhichLooksLikeID(t *testing.T) {
 func testAccCheckTFETeamExists(
 	n string, team *tfe.Team) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -360,7 +360,7 @@ func testAccCheckTFETeamExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		t, err := tfeClient.Teams.Read(ctx, rs.Primary.ID)
+		t, err := config.Client.Teams.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -449,7 +449,7 @@ func testAccCheckTFETeamAttributes_full_update(
 }
 
 func testAccCheckTFETeamDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team" {
@@ -460,7 +460,7 @@ func testAccCheckTFETeamDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Teams.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.Teams.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Team %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_team_token.go
+++ b/tfe/resource_tfe_team_token.go
@@ -42,13 +42,13 @@ func resourceTFETeamToken() *schema.Resource {
 }
 
 func resourceTFETeamTokenCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the team ID.
 	teamID := d.Get("team_id").(string)
 
 	log.Printf("[DEBUG] Check if a token already exists for team: %s", teamID)
-	_, err := tfeClient.TeamTokens.Read(ctx, teamID)
+	_, err := config.Client.TeamTokens.Read(ctx, teamID)
 	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 		return fmt.Errorf("error checking if a token exists for team %s: %w", teamID, err)
 	}
@@ -62,7 +62,7 @@ func resourceTFETeamTokenCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] Create new token for team: %s", teamID)
-	token, err := tfeClient.TeamTokens.Create(ctx, teamID)
+	token, err := config.Client.TeamTokens.Create(ctx, teamID)
 	if err != nil {
 		return fmt.Errorf(
 			"error creating new token for team %s: %w", teamID, err)
@@ -78,10 +78,10 @@ func resourceTFETeamTokenCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFETeamTokenRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read the token from team: %s", d.Id())
-	_, err := tfeClient.TeamTokens.Read(ctx, d.Id())
+	_, err := config.Client.TeamTokens.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Token for team %s no longer exists", d.Id())
@@ -95,10 +95,10 @@ func resourceTFETeamTokenRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFETeamTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete token from team: %s", d.Id())
-	err := tfeClient.TeamTokens.Delete(ctx, d.Id())
+	err := config.Client.TeamTokens.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -110,7 +110,7 @@ func TestAccTFETeamToken_import(t *testing.T) {
 func testAccCheckTFETeamTokenExists(
 	n string, token *tfe.TeamToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -121,7 +121,7 @@ func testAccCheckTFETeamTokenExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		tt, err := tfeClient.TeamTokens.Read(ctx, rs.Primary.ID)
+		tt, err := config.Client.TeamTokens.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func testAccCheckTFETeamTokenExists(
 }
 
 func testAccCheckTFETeamTokenDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_token" {
@@ -148,7 +148,7 @@ func testAccCheckTFETeamTokenDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.TeamTokens.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.TeamTokens.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Team token %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_terraform_version.go
+++ b/tfe/resource_tfe_terraform_version.go
@@ -63,7 +63,7 @@ func resourceTFETerraformVersion() *schema.Resource {
 }
 
 func resourceTFETerraformVersionCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	opts := tfe.AdminTerraformVersionCreateOptions{
 		Version:          tfe.String(d.Get("version").(string)),
@@ -77,7 +77,7 @@ func resourceTFETerraformVersionCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] Create new Terraform version: %s", *opts.Version)
-	v, err := tfeClient.Admin.TerraformVersions.Create(ctx, opts)
+	v, err := config.Client.Admin.TerraformVersions.Create(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("Error creating the new Terraform version %s: %w", *opts.Version, err)
 	}
@@ -88,10 +88,10 @@ func resourceTFETerraformVersionCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceTFETerraformVersionRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of Terraform version: %s", d.Id())
-	v, err := tfeClient.Admin.TerraformVersions.Read(ctx, d.Id())
+	v, err := config.Client.Admin.TerraformVersions.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Terraform version %s no longer exists", d.Id())
@@ -114,7 +114,7 @@ func resourceTFETerraformVersionRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceTFETerraformVersionUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	opts := tfe.AdminTerraformVersionUpdateOptions{
 		Version:          tfe.String(d.Get("version").(string)),
@@ -128,7 +128,7 @@ func resourceTFETerraformVersionUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] Update configuration of Terraform version: %s", d.Id())
-	v, err := tfeClient.Admin.TerraformVersions.Update(ctx, d.Id(), opts)
+	v, err := config.Client.Admin.TerraformVersions.Update(ctx, d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("Error updating Terraform version %s: %w", d.Id(), err)
 	}
@@ -139,10 +139,10 @@ func resourceTFETerraformVersionUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceTFETerraformVersionDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete Terraform version: %s", d.Id())
-	err := tfeClient.Admin.TerraformVersions.Delete(ctx, d.Id())
+	err := config.Client.Admin.TerraformVersions.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil
@@ -154,13 +154,13 @@ func resourceTFETerraformVersionDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceTFETerraformVersionImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Splitting by '-' and checking if the first elem is equal to tool
 	// determines if the string is a tool version ID
 	s := strings.Split(d.Id(), "-")
 	if s[0] != "tool" {
-		versionID, err := fetchTerraformVersionID(d.Id(), tfeClient)
+		versionID, err := fetchTerraformVersionID(d.Id(), config.Client)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving terraform version %s: %w", d.Id(), err)
 		}

--- a/tfe/resource_tfe_terraform_version_test.go
+++ b/tfe/resource_tfe_terraform_version_test.go
@@ -112,7 +112,7 @@ func TestAccTFETerraformVersion_full(t *testing.T) {
 }
 
 func testAccCheckTFETerraformVersionDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_terraform_version" {
@@ -123,7 +123,7 @@ func testAccCheckTFETerraformVersionDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Admin.TerraformVersions.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.Admin.TerraformVersions.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Terraform version %s still exists", rs.Primary.ID)
 		}
@@ -134,7 +134,7 @@ func testAccCheckTFETerraformVersionDestroy(s *terraform.State) error {
 
 func testAccCheckTFETerraformVersionExists(n string, tfVersion *tfe.AdminTerraformVersion) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -145,7 +145,7 @@ func testAccCheckTFETerraformVersionExists(n string, tfVersion *tfe.AdminTerrafo
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		v, err := tfeClient.Admin.TerraformVersions.Read(ctx, rs.Primary.ID)
+		v, err := config.Client.Admin.TerraformVersions.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -127,7 +127,7 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 		return resourceTFEVariableSetVariableCreate(d, meta)
 	}
 
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get key and category.
 	key := d.Get("key").(string)
@@ -135,7 +135,7 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Get the workspace
 	workspaceID := d.Get("workspace_id").(string)
-	ws, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+	ws, err := config.Client.Workspaces.ReadByID(ctx, workspaceID)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving workspace %s: %w", workspaceID, err)
@@ -152,7 +152,7 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Create %s variable: %s", category, key)
-	variable, err := tfeClient.Variables.Create(ctx, ws.ID, options)
+	variable, err := config.Client.Variables.Create(ctx, ws.ID, options)
 	if err != nil {
 		return fmt.Errorf("Error creating %s variable %s: %w", category, key, err)
 	}
@@ -163,7 +163,7 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFEVariableSetVariableCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get key and category.
 	key := d.Get("key").(string)
@@ -171,7 +171,7 @@ func resourceTFEVariableSetVariableCreate(d *schema.ResourceData, meta interface
 
 	// Get the variable set
 	variableSetID := d.Get("variable_set_id").(string)
-	vs, err := tfeClient.VariableSets.Read(ctx, variableSetID, nil)
+	vs, err := config.Client.VariableSets.Read(ctx, variableSetID, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving variable set %s: %w", variableSetID, err)
@@ -188,7 +188,7 @@ func resourceTFEVariableSetVariableCreate(d *schema.ResourceData, meta interface
 	}
 
 	log.Printf("[DEBUG] Create %s variable: %s", category, key)
-	variable, err := tfeClient.VariableSetVariables.Create(ctx, vs.ID, &options)
+	variable, err := config.Client.VariableSetVariables.Create(ctx, vs.ID, &options)
 	if err != nil {
 		return fmt.Errorf("Error creating %s variable %s: %w", category, key, err)
 	}
@@ -205,11 +205,11 @@ func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 		return resourceTFEVariableSetVariableRead(d, meta)
 	}
 
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the workspace.
 	workspaceID := d.Get("workspace_id").(string)
-	ws, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+	ws, err := config.Client.Workspaces.ReadByID(ctx, workspaceID)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Workspace %s no longer exists", workspaceID)
@@ -221,7 +221,7 @@ func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Read variable: %s", d.Id())
-	variable, err := tfeClient.Variables.Read(ctx, ws.ID, d.Id())
+	variable, err := config.Client.Variables.Read(ctx, ws.ID, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Variable %s no longer exists", d.Id())
@@ -247,11 +247,11 @@ func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFEVariableSetVariableRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the variable set
 	variableSetID := d.Get("variable_set_id").(string)
-	vs, err := tfeClient.VariableSets.Read(ctx, variableSetID, nil)
+	vs, err := config.Client.VariableSets.Read(ctx, variableSetID, nil)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Variable set %s no longer exists", variableSetID)
@@ -263,7 +263,7 @@ func resourceTFEVariableSetVariableRead(d *schema.ResourceData, meta interface{}
 	}
 
 	log.Printf("[DEBUG] Read variable: %s", d.Id())
-	variable, err := tfeClient.VariableSetVariables.Read(ctx, vs.ID, d.Id())
+	variable, err := config.Client.VariableSetVariables.Read(ctx, vs.ID, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Variable %s no longer exists", d.Id())
@@ -295,11 +295,11 @@ func resourceTFEVariableUpdate(d *schema.ResourceData, meta interface{}) error {
 		return resourceTFEVariableSetVariableUpdate(d, meta)
 	}
 
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the workspace.
 	workspaceID := d.Get("workspace_id").(string)
-	ws, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+	ws, err := config.Client.Workspaces.ReadByID(ctx, workspaceID)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving workspace %s: %w", workspaceID, err)
@@ -315,7 +315,7 @@ func resourceTFEVariableUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Update variable: %s", d.Id())
-	_, err = tfeClient.Variables.Update(ctx, ws.ID, d.Id(), options)
+	_, err = config.Client.Variables.Update(ctx, ws.ID, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error updating variable %s: %w", d.Id(), err)
 	}
@@ -324,11 +324,11 @@ func resourceTFEVariableUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFEVariableSetVariableUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the variable set.
 	variableSetID := d.Get("variable_set_id").(string)
-	vs, err := tfeClient.VariableSets.Read(ctx, variableSetID, nil)
+	vs, err := config.Client.VariableSets.Read(ctx, variableSetID, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving variable set %s: %w", variableSetID, err)
@@ -344,7 +344,7 @@ func resourceTFEVariableSetVariableUpdate(d *schema.ResourceData, meta interface
 	}
 
 	log.Printf("[DEBUG] Update variable: %s", d.Id())
-	_, err = tfeClient.VariableSetVariables.Update(ctx, vs.ID, d.Id(), &options)
+	_, err = config.Client.VariableSetVariables.Update(ctx, vs.ID, d.Id(), &options)
 	if err != nil {
 		return fmt.Errorf("Error updating variable %s: %w", d.Id(), err)
 	}
@@ -359,18 +359,18 @@ func resourceTFEVariableDelete(d *schema.ResourceData, meta interface{}) error {
 		return resourceTFEVariableSetVariableDelete(d, meta)
 	}
 
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the workspace.
 	workspaceID := d.Get("workspace_id").(string)
-	ws, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+	ws, err := config.Client.Workspaces.ReadByID(ctx, workspaceID)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving workspace %s: %w", workspaceID, err)
 	}
 
 	log.Printf("[DEBUG] Delete variable: %s", d.Id())
-	err = tfeClient.Variables.Delete(ctx, ws.ID, d.Id())
+	err = config.Client.Variables.Delete(ctx, ws.ID, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil
@@ -382,18 +382,18 @@ func resourceTFEVariableDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceTFEVariableSetVariableDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the variable set.
 	variableSetID := d.Get("variable_set_id").(string)
-	vs, err := tfeClient.VariableSets.Read(ctx, variableSetID, nil)
+	vs, err := config.Client.VariableSets.Read(ctx, variableSetID, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving variable set %s: %w", variableSetID, err)
 	}
 
 	log.Printf("[DEBUG] Delete variable: %s", d.Id())
-	err = tfeClient.VariableSetVariables.Delete(ctx, vs.ID, d.Id())
+	err = config.Client.VariableSetVariables.Delete(ctx, vs.ID, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil
@@ -405,7 +405,7 @@ func resourceTFEVariableSetVariableDelete(d *schema.ResourceData, meta interface
 }
 
 func resourceTFEVariableImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	s := strings.SplitN(d.Id(), "/", 3)
 	if len(s) != 3 {
@@ -420,7 +420,7 @@ func resourceTFEVariableImporter(ctx context.Context, d *schema.ResourceData, me
 		d.Set("variable_set_id", s[1])
 	} else {
 		// Set the fields that are part of the import ID.
-		workspaceID, err := fetchWorkspaceExternalID(s[0]+"/"+s[1], tfeClient)
+		workspaceID, err := fetchWorkspaceExternalID(s[0]+"/"+s[1], config.Client)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"error retrieving workspace %s from organization %s: %w", s[1], s[0], err)

--- a/tfe/resource_tfe_variable_migrate.go
+++ b/tfe/resource_tfe_variable_migrate.go
@@ -59,10 +59,10 @@ func resourceTfeVariableResourceV0() *schema.Resource {
 }
 
 func resourceTfeVariableStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	humanID := rawState["workspace_id"].(string)
-	id, err := fetchWorkspaceExternalID(humanID, tfeClient)
+	id, err := fetchWorkspaceExternalID(humanID, config.Client)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading configuration of workspace %s: %w", humanID, err)
 	}

--- a/tfe/resource_tfe_variable_migrate_test.go
+++ b/tfe/resource_tfe_variable_migrate_test.go
@@ -24,12 +24,14 @@ func TestResourceTfeVariableStateUpgradeV0(t *testing.T) {
 	client := testTfeClient(t, testClientOptions{defaultWorkspaceID: "ws-123"})
 	name := "a-workspace"
 
-	client.Workspaces.Create(nil, "hashicorp", tfe.WorkspaceCreateOptions{
+	client.Workspaces.Create(context.TODO(), "hashicorp", tfe.WorkspaceCreateOptions{
 		Name: &name,
 	})
 
 	expected := testResourceTfeVariableStateDataV1()
-	actual, err := resourceTfeVariableStateUpgradeV0(context.Background(), testResourceTfeVariableStateDataV0(), client)
+	actual, err := resourceTfeVariableStateUpgradeV0(context.Background(), testResourceTfeVariableStateDataV0(), ConfiguredClient{
+		Client: client,
+	})
 	if err != nil {
 		t.Fatalf("error migrating state: %s", err)
 	}

--- a/tfe/resource_tfe_variable_set.go
+++ b/tfe/resource_tfe_variable_set.go
@@ -41,7 +41,8 @@ func resourceTFEVariableSet() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -60,7 +61,10 @@ func resourceTFEVariableSetCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.VariableSetCreateOptions{

--- a/tfe/resource_tfe_variable_set.go
+++ b/tfe/resource_tfe_variable_set.go
@@ -56,7 +56,7 @@ func resourceTFEVariableSet() *schema.Resource {
 }
 
 func resourceTFEVariableSetCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
@@ -72,7 +72,7 @@ func resourceTFEVariableSetCreate(d *schema.ResourceData, meta interface{}) erro
 		options.Description = tfe.String(description.(string))
 	}
 
-	variableSet, err := tfeClient.VariableSets.Create(ctx, organization, &options)
+	variableSet, err := config.Client.VariableSets.Create(ctx, organization, &options)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating variable set %s, for organization: %s: %w", name, organization, err)
@@ -91,7 +91,7 @@ func resourceTFEVariableSetCreate(d *schema.ResourceData, meta interface{}) erro
 			}
 		}
 
-		_, err := tfeClient.VariableSets.UpdateWorkspaces(ctx, variableSet.ID, &applyOptions)
+		_, err := config.Client.VariableSets.UpdateWorkspaces(ctx, variableSet.ID, &applyOptions)
 		if err != nil {
 			return fmt.Errorf(
 				"Error applying variable set %s (%s) to given workspaces: %w", name, variableSet.ID, err)
@@ -102,10 +102,10 @@ func resourceTFEVariableSetCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of variable set: %s", d.Id())
-	variableSet, err := tfeClient.VariableSets.Read(ctx, d.Id(), &tfe.VariableSetReadOptions{
+	variableSet, err := config.Client.VariableSets.Read(ctx, d.Id(), &tfe.VariableSetReadOptions{
 		Include: &[]tfe.VariableSetIncludeOpt{tfe.VariableSetWorkspaces},
 	})
 	if err != nil {
@@ -133,7 +133,7 @@ func resourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceTFEVariableSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	if d.HasChange("name") || d.HasChange("description") || d.HasChange("global") {
 		options := tfe.VariableSetUpdateOptions{
@@ -143,7 +143,7 @@ func resourceTFEVariableSetUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		log.Printf("[DEBUG] Update variable set: %s", d.Id())
-		_, err := tfeClient.VariableSets.Update(ctx, d.Id(), &options)
+		_, err := config.Client.VariableSets.Update(ctx, d.Id(), &options)
 		if err != nil {
 			return fmt.Errorf("Error updateing variable %s: %w", d.Id(), err)
 		}
@@ -161,7 +161,7 @@ func resourceTFEVariableSetUpdate(d *schema.ResourceData, meta interface{}) erro
 
 		log.Printf("[DEBUG] Apply variable set %s to workspaces %v", d.Id(), workspaceIDs)
 		warnWorkspaceIdsDeprecation()
-		_, err := tfeClient.VariableSets.UpdateWorkspaces(ctx, d.Id(), &applyOptions)
+		_, err := config.Client.VariableSets.UpdateWorkspaces(ctx, d.Id(), &applyOptions)
 		if err != nil {
 			return fmt.Errorf(
 				"Error applying variable set %s to given workspaces: %w", d.Id(), err)
@@ -172,10 +172,10 @@ func resourceTFEVariableSetUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceTFEVariableSetDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete variable set: %s", d.Id())
-	err := tfeClient.VariableSets.Delete(ctx, d.Id())
+	err := config.Client.VariableSets.Delete(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil

--- a/tfe/resource_tfe_variable_set_test.go
+++ b/tfe/resource_tfe_variable_set_test.go
@@ -136,7 +136,7 @@ func TestAccTFEVariableSet_import(t *testing.T) {
 func testAccCheckTFEVariableSetExists(
 	n string, variableSet *tfe.VariableSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -147,7 +147,7 @@ func testAccCheckTFEVariableSetExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		vs, err := tfeClient.VariableSets.Read(
+		vs, err := config.Client.VariableSets.Read(
 			ctx,
 			rs.Primary.ID,
 			&tfe.VariableSetReadOptions{Include: &[]tfe.VariableSetIncludeOpt{tfe.VariableSetWorkspaces}},
@@ -217,7 +217,7 @@ func testAccCheckTFEVariableSetApplicationUpdate(variableSet *tfe.VariableSet) r
 }
 
 func testAccCheckTFEVariableSetDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_variable_set" {
@@ -228,7 +228,7 @@ func testAccCheckTFEVariableSetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.VariableSets.Read(ctx, rs.Primary.ID, nil)
+		_, err := config.Client.VariableSets.Read(ctx, rs.Primary.ID, nil)
 		if err == nil {
 			return fmt.Errorf("Variable Set %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -211,7 +211,7 @@ func TestAccTFEVariable_import(t *testing.T) {
 func testAccCheckTFEVariableExists(
 	n string, variable *tfe.Variable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -223,13 +223,13 @@ func testAccCheckTFEVariableExists(
 		}
 
 		wsID := rs.Primary.Attributes["workspace_id"]
-		ws, err := tfeClient.Workspaces.ReadByID(ctx, wsID)
+		ws, err := config.Client.Workspaces.ReadByID(ctx, wsID)
 		if err != nil {
 			return fmt.Errorf(
 				"Error retrieving workspace %s: %w", wsID, err)
 		}
 
-		v, err := tfeClient.Variables.Read(ctx, ws.ID, rs.Primary.ID)
+		v, err := config.Client.Variables.Read(ctx, ws.ID, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -243,7 +243,7 @@ func testAccCheckTFEVariableExists(
 func testAccCheckTFEVariableSetVariableExists(
 	n string, variable *tfe.VariableSetVariable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -255,13 +255,13 @@ func testAccCheckTFEVariableSetVariableExists(
 		}
 
 		vsID := rs.Primary.Attributes["variable_set_id"]
-		vs, err := tfeClient.VariableSets.Read(ctx, vsID, nil)
+		vs, err := config.Client.VariableSets.Read(ctx, vsID, nil)
 		if err != nil {
 			return fmt.Errorf(
 				"Error retrieving variable set %s: %w", vsID, err)
 		}
 
-		v, err := tfeClient.VariableSetVariables.Read(ctx, vs.ID, rs.Primary.ID)
+		v, err := config.Client.VariableSetVariables.Read(ctx, vs.ID, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -408,7 +408,7 @@ func testAccCheckTFEVariableIDsNotEqual(
 }
 
 func testAccCheckTFEVariableDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_variable" {
@@ -419,7 +419,7 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Variables.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
+		_, err := config.Client.Variables.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Variable %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -62,7 +62,8 @@ func resourceTFEWorkspace() *schema.Resource {
 
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 
@@ -254,7 +255,10 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 
 	// Get the name and organization.
 	name := d.Get("name").(string)
-	organization := d.Get("organization").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
 
 	// Create a new options struct.
 	options := tfe.WorkspaceCreateOptions{

--- a/tfe/resource_tfe_workspace_policy_set_test.go
+++ b/tfe/resource_tfe_workspace_policy_set_test.go
@@ -75,7 +75,7 @@ func TestAccTFEWorkspacePolicySet_incorrectImportSyntax(t *testing.T) {
 
 func testAccCheckTFEWorkspacePolicySetExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -97,7 +97,7 @@ func testAccCheckTFEWorkspacePolicySetExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No workspace id set")
 		}
 
-		policySet, err := tfeClient.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
+		policySet, err := config.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
 			Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaces},
 		})
 		if err != nil {
@@ -114,7 +114,7 @@ func testAccCheckTFEWorkspacePolicySetExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckTFEWorkspacePolicySetDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy_set" {
@@ -125,7 +125,7 @@ func testAccCheckTFEWorkspacePolicySetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.PolicySets.Read(ctx, rs.Primary.ID)
+		_, err := config.Client.PolicySets.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Policy Set %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_workspace_run_task.go
+++ b/tfe/resource_tfe_workspace_run_task.go
@@ -104,18 +104,18 @@ func resourceTFEWorkspaceRunTask() *schema.Resource {
 }
 
 func resourceTFEWorkspaceRunTaskCreate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	workspaceID := d.Get("workspace_id").(string)
 	taskID := d.Get("task_id").(string)
 
-	task, err := tfeClient.RunTasks.Read(ctx, taskID)
+	task, err := config.Client.RunTasks.Read(ctx, taskID)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving task %s: %w", taskID, err)
 	}
 
-	ws, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
+	ws, err := config.Client.Workspaces.ReadByID(ctx, workspaceID)
 	if err != nil {
 		return fmt.Errorf(
 			"Error retrieving workspace %s: %w", workspaceID, err)
@@ -129,7 +129,7 @@ func resourceTFEWorkspaceRunTaskCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] Create task %s in workspace %s", task.ID, ws.ID)
-	wstask, err := tfeClient.WorkspaceRunTasks.Create(ctx, ws.ID, options)
+	wstask, err := config.Client.WorkspaceRunTasks.Create(ctx, ws.ID, options)
 	if err != nil {
 		return fmt.Errorf("Error creating task %s in workspace %s: %w", task.ID, ws.ID, err)
 	}
@@ -140,13 +140,13 @@ func resourceTFEWorkspaceRunTaskCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceTFEWorkspaceRunTaskDelete(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the workspace
 	workspaceID := d.Get("workspace_id").(string)
 
 	log.Printf("[DEBUG] Delete task %s in workspace %s", d.Id(), workspaceID)
-	err := tfeClient.WorkspaceRunTasks.Delete(ctx, workspaceID, d.Id())
+	err := config.Client.WorkspaceRunTasks.Delete(ctx, workspaceID, d.Id())
 	if err != nil && !isErrResourceNotFound(err) {
 		return fmt.Errorf("Error deleting task %s in workspace %s: %w", d.Id(), workspaceID, err)
 	}
@@ -155,7 +155,7 @@ func resourceTFEWorkspaceRunTaskDelete(d *schema.ResourceData, meta interface{})
 }
 
 func resourceTFEWorkspaceRunTaskUpdate(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the workspace
 	workspaceID := d.Get("workspace_id").(string)
@@ -171,7 +171,7 @@ func resourceTFEWorkspaceRunTaskUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	log.Printf("[DEBUG] Update configuration of task %s in workspace %s", d.Id(), workspaceID)
-	_, err := tfeClient.WorkspaceRunTasks.Update(ctx, workspaceID, d.Id(), options)
+	_, err := config.Client.WorkspaceRunTasks.Update(ctx, workspaceID, d.Id(), options)
 	if err != nil {
 		return fmt.Errorf("Error updating task %s in workspace %s: %w", d.Id(), workspaceID, err)
 	}
@@ -180,12 +180,12 @@ func resourceTFEWorkspaceRunTaskUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceTFEWorkspaceRunTaskRead(d *schema.ResourceData, meta interface{}) error {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	// Get the workspace
 	workspaceID := d.Get("workspace_id").(string)
 
-	wstask, err := tfeClient.WorkspaceRunTasks.Read(ctx, workspaceID, d.Id())
+	wstask, err := config.Client.WorkspaceRunTasks.Read(ctx, workspaceID, d.Id())
 	if err != nil {
 		if isErrResourceNotFound(err) {
 			log.Printf("[DEBUG] Workspace Task %s does not exist in workspace %s", d.Id(), workspaceID)
@@ -205,7 +205,7 @@ func resourceTFEWorkspaceRunTaskRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceTFEWorkspaceRunTaskImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	tfeClient := meta.(*tfe.Client)
+	config := meta.(ConfiguredClient)
 
 	s := strings.Split(d.Id(), "/")
 	if len(s) != 3 {
@@ -215,7 +215,7 @@ func resourceTFEWorkspaceRunTaskImporter(ctx context.Context, d *schema.Resource
 		)
 	}
 
-	wstask, err := fetchWorkspaceRunTask(s[2], s[1], s[0], tfeClient)
+	wstask, err := fetchWorkspaceRunTask(s[2], s[1], s[0], config.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/tfe/resource_tfe_workspace_run_task_test.go
+++ b/tfe/resource_tfe_workspace_run_task_test.go
@@ -113,7 +113,7 @@ func TestAccTFEWorkspaceRunTask_import(t *testing.T) {
 
 func testAccCheckTFEWorkspaceRunTaskExists(n string, runTask *tfe.WorkspaceRunTask) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -128,7 +128,7 @@ func testAccCheckTFEWorkspaceRunTaskExists(n string, runTask *tfe.WorkspaceRunTa
 			return fmt.Errorf("No Workspace ID is set")
 		}
 
-		rt, err := tfeClient.WorkspaceRunTasks.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
+		rt, err := config.Client.WorkspaceRunTasks.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error reading Workspace Run Task: %w", err)
 		}
@@ -144,7 +144,7 @@ func testAccCheckTFEWorkspaceRunTaskExists(n string, runTask *tfe.WorkspaceRunTa
 }
 
 func testAccCheckTFEWorkspaceRunTaskDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_workspace_run_task" {
@@ -158,7 +158,7 @@ func testAccCheckTFEWorkspaceRunTaskDestroy(s *terraform.State) error {
 			return fmt.Errorf("No Workspace ID is set")
 		}
 
-		_, err := tfeClient.WorkspaceRunTasks.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
+		_, err := config.Client.WorkspaceRunTasks.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Workspace Run Tasks %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -2092,7 +2092,7 @@ func TestTFEWorkspace_delete_withoutCanForceDeletePermission(t *testing.T) {
 func testAccCheckTFEWorkspaceExists(
 	n string, workspace *tfe.Workspace) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -2104,7 +2104,7 @@ func testAccCheckTFEWorkspaceExists(
 		}
 
 		// Get the workspace
-		w, err := tfeClient.Workspaces.ReadByID(ctx, rs.Primary.ID)
+		w, err := config.Client.Workspaces.ReadByID(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -2125,7 +2125,7 @@ func testAccCheckTFEWorkspaceExists(
 // resource_tfe_workspace.go:208 resourceTFEWorkspaceRead(...)
 func testAccCheckTFEWorkspacePanic(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		// Grab the resource out of the state and delete it from TFC/E directly.
 		rs, ok := s.RootModule().Resources[n]
@@ -2133,7 +2133,7 @@ func testAccCheckTFEWorkspacePanic(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		err := tfeClient.Workspaces.DeleteByID(ctx, rs.Primary.ID)
+		err := config.Client.Workspaces.DeleteByID(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Could not delete %s: %w", n, err)
 		}
@@ -2256,9 +2256,9 @@ func testAccCheckTFEWorkspaceMonorepoAttributes(
 
 func testAccCheckTFEWorkspaceRename(orgName string) func() {
 	return func() {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
-		w, err := tfeClient.Workspaces.Update(
+		w, err := config.Client.Workspaces.Update(
 			context.Background(),
 			orgName,
 			"workspace-test",
@@ -2420,7 +2420,7 @@ func testAccCheckTFEWorkspaceUpdatedRemoveVCSRepoAttributes(
 }
 
 func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_workspace" {
@@ -2431,7 +2431,7 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Workspaces.ReadByID(ctx, rs.Primary.ID)
+		_, err := config.Client.Workspaces.ReadByID(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Workspace %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_workspace_variable_set_test.go
+++ b/tfe/resource_tfe_workspace_variable_set_test.go
@@ -39,7 +39,7 @@ func TestAccTFEWorkspaceVariableSet_basic(t *testing.T) {
 
 func testAccCheckTFEWorkspaceVariableSetExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		tfeClient := testAccProvider.Meta().(*tfe.Client)
+		config := testAccProvider.Meta().(ConfiguredClient)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -56,7 +56,7 @@ func testAccCheckTFEWorkspaceVariableSetExists(n string) resource.TestCheckFunc 
 			return fmt.Errorf("error decoding ID (%s): %w", id, err)
 		}
 
-		vS, err := tfeClient.VariableSets.Read(ctx, vSID, &tfe.VariableSetReadOptions{
+		vS, err := config.Client.VariableSets.Read(ctx, vSID, &tfe.VariableSetReadOptions{
 			Include: &[]tfe.VariableSetIncludeOpt{tfe.VariableSetWorkspaces},
 		})
 		if err != nil {
@@ -73,7 +73,7 @@ func testAccCheckTFEWorkspaceVariableSetExists(n string) resource.TestCheckFunc 
 }
 
 func testAccCheckTFEWorkspaceVariableSetDestroy(s *terraform.State) error {
-	tfeClient := testAccProvider.Meta().(*tfe.Client)
+	config := testAccProvider.Meta().(ConfiguredClient)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_variable_set" {
@@ -84,7 +84,7 @@ func testAccCheckTFEWorkspaceVariableSetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.VariableSets.Read(ctx, rs.Primary.ID, nil)
+		_, err := config.Client.VariableSets.Read(ctx, rs.Primary.ID, nil)
 		if err == nil {
 			return fmt.Errorf("Variable Set %s still exists", rs.Primary.ID)
 		}

--- a/tfe/tfe_sweeper_test.go
+++ b/tfe/tfe_sweeper_test.go
@@ -20,13 +20,13 @@ func getOrgSweeper(name string) *resource.Sweeper {
 	return &resource.Sweeper{
 		Name: name,
 		F: func(ununsed string) error {
-			client, err := getClientUsingEnv()
+			tfeClient, err := getClientUsingEnv()
 			if err != nil {
 				return fmt.Errorf("Error getting client: %w", err)
 			}
 
 			ctx := context.TODO()
-			orgList, err := client.Organizations.List(ctx, &tfe.OrganizationListOptions{})
+			orgList, err := tfeClient.Organizations.List(ctx, &tfe.OrganizationListOptions{})
 			if err != nil {
 				return fmt.Errorf("Error listing organizations: %w", err)
 			}
@@ -34,7 +34,7 @@ func getOrgSweeper(name string) *resource.Sweeper {
 				log.Printf("[DEBUG] Testing if org %s starts with tst-terraform or named terraform-updated", org.Name)
 				if strings.HasPrefix(org.Name, "tst-terraform") {
 					log.Printf("[DEBUG] deleting org %s", org.Name)
-					err = client.Organizations.Delete(ctx, org.Name)
+					err = tfeClient.Organizations.Delete(ctx, org.Name)
 					if err != nil {
 						return fmt.Errorf("Error deleting organization %q %w", org.Name, err)
 					}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -122,3 +122,6 @@ The following arguments are supported:
 * `ssl_skip_verify` - (Optional) Whether or not to skip certificate verifications.
   Defaults to `false`. Can be overridden setting the `TFE_SSL_SKIP_VERIFY`
   environment variable.
+* `default_organization` - (Optional) The default organization that resources should
+  belong to. If provided, it's usually possible to omit resource-specific `organization`
+  arguments.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -125,3 +125,4 @@ The following arguments are supported:
 * `organization` - (Optional) The default organization that resources should
   belong to. If provided, it's usually possible to omit resource-specific `organization`
   arguments. Ensure that the organization already exists prior to using this argument.
+  This can also be specified using the `TFE_ORGANIZATION` environment variable.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -122,6 +122,6 @@ The following arguments are supported:
 * `ssl_skip_verify` - (Optional) Whether or not to skip certificate verifications.
   Defaults to `false`. Can be overridden setting the `TFE_SSL_SKIP_VERIFY`
   environment variable.
-* `default_organization` - (Optional) The default organization that resources should
+* `organization` - (Optional) The default organization that resources should
   belong to. If provided, it's usually possible to omit resource-specific `organization`
-  arguments.
+  arguments. Ensure that the organization already exists prior to using this argument.

--- a/website/docs/r/admin_organization_settings.markdown
+++ b/website/docs/r/admin_organization_settings.markdown
@@ -54,7 +54,7 @@ resource "tfe_admin_organization_settings" "test-settings" {
 
 The following arguments are supported:
 
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization provider config must be defined.
 * `access_beta_tools` - (Optional) True if the organization has access to beta tool versions.
 * `workspace_limit` - (Optional) Maximum number of workspaces for this organization. If this number is set to a value lower than the number of workspaces the organization has, it will prevent additional workspaces from being created, but existing workspaces will not be affected. If set to 0, this limit will have no effect.
 * `global_module_sharing` - (Optional) If true, modules in the organization's private module repository will be available to all other organizations. Enabling this will disable any previously configured module_sharing_consumer_organizations. Cannot be true if module_sharing_consumer_organizations is set.

--- a/website/docs/r/admin_organization_settings.markdown
+++ b/website/docs/r/admin_organization_settings.markdown
@@ -54,7 +54,7 @@ resource "tfe_admin_organization_settings" "test-settings" {
 
 The following arguments are supported:
 
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `access_beta_tools` - (Optional) True if the organization has access to beta tool versions.
 * `workspace_limit` - (Optional) Maximum number of workspaces for this organization. If this number is set to a value lower than the number of workspaces the organization has, it will prevent additional workspaces from being created, but existing workspaces will not be affected. If set to 0, this limit will have no effect.
 * `global_module_sharing` - (Optional) If true, modules in the organization's private module repository will be available to all other organizations. Enabling this will disable any previously configured module_sharing_consumer_organizations. Cannot be true if module_sharing_consumer_organizations is set.

--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -36,7 +36,7 @@ resource "tfe_agent_pool" "test-agent-pool" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the agent pool.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 
 ## Attributes Reference
 

--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -36,7 +36,7 @@ resource "tfe_agent_pool" "test-agent-pool" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the agent pool.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 
 ## Attributes Reference
 

--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -70,7 +70,7 @@ resource "tfe_oauth_client" "test" {
 The following arguments are supported:
 
 * `name` - (Optional) Display name for the OAuth Client. Defaults to the `service_provider` if not supplied.
-* `organization` - (Required) Name of the Terraform organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `api_url` - (Required) The base URL of your VCS provider's API (e.g.
   `https://api.github.com` or `https://ghe.example.com/api/v3`).
 * `http_url` - (Required) The homepage of your VCS provider (e.g.

--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -70,7 +70,7 @@ resource "tfe_oauth_client" "test" {
 The following arguments are supported:
 
 * `name` - (Optional) Display name for the OAuth Client. Defaults to the `service_provider` if not supplied.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `api_url` - (Required) The base URL of your VCS provider's API (e.g.
   `https://api.github.com` or `https://ghe.example.com/api/v3`).
 * `http_url` - (Required) The homepage of your VCS provider (e.g.

--- a/website/docs/r/organization_membership.html.markdown
+++ b/website/docs/r/organization_membership.html.markdown
@@ -32,7 +32,7 @@ resource "tfe_organization_membership" "test" {
 
 The following arguments are supported:
 
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `email` - (Required) Email of the user to add.
 
 ## Attributes Reference

--- a/website/docs/r/organization_membership.html.markdown
+++ b/website/docs/r/organization_membership.html.markdown
@@ -32,7 +32,7 @@ resource "tfe_organization_membership" "test" {
 
 The following arguments are supported:
 
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `email` - (Required) Email of the user to add.
 
 ## Attributes Reference

--- a/website/docs/r/organization_module_sharing.html.markdown
+++ b/website/docs/r/organization_module_sharing.html.markdown
@@ -27,5 +27,5 @@ resource "tfe_organization_module_sharing" "test" {
 
 The following arguments are supported:
 
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `module_consumers` - (Required) Names of the organizations to consume the module registry.

--- a/website/docs/r/organization_module_sharing.html.markdown
+++ b/website/docs/r/organization_module_sharing.html.markdown
@@ -27,5 +27,5 @@ resource "tfe_organization_module_sharing" "test" {
 
 The following arguments are supported:
 
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `module_consumers` - (Required) Names of the organizations to consume the module registry.

--- a/website/docs/r/organization_run_task.html.markdown
+++ b/website/docs/r/organization_run_task.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `description` - (Optional) A short description of the the task.
 * `hmac_key` - (Optional) HMAC key to verify run task.
 * `name` - (Required) Name of the task.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `url` - (Required) URL to send a run task payload.
 
 ## Attributes Reference

--- a/website/docs/r/organization_run_task.html.markdown
+++ b/website/docs/r/organization_run_task.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `description` - (Optional) A short description of the the task.
 * `hmac_key` - (Optional) HMAC key to verify run task.
 * `name` - (Required) Name of the task.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `url` - (Required) URL to send a run task payload.
 
 ## Attributes Reference

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -24,7 +24,7 @@ resource "tfe_organization_token" "test" {
 
 The following arguments are supported:
 
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -24,7 +24,7 @@ resource "tfe_organization_token" "test" {
 
 The following arguments are supported:
 
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -50,11 +50,11 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the policy.
 * `description` - (Optional) A description of the policy's purpose.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `kind` - (Optional) The policy-as-code framework associated with the policy.
-   Defaults to `sentinel` if not provided. Valid values are `sentinel` and `opa`. 
-* `query` - (Optional) The OPA query to identify a specific policy rule that 
-   needs to run within your Rego code. Required for all OPA policies. 
+   Defaults to `sentinel` if not provided. Valid values are `sentinel` and `opa`.
+* `query` - (Optional) The OPA query to identify a specific policy rule that
+   needs to run within your Rego code. Required for all OPA policies.
 * `policy` - (Required) The actual policy itself.
 * `enforce_mode` - (Optional) The enforcement level of the policy. Valid
   values for Sentinel are `advisory`, `hard-mandatory` and `soft-mandatory`. Defaults

--- a/website/docs/r/policy.html.markdown
+++ b/website/docs/r/policy.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the policy.
 * `description` - (Optional) A description of the policy's purpose.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `kind` - (Optional) The policy-as-code framework associated with the policy.
    Defaults to `sentinel` if not provided. Valid values are `sentinel` and `opa`.
 * `query` - (Optional) The OPA query to identify a specific policy rule that

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
    A policy set can only have policies that have the same underlying kind.
 * `overridable` - (Optional) Whether or not users can override this policy when
    it fails during a run. Defaults to `false`. Only valid for OPA policies.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `policies_path` - (Optional) The sub-path within the attached VCS repository
   to ingress when using `vcs_repo`. All files and directories outside of this
   sub-path will be ignored. This option can only be supplied when `vcs_repo` is

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # tfe_policy_set
 
-Policies are rules enforced on Terraform runs. Two policy-as-code frameworks are 
+Policies are rules enforced on Terraform runs. Two policy-as-code frameworks are
 integrated with Terraform Enterprise: Sentinel and Open Policy Agent (OPA).
 
 Policy sets are groups of policies that are applied together to related workspaces.
@@ -81,18 +81,18 @@ The following arguments are supported:
 * `kind` - (Optional) The policy-as-code framework associated with the policy.
    Defaults to `sentinel` if not provided. Valid values are `sentinel` and `opa`.
    A policy set can only have policies that have the same underlying kind.
-* `overridable` - (Optional) Whether or not users can override this policy when 
-   it fails during a run. Defaults to `false`. Only valid for OPA policies. 
-* `organization` - (Required) Name of the organization.
+* `overridable` - (Optional) Whether or not users can override this policy when
+   it fails during a run. Defaults to `false`. Only valid for OPA policies.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `policies_path` - (Optional) The sub-path within the attached VCS repository
   to ingress when using `vcs_repo`. All files and directories outside of this
   sub-path will be ignored. This option can only be supplied when `vcs_repo` is
   present. Forces a new resource if changed.
-* `policy_ids` - (Optional) A list of Sentinel policy IDs. This value _must not_ be provided 
+* `policy_ids` - (Optional) A list of Sentinel policy IDs. This value _must not_ be provided
   if `vcs_repo` is provided.
 * `vcs_repo` - (Optional) Settings for the policy sets VCS repository. Forces a
   new resource if changed. This value _must not_ be provided if `policy_ids` are provided.
-* `workspace_ids` - (Optional) A list of workspace IDs. This value _must not_ be provided 
+* `workspace_ids` - (Optional) A list of workspace IDs. This value _must not_ be provided
   if `global` is provided.
 * `slug` - (Optional) A reference to the `tfe_slug` data source that contains
   the `source_path` to where the local policies are located. This is used when

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -32,7 +32,7 @@ resource "tfe_project" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the project.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 
 ## Attributes Reference
 

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -32,7 +32,7 @@ resource "tfe_project" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the project.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 
 ## Attributes Reference
 

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the policy.
 * `description` - (Optional) A description of the policy's purpose.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `policy` - (Required) The actual policy itself.
 * `enforce_mode` - (Optional) The enforcement level of the policy. Valid
   values are `advisory`, `hard-mandatory` and `soft-mandatory`. Defaults

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the policy.
 * `description` - (Optional) A description of the policy's purpose.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `policy` - (Required) The actual policy itself.
 * `enforce_mode` - (Optional) The enforcement level of the policy. Valid
   values are `advisory`, `hard-mandatory` and `soft-mandatory`. Defaults

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -27,7 +27,7 @@ resource "tfe_ssh_key" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name to identify the SSH key.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `key` - (Required) The text of the SSH private key.
 
 ## Attributes Reference

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -27,7 +27,7 @@ resource "tfe_ssh_key" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name to identify the SSH key.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `key` - (Required) The text of the SSH private key.
 
 ## Attributes Reference

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -37,7 +37,7 @@ resource "tfe_team" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the team.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `visibility` - (Optional) The visibility of the team ("secret" or "organization"). Defaults to "secret".
 * `organization_access` - (Optional) Settings for the team's [organization access](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/permissions#organization-permissions).
 * `sso_team_id` - (Optional) Unique Identifier to control [team membership](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) via SAML. Defaults to `null`
@@ -64,7 +64,7 @@ example:
 ```shell
 terraform import tfe_team.test my-org-name/team-uomQZysH9ou42ZYY
 ```
-or 
+or
 ```shell
 terraform import tfe_team.test my-org-name/my-team-name
 ```

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -37,7 +37,7 @@ resource "tfe_team" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the team.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `visibility` - (Optional) The visibility of the team ("secret" or "organization"). Defaults to "secret".
 * `organization_access` - (Optional) Settings for the team's [organization access](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/permissions#organization-permissions).
 * `sso_team_id` - (Optional) Unique Identifier to control [team membership](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) via SAML. Defaults to `null`

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the variable set.
 * `description` - (Optional) Description of the variable set.
 * `global` - (Optional) Whether or not the variable set applies to all workspaces in the organization. Defaults to `false`.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `workspace_ids` - **Deprecated** (Optional) IDs of the workspaces that use the variable set.
   Must not be set if `global` is set. This argument is mutually exclusive with using the resource
   [tfe_workspace_variable_set](workspace_variable_set.html) which is the preferred method of associating a workspace

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the variable set.
 * `description` - (Optional) Description of the variable set.
 * `global` - (Optional) Whether or not the variable set applies to all workspaces in the organization. Defaults to `false`.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `workspace_ids` - **Deprecated** (Optional) IDs of the workspaces that use the variable set.
   Must not be set if `global` is set. This argument is mutually exclusive with using the resource
   [tfe_workspace_variable_set](workspace_variable_set.html) which is the preferred method of associating a workspace

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -54,7 +54,7 @@ resource "tfe_workspace" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the workspace.
-* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `description` - (Optional) A description for the workspace.
 * `agent_pool_id` - (Optional) The ID of an agent pool to assign to the workspace. Requires `execution_mode`
   to be set to `agent`. This value _must not_ be provided if `execution_mode` is set to any other value or if `operations` is

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -54,7 +54,7 @@ resource "tfe_workspace" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the workspace.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, default_organization provider config must be defined.
 * `description` - (Optional) A description for the workspace.
 * `agent_pool_id` - (Optional) The ID of an agent pool to assign to the workspace. Requires `execution_mode`
   to be set to `agent`. This value _must not_ be provided if `execution_mode` is set to any other value or if `operations` is


### PR DESCRIPTION
## Description

Drawing inspiration from the [google provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs), this adds a new provider config field `organization` which could make all the resource-specific organization fields optional if defined. **Please review commit-wise**

## Testing plan

My testing methodology was making sure that config can be refactored from resource-specific org to default org with no infrastructure changes and vice-versa.

<details>
<summary>Example Config</summary>

The config contains all the resources that previously required an organization field:

```
provider "tfe" {
  hostname = "..."
  token = "..."
  organization = "hashicorp"
}

variable "gh_token" {
  type = string
}

variable "ssh_key" {
  type = string
}

resource "tfe_workspace" "foo" {
  name = "foo"
}

resource "tfe_variable_set" "foo" {
  name          = "Test Varset"
  description   = "Some description."
}

resource "tfe_workspace_variable_set" "foo" {
  workspace_id    = tfe_workspace.foo.id
  variable_set_id = tfe_variable_set.foo.id
}

resource "tfe_variable" "test-a" {
  key             = "seperate_variable"
  value           = "my_value_name"
  category        = "terraform"
  description     = "a useful description"
  variable_set_id = tfe_variable_set.foo.id
}

resource "tfe_agent_pool" "foo" {
  name         = "my-agent-pool-name"
}

resource "tfe_oauth_client" "foo" {
  name             = "my-github-oauth-client"
  api_url          = "https://api.github.com"
  http_url         = "https://github.com"
  oauth_token      = var.gh_token
  service_provider = "github"
}

resource "tfe_organization_membership" "test1" {
  email = "example1@company.com"
}

resource "tfe_organization_membership" "test2" {
  email = "example2@company.com"
}

resource "tfe_organization_token" "test" {
  force_regenerate = true
}

resource "tfe_policy" "test" {
  name         = "my-policy-name"
  description  = "This policy always passes"
  kind         = "sentinel"
  policy       = "main = rule { true }"
  enforce_mode = "hard-mandatory"
}

resource "tfe_policy_set" "test" {
  name          = "my-policy-set"
  description   = "A brand new policy set"
  kind          = "sentinel"
  policy_ids    = [tfe_policy.test.id]
  workspace_ids = [tfe_workspace.foo.id]
}

resource "tfe_project" "test" {
  name = "projectname"
}

resource "tfe_ssh_key" "test" {
  name         = "my-ssh-key-name"
  key          = var.ssh_key
}

resource "tfe_team" "test" {
  name         = "my-team-name"
}

data "tfe_agent_pool" "test" {
  name          = "my-agent-pool-name"
}

output "agent-pool" {
  value = data.tfe_agent_pool.test.id
}
```
</details>

## External links

Closes #434 

