### PR TITLE
update website doc to depict the use of sets in members resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BUG FIXES:
 
 ENHANCEMENTS:
 * Update API doc links from terraform.io to developer.hashicorp domain by @uk1288 [#764](https://github.com/hashicorp/terraform-provider-tfe/pull/764)
+* Update website docs to depict the use of set with `tfe_team_organization_members` and `tfe_team_members` by @uk1288 [#767](https://github.com/hashicorp/terraform-provider-tfe/pull/767)
 
 FEATURES:
 * r/tfe_team: Teams can now be imported using `<ORGANIZATION NAME>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))

--- a/tfe/resource_tfe_team_members.go
+++ b/tfe/resource_tfe_team_members.go
@@ -67,7 +67,7 @@ func resourceTFETeamMembersRead(d *schema.ResourceData, meta interface{}) error 
 	users, err := tfeClient.TeamMembers.List(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
-			log.Printf("[DEBUG] Users do no longer exist")
+			log.Printf("[DEBUG] Users no longer exist")
 			d.SetId("")
 			return nil
 		}
@@ -82,7 +82,7 @@ func resourceTFETeamMembersRead(d *schema.ResourceData, meta interface{}) error 
 	if len(usernames) > 0 {
 		d.Set("usernames", usernames)
 	} else {
-		log.Printf("[DEBUG] Users do no longer exist")
+		log.Printf("[DEBUG] Users no longer exist")
 		d.SetId("")
 	}
 

--- a/tfe/resource_tfe_team_organization_members.go
+++ b/tfe/resource_tfe_team_organization_members.go
@@ -70,7 +70,7 @@ func resourceTFETeamOrganizationMembersRead(d *schema.ResourceData, meta interfa
 	organizationMemberships, err := tfeClient.TeamMembers.ListOrganizationMemberships(ctx, d.Id())
 	if err != nil {
 		if errors.Is(err, tfe.ErrResourceNotFound) {
-			log.Printf("[DEBUG] Organization memberships for team %s do no longer exist", d.Id())
+			log.Printf("[DEBUG] Organization memberships for team %s no longer exist", d.Id())
 			d.SetId("")
 			return nil
 		}
@@ -88,7 +88,7 @@ func resourceTFETeamOrganizationMembersRead(d *schema.ResourceData, meta interfa
 		d.Set("team_id", d.Id())
 		d.Set("organization_membership_ids", organizationMembershipIDs)
 	} else {
-		log.Printf("[DEBUG] Organization memberships for team %s do no longer exist", d.Id())
+		log.Printf("[DEBUG] Organization memberships for team %s no longer exist", d.Id())
 		d.SetId("")
 	}
 
@@ -180,7 +180,7 @@ func resourceTFETeamOrganizationMembersDelete(d *schema.ResourceData, meta inter
 	organizationMemberships, err := tfeClient.TeamMembers.ListOrganizationMemberships(ctx, d.Id())
 	if err != nil {
 		if errors.Is(err, tfe.ErrResourceNotFound) {
-			log.Printf("[DEBUG] Organization memberships for team %s do no longer exist", d.Id())
+			log.Printf("[DEBUG] Organization memberships for team %s no longer exist", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/website/docs/r/team_members.html.markdown
+++ b/website/docs/r/team_members.html.markdown
@@ -34,6 +34,27 @@ resource "tfe_team_members" "test" {
 }
 ```
 
+With a set of usernames:
+
+```hcl
+locals {
+  all_usernames = toset([
+    "user1",
+    "user2",
+  ])
+}
+
+resource "tfe_team" "test" {
+  name         = "my-team-name"
+  organization = "my-org-name"
+}
+
+resource "tfe_team_members" "test" {
+  team_id   = tfe_team.test.id
+  usernames = [for user in local.all_usernames : user]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/team_organization_members.html.markdown
+++ b/website/docs/r/team_organization_members.html.markdown
@@ -46,6 +46,33 @@ resource "tfe_team_organization_members" "test" {
 }
 ```
 
+With a set of organization members:
+
+```hcl
+locals {
+  all_users = toset([
+    "user1@hashicorp.com",
+    "user2@hashicorp.com",
+  ])
+}
+
+resource "tfe_team" "test" {
+  name         = "my-team-name"
+  organization = "my-org-name"
+}
+
+resource "tfe_organization_membership" "all_membership" {
+  organization = "my-org-name"
+  for_each     = local.all_users
+  email        = each.key
+}
+
+resource "tfe_team_organization_members" "test" {
+  team_id = tfe_team.test.id
+  organization_membership_ids = [for member in local.all_users : tfe_organization_membership.all_membership[member].id]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
## Description

Related Issue: [761](https://github.com/hashicorp/terraform-provider-tfe/issues/761)

Terraform creates an instance for each member of a given set, when `for_each` is used to configure a resource block. 

If `for_each` is used with resources that do bulk management like the `tfe_team_organization_members` and `tfe_team_members`, it results in the creation of multiple instances managing the same set of resources. See the example config below:

```
locals {
  all_users = toset([
    "user1@hashicorp.com",
    "user2@hashicorp.com",
  ])
}

resource "tfe_team" "test" {
  name         = "my-team-name"
  organization = "my-org-name"
}

resource "tfe_organization_membership" "all_membership" {
  organization = "my-org-name"
  for_each     = local.all_users
  email        = each.key
}

resource "tfe_team_organization_members" "all-members" {
  team_id  = tfe_team.test.id
  for_each = local.all_users
  organization_membership_ids = [
    tfe_organization_membership.all_membership[each.key].id
  ]
}

```

The above config results in multiple instances of `tfe_team_organization_members` managing a set of memberships. Running an Apply will succeed. During the destroy phase, each instance of the `tfe_team_organization_members` resource attempts to delete the same organization members. The first delete request succeeds but the subsequent requests fail. If there are `n` number of `local.all_users`, there will be `n` DELETE API request made with the same membership id set (the current delete implementation attempts to delete all existing memberships).

What is needed here, is for Terraform to create just `1 instance` of `tfe_team_organization_members` which will manage all the organization members in the set. The `for` expression will accomplish this, see the updated tfe_team_organization_members config below:

```
resource "tfe_team_organization_members" "all-members" {
  team_id = tfe_team.test.id
  organization_membership_ids = [for member in local.all_users : 
     tfe_organization_membership.all_membership[member].id]
}

```

After investigating this issue, the conclusion is that it is beneficial to add this use case example to the doc hence this PR.


## Testing plan

1.  _Apply and compare the listed config above_

## External links

- [API documentation - for-each meta argument](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each)
- [API documentation - for expression](https://developer.hashicorp.com/terraform/language/expressions/for)

## Output from acceptance tests

