### PR TITLE
Allow managing project permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ ENHANCEMENTS:
 
 FEATURES:
 * **New Provider Config**: `organization` defines a default organization for all resources, making all resource-specific organization arguments optional.
+* **New Resource**: r/tfe_team_project_access is a new resource that allows managing team project permissions.
+* **New Data Source**: d/tfe_team_project_access is a new datasource to allows reading existing team project permissions.
 * r/tfe_team: Teams can now be imported using `<ORGANIZATION NAME>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
+* r/tfe_team: Add attribute `manage_projects` to `tfe_team`.
 * r/tfe_team_organization_member: Team Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
 
 ## v0.41.0 (January 4, 2023)

--- a/tfe/data_source_team_project_access.go
+++ b/tfe/data_source_team_project_access.go
@@ -1,0 +1,75 @@
+package tfe
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceTFETeamProjectAccess() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTFETeamProjectAccessRead,
+
+		Schema: map[string]*schema.Schema{
+			"access": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"team_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceTFETeamProjectAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(ConfiguredClient)
+
+	// Get the team ID.
+	teamID := d.Get("team_id").(string)
+
+	// Get the project
+	projectID := d.Get("project_id").(string)
+	proj, err := config.Client.Projects.Read(ctx, projectID)
+	if err != nil {
+		return diag.Errorf(
+			"Error retrieving project %s: %v", projectID, err)
+	}
+
+	options := tfe.TeamProjectAccessListOptions{
+		ProjectID: proj.ID,
+	}
+
+	for {
+		l, err := config.Client.TeamProjectAccess.List(ctx, options)
+		if err != nil {
+			return diag.Errorf("Error retrieving team access list: %v", err)
+		}
+
+		for _, ta := range l.Items {
+			if ta.Team.ID == teamID {
+				d.SetId(ta.ID)
+				return resourceTFETeamProjectAccessRead(ctx, d, meta)
+			}
+		}
+
+		// Exit the loop when we've seen all pages.
+		if l.CurrentPage >= l.TotalPages {
+			break
+		}
+
+		// Update the page number to get the next page.
+		options.PageNumber = l.NextPage
+	}
+
+	return diag.Errorf("could not find team project access for %s and project %s", teamID, proj.Name)
+}

--- a/tfe/data_source_team_project_access_test.go
+++ b/tfe/data_source_team_project_access_test.go
@@ -1,0 +1,62 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFETeamProjectAccessDataSource_basic(t *testing.T) {
+	skipUnlessBeta(t)
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectAccessDataSourceConfig(org.Name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar", "access", "read"),
+					resource.TestCheckResourceAttrSet("data.tfe_team_project_access.foobar", "id"),
+					resource.TestCheckResourceAttrSet("data.tfe_team_project_access.foobar", "team_id"),
+					resource.TestCheckResourceAttrSet("data.tfe_team_project_access.foobar", "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFETeamProjectAccessDataSourceConfig(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_team" "foobar" {
+  name         = "team-test"
+  organization = "%s"
+}
+
+resource "tfe_project" "foobar" {
+  name         = "projecttest"
+  organization = "%s"
+}
+
+resource "tfe_team_project_access" "foobar" {
+  access       = "read"
+  team_id      = tfe_team.foobar.id
+  project_id   = tfe_project.foobar.id
+}
+
+data "tfe_team_project_access" "foobar" {
+  team_id      = tfe_team.foobar.id
+  project_id   = tfe_project.foobar.id
+  depends_on = [tfe_team_project_access.foobar]
+}`, organization, organization)
+}

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -114,6 +114,7 @@ func Provider() *schema.Provider {
 			"tfe_ssh_key":                 dataSourceTFESSHKey(),
 			"tfe_team":                    dataSourceTFETeam(),
 			"tfe_team_access":             dataSourceTFETeamAccess(),
+			"tfe_team_project_access":     dataSourceTFETeamProjectAccess(),
 			"tfe_workspace":               dataSourceTFEWorkspace(),
 			"tfe_workspace_ids":           dataSourceTFEWorkspaceIDs(),
 			"tfe_workspace_run_task":      dataSourceTFEWorkspaceRunTask(),

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -146,6 +146,7 @@ func Provider() *schema.Provider {
 			"tfe_team_access":                 resourceTFETeamAccess(),
 			"tfe_team_organization_member":    resourceTFETeamOrganizationMember(),
 			"tfe_team_organization_members":   resourceTFETeamOrganizationMembers(),
+			"tfe_team_project_access":         resourceTFETeamProjectAccess(),
 			"tfe_team_member":                 resourceTFETeamMember(),
 			"tfe_team_members":                resourceTFETeamMembers(),
 			"tfe_team_token":                  resourceTFETeamToken(),

--- a/tfe/resource_tfe_project.go
+++ b/tfe/resource_tfe_project.go
@@ -8,7 +8,10 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"regexp"
 )
+
+var projectIDRegexp = regexp.MustCompile("^prj-[a-zA-Z0-9]{16}$")
 
 func resourceTFEProject() *schema.Resource {
 	return &schema.Resource{

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -75,6 +75,11 @@ func resourceTFETeam() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"manage_projects": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -121,6 +126,7 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 			ManageProviders:       tfe.Bool(organizationAccess["manage_providers"].(bool)),
 			ManageModules:         tfe.Bool(organizationAccess["manage_modules"].(bool)),
 			ManageRunTasks:        tfe.Bool(organizationAccess["manage_run_tasks"].(bool)),
+			ManageProjects:        tfe.Bool(organizationAccess["manage_projects"].(bool)),
 		}
 	}
 
@@ -177,6 +183,7 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 			"manage_providers":        team.OrganizationAccess.ManageProviders,
 			"manage_modules":          team.OrganizationAccess.ManageModules,
 			"manage_run_tasks":        team.OrganizationAccess.ManageRunTasks,
+			"manage_projects":         team.OrganizationAccess.ManageProjects,
 		}}
 		if err := d.Set("organization_access", organizationAccess); err != nil {
 			return fmt.Errorf("error setting organization access for team %s: %w", d.Id(), err)
@@ -210,6 +217,7 @@ func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
 			ManageProviders:       tfe.Bool(organizationAccess["manage_providers"].(bool)),
 			ManageModules:         tfe.Bool(organizationAccess["manage_modules"].(bool)),
 			ManageRunTasks:        tfe.Bool(organizationAccess["manage_run_tasks"].(bool)),
+			ManageProjects:        tfe.Bool(organizationAccess["manage_projects"].(bool)),
 		}
 	}
 

--- a/tfe/resource_tfe_team_project_access.go
+++ b/tfe/resource_tfe_team_project_access.go
@@ -1,0 +1,162 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"log"
+)
+
+func resourceTFETeamProjectAccess() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTFETeamProjectAccessCreate,
+		ReadContext:   resourceTFETeamProjectAccessRead,
+		UpdateContext: resourceTFETeamProjectAccessUpdate,
+		DeleteContext: resourceTFETeamProjectAccessDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		SchemaVersion: 1,
+
+		Schema: map[string]*schema.Schema{
+			"access": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(tfe.TeamProjectAccessAdmin),
+						string(tfe.TeamProjectAccessRead),
+					},
+					false,
+				),
+			},
+
+			"team_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					projectIDRegexp,
+					"must be a valid project ID (prj-<RANDOM STRING>)",
+				),
+			},
+		},
+	}
+}
+
+func resourceTFETeamProjectAccessCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(ConfiguredClient)
+
+	// Get the access level
+	access := d.Get("access").(string)
+
+	// Get the project
+	projectID := d.Get("project_id").(string)
+	proj, err := config.Client.Projects.Read(ctx, projectID)
+	if err != nil {
+		return diag.Errorf(
+			"Error retrieving project %s: %v", projectID, err)
+	}
+
+	// Get the team.
+	teamID := d.Get("team_id").(string)
+	tm, err := config.Client.Teams.Read(ctx, teamID)
+	if err != nil {
+		return diag.Errorf("Error retrieving team %s: %v", teamID, err)
+	}
+
+	// Create a new options struct.
+	options := tfe.TeamProjectAccessAddOptions{
+		Access:  *tfe.ProjectAccess(tfe.TeamProjectAccessType(access)),
+		Team:    tm,
+		Project: proj,
+	}
+
+	log.Printf("[DEBUG] Give team %s %s access to project: %s", tm.Name, access, proj.Name)
+	tmAccess, err := config.Client.TeamProjectAccess.Add(ctx, options)
+	if err != nil {
+		return diag.Errorf(
+			"Error giving team %s %s access to project %s: %v", tm.Name, access, proj.Name, err)
+	}
+
+	d.SetId(tmAccess.ID)
+
+	return resourceTFETeamProjectAccessRead(ctx, d, meta)
+}
+
+func resourceTFETeamProjectAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(ConfiguredClient)
+
+	log.Printf("[DEBUG] Read configuration of team access: %s", d.Id())
+	tmAccess, err := config.Client.TeamProjectAccess.Read(ctx, d.Id())
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			log.Printf("[DEBUG] Team project access %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error reading configuration of team project access %s: %v", d.Id(), err)
+	}
+
+	// Update config.
+	d.Set("access", string(tmAccess.Access))
+
+	if tmAccess.Team != nil {
+		d.Set("team_id", tmAccess.Team.ID)
+	} else {
+		d.Set("team_id", "")
+	}
+
+	if tmAccess.Project != nil {
+		d.Set("project_id", tmAccess.Project.ID)
+	} else {
+		d.Set("project_id", "")
+	}
+
+	return nil
+}
+
+func resourceTFETeamProjectAccessUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(ConfiguredClient)
+
+	// create an options struct
+	options := tfe.TeamProjectAccessUpdateOptions{}
+
+	// Set access level
+	access := d.Get("access").(string)
+	options.Access = tfe.ProjectAccess(tfe.TeamProjectAccessType(access))
+
+	log.Printf("[DEBUG] Update team project access: %s", d.Id())
+	_, err := config.Client.TeamProjectAccess.Update(ctx, d.Id(), options)
+	if err != nil {
+		return diag.Errorf(
+			"Error updating team project access %s: %v", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceTFETeamProjectAccessDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(ConfiguredClient)
+
+	log.Printf("[DEBUG] Delete team access: %s", d.Id())
+	err := config.Client.TeamAccess.Remove(ctx, d.Id())
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			return nil
+		}
+		return diag.Errorf("Error deleting team project access %s: %v", d.Id(), err)
+	}
+
+	return nil
+}

--- a/tfe/resource_tfe_team_project_access_test.go
+++ b/tfe/resource_tfe_team_project_access_test.go
@@ -1,0 +1,143 @@
+package tfe
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccTFETeamProjectAccess_admin(t *testing.T) {
+	skipUnlessBeta(t)
+
+	tmAccess := &tfe.TeamProjectAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	for _, access := range []tfe.TeamProjectAccessType{tfe.TeamProjectAccessAdmin, tfe.TeamProjectAccessRead} {
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFETeamProjectAccess(rInt, access),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckTFETeamProjectAccessExists(
+							"tfe_team_project_access.foobar", tmAccess),
+						testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+						resource.TestCheckResourceAttr("tfe_team_project_access.foobar", "access", string(access)),
+					),
+				},
+			},
+		})
+	}
+}
+
+func TestAccTFETeamProjectAccess_import(t *testing.T) {
+	skipUnlessBeta(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectAccess(rInt, tfe.TeamProjectAccessAdmin),
+			},
+			{
+				ResourceName:      "tfe_team_project_access.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTFETeamProjectAccessExists(
+	n string, tmAccess *tfe.TeamProjectAccess) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(ConfiguredClient)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no instance ID is set")
+		}
+
+		ta, err := config.Client.TeamProjectAccess.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error reading team project access %s: %w", rs.Primary.ID, err)
+		}
+
+		if ta == nil {
+			return fmt.Errorf("TeamAccess not found")
+		}
+
+		*tmAccess = *ta
+
+		return nil
+	}
+}
+
+func testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess *tfe.TeamProjectAccess, access tfe.TeamProjectAccessType) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if tmAccess.Access != access {
+			return fmt.Errorf("Bad access: %s", tmAccess.Access)
+		}
+		return nil
+	}
+}
+
+func testAccCheckTFETeamProjectAccessDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(ConfiguredClient)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_team_project_access" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := config.Client.TeamProjectAccess.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Team project access %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccTFETeamProjectAccess(rInt int, access tfe.TeamProjectAccessType) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar" {
+  name         = "team-test"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_project" "foobar" {
+  name         = "projecttest"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_team_project_access" "foobar" {
+  access       = "%s"
+  team_id      = tfe_team.foobar.id
+  project_id   = tfe_project.foobar.id
+}`, rInt, access)
+}

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -3,6 +3,8 @@ package tfe
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"net/url"
 	"os"
 	"testing"
@@ -239,5 +241,15 @@ func retry(maxRetries, secondsBetween int, f retryableFn) (interface{}, error) {
 		}
 
 		retries += 1
+	}
+}
+
+// Allows skipping the given TestCheckFunc unless beta checks enabled.
+func betaOnlyCheck(testFunc resource.TestCheckFunc) resource.TestCheckFunc {
+	if betaFeaturesEnabled() {
+		return testFunc
+	}
+	return func(state *terraform.State) error {
+		return nil
 	}
 }

--- a/website/docs/d/team_project_access.html.markdown
+++ b/website/docs/d/team_project_access.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_team_project_access"
+description: |-
+  Get information on team permissions on a project.
+---
+
+# Data Source: tfe_team_project_access
+
+Use this data source to get information about team permissions for a project.
+
+## Example Usage
+
+```hcl
+data "tfe_team_project_access" "test" {
+  team_id      = "my-team-id"
+  project_id   = "my-project-id"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `team_id` - (Required) ID of the team.
+* `project_id` - (Required) ID of the project.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` The team project access ID.
+* `access` - The type of access granted to the team on the project.

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -51,6 +51,7 @@ The `organization_access` block supports:
 * `manage_providers` - (Optional) Allow members to publish and delete providers in the organization's private registry.
 * `manage_modules` - (Optional) Allow members to publish and delete modules in the organization's private registry.
 * `manage_run_tasks` - (Optional) Allow members to create, edit, and delete the organization's run tasks.
+* `manage_projects` - (Optional) Allow members to create and administrate all projects within the organization.
 
 ## Attributes Reference
 

--- a/website/docs/r/team_project_access.html.markdown
+++ b/website/docs/r/team_project_access.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_team_project_access"
+description: |-
+  Associate a team to permissions on a project.
+---
+
+# tfe_team_project_access
+
+Associate a team to permissions on a project.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_team" "admin" {
+  name         = "my-admin-team"
+  organization = "my-org-name"
+}
+
+resource "tfe_project" "test" {
+  name         = "myproject"
+  organization = "my-org-name"
+}
+
+resource "tfe_team_project_access" "admin" {
+  access       = "admin"
+  team_id      = tfe_team.admin.id
+  project_id   = tfe_project.test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `team_id` - (Required) ID of the team to add to the project.
+* `project_id` - (Required) ID of the project to which the team will be added.
+* `access` - (Required) Type of fixed access to grant. Valid values are `admin` or `read`.
+
+## Attributes Reference
+
+* `id` The team project access ID.
+
+## Import
+
+Team project accesses can be imported; use the project team access ID as the import ID. For
+example:
+
+```shell
+terraform import tfe_team_project_access.admin tprj-2pmtXpZa4YzVMTPi
+```


### PR DESCRIPTION
## Description

This adds support for managing a team's project permissions. It introduces a new resource called `tfe_team_project_access` to grant a team read or admin permission on a specific project, and adds a new `manage_projects` attribute on the `tfe_team` resource to allow giving a team access to all projects in an org.

## Testing plan

1.  Ensure new tests pass
2. Try importing existing resources
3. Ensure existing configs still apply cleanly
4. Manually test with various configurations similar to:

```
resource "tfe_organization" "test-organization" {
  name  = "my-org-name"
  email = "admin@company.com"
}

resource "tfe_project" "test" {
  organization = tfe_organization.test-organization.name
  name = "projectname"
}

resource "tfe_team" "manage-proj" {
  organization = tfe_organization.test-organization.name
  name = "manage-proj"
  organization_access {
    manage_projects = true
    manage_workspaces = true
  }
}

resource "tfe_team" "read-proj" {
  organization = tfe_organization.test-organization.name
  name = "read-proj"
}

resource "tfe_team_project_access" "read" {
  team_id = tfe_team.read-proj.id
  project_id = tfe_project.test.id
  access = "read"
}

resource "tfe_team" "admin-proj" {
  organization = tfe_organization.test-organization.name
  name = "admin-proj"
}

resource "tfe_team_project_access" "admin" {
  team_id = tfe_team.admin-proj.id
  project_id = tfe_project.test.id
  access = "admin"
}

data "tfe_team" "manage-proj" {
  organization = tfe_organization.test-organization.name
  name = "manage-proj"
}

data "tfe_team_project_access" "reader" {
  team_id = tfe_team.read-proj.id
  project_id = tfe_project.test.id
}

output "reader-access" {
  value = data.tfe_team_project_access.reader.access
}
```

## External links


- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe#TeamProjectAccess)
- [API documentation](https://terraform-docs-common-git-projects-docs-hashicorp.vercel.app/terraform/cloud-docs/api-docs/project-team-access)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

**Ran with ENABLE_BETA=1**
```
=== RUN   TestAccTFETeamProjectAccess_admin
--- PASS: TestAccTFETeamProjectAccess_admin (24.28s)
=== RUN   TestAccTFETeamProjectAccess_import
--- PASS: TestAccTFETeamProjectAccess_import (13.18s)
PASS

=== RUN   TestAccTFETeamProjectAccessDataSource_basic
--- PASS: TestAccTFETeamProjectAccessDataSource_basic (15.64s)
PASS

Process finished with the exit code 0

...
```


