### PR TITLE
Add beta policy and test infra information to contributor guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ provider_tfe_override.tfrc
 
 # Other
 .idea/
+
+# mkdocs build output
+site/

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -1,0 +1,22 @@
+# Introducing Beta Features
+
+This guide discusses how to introduce features that are not yet generally available in Terraform Cloud.
+
+In general, beta features should not be merged/released until generally available (GA). However, the maintainers recognize almost any reason to release beta features on a case-by-case basis. These could include: partial customer availability, software dependency, or any reason short of feature completeness.
+
+If planning to release a limited beta feature, each resource should be clearly noted as such in the website documentation and CHANGELOG.
+
+```markdown
+~> **NOTE:** This resource is currently in beta and isn't generally
+available to all users. It is subject to change or be removed.
+```
+
+When adding test cases, understand that feature flags are not evaluated in our [automated test infrastructure](test-infrastructure.md). Features that are behind a feature flag will probably fail. You can temporarily use the `skipUnlessBeta` test helper to omit beta features from running in CI.
+
+```go
+func TestAccTFEMyNewResource_basic(t *testing.T) {
+  skipUnlessBeta(t)
+}
+```
+
+When the feature reaches general availability _and_ the feature flag is removed, you should create a new PR to remove the `skipUnlessBeta` flags, beta notes, and re-announce the feature in the CHANGELOG as being generally available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,6 @@
 
 Thanks for your interest in contributing to the official Terraform Cloud/Enterprise provider. We appreciate your help! If you're unsure or afraid of anything, you can submit a work in progress (WIP) pull request, or file an issue with the parts you know. We'll do our best to guide you in the right direction, and let you know if there are guidelines we will need to follow. We want people to be able to participate without fear of doing the wrong thing.
 
-This guide is broken down into sections to help you [configure your environment](development-environment/), [write](writing-code/), [debug](debugging/), and [test](testing/) code to ensure your contribution can be included in a release.
+This guide is broken down into sections to help you [configure your environment](development-environment.md), [debug](debugging.md), and [test](testing.md) code to ensure your contribution can be included in a release.
+
+If you are contributing a new feature that is not yet generally available, review our [beta feature policy](beta.md).

--- a/docs/test-infrastructure.md
+++ b/docs/test-infrastructure.md
@@ -6,4 +6,4 @@ Within the Pull Request process, test checks are executed against infrastructure
 
 In addition, we test the main branch of the provider once each night against the same image but configured to simulate Terraform Enterprise. Tests that use the helper `skipIfEnterprise` are skipped during this nightly job.
 
-In both cases, all feature flags are disabled and not evaluated. Features that are behind a feature flag should use the `skipUnlessBeta` flag to avoid failing. See our [beta feature policy](beta.md) for more details.
+In both cases, all feature flags are disabled and not evaluated. Features that are behind a feature flag should use the `skipUnlessBeta` flag to avoid failing, even if that feature flag is enabled for all users in production. See our [beta feature policy](beta.md) for more details.

--- a/docs/test-infrastructure.md
+++ b/docs/test-infrastructure.md
@@ -1,0 +1,9 @@
+# Test Infrastructure
+
+We rely on acceptance tests that test the provider against infrastructure that simulates both Terraform Cloud and Terraform Enterprise. The only exception is features that depend on a feature flag evaluation: In this case, we rely on running the tests locally and reporting the results in the PR description.
+
+Within the Pull Request process, test checks are executed against infrastructure that simulates Terraform Cloud, which is rebuilt nightly and uses the latest nightly TFE build image. Changes to the underlying Terraform Cloud platform may take 24-48 hours to be reflected in this infrastructure. Tests that use the helper `skipIfCloud` are skipped during this check.
+
+In addition, we test the main branch of the provider once each night against the same image but configured to simulate Terraform Enterprise. Tests that use the helper `skipIfEnterprise` are skipped during this nightly job.
+
+In both cases, all feature flags are disabled and not evaluated. Features that are behind a feature flag should use the `skipUnlessBeta` flag to avoid failing. See our [beta feature policy](beta.md) for more details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: Terraform Cloud/Enterprise Provider - Contributor Guide
+site_name: hashicorp/tfe Terraform Provider - Contributor Guide
 site_description: 'Contributor documentation and reference for the
-                   Terraform Cloud/Enterprise Provider (tfe)'
+                   hashicorp/tfe Terraform provider'
 copyright: HashiCorp
 repo_name: hashicorp/terraform-provider-tfe
 repo_url: https://github.com/hashicorp/terraform-provider-tfe
@@ -10,9 +10,11 @@ nav:
   - Welcome: index.md
   - Contribute:
       - Development Environment: development-environment.md
+      - Test Infrastructure: test-infrastructure.md
       - Contribution Guides:
-          - Debugging: debugging.md
           - Testing: testing.md
+          - Introducing Beta Features: beta.md
+          - Debugging: debugging.md
       - Acceptance Tests: writing-acceptance-tests.md
       - Changelog Process: changelog-process.md
 


### PR DESCRIPTION
## Description

The test infrastructure and skip helpers, as well as a general overview of how we release less-than-generally-available features, seem to be missing from our contributor guide.

## Screenshots

![Screen Shot 2023-01-18 at 2 30 10 PM](https://user-images.githubusercontent.com/174332/213299837-03b9150a-d8d0-48a0-83aa-11ced4e35ea7.png)

![Screen Shot 2023-01-18 at 2 30 05 PM](https://user-images.githubusercontent.com/174332/213299839-f1fdd7b9-561e-4b41-9a4d-ac8b5d47ebcb.png)

![Screen Shot 2023-01-18 at 2 30 16 PM](https://user-images.githubusercontent.com/174332/213299832-287fc385-e9fc-4bd3-aa85-84e8358ee8e8.png)
