### PR TITLE
Add execution_mode to datasource tfe_workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BUG FIXES:
 ENHANCEMENTS:
 * Update API doc links from terraform.io to developer.hashicorp domain by @uk1288 [#764](https://github.com/hashicorp/terraform-provider-tfe/pull/764)
 * Update website docs to depict the use of set with `tfe_team_organization_members` and `tfe_team_members` by @uk1288 [#767](https://github.com/hashicorp/terraform-provider-tfe/pull/767)
+* d/tfe_workspace: Add `execution_mode` field to workspace datasoure @Uk1288 ([#772](https://github.com/hashicorp/terraform-provider-tfe/pull/772))
 
 FEATURES:
 * **New Provider Config**: `organization` defines a default organization for all resources, making all resource-specific organization arguments optional.

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -138,6 +138,11 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Computed: true,
 			},
 
+			"execution_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"vcs_repo": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -216,6 +221,7 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("trigger_prefixes", workspace.TriggerPrefixes)
 	d.Set("trigger_patterns", workspace.TriggerPatterns)
 	d.Set("working_directory", workspace.WorkingDirectory)
+	d.Set("execution_mode", workspace.ExecutionMode)
 
 	// Set remote_state_consumer_ids if global_remote_state is false
 	globalRemoteState := workspace.GlobalRemoteState

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -2,11 +2,12 @@ package tfe
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-tfe"
 	"math/rand"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-tfe"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -109,6 +110,8 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 						"data.tfe_workspace.foobar", "trigger_prefixes.1", "/shared"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "working_directory", "terraform/test"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "execution_mode", "remote"),
 				),
 			},
 		},

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -57,7 +57,7 @@ In addition to all arguments above, the following attributes are exported:
 * `trigger_patterns` - List of [glob patterns](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#glob-patterns-for-automatic-run-triggering) that describe the files Terraform Cloud monitors for changes. Trigger patterns are always appended to the root directory of the repository.
 * `vcs_repo` - Settings for the workspace's VCS repository.
 * `working_directory` - A relative path that Terraform will execute within.
-* `execution_mode` - Indicates whether to use Terraform Cloud or local machine or agents as the Terraform execution platform for this workspace.
+* `execution_mode` - Indicates the [execution mode](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#execution-mode) of the workspace. Possible values include `remote`, `local`, or `agent`.
 
 
 The `vcs_repo` block contains:

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -57,6 +57,7 @@ In addition to all arguments above, the following attributes are exported:
 * `trigger_patterns` - List of [glob patterns](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#glob-patterns-for-automatic-run-triggering) that describe the files Terraform Cloud monitors for changes. Trigger patterns are always appended to the root directory of the repository.
 * `vcs_repo` - Settings for the workspace's VCS repository.
 * `working_directory` - A relative path that Terraform will execute within.
+* `execution_mode` - Indicates whether to use Terraform Cloud or local machine or agents as the Terraform execution platform for this workspace.
 
 
 The `vcs_repo` block contains:


### PR DESCRIPTION
## Description

This PR adds `execution_mode` field to `tfe_workspace` datasource

## Testing plan

1.  _Create workspaces with different execution modes i.e, local, remote, agent. For backward compatibility, create some with `operations` field set as well_
2.  _Read the workspace using tfe_workspace datasource for example:_
```
data tfe_workspace "read_workspace_local_ex_mode" {
  name         = tfe_workspace.workspace_local_ex_mode.name
  organization = "my-org"
}

data tfe_workspace "read_workspace_remote_ex_mode" {
  name         = tfe_workspace.workspace_remote_ex_mode.name
  organization = "my-org"
}

data tfe_workspace "read_workspace_agent_ex" {
  name         = tfe_workspace.workspace_agent_ex_mode.name
  organization = "my-org"
}

data tfe_workspace "read_workspace_operation_true" {
  name         = tfe_workspace.workspace_operations_true.name
  organization = "my-org"
}

data tfe_workspace "read_workspace_operation_false" {
  name         = tfe_workspace.workspace_operations_false.name
  organization = "my-org"
}
```
3.  _The execution-mode field should now be populated_

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#show-workspace)

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEWorkspaceDataSource" make testacc

=== RUN   TestAccTFEWorkspaceDataSource_remoteStateConsumers
--- PASS: TestAccTFEWorkspaceDataSource_remoteStateConsumers (15.67s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (10.66s)
=== RUN   TestAccTFEWorkspaceDataSourceWithTriggerPatterns
--- PASS: TestAccTFEWorkspaceDataSourceWithTriggerPatterns (7.68s)
=== RUN   TestAccTFEWorkspaceDataSource_readProjectIDDefault
--- PASS: TestAccTFEWorkspaceDataSource_readProjectIDDefault (10.51s)
=== RUN   TestAccTFEWorkspaceDataSource_readProjectIDNonDefault
--- PASS: TestAccTFEWorkspaceDataSource_readProjectIDNonDefault (12.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe

```
