### PR TITLE
Mark `vcs_repo` as computed, allowing for manual configuration. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ BUG FIXES:
 ENHANCEMENTS:
 * Update API doc links from terraform.io to developer.hashicorp domain by @uk1288 [#764](https://github.com/hashicorp/terraform-provider-tfe/pull/764)
 * Update website docs to depict the use of set with `tfe_team_organization_members` and `tfe_team_members` by @uk1288 [#767](https://github.com/hashicorp/terraform-provider-tfe/pull/767)
-* d/tfe_workspace: Add `execution_mode` field to workspace datasoure @Uk1288 ([#772](https://github.com/hashicorp/terraform-provider-tfe/pull/772))
+* d/tfe_workspace: Add `execution_mode` field to workspace datasoure by @uk1288 ([#772](https://github.com/hashicorp/terraform-provider-tfe/pull/772))
+* r/tfe_workspace: `vcs_repo` is now marked as computed, allowing for manual VCS configuration by @sebasslash ([#777](https://github.com/hashicorp/terraform-provider-tfe/pull/777))
 
 FEATURES:
 * **New Provider Config**: `organization` defines a default organization for all resources, making all resource-specific organization arguments optional.

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -204,6 +204,7 @@ func resourceTFEWorkspace() *schema.Resource {
 			"vcs_repo": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MinItems: 1,
 				MaxItems: 1,
 				Elem: &schema.Resource{


### PR DESCRIPTION
## Description

This change stems from #338 , where users were unable to manually configure a VCS connection on a TFC workspace that was provisioned with Terraform. By marking the attribute as computed, it can read the value from the API and not result in perpetual planned changes if the attribute is not defined in the configuration. 

## Testing plan

### Acceptance Test
```
export GITHUB_TOKEN=<your github token>
export GITHUB_WORKSPACE_IDENTIFIER=<your-username>/<repo-name>
TESTARGS="-run TestAccTFEWorkspace_vcsRepoDrift" make testacc
```
### Smoke Test
1. Create a workspace config and apply
```hcl
resource "tfe_workspace" "foo" {
  name = "foo"
  organization = "hashicorp"
}
```
2. Visit the UI and add a VCS connection to the workspace you just provisioned
3. Reapply the above config and there should be no planned changes. 

