### PR TITLE
Prepare 0.42.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## v0.42.0 (January 31, 2023)
 
 FEATURES:
-* **New Provider Config**: `organization` (or the `TFE_ORGANIZATION` environment variable) defines a default organization for all resources, making all resource-specific organization arguments optional. ([#762](https://github.com/hashicorp/terraform-provider-tfe/pull/762))
-* **New Resource**: `r/tfe_team_project_access` manages team project permissions. ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
-* **New Data Source**: `d/tfe_team_project_access` reads existing team project permissions. ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
-* `r/tfe_team`: Teams can now be imported using `<ORGANIZATION NAME>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
-* `r/tfe_team`: Add attribute `manage_projects` to `tfe_team`. ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
-* `r/tfe_team_organization_member`: Team Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
+* **New Provider Config**: `organization` (or the `TFE_ORGANIZATION` environment variable) defines a default organization for all resources, making all resource-specific organization arguments optional, by @brandonc ([#762](https://github.com/hashicorp/terraform-provider-tfe/pull/762))
+* **New Resource**: `r/tfe_team_project_access` manages team project permissions, by @mwudka ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
+* **New Data Source**: `d/tfe_team_project_access` reads existing team project permissions, by @mwudka ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
+* `r/tfe_team`: Add attribute `manage_projects` to `tfe_team`, by @mwudka ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
+* `r/tfe_team`: Teams can now be imported using `<ORGANIZATION NAME>/<TEAM NAME>`, by @JarrettSpiker ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
+* `r/tfe_team_organization_member`: Team Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>/<TEAM NAME>`, by @JarrettSpiker ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
 
 ENHANCEMENTS:
 * Update API doc links from terraform.io to developer.hashicorp domain by @uk1288 [#764](https://github.com/hashicorp/terraform-provider-tfe/pull/764)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
-## Unreleased
+## v0.42.0 (January 31, 2023)
 
-BUG FIXES:
-* `r/tfe_workspace`: Return all workspace safe deletion errors by @skeggse ([#758](https://github.com/hashicorp/terraform-provider-tfe/pull/758))
+FEATURES:
+* **New Provider Config**: `organization` (or the `TFE_ORGANIZATION` environment variable) defines a default organization for all resources, making all resource-specific organization arguments optional. ([#762](https://github.com/hashicorp/terraform-provider-tfe/pull/762))
+* **New Resource**: `r/tfe_team_project_access` manages team project permissions. ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
+* **New Data Source**: `d/tfe_team_project_access` reads existing team project permissions. ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
+* `r/tfe_team`: Teams can now be imported using `<ORGANIZATION NAME>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
+* `r/tfe_team`: Add attribute `manage_projects` to `tfe_team`. ([#768](https://github.com/hashicorp/terraform-provider-tfe/pull/768))
+* `r/tfe_team_organization_member`: Team Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
 
 ENHANCEMENTS:
 * Update API doc links from terraform.io to developer.hashicorp domain by @uk1288 [#764](https://github.com/hashicorp/terraform-provider-tfe/pull/764)
 * Update website docs to depict the use of set with `tfe_team_organization_members` and `tfe_team_members` by @uk1288 [#767](https://github.com/hashicorp/terraform-provider-tfe/pull/767)
-* d/tfe_workspace: Add `execution_mode` field to workspace datasoure @Uk1288 ([#772](https://github.com/hashicorp/terraform-provider-tfe/pull/772))
+* `d/tfe_workspace`: Add `execution_mode` field to workspace datasource @Uk1288 ([#772](https://github.com/hashicorp/terraform-provider-tfe/pull/772))
 
-FEATURES:
-* **New Provider Config**: `organization` defines a default organization for all resources, making all resource-specific organization arguments optional.
-* **New Resource**: r/tfe_team_project_access is a new resource that allows managing team project permissions.
-* **New Data Source**: d/tfe_team_project_access is a new datasource to allows reading existing team project permissions.
-* r/tfe_team: Teams can now be imported using `<ORGANIZATION NAME>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
-* r/tfe_team: Add attribute `manage_projects` to `tfe_team`.
-* r/tfe_team_organization_member: Team Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>/<TEAM NAME>` ([#745](https://github.com/hashicorp/terraform-provider-tfe/pull/745))
+BUG FIXES:
+* `r/tfe_workspace`: Return all workspace safe deletion errors by @skeggse ([#758](https://github.com/hashicorp/terraform-provider-tfe/pull/758))
 
 ## v0.41.0 (January 4, 2023)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Declare the provider in your configuration and `terraform init` will automatical
 terraform {
   required_providers {
     tfe = {
-      version = "~> 0.41.0"
+      version = "~> 0.42.0"
     }
   }
 }
@@ -45,7 +45,7 @@ The above snippet using `required_providers` is for Terraform 0.13+; if you are 
 
 ```hcl
 provider "tfe" {
-  version = "~> 0.41.0"
+  version = "~> 0.42.0"
   ...
 }
 ```

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -75,7 +75,7 @@ automatically installed by `terraform init` in the future:
 terraform {
   required_providers {
     tfe = {
-      version = "~> 0.41.0"
+      version = "~> 0.42.0"
     }
   }
 }
@@ -88,7 +88,7 @@ The above snippet using `required_providers` is for Terraform 0.13+; if you are 
 
 ```hcl
 provider "tfe" {
-  version = "~> 0.41.0"
+  version = "~> 0.42.0"
   ...
 }
 ```
@@ -101,7 +101,7 @@ For more information on provider installation and constraining provider versions
 provider "tfe" {
   hostname = var.hostname # Optional, defaults to Terraform Cloud `app.terraform.io`
   token    = var.token
-  version  = "~> 0.41.0"
+  version  = "~> 0.42.0"
 }
 
 # Create an organization


### PR DESCRIPTION
## Description

Hello! It's time again for a release of the tfe provider. Here's the changelog update and the version number bumps. 

## Output from acceptance tests

As you can see in the Actions tab, the nightly TFE tests are currently **passing.**