### PR TITLE
Changelog: Restore the "Unreleased" header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## v0.42.0 (January 31, 2023)
 
 FEATURES:


### PR DESCRIPTION
## Description

This just adds the "Unreleased" header back to the changelog, as a landing pad for upcoming PRs. 