### PR TITLE
Adds html_url attribute to d/tfe_workspace and r/tfe_workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ ENHANCEMENTS:
 * r/tfe_organization_membership: Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>` ([#715](https://github.com/hashicorp/terraform-provider-tfe/pull/715))
 * Clarify usage of `organization` fields in documentation describing VCS repository config blocks ([#792](https://github.com/hashicorp/terraform-provider-tfe/pull/792))
 
+* `r/tfe_workspace` and `d/tfe_workspace`: Add attribute `html_url` by @brandonc ([#784](https://github.com/hashicorp/terraform-provider-tfe/pull/784))
+
 BUG FIXES:
 
 ## v0.42.0 (January 31, 2023)

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -188,6 +189,10 @@ func dataSourceTFEWorkspace() *schema.Resource {
 					},
 				},
 			},
+			"html_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -237,6 +242,17 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("trigger_patterns", workspace.TriggerPatterns)
 	d.Set("working_directory", workspace.WorkingDirectory)
 	d.Set("execution_mode", workspace.ExecutionMode)
+
+	if workspace.Links["self-html"] != nil {
+		baseAPI := config.Client.BaseURL()
+		htmlURL := url.URL{
+			Scheme: baseAPI.Scheme,
+			Host:   baseAPI.Host,
+			Path:   workspace.Links["self-html"].(string),
+		}
+
+		d.Set("html_url", htmlURL.String())
+	}
 
 	// Set remote_state_consumer_ids if global_remote_state is false
 	globalRemoteState := workspace.GlobalRemoteState

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -60,6 +61,7 @@ func testAccCheckTFEWorkspaceDataSourceHasRemoteStateConsumers(dataWorkspace str
 func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	workspaceName := fmt.Sprintf("workspace-test-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -70,7 +72,7 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.tfe_workspace.foobar", "id"),
 					resource.TestCheckResourceAttr(
-						"data.tfe_workspace.foobar", "name", fmt.Sprintf("workspace-test-%d", rInt)),
+						"data.tfe_workspace.foobar", "name", workspaceName),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "organization", orgName),
 					resource.TestCheckResourceAttr(
@@ -115,6 +117,8 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 						"data.tfe_workspace.foobar", "working_directory", "terraform/test"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "execution_mode", "remote"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "html_url", fmt.Sprintf("https://%s/app/%s/workspaces/%s", os.Getenv("TFE_HOSTNAME"), orgName, workspaceName)),
 				),
 			},
 		},

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -264,6 +265,10 @@ func resourceTFEWorkspace() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"html_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -438,6 +443,17 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("working_directory", workspace.WorkingDirectory)
 	d.Set("organization", workspace.Organization.Name)
 	d.Set("resource_count", workspace.ResourceCount)
+
+	if workspace.Links["self-html"] != nil {
+		baseAPI := config.Client.BaseURL()
+		htmlURL := url.URL{
+			Scheme: baseAPI.Scheme,
+			Host:   baseAPI.Host,
+			Path:   workspace.Links["self-html"].(string),
+		}
+
+		d.Set("html_url", htmlURL.String())
+	}
 
 	// Project will be nil for versions of TFE that predate projects
 	if workspace.Project != nil {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -25,6 +26,9 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 	workspace := &tfe.Workspace{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	workspaceName := "workspace-test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -37,7 +41,7 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 						"tfe_workspace.foobar", workspace, testAccProvider),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
-						"tfe_workspace.foobar", "name", "workspace-test"),
+						"tfe_workspace.foobar", "name", workspaceName),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "My favorite workspace!"),
 					resource.TestCheckResourceAttr(
@@ -66,6 +70,8 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 						"tfe_workspace.foobar", "working_directory", ""),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "resource_count", "0"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "html_url", fmt.Sprintf("https://%s/app/%s/workspaces/%s", os.Getenv("TFE_HOSTNAME"), orgName, workspaceName)),
 				),
 			},
 		},

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -59,7 +59,7 @@ In addition to all arguments above, the following attributes are exported:
 * `trigger_patterns` - List of [glob patterns](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#glob-patterns-for-automatic-run-triggering) that describe the files Terraform Cloud monitors for changes. Trigger patterns are always appended to the root directory of the repository.
 * `vcs_repo` - Settings for the workspace's VCS repository.
 * `working_directory` - A relative path that Terraform will execute within.
-* `execution_mode` - Indicates the [execution mode](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#execution-mode) of the workspace. Possible values include `remote`, `local`, or `agent`.
+* `html_url` - The URL to the browsable HTML overview of the workspace
 
 
 The `vcs_repo` block contains:

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -145,6 +145,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The workspace ID.
 * `resource_count` - The number of resources managed by the workspace.
+* `html_url` - The URL to the browsable HTML overview of the workspace
 
 ## Import
 


### PR DESCRIPTION
## Description

Adds html_url attribute to workspace resource & data source which is the URL to the browsable terraform cloud workspace overview as reported by the API

- [x] ~This PR is blocked until the next [go-tfe release](https://github.com/hashicorp/go-tfe) (1.18)~

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEWorkspace_basic" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspace_basic -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEWorkspace_basic
--- PASS: TestAccTFEWorkspace_basic (38.37s)
=== RUN   TestAccTFEWorkspace_basicReadProjectId
    testing.go:186: Skipping test related to a Terraform Cloud/Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEWorkspace_basicReadProjectId (0.00s)
=== RUN   TestAccTFEWorkspace_basicAssessmentsEnabled
--- PASS: TestAccTFEWorkspace_basicAssessmentsEnabled (61.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	100.627s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
...
```
