### PR TITLE
Add tfe_workspace_run resource

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,7 @@ issues:
     text: "regexpSimplify: can re-write"
   - linters:
       - gosec
-    path: _test\.go
+    path: (_test|workspace_run_helpers)\.go
   - linters:
       - nestif
     path: (resource_tfe_team_access|resource_tfe_workspace|credentials|resource_tfe_policy_set|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BREAKING CHANGES:
 
 FEATURES:
 * `r/tfe_team`: Add attribute `manage_membership` to `organization_access` on `tfe_team` by @JarrettSpiker ([#801](https://github.com/hashicorp/terraform-provider-tfe/pull/801))
+* **New Resource**: `r/tfe_workspace_run` manages create and destroy lifecycles in a workspace, by @uk1288 ([#786](https://github.com/hashicorp/terraform-provider-tfe/pull/786))
 
 ENHANCEMENTS:
 

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -168,6 +168,7 @@ func Provider() *schema.Provider {
 			"tfe_variable_set":                resourceTFEVariableSet(),
 			"tfe_workspace_variable_set":      resourceTFEWorkspaceVariableSet(),
 			"tfe_workspace_policy_set":        resourceTFEWorkspacePolicySet(),
+			"tfe_workspace_run":               resourceTFEWorkspaceRun(),
 		},
 		ConfigureContextFunc: configure(),
 	}

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -67,10 +67,11 @@ func resourceTFEWorkspaceRun() *schema.Resource {
 				ForceNew: true,
 			},
 			"apply": {
-				Type:     schema.TypeList,
-				Elem:     resourceTFEWorkspaceRunSchema(),
-				Required: true,
-				MaxItems: 1,
+				Type:         schema.TypeList,
+				Elem:         resourceTFEWorkspaceRunSchema(),
+				Optional:     true,
+				AtLeastOneOf: []string{"apply", "destroy"},
+				MaxItems:     1,
 			},
 			"destroy": {
 				Type:     schema.TypeList,

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -63,7 +63,7 @@ func resourceTFEWorkspaceRun() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"workspace": {

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -100,6 +100,11 @@ func resourceTFEWorkspaceRun() *schema.Resource {
 							Optional: true,
 							Default:  30,
 						},
+						"wait_for_run": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
 					},
 				},
 				Optional:     true,
@@ -134,6 +139,11 @@ func resourceTFEWorkspaceRun() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  30,
+						},
+						"wait_for_run": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
 						},
 					},
 				},

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -14,16 +14,17 @@ var (
 	backoffMax = 3000.0
 )
 
-var planPendingStatus = map[tfe.RunStatus]bool{
+var planPendingStatuses = map[tfe.RunStatus]bool{
 	tfe.RunPending:        true,
 	tfe.RunPlanQueued:     true,
 	tfe.RunPlanning:       true,
 	tfe.RunCostEstimating: true,
 	tfe.RunPolicyChecking: true,
 	tfe.RunQueuing:        true,
+	tfe.RunFetching:       true,
 }
 
-var planTerminalStatus = map[tfe.RunStatus]bool{
+var planTerminalStatuses = map[tfe.RunStatus]bool{
 	tfe.RunPlanned:            true,
 	tfe.RunPlannedAndFinished: true,
 	tfe.RunErrored:            true,
@@ -33,19 +34,20 @@ var planTerminalStatus = map[tfe.RunStatus]bool{
 	tfe.RunPolicyOverride:     true,
 }
 
-var applyPendingStatus = map[tfe.RunStatus]bool{
+var applyPendingStatuses = map[tfe.RunStatus]bool{
 	tfe.RunConfirmed:   true,
 	tfe.RunApplyQueued: true,
 	tfe.RunApplying:    true,
 	tfe.RunQueuing:     true,
+	tfe.RunFetching:    true,
 }
 
-var applyDoneStatus = map[tfe.RunStatus]bool{
+var applyDoneStatuses = map[tfe.RunStatus]bool{
 	tfe.RunApplied: true,
 	tfe.RunErrored: true,
 }
 
-var confirmationDoneStatus = map[tfe.RunStatus]bool{
+var confirmationDoneStatuses = map[tfe.RunStatus]bool{
 	tfe.RunConfirmed:   true,
 	tfe.RunApplyQueued: true,
 	tfe.RunApplying:    true,
@@ -74,34 +76,29 @@ func resourceTFEWorkspaceRun() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"manual_confirm": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
-							Description: "",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"retry": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     true,
-							Description: "",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
 						},
 						"retry_attempts": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     3,
-							Description: "",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  3,
 						},
 						"retry_backoff_min": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     1,
-							Description: "",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  1,
 						},
 						"retry_backoff_max": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     30,
-							Description: "",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  30,
 						},
 					},
 				},
@@ -114,34 +111,29 @@ func resourceTFEWorkspaceRun() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"manual_confirm": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
-							Description: "",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 						"retry": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     true,
-							Description: "",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
 						},
 						"retry_attempts": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     3,
-							Description: "",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  3,
 						},
 						"retry_backoff_min": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     1,
-							Description: "",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  1,
 						},
 						"retry_backoff_max": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     30,
-							Description: "",
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  30,
 						},
 					},
 				},
@@ -183,7 +175,7 @@ func resourceTFEWorkspaceRunRead(d *schema.ResourceData, meta interface{}) error
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading run %s: %w", d.Id(), err)
+		return fmt.Errorf("error reading run %s: %w", d.Id(), err)
 	}
 
 	return nil

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -66,87 +66,21 @@ func resourceTFEWorkspaceRun() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"workspace": {
+			"workspace_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 			"apply": {
-				Type: schema.TypeList,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"manual_confirm": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"retry": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"retry_attempts": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  3,
-						},
-						"retry_backoff_min": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  1,
-						},
-						"retry_backoff_max": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  30,
-						},
-						"wait_for_run": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-					},
-				},
+				Type:         schema.TypeList,
+				Elem:         resourceTFEWorkspaceRunSchema(),
 				Optional:     true,
 				AtLeastOneOf: []string{"apply", "destroy"},
 				MaxItems:     1,
 			},
 			"destroy": {
-				Type: schema.TypeList,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"manual_confirm": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"retry": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"retry_attempts": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  3,
-						},
-						"retry_backoff_min": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  1,
-						},
-						"retry_backoff_max": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  30,
-						},
-						"wait_for_run": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-					},
-				},
+				Type:     schema.TypeList,
+				Elem:     resourceTFEWorkspaceRunSchema(),
 				Optional: true,
 				MaxItems: 1,
 			},
@@ -189,4 +123,40 @@ func resourceTFEWorkspaceRunRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	return nil
+}
+
+func resourceTFEWorkspaceRunSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"manual_confirm": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"retry": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"retry_attempts": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  3,
+			},
+			"retry_backoff_min": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
+			"retry_backoff_max": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  30,
+			},
+			"wait_for_run": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+		},
+	}
 }

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -1,0 +1,190 @@
+package tfe
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var (
+	backoffMin = 1000.0
+	backoffMax = 3000.0
+)
+
+var planPendingStatus = map[tfe.RunStatus]bool{
+	tfe.RunPending:        true,
+	tfe.RunPlanQueued:     true,
+	tfe.RunPlanning:       true,
+	tfe.RunCostEstimating: true,
+	tfe.RunPolicyChecking: true,
+	tfe.RunQueuing:        true,
+}
+
+var planTerminalStatus = map[tfe.RunStatus]bool{
+	tfe.RunPlanned:            true,
+	tfe.RunPlannedAndFinished: true,
+	tfe.RunErrored:            true,
+	tfe.RunCostEstimated:      true,
+	tfe.RunPolicyChecked:      true,
+	tfe.RunPolicySoftFailed:   true,
+	tfe.RunPolicyOverride:     true,
+}
+
+var applyPendingStatus = map[tfe.RunStatus]bool{
+	tfe.RunConfirmed:   true,
+	tfe.RunApplyQueued: true,
+	tfe.RunApplying:    true,
+	tfe.RunQueuing:     true,
+}
+
+var applyDoneStatus = map[tfe.RunStatus]bool{
+	tfe.RunApplied: true,
+	tfe.RunErrored: true,
+}
+
+var confirmationDoneStatus = map[tfe.RunStatus]bool{
+	tfe.RunConfirmed:   true,
+	tfe.RunApplyQueued: true,
+	tfe.RunApplying:    true,
+}
+
+func resourceTFEWorkspaceRun() *schema.Resource {
+	return &schema.Resource{
+		Create:        resourceTFEWorkspaceRunCreate,
+		Delete:        resourceTFEWorkspaceRunDelete,
+		Read:          resourceTFEWorkspaceRunRead,
+		Update:        resourceTFEWorkspaceRunUpdate,
+		SchemaVersion: 1,
+		Schema: map[string]*schema.Schema{
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"apply": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"manual_confirm": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "",
+						},
+						"retry": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: "",
+						},
+						"retry_attempts": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     3,
+							Description: "",
+						},
+						"retry_backoff_min": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1,
+							Description: "",
+						},
+						"retry_backoff_max": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     30,
+							Description: "",
+						},
+					},
+				},
+				Optional:     true,
+				AtLeastOneOf: []string{"apply", "destroy"},
+				MaxItems:     1,
+			},
+			"destroy": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"manual_confirm": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "",
+						},
+						"retry": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: "",
+						},
+						"retry_attempts": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     3,
+							Description: "",
+						},
+						"retry_backoff_min": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1,
+							Description: "",
+						},
+						"retry_backoff_max": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     30,
+							Description: "",
+						},
+					},
+				},
+				Optional: true,
+				MaxItems: 1,
+			},
+		},
+	}
+}
+
+func resourceTFEWorkspaceRunCreate(d *schema.ResourceData, meta interface{}) error {
+	// var isDestroyRun & currentRetryAttempts is declared for the sole purpose of code readability
+	isDestroyRun := false
+	currentRetryAttempts := 0
+	return createWorkspaceRun(d, meta, isDestroyRun, currentRetryAttempts)
+}
+
+func resourceTFEWorkspaceRunDelete(d *schema.ResourceData, meta interface{}) error {
+	// var isDestroyRun & currentRetryAttempts is declared for the sole purpose of code readability
+	isDestroyRun := true
+	currentRetryAttempts := 0
+	return createWorkspaceRun(d, meta, isDestroyRun, currentRetryAttempts)
+}
+
+func resourceTFEWorkspaceRunUpdate(d *schema.ResourceData, meta interface{}) error {
+	// update is a noop since this resource only creates a run during a destroy or an initial apply phase
+	return nil
+}
+
+func resourceTFEWorkspaceRunRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(ConfiguredClient)
+
+	log.Printf("[DEBUG] Read run for: %s", d.Id())
+	runID := d.Id()
+	_, err := config.Client.Runs.Read(ctx, runID)
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			log.Printf("[DEBUG] Run %s does not exist", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading run %s: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -61,22 +61,16 @@ func resourceTFEWorkspaceRun() *schema.Resource {
 		Update:        resourceTFEWorkspaceRunUpdate,
 		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
-			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
 			"workspace_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 			"apply": {
-				Type:         schema.TypeList,
-				Elem:         resourceTFEWorkspaceRunSchema(),
-				Optional:     true,
-				AtLeastOneOf: []string{"apply", "destroy"},
-				MaxItems:     1,
+				Type:     schema.TypeList,
+				Elem:     resourceTFEWorkspaceRunSchema(),
+				Required: true,
+				MaxItems: 1,
 			},
 			"destroy": {
 				Type:     schema.TypeList,

--- a/tfe/resource_tfe_workspace_run_test.go
+++ b/tfe/resource_tfe_workspace_run_test.go
@@ -127,7 +127,7 @@ func TestAccTFEWorkspaceRun_invalidParams(t *testing.T) {
 	}{
 		{
 			Config:      testAccTFEWorkspaceRun_noApplyOrDestroyBlockProvided(organization.Name, rInt),
-			ExpectError: regexp.MustCompile("Insufficient apply blocks"),
+			ExpectError: regexp.MustCompile("\"apply\": one of `apply,destroy` must be specified"),
 		},
 		{
 			Config:      testAccTFEWorkspaceRun_noWorkspaceProvided(),

--- a/tfe/resource_tfe_workspace_run_test.go
+++ b/tfe/resource_tfe_workspace_run_test.go
@@ -1,0 +1,619 @@
+package tfe
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccTFEWorkspaceRun_create(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	organization, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	runForParentWorkspace := &tfe.Run{}
+	runForChildWorkspace := &tfe.Run{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccGithubPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceRun_create(organization.Name, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceRunExistWithExpectedStatus("tfe_workspace_run.ws_run_parent", runForParentWorkspace, tfe.RunApplied),
+					testAccCheckTFEWorkspaceRunExistWithExpectedStatus("tfe_workspace_run.ws_run_child", runForChildWorkspace, tfe.RunApplied),
+					resource.TestCheckResourceAttrWith("tfe_workspace_run.ws_run_parent", "id", func(value string) error {
+						if value != runForParentWorkspace.ID {
+							return fmt.Errorf("run ID for ws_run_parent should be %s but was %s", runForParentWorkspace.ID, value)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("tfe_workspace_run.ws_run_child", "id", func(value string) error {
+						if value != runForChildWorkspace.ID {
+							return fmt.Errorf("run ID for ws_run_child should be %s but was %s", runForChildWorkspace.ID, value)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspaceRun_createWithDefaults(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	organization, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	runForParentWorkspace := &tfe.Run{}
+	runForChildWorkspace := &tfe.Run{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccGithubPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceRun_createWithDefaults(organization.Name, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceRunExistWithExpectedStatus("tfe_workspace_run.ws_run_parent", runForParentWorkspace, tfe.RunApplied),
+					testAccCheckTFEWorkspaceRunExistWithExpectedStatus("tfe_workspace_run.ws_run_child", runForChildWorkspace, tfe.RunApplied),
+					resource.TestCheckResourceAttrWith("tfe_workspace_run.ws_run_parent", "id", func(value string) error {
+						if value != runForParentWorkspace.ID {
+							return fmt.Errorf("run ID for ws_run_parent should be %s but was %s", runForParentWorkspace.ID, value)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("tfe_workspace_run.ws_run_child", "id", func(value string) error {
+						if value != runForChildWorkspace.ID {
+							return fmt.Errorf("run ID for ws_run_child should be %s but was %s", runForChildWorkspace.ID, value)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspaceRun_createAndDestroyRuns(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	oauthClient, err := tfeClient.OAuthClients.Create(ctx, org.Name, tfe.OAuthClientCreateOptions{
+		APIURL:          tfe.String("https://api.github.com"),
+		HTTPURL:         tfe.String("https://github.com"),
+		ServiceProvider: tfe.ServiceProvider(tfe.ServiceProviderGithub),
+		OAuthToken:      tfe.String(envGithubToken),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(oauthClient.OAuthTokens) == 0 {
+		t.Fatal("Expected OAuthClient to have OAuthTokens, 0 found")
+	}
+
+	t.Cleanup(func() {
+		if err := tfeClient.OAuthClients.Delete(ctx, oauthClient.ID); err != nil {
+			t.Errorf("Error destroying Oauth client! WARNING: Dangling resources\n"+
+				"may exist! The full error is show below:\n\n"+
+				"Oauth client:%s\nError: %s", oauthClient.ID, err)
+		}
+	})
+
+	workspaceA := &tfe.Workspace{}
+	workspaceB := &tfe.Workspace{}
+
+	// create workspace outside of the config, to allow for testing check destroy runs prior to deleting the workspace
+	for _, wsName := range []string{fmt.Sprintf("tst-terraform-%d-A", rInt), fmt.Sprintf("tst-terraform-%d-B", rInt)} {
+		ws, err := tfeClient.Workspaces.Create(ctx, org.Name, tfe.WorkspaceCreateOptions{
+			Name:         tfe.String(wsName),
+			QueueAllRuns: tfe.Bool(false),
+			VCSRepo: &tfe.VCSRepoOptions{
+				Branch:       tfe.String(envGithubWorkspaceBranch),
+				Identifier:   tfe.String(envGithubWorkspaceIdentifier),
+				OAuthTokenID: tfe.String(oauthClient.OAuthTokens[0].ID),
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if wsName == fmt.Sprintf("tst-terraform-%d-A", rInt) {
+			*workspaceA = *ws
+		} else {
+			*workspaceB = *ws
+		}
+	}
+
+	t.Cleanup(func() {
+		if err := tfeClient.Workspaces.DeleteByID(ctx, workspaceA.ID); err != nil {
+			t.Errorf("Error destroying Workspace! WARNING: Dangling resources\n"+
+				"may exist! The full error is show below:\n\n"+
+				"Workspace:%s\nError: %s", workspaceA.ID, err)
+		}
+	})
+	t.Cleanup(func() {
+		if err := tfeClient.Workspaces.DeleteByID(ctx, workspaceB.ID); err != nil {
+			t.Errorf("Error destroying Workspace! WARNING: Dangling resources\n"+
+				"may exist! The full error is show below:\n\n"+
+				"Workspace:%s\nError: %s", workspaceB.ID, err)
+		}
+	})
+
+	runForWorkspaceRootA := &tfe.Run{}
+	runForWorkspaceB := &tfe.Run{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccGithubPreCheck(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckTFEWorkspaceRunDestroy(workspaceA.ID),
+			testAccCheckTFEWorkspaceRunDestroy(workspaceB.ID),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceRun_createAndDestroyRuns(org.Name, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceRunExistWithExpectedStatus("tfe_workspace_run.ws_run_root_A", runForWorkspaceRootA, tfe.RunApplied),
+					testAccCheckTFEWorkspaceRunExistWithExpectedStatus("tfe_workspace_run.ws_run_B", runForWorkspaceB, tfe.RunApplied),
+					resource.TestCheckResourceAttrWith("tfe_workspace_run.ws_run_root_A", "id", func(value string) error {
+						if value != runForWorkspaceRootA.ID {
+							return fmt.Errorf("run ID for ws_run_root_A should be %s but was %s", runForWorkspaceRootA.ID, value)
+						}
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("tfe_workspace_run.ws_run_B", "id", func(value string) error {
+						if value != runForWorkspaceB.ID {
+							return fmt.Errorf("run ID for ws_run_B should be %s but was %s", runForWorkspaceB.ID, value)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspaceRun_invalidParams(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	organization, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	invalidCases := []struct {
+		Config      string
+		ExpectError *regexp.Regexp
+	}{
+		{
+			Config:      testAccTFEWorkspaceRun_noApplyOrDestroyBlockProvided(organization.Name, rInt),
+			ExpectError: regexp.MustCompile("\"apply\": one of `apply,destroy` must be specified"),
+		},
+		{
+			Config:      testAccTFEWorkspaceRun_noOrganizationProvided(organization.Name, rInt),
+			ExpectError: regexp.MustCompile(`The argument "organization" is required, but no definition was found`),
+		},
+		{
+			Config:      testAccTFEWorkspaceRun_noWorkspaceProvided(organization.Name),
+			ExpectError: regexp.MustCompile(`The argument "workspace" is required, but no definition was found`),
+		},
+	}
+
+	for _, invalidCase := range invalidCases {
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				testAccPreCheck(t)
+				testAccGithubPreCheck(t)
+			},
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config:      invalidCase.Config,
+					ExpectError: invalidCase.ExpectError,
+				},
+			},
+		})
+	}
+}
+
+func TestAccTFEWorkspaceRun_WhenRunErrors(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	workspace, err := tfeClient.Workspaces.Create(ctx, org.Name, tfe.WorkspaceCreateOptions{Name: tfe.String(fmt.Sprintf("tst-terraform-%d-A", rInt))})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := tfeClient.Workspaces.DeleteByID(ctx, workspace.ID); err != nil {
+			t.Errorf("Error destroying Workspace! WARNING: Dangling resources\n"+
+				"may exist! The full error is show below:\n\n"+
+				"Workspace:%s\nError: %s", workspace.ID, err)
+		}
+	})
+
+	_ = createAndUploadConfigurationVersion(t, workspace, tfeClient, "test-fixtures/config-with-error-during-plan")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccGithubPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEWorkspaceRun_WhenRunErrors(org.Name, workspace.Name),
+				ExpectError: regexp.MustCompile(`run errored during plan`),
+			},
+		},
+	})
+}
+
+func testAccCheckTFEWorkspaceRunExistWithExpectedStatus(n string, run *tfe.Run, expectedStatus tfe.RunStatus) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(ConfiguredClient)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		runData, err := config.Client.Runs.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Unable to read run, %w", err)
+		}
+
+		if runData == nil {
+			return fmt.Errorf("Run not found")
+		}
+
+		if runData.Status != expectedStatus {
+			return fmt.Errorf("Expected run status to be %s, but got %s", expectedStatus, runData.Status)
+		}
+
+		if runData.IsDestroy {
+			return fmt.Errorf("Expected run to create resources")
+		}
+
+		*run = *runData
+
+		return nil
+	}
+}
+
+func testAccCheckTFEWorkspaceRunDestroy(workspaceID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(ConfiguredClient)
+
+		runList, err := config.Client.Runs.List(ctx, workspaceID, &tfe.RunListOptions{
+			Operation: "destroy",
+			Status:    string(tfe.RunApplied),
+		})
+		if err != nil {
+			return fmt.Errorf("Unable to find destroy run, %w", err)
+		}
+
+		if runList.TotalCount == 0 {
+			return fmt.Errorf("Destroy run not found")
+		}
+
+		if len(runList.Items) > 1 {
+			return fmt.Errorf("Expected only 1 destroy run but found %d", runList.TotalCount)
+		}
+
+		return nil
+	}
+}
+
+func testAccTFEWorkspaceRun_create(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_oauth_client" "test" {
+		organization     = "%s"
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+
+	resource "tfe_workspace" "parent" {
+		name                 = "tst-terraform-%d-parent"
+		organization         = "%s"
+		queue_all_runs       = false
+		vcs_repo {
+			branch             = "%s"
+			identifier         = "%s"
+			oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+		}
+	}
+
+	resource "tfe_workspace" "child" {
+		name                 = "tst-terraform-%d-child"
+		organization         = "%s"
+		queue_all_runs       = false
+		vcs_repo {
+			branch             = "%s"
+			identifier         = "%s"
+			oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+		}
+	}
+
+	resource "tfe_workspace_run" "ws_run_parent" {
+		organization = "%s"
+		workspace    = tfe_workspace.parent.name
+
+		apply {
+			manual_confirm = false
+			retry = true
+		}
+
+		destroy {
+			manual_confirm = false
+			retry = true
+		}
+	}
+
+	resource "tfe_workspace_run" "ws_run_child" {
+		organization = "%s"
+		workspace    = tfe_workspace.child.name
+		depends_on   = [tfe_workspace_run.ws_run_parent]
+
+		apply {
+			manual_confirm = false
+			retry = true
+		}
+
+		destroy {
+			manual_confirm = false
+			retry = true
+		}
+	}`, orgName, envGithubToken, rInt, orgName, envGithubWorkspaceBranch, envGithubWorkspaceIdentifier, rInt, orgName, envGithubWorkspaceBranch, envGithubWorkspaceIdentifier, orgName, orgName)
+}
+
+func testAccTFEWorkspaceRun_createWithDefaults(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_oauth_client" "test" {
+		organization     = "%s"
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+
+	resource "tfe_workspace" "parent" {
+		name                 = "tst-terraform-%d-parent"
+		organization         = "%s"
+		queue_all_runs       = false
+		vcs_repo {
+			branch             = "%s"
+			identifier         = "%s"
+			oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+		}
+	}
+
+	resource "tfe_workspace" "child" {
+		name                 = "tst-terraform-%d-child"
+		organization         = "%s"
+		queue_all_runs       = false
+		vcs_repo {
+			branch             = "%s"
+			identifier         = "%s"
+			oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+		}
+	}
+
+	resource "tfe_workspace_run" "ws_run_parent" {
+		organization = "%s"
+		workspace    = tfe_workspace.parent.name
+
+		apply {}
+
+		destroy {}
+	}
+
+	resource "tfe_workspace_run" "ws_run_child" {
+		organization = "%s"
+		workspace    = tfe_workspace.child.name
+		depends_on   = [tfe_workspace_run.ws_run_parent]
+
+		apply {}
+
+		destroy {}
+	}`, orgName, envGithubToken, rInt, orgName, envGithubWorkspaceBranch, envGithubWorkspaceIdentifier, rInt, orgName, envGithubWorkspaceBranch, envGithubWorkspaceIdentifier, orgName, orgName)
+}
+
+func testAccTFEWorkspaceRun_createAndDestroyRuns(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	data "tfe_workspace" "root_A" {
+		name                 = "tst-terraform-%d-A"
+		organization         = "%s"
+	}
+
+	data "tfe_workspace" "B_depends_on_A" {
+		name                 = "tst-terraform-%d-B"
+		organization         = "%s"
+	}
+
+	resource "tfe_workspace_run" "ws_run_root_A" {
+		organization = "%s"
+		workspace    = data.tfe_workspace.root_A.name
+
+		apply {
+			manual_confirm = false
+			retry = true
+		}
+
+		destroy {
+			manual_confirm = false
+			retry = true
+		}
+	}
+
+	resource "tfe_workspace_run" "ws_run_B" {
+		organization = "%s"
+		workspace    = data.tfe_workspace.B_depends_on_A.name
+		depends_on   = [tfe_workspace_run.ws_run_root_A]
+
+		apply {
+			manual_confirm = false
+			retry = true
+		}
+
+		destroy {
+			manual_confirm = false
+			retry = true
+		}
+	}`, rInt, orgName, rInt, orgName, orgName, orgName)
+}
+
+func testAccTFEWorkspaceRun_noApplyOrDestroyBlockProvided(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_oauth_client" "test" {
+		organization     = "%s"
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+
+	resource "tfe_workspace" "root_A" {
+		name                 = "tst-terraform-%d-A"
+		organization         = "%s"
+		queue_all_runs       = false
+		vcs_repo {
+			branch             = "%s"
+			identifier         = "%s"
+			oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+		}
+	}
+
+	resource "tfe_workspace_run" "ws_run_root_A" {
+		organization = "%s"
+		workspace    = tfe_workspace.root_A.name
+	}
+`, orgName, envGithubToken, rInt, orgName, envGithubWorkspaceBranch, envGithubWorkspaceIdentifier, orgName)
+}
+
+func testAccTFEWorkspaceRun_noOrganizationProvided(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_oauth_client" "test" {
+		organization     = "%s"
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+
+	resource "tfe_workspace" "root_A" {
+		name                 = "tst-terraform-%d-A"
+		organization         = "%s"
+		queue_all_runs       = false
+		vcs_repo {
+			branch             = "%s"
+			identifier         = "%s"
+			oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+		}
+	}
+
+	resource "tfe_workspace_run" "ws_run_root_A" {
+		workspace    = tfe_workspace.root_A.name
+
+		apply {
+			manual_confirm = false
+			retry = true
+		}
+
+		destroy {
+			manual_confirm = false
+			retry = true
+		}
+	}
+`, orgName, envGithubToken, rInt, orgName, envGithubWorkspaceBranch, envGithubWorkspaceIdentifier)
+}
+
+func testAccTFEWorkspaceRun_noWorkspaceProvided(orgName string) string {
+	return fmt.Sprintf(`
+	resource "tfe_workspace_run" "ws_run_root_A" {
+		organization = "%s"
+
+		apply {
+			manual_confirm = false
+			retry = true
+		}
+
+		destroy {
+			manual_confirm = false
+			retry = true
+		}
+	}
+`, orgName)
+}
+
+func testAccTFEWorkspaceRun_WhenRunErrors(orgName string, workspaceName string) string {
+	return fmt.Sprintf(`
+	resource "tfe_workspace_run" "ws_run_root" {
+		organization = "%s"
+		workspace    = "%s"
+
+		apply {
+			manual_confirm = false
+			retry = false
+		}
+
+		destroy {
+			manual_confirm = false
+			retry = false
+		}
+	}
+`, orgName, workspaceName)
+}

--- a/tfe/resource_tfe_workspace_run_test.go
+++ b/tfe/resource_tfe_workspace_run_test.go
@@ -351,7 +351,7 @@ func testAccTFEWorkspaceRun_noApplyOrDestroyBlockProvided(orgName string, rInt i
 }
 
 func testAccTFEWorkspaceRun_noWorkspaceProvided() string {
-	return fmt.Sprintf(`
+	return `
 	resource "tfe_workspace_run" "ws_run_parent" {
 		apply {
 			manual_confirm = false
@@ -363,7 +363,7 @@ func testAccTFEWorkspaceRun_noWorkspaceProvided() string {
 			retry = true
 		}
 	}
-`)
+`
 }
 
 func testAccTFEWorkspaceRun_WhenRunErrors(workspaceID string) string {

--- a/tfe/test-fixtures/basic-config/main.tf
+++ b/tfe/test-fixtures/basic-config/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.1.0"
+    }
+  }
+  required_version = ">= 0.14.9"
+}
+
+resource "random_pet" "always_new" {
+  keepers = {
+    uuid = uuid()
+  }
+  length = 5
+}
+
+output "pet" {
+  value = { name_of_pet : random_pet.always_new.id }
+}

--- a/tfe/test-fixtures/config-with-error-during-plan/main.tf
+++ b/tfe/test-fixtures/config-with-error-during-plan/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.14.9"
+}
+
+variable "name_length" {
+  default = 4
+  validation = {
+    condition     = var.name_length > 10
+    error_message = "Name length must be greater than 10"
+  }
+}

--- a/tfe/workspace_run_helpers.go
+++ b/tfe/workspace_run_helpers.go
@@ -1,0 +1,338 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"time"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func createWorkspaceRun(d *schema.ResourceData, meta interface{}, isDestroyRun bool, currentRetryAttempts int) error {
+	var runArgs map[string]interface{}
+
+	if isDestroyRun {
+		// destroy block is optional, if it is not set then destroy action is noop for a destroy type run
+		destroyArgs, ok := d.GetOk("destroy")
+		if !ok {
+			return nil
+		}
+		runArgs = destroyArgs.([]interface{})[0].(map[string]interface{})
+	} else {
+		// apply block is optional, if it is not set then create action is noop for a create type run
+		createArgs, ok := d.GetOk("apply")
+		if !ok {
+			return nil
+		}
+		runArgs = createArgs.([]interface{})[0].(map[string]interface{})
+	}
+
+	retryBOMin := runArgs["retry_backoff_min"].(int)
+	retryBOMax := runArgs["retry_backoff_max"].(int)
+	retry := runArgs["retry"].(bool)
+	retryMaxAttempts := runArgs["retry_attempts"].(int)
+
+	isRunInitialAttempt := currentRetryAttempts == 0
+
+	// only perform exponential backoff during retries, not during initial attempt
+	if !isRunInitialAttempt {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("Context canceled: %w", ctx.Err())
+		case <-time.After(backoff(float64(retryBOMin), float64(retryBOMax), currentRetryAttempts)):
+		}
+	}
+
+	config := meta.(ConfiguredClient)
+
+	workspace := d.Get("workspace").(string)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Read workspace %s for organization: %s", workspace, organization)
+	ws, err := config.Client.Workspaces.Read(ctx, organization, workspace)
+	if err != nil {
+		return fmt.Errorf(
+			"Error reading workspace %s for organization %s: %w", workspace, organization, err)
+	}
+
+	runConfig := tfe.RunCreateOptions{
+		Workspace: ws,
+		IsDestroy: tfe.Bool(isDestroyRun),
+		Message: tfe.String(fmt.Sprintf(
+			"Triggered by tfe_workspace_run resource via terraform-provider-tfe on %s",
+			time.Now().Format(time.UnixDate),
+		)),
+		/**
+			autoapply is set to false to give the tfe_workspace_run resource
+			full control of run confirmation.
+		**/
+		AutoApply: tfe.Bool(false),
+	}
+	log.Printf("[DEBUG] Create run for workspace: %s", workspace)
+	run, err := config.Client.Runs.Create(ctx, runConfig)
+	if err != nil {
+		return fmt.Errorf(
+			"Error creating run for workspace %s: %w", workspace, err)
+	}
+
+	if run == nil {
+		log.Printf("[ERROR] The client returned both a nil run and nil error, this should not happen")
+		return fmt.Errorf(
+			"The client returned both a nil run and nil error for workspace %s, this should not happen", workspace)
+	}
+
+	log.Printf("[DEBUG] Run %s created for workspace %s", run.ID, workspace)
+
+	isPlanOp := true
+	run, err = awaitRun(meta, run.ID, ws.ID, organization, isPlanOp, planPendingStatus, planTerminalStatus)
+	if err != nil {
+		return err
+	}
+
+	if run.Status == tfe.RunErrored || run.Status == tfe.RunStatus(tfe.PolicySoftFailed) {
+		if retry && currentRetryAttempts < retryMaxAttempts {
+			currentRetryAttempts++
+			log.Printf("[INFO] Run errored during plan, retrying run, retry count: %d", currentRetryAttempts)
+			return createWorkspaceRun(d, meta, isDestroyRun, currentRetryAttempts)
+		}
+
+		return fmt.Errorf("Run errored during plan, use the run ID %s to debug error", run.ID)
+	}
+
+	// A run is complete when it is successfully planned with no changes to apply
+	if !run.HasChanges || run.Status == tfe.RunPlannedAndFinished {
+		log.Printf("[INFO] Plan finished, no changes to apply")
+		d.SetId(run.ID)
+		return nil
+	}
+
+	if run.Status == tfe.RunPolicyOverride {
+		log.Printf("[INFO] Policy check soft-failed, awaiting manual override for run %q", run.ID)
+		run, err = awaitRun(meta, run.ID, ws.ID, organization, isPlanOp, map[tfe.RunStatus]bool{tfe.RunPolicyOverride: true}, confirmationDoneStatus)
+		if err != nil {
+			return err
+		}
+	}
+
+	manualConfirm := runArgs["manual_confirm"].(bool)
+	// if human approval is required, an apply will kick off automatically only when run is manually approved
+	if manualConfirm {
+		confirmationPendingStatus := map[tfe.RunStatus]bool{}
+		confirmationPendingStatus[run.Status] = true
+
+		log.Printf("[INFO] Plan complete, waiting for manual confirm before proceeding run %q", run.ID)
+		run, err = awaitRun(meta, run.ID, ws.ID, organization, isPlanOp, confirmationPendingStatus, confirmationDoneStatus)
+		if err != nil {
+			return err
+		}
+	} else {
+		// if human approval is NOT required, go ahead and kick off an apply
+		log.Printf("[INFO] Plan complete, confirming an apply for run %q", run.ID)
+		err = config.Client.Runs.Apply(ctx, run.ID, tfe.RunApplyOptions{
+			Comment: tfe.String(fmt.Sprintf("Run confirmed by tfe_workspace_run resource via terraform-provider-tfe on %s",
+				time.Now().Format(time.UnixDate))),
+		})
+		if err != nil {
+			return fmt.Errorf("Run errored while applying run %s: %w", run.ID, err)
+		}
+	}
+
+	isPlanOp = false
+	run, err = awaitRun(meta, run.ID, ws.ID, organization, isPlanOp, applyPendingStatus, applyDoneStatus)
+	if err != nil {
+		return err
+	}
+
+	switch run.Status {
+	case tfe.RunApplied:
+		log.Printf("[INFO] Apply complete for run %q", run.ID)
+		d.SetId(run.ID)
+		return nil
+	case tfe.RunErrored:
+		if retry && currentRetryAttempts < retryMaxAttempts {
+			currentRetryAttempts++
+			log.Printf("[INFO] Run errored during apply, retrying run, retry count: %d", currentRetryAttempts)
+			return createWorkspaceRun(d, meta, isDestroyRun, currentRetryAttempts)
+		}
+		return fmt.Errorf("Run errored during apply, use the run ID %s to debug error", run.ID)
+	default:
+		// unexpected run states including canceled and discarded is handled by this block
+		return fmt.Errorf("Run %s entered unexpected state %s, expected %s state", run.ID, run.Status, tfe.RunApplied)
+	}
+}
+
+func awaitRun(meta interface{}, runID string, wsID string, organization string, isPlanOp bool, runPendingStatus map[tfe.RunStatus]bool,
+	runTerminalStatus map[tfe.RunStatus]bool) (*tfe.Run, error) {
+	config := meta.(ConfiguredClient)
+
+	for i := 0; ; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("Context canceled: %w", ctx.Err())
+		case <-time.After(backoff(backoffMin, backoffMax, i)):
+			log.Printf("[DEBUG] Polling run %s", runID)
+			run, err := config.Client.Runs.Read(ctx, runID)
+			if err != nil {
+				return nil, fmt.Errorf("Could not read run %s: %w", runID, err)
+			}
+
+			_, runHasEnded := runTerminalStatus[run.Status]
+			_, runIsInProgress := runPendingStatus[run.Status]
+
+			switch {
+			case runHasEnded:
+				log.Printf("[INFO] Run %s has reached a terminal state: %s", runID, run.Status)
+				return run, nil
+			case runIsInProgress:
+				log.Printf("[DEBUG] Reading workspace %s", wsID)
+				ws, err := config.Client.Workspaces.ReadByID(ctx, wsID)
+				if err != nil {
+					return nil, fmt.Errorf("Unable to read workspace %s: %w", wsID, err)
+				}
+
+				// if the workspace is locked and there is no current run, assume that workspace was locked for other purposes.
+				// display a message to indicate that the workspace is waiting to be manually unlocked before the run can proceed
+				if ws.Locked && ws.CurrentRun != nil {
+					currentRun, err := config.Client.Runs.Read(ctx, ws.CurrentRun.ID)
+					if err != nil {
+						return nil, fmt.Errorf("Unable to read current run %s: %w", ws.CurrentRun.ID, err)
+					}
+
+					if currentRun.Status == tfe.RunPending {
+						log.Printf("[INFO] Waiting for manually locked workspace to be unlocked")
+						continue
+					}
+				}
+
+				// if this run is the current run in it's workspace, display it's position in the organization queue
+				if ws.CurrentRun != nil && ws.CurrentRun.ID == runID {
+					runPositionInOrg, err := readRunPositionInOrgQueue(meta, runID, wsID, organization)
+					if err != nil {
+						return nil, err
+					}
+
+					orgCapacity, err := config.Client.Organizations.ReadCapacity(ctx, organization)
+					if err != nil {
+						return nil, fmt.Errorf("Unable to read capacity for organization %s: %w", organization, err)
+					}
+					if runPositionInOrg > 0 {
+						log.Printf("[INFO] Waiting for %d queued run(s) before starting run", runPositionInOrg-orgCapacity.Running)
+						continue
+					}
+				}
+
+				// if this run is not the current run in it's workspace, display it's position in the workspace queue
+				runPositionInWorkspace, err := readRunPositionInWorkspaceQueue(meta, runID, wsID, isPlanOp, ws.CurrentRun)
+				if err != nil {
+					return nil, err
+				}
+
+				if runPositionInWorkspace > 0 {
+					log.Printf(
+						"[INFO] Waiting for %d run(s) to finish in workspace %s before being queued...",
+						runPositionInWorkspace,
+						ws.Name,
+					)
+					continue
+				}
+
+				log.Printf("[INFO] Waiting for run %s, status is %s", runID, run.Status)
+			default:
+				log.Printf("[INFO] Run %s has entered state: %s", runID, run.Status)
+				return run, nil
+			}
+		}
+	}
+}
+
+func readRunPositionInOrgQueue(meta interface{}, runID string, wsID string, organization string) (int, error) {
+	config := meta.(ConfiguredClient)
+	position := 0
+	options := tfe.ReadRunQueueOptions{}
+
+	for {
+		runQueue, err := config.Client.Organizations.ReadRunQueue(ctx, organization, options)
+		if err != nil {
+			return position, fmt.Errorf("Unable to read run queue for organization %s: %w", organization, err)
+		}
+		for _, item := range runQueue.Items {
+			if runID == item.ID {
+				position = item.PositionInQueue
+				return position, nil
+			}
+		}
+
+		// Exit the loop when we've seen all pages.
+		if runQueue.CurrentPage >= runQueue.TotalPages {
+			break
+		}
+
+		options.PageNumber = runQueue.NextPage
+	}
+
+	return position, nil
+}
+
+func readRunPositionInWorkspaceQueue(meta interface{}, runID string, wsID string, isPlanOp bool, currentRun *tfe.Run) (int, error) {
+	config := meta.(ConfiguredClient)
+	position := 0
+	options := tfe.RunListOptions{}
+	found := false
+
+	for {
+		runList, err := config.Client.Runs.List(ctx, wsID, &options)
+		if err != nil {
+			return position, fmt.Errorf("Unable to read run list for workspace %s: %w", wsID, err)
+		}
+
+		for _, item := range runList.Items {
+			if !found {
+				if runID == item.ID {
+					found = true
+				}
+
+				continue
+			}
+
+			// ignore runs with final states while computing queue count
+			switch item.Status {
+			case tfe.RunApplied, tfe.RunCanceled, tfe.RunDiscarded, tfe.RunErrored, tfe.RunPlannedAndFinished:
+				continue
+			case tfe.RunPlanned:
+				if isPlanOp {
+					continue
+				}
+			}
+
+			position++
+
+			if currentRun != nil && currentRun.ID == item.ID {
+				return position, nil
+			}
+		}
+
+		// Exit the loop when we've seen all pages.
+		if runList.CurrentPage >= runList.TotalPages {
+			break
+		}
+
+		options.PageNumber = runList.NextPage
+	}
+
+	return position, nil
+}
+
+// perform exponential backoff based on the iteration and
+// limited by the provided min and max durations in milliseconds.
+func backoff(min, max float64, iter int) time.Duration {
+	backoff := math.Pow(2, float64(iter)/5) * min
+	if backoff > max {
+		backoff = max
+	}
+	return time.Duration(backoff) * time.Millisecond
+}

--- a/tfe/workspace_run_helpers.go
+++ b/tfe/workspace_run_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"math/rand"
 	"time"
 
 	"github.com/hashicorp/go-tfe"
@@ -21,8 +22,12 @@ func createWorkspaceRun(d *schema.ResourceData, meta interface{}, isDestroyRun b
 		}
 		runArgs = destroyArgs.([]interface{})[0].(map[string]interface{})
 	} else {
-		// apply block is required
-		createArgs, _ := d.GetOk("apply")
+		createArgs, ok := d.GetOk("apply")
+		if !ok {
+			// apply block is optional, if it is not set then set a random ID to allow for consistent result after apply ops
+			d.SetId(fmt.Sprintf("%d", rand.New(rand.NewSource(time.Now().UnixNano())).Int()))
+			return nil
+		}
 		runArgs = createArgs.([]interface{})[0].(map[string]interface{})
 	}
 

--- a/tfe/workspace_run_helpers_test.go
+++ b/tfe/workspace_run_helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/golang/mock/gomock"
 	tfe "github.com/hashicorp/go-tfe"
 	tfemocks "github.com/hashicorp/go-tfe/mocks"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func MockRunsListForWorkspaceQueue(t *testing.T, client *tfe.Client, workspaceIDWithExpectedRun string, workspaceIDWithUnexpectedRun string) {
@@ -80,7 +79,7 @@ func MockRunsListForWorkspaceQueue(t *testing.T, client *tfe.Client, workspaceID
 
 func TestReadRunPositionInWorkspaceQueue(t *testing.T) {
 	defaultOrganization := "my-org"
-	client := testTfeClient(t, testClientOptions{defaultOrganization: defaultOrganization})
+	client := testTfeClient(t, testClientOptions{})
 	MockRunsListForWorkspaceQueue(t, client, "ws-1", "ws-2")
 
 	testCases := map[string]struct {
@@ -194,7 +193,7 @@ func MockRunsQueueForOrg(t *testing.T, client *tfe.Client, orgName string, orgNa
 
 func TestReadRunPositionInOrgQueue(t *testing.T) {
 	defaultOrganization := "my-org"
-	client := testTfeClient(t, testClientOptions{defaultOrganization: defaultOrganization})
+	client := testTfeClient(t, testClientOptions{})
 	MockRunsQueueForOrg(t, client, "another-org", defaultOrganization)
 
 	testCases := map[string]struct {
@@ -233,34 +232,6 @@ func TestReadRunPositionInOrgQueue(t *testing.T) {
 
 			if position != testCase.returnVal {
 				t.Fatalf("expected returned value is %d, got %v", testCase.returnVal, position)
-			}
-		})
-	}
-}
-
-func TestCreateWorkspaceRun(t *testing.T) {
-	testCases := map[string]struct {
-		isDestroyRun bool
-	}{
-		"when destroy block is not set OnDestroy": {
-			true,
-		},
-		"when apply block is not set OnCreate": {
-			false,
-		},
-	}
-
-	for name, testCase := range testCases {
-		t.Run(name, func(t *testing.T) {
-			d := &schema.ResourceData{}
-			client := testTfeClient(t, testClientOptions{defaultOrganization: "my-org"})
-			meta := ConfiguredClient{Client: client, Organization: "my-org"}
-			currentRetryAttempts := 0
-
-			err := createWorkspaceRun(d, meta, testCase.isDestroyRun, currentRetryAttempts)
-
-			if err != nil {
-				t.Fatalf("expected error is nil, got %v", err)
 			}
 		})
 	}

--- a/tfe/workspace_run_helpers_test.go
+++ b/tfe/workspace_run_helpers_test.go
@@ -1,0 +1,267 @@
+package tfe
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	tfe "github.com/hashicorp/go-tfe"
+	tfemocks "github.com/hashicorp/go-tfe/mocks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func MockRunsListForWorkspaceQueue(t *testing.T, client *tfe.Client, workspaceIDWithExpectedRun string, workspaceIDWithUnexpectedRun string) {
+	ctrl := gomock.NewController(t)
+	mockRunsAPI := tfemocks.NewMockRuns(ctrl)
+
+	runListWithExpectedIDNotIncluded := tfe.RunList{
+		Items: []*tfe.Run{
+			{
+				ID:     "run-01",
+				Status: tfe.RunPending,
+			},
+		},
+		Pagination: &tfe.Pagination{
+			CurrentPage: 1,
+			TotalPages:  1,
+			TotalCount:  1,
+		},
+	}
+
+	runListWithExpectedIDIncluded := tfe.RunList{
+		Items: []*tfe.Run{
+			{
+				ID:     "run-01",
+				Status: tfe.RunPending,
+			},
+			{
+				ID:     "run-02",
+				Status: tfe.RunPending,
+			},
+			{
+				ID:     "run-03",
+				Status: tfe.RunApplied,
+			},
+			{
+				ID:     "run-04",
+				Status: tfe.RunPending,
+			},
+			{
+				ID:     "run-05",
+				Status: tfe.RunApplying,
+			},
+		},
+		Pagination: &tfe.Pagination{
+			CurrentPage: 1,
+			TotalPages:  1,
+			TotalCount:  4,
+		},
+	}
+
+	mockRunsAPI.
+		EXPECT().
+		List(gomock.Any(), workspaceIDWithExpectedRun, gomock.Any()).
+		Return(&runListWithExpectedIDIncluded, nil).
+		AnyTimes()
+
+	mockRunsAPI.
+		EXPECT().
+		List(gomock.Any(), workspaceIDWithUnexpectedRun, gomock.Any()).
+		Return(&runListWithExpectedIDNotIncluded, nil).
+		AnyTimes()
+
+	mockRunsAPI.
+		EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, tfe.ErrInvalidOrg).
+		AnyTimes()
+
+	client.Runs = mockRunsAPI
+}
+
+func TestReadRunPositionInWorkspaceQueue(t *testing.T) {
+	defaultOrganization := "my-org"
+	client := testTfeClient(t, testClientOptions{defaultOrganization: defaultOrganization})
+	MockRunsListForWorkspaceQueue(t, client, "ws-1", "ws-2")
+
+	testCases := map[string]struct {
+		currentRunID string
+		workspace    string
+		err          bool
+		returnVal    int
+	}{
+		"when fetching run list returns error": {
+			"run-02",
+			"ws-unknown",
+			true,
+			0,
+		},
+		"when runID is found in the workspace queue": {
+			"run-02",
+			"ws-1",
+			false,
+			2,
+		},
+		"when runID is not found in the workspace queue": {
+			"run-02",
+			"ws-2",
+			false,
+			0,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			position, err := readRunPositionInWorkspaceQueue(
+				ConfiguredClient{Client: client, Organization: defaultOrganization},
+				testCase.currentRunID,
+				testCase.workspace,
+				false,
+				&tfe.Run{
+					ID:     "run-02",
+					Status: tfe.RunApplying,
+				})
+
+			if (err != nil) != testCase.err {
+				t.Fatalf("expected error is %t, got %v", testCase.err, err)
+			}
+
+			if position != testCase.returnVal {
+				t.Fatalf("expected returned value is %d, got %v", testCase.returnVal, position)
+			}
+		})
+	}
+}
+
+func MockRunsQueueForOrg(t *testing.T, client *tfe.Client, orgName string, orgNameWithRun string) {
+	ctrl := gomock.NewController(t)
+	mockRunQueueAPI := tfemocks.NewMockOrganizations(ctrl)
+
+	runQueueWithExpectedIDNotIncluded := tfe.RunQueue{
+		Items: []*tfe.Run{
+			{
+				ID:              "run-01",
+				Status:          tfe.RunPending,
+				PositionInQueue: 0,
+			},
+		},
+		Pagination: &tfe.Pagination{
+			CurrentPage: 1,
+			TotalPages:  1,
+			TotalCount:  1,
+		},
+	}
+
+	runQueueWithExpectedIDIncluded := tfe.RunQueue{
+		Items: []*tfe.Run{
+			{
+				ID:              "run-01",
+				Status:          tfe.RunPending,
+				PositionInQueue: 0,
+			},
+			{
+				ID:              "run-02",
+				Status:          tfe.RunPending,
+				PositionInQueue: 1,
+			},
+		},
+		Pagination: &tfe.Pagination{
+			CurrentPage: 1,
+			TotalPages:  1,
+			TotalCount:  2,
+		},
+	}
+
+	mockRunQueueAPI.
+		EXPECT().
+		ReadRunQueue(gomock.Any(), orgNameWithRun, gomock.Any()).
+		Return(&runQueueWithExpectedIDIncluded, nil).
+		AnyTimes()
+
+	mockRunQueueAPI.
+		EXPECT().
+		ReadRunQueue(gomock.Any(), orgName, gomock.Any()).
+		Return(&runQueueWithExpectedIDNotIncluded, nil).
+		AnyTimes()
+
+	mockRunQueueAPI.
+		EXPECT().
+		ReadRunQueue(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, tfe.ErrInvalidOrg).
+		AnyTimes()
+
+	client.Organizations = mockRunQueueAPI
+}
+
+func TestReadRunPositionInOrgQueue(t *testing.T) {
+	defaultOrganization := "my-org"
+	client := testTfeClient(t, testClientOptions{defaultOrganization: defaultOrganization})
+	MockRunsQueueForOrg(t, client, "another-org", defaultOrganization)
+
+	testCases := map[string]struct {
+		orgName   string
+		err       bool
+		returnVal int
+	}{
+		"when fetching organization run queue returns error": {
+			"unknown-org",
+			true,
+			0,
+		},
+		"when run is found in organization run queue": {
+			defaultOrganization,
+			false,
+			1,
+		},
+		"when run is not found in organization run queue": {
+			"another-org",
+			false,
+			0,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			position, err := readRunPositionInOrgQueue(
+				ConfiguredClient{Client: client, Organization: defaultOrganization},
+				"run-02",
+				testCase.orgName,
+			)
+
+			if (err != nil) != testCase.err {
+				t.Fatalf("expected error is %t, got %v", testCase.err, err)
+			}
+
+			if position != testCase.returnVal {
+				t.Fatalf("expected returned value is %d, got %v", testCase.returnVal, position)
+			}
+		})
+	}
+}
+
+func TestCreateWorkspaceRun(t *testing.T) {
+	testCases := map[string]struct {
+		isDestroyRun bool
+	}{
+		"when destroy block is not set OnDestroy": {
+			true,
+		},
+		"when apply block is not set OnCreate": {
+			false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			d := &schema.ResourceData{}
+			client := testTfeClient(t, testClientOptions{defaultOrganization: "my-org"})
+			meta := ConfiguredClient{Client: client, Organization: "my-org"}
+			currentRetryAttempts := 0
+
+			err := createWorkspaceRun(d, meta, testCase.isDestroyRun, currentRetryAttempts)
+
+			if err != nil {
+				t.Fatalf("expected error is nil, got %v", err)
+			}
+		})
+	}
+}

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -1,0 +1,192 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_workspace_run"
+description: |-
+  Manages run create and destroy lifecycles in a workspace.
+---
+
+# tfe_workspace_run
+
+Provides a resource to manage create and destroy lifecycles in a workspace.
+The `tfe_workspace_run` expects to own exactly one apply during a creation and one destroy during a destruction. This implies that the `tfe_workspace_run` resource will queue an apply even though previous successful applies exist in the workspace prior to adding this resource.
+
+
+## Example Usage
+
+Basic usage with multiple workspaces:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "test" {
+  organization     = tfe_organization.test-organization
+  api_url          = "https://api.github.com"
+  http_url         = "https://github.com"
+  oauth_token      = "oauth_token_id"
+  service_provider = "github"
+}
+
+resource "tfe_workspace" "parent" {
+  name                 = "parent-ws"
+  organization         = tfe_organization.test-organization
+  queue_all_runs       = false
+  vcs_repo {
+    branch             = "main"
+    identifier         = "my-org-name/vcs-repository"
+    oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+  }
+}
+
+resource "tfe_workspace" "child" {
+  name                 = "child-ws"
+  organization         = tfe_organization.test-organization
+  queue_all_runs       = false
+  vcs_repo {
+    branch             = "main"
+    identifier         = "my-org-name/vcs-repository"
+    oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+  }
+}
+
+resource "tfe_workspace_run" "ws_run_parent" {
+  organization = tfe_organization.test-organization
+  workspace    = tfe_workspace.parent.name
+
+  apply {
+    retry_attempts = 5
+    retry_backoff_min = 5
+  }
+
+  destroy {
+    retry_attempts = 3
+    retry_backoff_min = 10
+  }
+}
+
+resource "tfe_workspace_run" "ws_run_child" {
+  organization = tfe_organization.test-organization
+  workspace    = tfe_workspace.child.name
+  depends_on   = [tfe_workspace_run.ws_run_parent]
+
+  apply {
+    retry_attempts = 5
+    retry_backoff_min = 5
+  }
+
+  destroy {
+    retry_attempts = 3
+    retry_backoff_min = 10
+  }
+}
+```
+
+With manual confirmation:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "test" {
+  organization     = tfe_organization.test-organization
+  api_url          = "https://api.github.com"
+  http_url         = "https://github.com"
+  oauth_token      = "oauth_token_id"
+  service_provider = "github"
+}
+
+resource "tfe_workspace" "parent" {
+  name                 = "parent-ws"
+  organization         = tfe_organization.test-organization
+  queue_all_runs       = false
+  vcs_repo {
+    branch             = "main"
+    identifier         = "my-org-name/vcs-repository"
+    oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+  }
+}
+
+resource "tfe_workspace_run" "ws_run_parent" {
+  organization = tfe_organization.test-organization
+  workspace    = tfe_workspace.parent.name
+
+  apply {
+    manual_confirm = true
+  }
+
+  destroy {
+    manual_confirm = true
+  }
+}
+
+```
+
+With no retries:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "test" {
+  organization     = tfe_organization.test-organization
+  api_url          = "https://api.github.com"
+  http_url         = "https://github.com"
+  oauth_token      = "oauth_token_id"
+  service_provider = "github"
+}
+
+resource "tfe_workspace" "parent" {
+  name                 = "parent-ws"
+  organization         = tfe_organization.test-organization
+  queue_all_runs       = false
+  vcs_repo {
+    branch             = "main"
+    identifier         = "my-org-name/vcs-repository"
+    oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+  }
+}
+
+resource "tfe_workspace_run" "ws_run_parent" {
+  organization = tfe_organization.test-organization
+  workspace    = tfe_workspace.parent.name
+
+  apply {
+    retry = false
+  }
+
+  destroy {
+    retry = false
+  }
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `workspace` - (Required) Name of the workspace to execute the run.
+* `organization` - (Optional) Name of the Terraform Cloud organization. If omitted, organization must be defined in the provider config.
+* `apply` - (Optional) Settings for the workspace's apply run during creation.
+* `destroy` - (Optional) Settings for the workspace's destroy run during destruction.
+
+Both `apply` and `destroy` block supports:
+
+* `manual_confirm` - (Optional) If set to true a human will have to manually confirm a plan to start an apply. If set to false, this resource will auto confirm the plan. The exception is the case of policy check soft-failed where a human has to perform an override by manually confirming the plan even though `manual_confirm` is set to false. Defaults to `false`.
+* `retry` - (Optional) Whether or not to retry on plan or apply errors. When set to true, `retry_attempts` must also be greater than zero inorder for retries to happen. Defaults to `true`.
+* `retry_attempts` - (Optional) The number to retry attempts made after an initial error. Defaults to `3`.
+* `retry_backoff_min` - (Optional) The minimum time in seconds to backoff before attempting a retry. Defaults to `1`.
+* `retry_backoff_max` - (Optional) The maximum time in seconds to backoff before attempting a retry. Defaults to `30`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the run created by this resource.
+

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -174,7 +174,7 @@ resource "tfe_workspace_run" "ws_run_parent" {
 The following arguments are supported:
 
 * `workspace_id` - (Required) ID of the workspace to execute the run.
-* `apply` - (Required) Settings for the workspace's apply run during creation.
+* `apply` - (Optional) Settings for the workspace's apply run during creation.
 * `destroy` - (Optional) Settings for the workspace's destroy run during destruction.
 
 Both `apply` and `destroy` block supports:

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -7,9 +7,17 @@ description: |-
 
 # tfe_workspace_run
 
-Provides a resource to manage create and destroy lifecycles in a workspace.
-The `tfe_workspace_run` expects to own exactly one apply during a creation and/or one destroy during a destruction. This implies that even though previous successful applies exist in the workspace, the `tfe_workspace_run` resource will queue a new apply when added to a config.
+Provides a resource to manage the _initial_ and/or _final_ Terraform run in a given workspace. These initial and final runs often have a special relationship to other things that depend on the workspace's existence, so it can be useful to manage the completion of these runs in the same Terraform configuration that manages the workspace.
 
+There are a few main use cases this resource was designed for:
+
+- **Workspaces that depend on other workspaces.** If a workspace will create infrastructure that other workspaces rely on (for example, a Kubernetes cluster to deploy resources into), those downstream workspaces can depend on an initial `apply` with `wait_for_run = true`, so they aren't created before their infrastructure dependencies.
+- **A more reliable `queue_all_runs = true`.** The `queue_all_runs` argument on `tfe_workspace` requests an initial run, which can complete asynchronously outside of the Terraform run that creates the workspace. Unfortunately, it can't be used with workspaces that require variables to be set, because the `tfe_variable` resources themselves depend on the `tfe_workspace`. By managing an initial `apply` with `wait_for_run = false` that depends on your `tfe_variables`, you can accomplish the same goal without a circular dependency.
+- **Safe workspace destruction.** To ensure a workspace's managed resources are destroyed before deleting it, manage a `destroy` with `wait_for_run = true`. When you destroy the whole configuration, Terraform will wait for the destroy run to complete before deleting the workspace.
+
+The `tfe_workspace_run` expects to own exactly one apply during a creation and/or one destroy during a destruction. This implies that even if previous successful applies exist in the workspace, a `tfe_workspace_run` resource that includes an `apply` block will queue a new apply when added to a config.
+
+~> **IMPORTANT:** When managing a `tfe_workspace_run` that includes a `destroy`, you must currently set `force_delete = true` on the associated `tfe_workspace` resource; otherwise, the destruction of the workspace after its final run completes can sometimes fail. This is a temporary limitation, due to a bug in the default safe deletion behavior of `tfe_workspace`. ([Issue #876](https://github.com/hashicorp/terraform-provider-tfe/issues/876))
 
 ## Example Usage
 
@@ -33,6 +41,7 @@ resource "tfe_workspace" "parent" {
   name                 = "parent-ws"
   organization         = tfe_organization.test-organization
   queue_all_runs       = false
+  force_delete         = true
   vcs_repo {
     branch             = "main"
     identifier         = "my-org-name/vcs-repository"
@@ -44,6 +53,7 @@ resource "tfe_workspace" "child" {
   name                 = "child-ws"
   organization         = tfe_organization.test-organization
   queue_all_runs       = false
+  force_delete         = true
   vcs_repo {
     branch             = "main"
     identifier         = "my-org-name/vcs-repository"
@@ -56,12 +66,14 @@ resource "tfe_workspace_run" "ws_run_parent" {
 
   apply {
     manual_confirm    = false
+    wait_for_run      = true
     retry_attempts    = 5
     retry_backoff_min = 5
   }
 
   destroy {
     manual_confirm    = false
+    wait_for_run      = true
     retry_attempts    = 3
     retry_backoff_min = 10
   }
@@ -79,6 +91,7 @@ resource "tfe_workspace_run" "ws_run_child" {
 
   destroy {
     manual_confirm    = false
+    wait_for_run      = true
     retry_attempts    = 3
     retry_backoff_min = 10
   }
@@ -105,6 +118,7 @@ resource "tfe_workspace" "parent" {
   name                 = "parent-ws"
   organization         = tfe_organization.test-organization
   queue_all_runs       = false
+  force_delete         = true
   vcs_repo {
     branch             = "main"
     identifier         = "my-org-name/vcs-repository"
@@ -121,6 +135,7 @@ resource "tfe_workspace_run" "ws_run_parent" {
 
   destroy {
     manual_confirm = true
+    wait_for_run   = true
   }
 }
 
@@ -146,6 +161,7 @@ resource "tfe_workspace" "parent" {
   name                 = "parent-ws"
   organization         = tfe_organization.test-organization
   queue_all_runs       = false
+  force_delete         = true
   vcs_repo {
     branch             = "main"
     identifier         = "my-org-name/vcs-repository"
@@ -164,6 +180,7 @@ resource "tfe_workspace_run" "ws_run_parent" {
   destroy {
     manual_confirm = false
     retry          = false
+    wait_for_run   = true
   }
 }
 
@@ -179,7 +196,7 @@ The following arguments are supported:
 
 Both `apply` and `destroy` block supports:
 
-* `manual_confirm` - (Required) If set to true a human will have to manually confirm a plan to start an apply. If set to false, this resource will auto confirm the plan. The exception is the case of policy check soft-failed where a human has to perform an override by manually confirming the plan even though `manual_confirm` is set to false. Defaults to `false`.
+* `manual_confirm` - (Required) If set to true a human will have to manually confirm a plan in Terraform Cloud's UI to start an apply. If set to false, this resource will auto confirm the plan. The exception is the case of policy check soft-failed where a human has to perform an override by manually confirming the plan even though `manual_confirm` is set to false. Defaults to `false`.
 * `retry` - (Optional) Whether or not to retry on plan or apply errors. When set to true, `retry_attempts` must also be greater than zero inorder for retries to happen. Defaults to `true`.
 * `retry_attempts` - (Optional) The number to retry attempts made after an initial error. Defaults to `3`.
 * `retry_backoff_min` - (Optional) The minimum time in seconds to backoff before attempting a retry. Defaults to `1`.
@@ -191,4 +208,3 @@ Both `apply` and `destroy` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the run created by this resource.
-

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -52,7 +52,6 @@ resource "tfe_workspace" "child" {
 }
 
 resource "tfe_workspace_run" "ws_run_parent" {
-  organization    = tfe_organization.test-organization
   workspace_id    = tfe_workspace.parent.id
 
   apply {
@@ -69,7 +68,6 @@ resource "tfe_workspace_run" "ws_run_parent" {
 }
 
 resource "tfe_workspace_run" "ws_run_child" {
-  organization = tfe_organization.test-organization
   workspace_id    = tfe_workspace.child.id
   depends_on   = [tfe_workspace_run.ws_run_parent]
 
@@ -115,8 +113,7 @@ resource "tfe_workspace" "parent" {
 }
 
 resource "tfe_workspace_run" "ws_run_parent" {
-  organization = tfe_organization.test-organization
-  workspace_id    = tfe_workspace.parent.id
+  workspace_id     = tfe_workspace.parent.id
 
   apply {
     manual_confirm = true
@@ -157,7 +154,6 @@ resource "tfe_workspace" "parent" {
 }
 
 resource "tfe_workspace_run" "ws_run_parent" {
-  organization = tfe_organization.test-organization
   workspace_id    = tfe_workspace.parent.id
 
   apply {
@@ -178,8 +174,7 @@ resource "tfe_workspace_run" "ws_run_parent" {
 The following arguments are supported:
 
 * `workspace_id` - (Required) ID of the workspace to execute the run.
-* `organization` - (Optional) Name of the Terraform Cloud organization. If omitted, organization must be defined in the provider config.
-* `apply` - (Optional) Settings for the workspace's apply run during creation.
+* `apply` - (Required) Settings for the workspace's apply run during creation.
 * `destroy` - (Optional) Settings for the workspace's destroy run during destruction.
 
 Both `apply` and `destroy` block supports:

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -53,7 +53,7 @@ resource "tfe_workspace" "child" {
 
 resource "tfe_workspace_run" "ws_run_parent" {
   organization = tfe_organization.test-organization
-  workspace    = tfe_workspace.parent.name
+  workspace_id    = tfe_workspace.parent.id
 
   apply {
     retry_attempts = 5
@@ -68,7 +68,7 @@ resource "tfe_workspace_run" "ws_run_parent" {
 
 resource "tfe_workspace_run" "ws_run_child" {
   organization = tfe_organization.test-organization
-  workspace    = tfe_workspace.child.name
+  workspace_id    = tfe_workspace.child.id
   depends_on   = [tfe_workspace_run.ws_run_parent]
 
   apply {
@@ -112,7 +112,7 @@ resource "tfe_workspace" "parent" {
 
 resource "tfe_workspace_run" "ws_run_parent" {
   organization = tfe_organization.test-organization
-  workspace    = tfe_workspace.parent.name
+  workspace_id    = tfe_workspace.parent.id
 
   apply {
     manual_confirm = true
@@ -154,7 +154,7 @@ resource "tfe_workspace" "parent" {
 
 resource "tfe_workspace_run" "ws_run_parent" {
   organization = tfe_organization.test-organization
-  workspace    = tfe_workspace.parent.name
+  workspace_id    = tfe_workspace.parent.id
 
   apply {
     retry = false
@@ -171,7 +171,7 @@ resource "tfe_workspace_run" "ws_run_parent" {
 
 The following arguments are supported:
 
-* `workspace` - (Required) Name of the workspace to execute the run.
+* `workspace_id` - (Required) ID of the workspace to execute the run.
 * `organization` - (Optional) Name of the Terraform Cloud organization. If omitted, organization must be defined in the provider config.
 * `apply` - (Optional) Settings for the workspace's apply run during creation.
 * `destroy` - (Optional) Settings for the workspace's destroy run during destruction.

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -8,7 +8,7 @@ description: |-
 # tfe_workspace_run
 
 Provides a resource to manage create and destroy lifecycles in a workspace.
-The `tfe_workspace_run` expects to own exactly one apply during a creation and one destroy during a destruction. This implies that the `tfe_workspace_run` resource will queue an apply even though previous successful applies exist in the workspace prior to adding this resource.
+The `tfe_workspace_run` expects to own exactly one apply during a creation and/or one destroy during a destruction. This implies that even though previous successful applies exist in the workspace, the `tfe_workspace_run` resource will queue a new apply when added to a config.
 
 
 ## Example Usage

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -52,16 +52,18 @@ resource "tfe_workspace" "child" {
 }
 
 resource "tfe_workspace_run" "ws_run_parent" {
-  organization = tfe_organization.test-organization
+  organization    = tfe_organization.test-organization
   workspace_id    = tfe_workspace.parent.id
 
   apply {
-    retry_attempts = 5
+    manual_confirm    = false
+    retry_attempts    = 5
     retry_backoff_min = 5
   }
 
   destroy {
-    retry_attempts = 3
+    manual_confirm    = false
+    retry_attempts    = 3
     retry_backoff_min = 10
   }
 }
@@ -72,12 +74,14 @@ resource "tfe_workspace_run" "ws_run_child" {
   depends_on   = [tfe_workspace_run.ws_run_parent]
 
   apply {
-    retry_attempts = 5
+    manual_confirm    = false
+    retry_attempts    = 5
     retry_backoff_min = 5
   }
 
   destroy {
-    retry_attempts = 3
+    manual_confirm    = false
+    retry_attempts    = 3
     retry_backoff_min = 10
   }
 }
@@ -157,11 +161,13 @@ resource "tfe_workspace_run" "ws_run_parent" {
   workspace_id    = tfe_workspace.parent.id
 
   apply {
-    retry = false
+    manual_confirm = false
+    retry          = false
   }
 
   destroy {
-    retry = false
+    manual_confirm = false
+    retry          = false
   }
 }
 
@@ -178,7 +184,7 @@ The following arguments are supported:
 
 Both `apply` and `destroy` block supports:
 
-* `manual_confirm` - (Optional) If set to true a human will have to manually confirm a plan to start an apply. If set to false, this resource will auto confirm the plan. The exception is the case of policy check soft-failed where a human has to perform an override by manually confirming the plan even though `manual_confirm` is set to false. Defaults to `false`.
+* `manual_confirm` - (Required) If set to true a human will have to manually confirm a plan to start an apply. If set to false, this resource will auto confirm the plan. The exception is the case of policy check soft-failed where a human has to perform an override by manually confirming the plan even though `manual_confirm` is set to false. Defaults to `false`.
 * `retry` - (Optional) Whether or not to retry on plan or apply errors. When set to true, `retry_attempts` must also be greater than zero inorder for retries to happen. Defaults to `true`.
 * `retry_attempts` - (Optional) The number to retry attempts made after an initial error. Defaults to `3`.
 * `retry_backoff_min` - (Optional) The minimum time in seconds to backoff before attempting a retry. Defaults to `1`.

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -183,6 +183,7 @@ Both `apply` and `destroy` block supports:
 * `retry_attempts` - (Optional) The number to retry attempts made after an initial error. Defaults to `3`.
 * `retry_backoff_min` - (Optional) The minimum time in seconds to backoff before attempting a retry. Defaults to `1`.
 * `retry_backoff_max` - (Optional) The maximum time in seconds to backoff before attempting a retry. Defaults to `30`.
+* `wait_for_run` - (Optional) Whether or not to wait for a run to reach completion before firing the next run. When set to false, `manual_confirm` will not be considered as run will be started with auto apply set to true . Defaults to `true`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

### Add tfe_workspace_run resource as per [discussed issue](https://github.com/hashicorp/terraform-provider-tfe/issues/742)

Resource format:
```
resource "tfe_workspace_run" "root_A" {
  workspace_id    = "ws_root_A_ID"

  apply {
    wait_for_run = true
    manual_confirm = true
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }

  destroy { 
    wait_for_run = true
    manual_confirm = true
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }
}
```

## Testing plan

1.  _Sample test config (Be sure that the org and workspaces exist)_
```
resource "tfe_workspace_run" "root_A" {
  workspace_id    = "ws_root_A_ID"

  apply {
    manual_confirm = true
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }

  destroy { 
    manual_confirm = true
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }
}

resource "tfe_workspace_run" "B_depends_on_A" {
  workspace_id    = "ws_B_depends_on_A_ID"
  depends_on   = [tfe_workspace_run.root_A]

  apply {
    manual_confirm = true
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }

  destroy {
    manual_confirm = true
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }
}

resource "tfe_workspace_run" "D_depends_on_B" {
  workspace_id    = "ws_D_depends_on_B_ID"
  depends_on   = [tfe_workspace_run.B_depends_on_A]

  apply {
    manual_confirm = false
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }

  destroy {
    manual_confirm = false
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }
}

resource "tfe_workspace_run" "C_depends_on_A" {
  workspace_id    = "ws_C_depends_on_A_ID"
  depends_on   = [tfe_workspace_run.root_A]

  apply {
    manual_confirm = false
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }

  destroy {
    manual_confirm = false
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }
}

resource "tfe_workspace_run" "E_depends_on_C_and_D" {
  workspace_id    = "ws_E_depends_on_C_and_D_ID"
  depends_on   = [tfe_workspace_run.D_depends_on_B, tfe_workspace_run.C_depends_on_A]

  apply {
    manual_confirm = false
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }

  destroy {
    manual_confirm = false
    retry = true
    retry_attempts = 2
    retry_backoff_min = 2
    retry_backoff_max = 15
  }
}
```
2.  _the `apply` runs should apply in order from root to leave nodes_
3.  _the `destroy` runs should apply from leave nodes to root node_
4. A second test case would be testing with `wait_for_run = false`. In this case when a run is created, it proceeds to a stage where no other human action is needed then it is considered complete without awaiting for run final state. If `manual_confirm` is `true`, then run will run wait up until approval is given.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Issue](https://github.com/hashicorp/terraform-provider-tfe/issues/742)

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEWorkspaceRun_" make testacc

...
```

<img width="1093" alt="Screen Shot 2023-05-02 at 6 52 37 AM" src="https://user-images.githubusercontent.com/22062046/235647615-e5ba43f5-0268-43f0-a227-930ba422fee1.png">

<img width="1052" alt="Screen Shot 2023-04-26 at 3 01 42 PM" src="https://user-images.githubusercontent.com/22062046/234677290-b8fad9eb-6f82-41ea-a380-e8c6bc34949d.png">

<img width="974" alt="Screen Shot 2023-04-26 at 3 02 41 PM" src="https://user-images.githubusercontent.com/22062046/234677292-4ccef1ad-c9d5-4ff2-a4c0-54380b22de67.png">
