### PR TITLE
Change CLI config functions to use values instead of pointers

### DIFF
--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -357,10 +357,10 @@ func getClient(tfeHost, token string, insecure bool) (*tfe.Client, error) {
 
 // cliConfig tries to find and parse the configuration of the Terraform CLI.
 // This is an optional step, so any errors are ignored.
-func cliConfig() *Config {
-	mainConfig := &Config{}
-	credentialsConfig := &Config{}
-	combinedConfig := &Config{}
+func cliConfig() Config {
+	mainConfig := Config{}
+	credentialsConfig := Config{}
+	combinedConfig := Config{}
 
 	// Main CLI config file; might contain manually-entered credentials, and/or
 	// some host service discovery objects. Location is configurable via
@@ -417,8 +417,8 @@ func locateConfigFile() string {
 	return filePath
 }
 
-func readCliConfigFile(configFilePath string) *Config {
-	config := &Config{}
+func readCliConfigFile(configFilePath string) Config {
+	config := Config{}
 
 	// Read the CLI config file content.
 	content, err := os.ReadFile(configFilePath)
@@ -442,7 +442,7 @@ func readCliConfigFile(configFilePath string) *Config {
 	return config
 }
 
-func credentialsSource(config *Config) auth.CredentialsSource {
+func credentialsSource(config Config) auth.CredentialsSource {
 	creds := auth.NoCredentials
 
 	// Add all configured credentials to the credentials source.


### PR DESCRIPTION
## Description

Fixes style issue. No nil was returned or checked.

## External links

Closes https://github.com/hashicorp/terraform-provider-tfe/issues/790

## Output from acceptance tests

```
$ TESTARGS="-run TestProvider" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestProvider -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_versionConstraints
--- PASS: TestProvider_versionConstraints (0.00s)
=== RUN   TestProvider_locateConfigFile
--- PASS: TestProvider_locateConfigFile (0.00s)
=== RUN   TestProvider_cliConfig
2023/02/06 07:18:15 [ERROR] Error reading CLI config or credentials file test-fixtures/cli-config-files/no-credentials/.terraform.d/credentials.tfrc.json: open test-fixtures/cli-config-files/no-credentials/.terraform.d/credentials.tfrc.json: no such file or directory
2023/02/06 07:18:15 [ERROR] Error reading CLI config or credentials file test-fixtures/cli-config-files/no-terraformrc: open test-fixtures/cli-config-files/no-terraformrc: no such file or directory
2023/02/06 07:18:15 [ERROR] Error reading CLI config or credentials file test-fixtures/cli-config-files/no-terraformrc: open test-fixtures/cli-config-files/no-terraformrc: no such file or directory
2023/02/06 07:18:15 [ERROR] Error reading CLI config or credentials file test-fixtures/cli-config-files/no-credentials/.terraform.d/credentials.tfrc.json: open test-fixtures/cli-config-files/no-credentials/.terraform.d/credentials.tfrc.json: no such file or directory
--- PASS: TestProvider_cliConfig (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	1.219s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
...
```
