### PR TITLE
Clarify <organization> usage in vcs_repo config blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ FEATURES:
 
 ENHANCEMENTS:
 * r/tfe_organization_membership: Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>` ([#715](https://github.com/hashicorp/terraform-provider-tfe/pull/715))
-* Clarify usage of organization fields in documentation describing VCS repository config blocks
+* Clarify usage of `organization` fields in documentation describing VCS repository config blocks ([#792](https://github.com/hashicorp/terraform-provider-tfe/pull/792))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 
 ENHANCEMENTS:
 * r/tfe_organization_membership: Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>` ([#715](https://github.com/hashicorp/terraform-provider-tfe/pull/715))
+* Clarify usage of organization fields in documentation describing VCS repository config blocks
 
 BUG FIXES:
 

--- a/website/docs/d/policy_set.html.markdown
+++ b/website/docs/d/policy_set.html.markdown
@@ -43,8 +43,8 @@ The following arguments are supported:
 
 The `vcs_repo` block contains:
 
-* `identifier` - A reference to your VCS repository in the format `<organization>/<repository>`
-  where `<organization>` and `<repository>` refer to the organization and repository in your VCS
+* `identifier` - A reference to your VCS repository in the format `<vcs organization>/<repository>`
+  where `<vcs organization>` and `<repository>` refer to the organization and repository in your VCS
   provider.
 * `branch` - The repository branch that Terraform will execute from.
 * `ingress_submodules` - Indicates whether submodules should be fetched when

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -62,8 +62,8 @@ In addition to all arguments above, the following attributes are exported:
 
 The `vcs_repo` block contains:
 
-* `identifier` - A reference to your VCS repository in the format `<organization>/<repository>`
-  where `<organization>` and `<repository>` refer to the organization and repository in your VCS
+* `identifier` - A reference to your VCS repository in the format `<vcs organization>/<repository>`
+  where `<vcs organization>` and `<repository>` refer to the organization and repository in your VCS
   provider.
 * `branch` - The repository branch that Terraform will execute from.
 * `ingress_submodules` - Indicates whether submodules should be fetched when

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -105,7 +105,7 @@ default is to create an empty non-VCS policy set.
 The `vcs_repo` block supports:
 
 * `identifier` - (Required) A reference to your VCS repository in the format
-  `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization and repository
+  `<vcs organization>/<repository>` where `<vcs organization>` and `<repository>` refer to the organization and repository
   in your VCS provider.
 * `branch` - (Optional) The repository branch that Terraform will execute from.
   This defaults to the repository's default branch (e.g. main).

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -118,8 +118,8 @@ The following arguments are supported:
 The `vcs_repo` block supports:
 
 * `identifier` - (Required) A reference to your VCS repository in the format
-  `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization and repository
-  in your VCS provider. The format for Azure DevOps is `<organization>/<project>/_git/<repository>`.
+  `<vcs organization>/<repository>` where `<vcs organization>` and `<repository>` refer to the organization and repository
+  in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `branch` - (Optional) The repository branch that Terraform will execute from.
   This defaults to the repository's default branch (e.g. main).
 * `ingress_submodules` - (Optional) Whether submodules should be fetched when


### PR DESCRIPTION
## Description

We should be try to differentiate between VCS organization from TFC organization more distinctly.

Closes #789 