### PR TITLE
Remove beta flags for Projects feature

### DIFF
--- a/tfe/data_source_organization_test.go
+++ b/tfe/data_source_organization_test.go
@@ -40,8 +40,6 @@ func TestAccTFEOrganizationDataSource_basic(t *testing.T) {
 }
 
 func TestAccTFEOrganizationDataSource_defaultProject(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	org := &tfe.Organization{}
 

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -171,8 +171,6 @@ func TestAccTFEWorkspaceDataSourceWithTriggerPatterns(t *testing.T) {
 }
 
 func TestAccTFEWorkspaceDataSource_readProjectIDDefault(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -188,8 +186,6 @@ func TestAccTFEWorkspaceDataSource_readProjectIDDefault(t *testing.T) {
 }
 
 func TestAccTFEWorkspaceDataSource_readProjectIDNonDefault(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -87,7 +87,6 @@ func TestAccTFEOrganization_full(t *testing.T) {
 }
 
 func TestAccTFEOrganization_defaultProject(t *testing.T) {
-	skipUnlessBeta(t)
 	org := &tfe.Organization{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 

--- a/tfe/resource_tfe_project_test.go
+++ b/tfe/resource_tfe_project_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestAccTFEProject_basic(t *testing.T) {
-	skipUnlessBeta(t)
-
 	project := &tfe.Project{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -43,8 +41,6 @@ func TestAccTFEProject_basic(t *testing.T) {
 }
 
 func TestAccTFEProject_update(t *testing.T) {
-	skipUnlessBeta(t)
-
 	project := &tfe.Project{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -78,8 +74,6 @@ func TestAccTFEProject_update(t *testing.T) {
 }
 
 func TestAccTFEProject_import(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	project := &tfe.Project{}
 	resource.Test(t, resource.TestCase{

--- a/tfe/resource_tfe_team_project_access_test.go
+++ b/tfe/resource_tfe_team_project_access_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestAccTFETeamProjectAccess_admin(t *testing.T) {
-	skipUnlessBeta(t)
-
 	tmAccess := &tfe.TeamProjectAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -41,8 +39,6 @@ func TestAccTFETeamProjectAccess_admin(t *testing.T) {
 }
 
 func TestAccTFETeamProjectAccess_import(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -110,8 +110,6 @@ func TestAccTFEWorkspace_defaultOrg(t *testing.T) {
 }
 
 func TestAccTFEWorkspace_basicReadProjectId(t *testing.T) {
-	skipUnlessBeta(t)
-
 	workspace := &tfe.Workspace{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -133,8 +131,6 @@ func TestAccTFEWorkspace_basicReadProjectId(t *testing.T) {
 }
 
 func TestAccTFEWorkspace_customProject(t *testing.T) {
-	skipUnlessBeta(t)
-
 	workspace := &tfe.Workspace{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -418,7 +414,6 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 }
 
 func TestAccTFEWorkspace_updateProject(t *testing.T) {
-	skipUnlessBeta(t)
 	workspace := &tfe.Workspace{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -1693,8 +1688,6 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 }
 
 func TestAccTFEWorkspace_importProject(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{

--- a/tfe/testing.go
+++ b/tfe/testing.go
@@ -6,8 +6,6 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"net/url"
 	"os"
 	"testing"
@@ -244,15 +242,5 @@ func retry(maxRetries, secondsBetween int, f retryableFn) (interface{}, error) {
 		}
 
 		retries += 1
-	}
-}
-
-// Allows skipping the given TestCheckFunc unless beta checks enabled.
-func betaOnlyCheck(testFunc resource.TestCheckFunc) resource.TestCheckFunc {
-	if betaFeaturesEnabled() {
-		return testFunc
-	}
-	return func(state *terraform.State) error {
-		return nil
 	}
 }

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -9,8 +9,6 @@ Manages projects.
 
 Provides a project resource.
 
-~> **NOTE:** Projects functionality is currently in beta.
-
 ## Example Usage
 
 Basic usage:


### PR DESCRIPTION
## Description

[Projects](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/projects) are now generally available. This PR removes all the related beta flags and notices. 

## Testing plan

Covered by integration tests

## External links

- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/704)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/768)