### PR TITLE
Add Manage Membership to team organization access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+BREAKING CHANGES:
+
+FEATURES:
+* `r/tfe_team`: Add attribute `manage_membership` to `organization_access` on `tfe_team` by @JarrettSpiker ([#801](https://github.com/hashicorp/terraform-provider-tfe/pull/801))
+
+ENHANCEMENTS:
+
+BUG FIXES:
+
 ## v0.44.1 (April 21, 2023)
 
 BUG FIXES:

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -93,6 +93,11 @@ func resourceTFETeam() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"manage_membership": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -142,6 +147,7 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 			ManageProjects:        tfe.Bool(organizationAccess["manage_projects"].(bool)),
 			ReadWorkspaces:        tfe.Bool(organizationAccess["read_workspaces"].(bool)),
 			ReadProjects:          tfe.Bool(organizationAccess["read_projects"].(bool)),
+			ManageMembership:      tfe.Bool(organizationAccess["manage_membership"].(bool)),
 		}
 	}
 
@@ -201,6 +207,7 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 			"manage_projects":         team.OrganizationAccess.ManageProjects,
 			"read_projects":           team.OrganizationAccess.ReadProjects,
 			"read_workspaces":         team.OrganizationAccess.ReadWorkspaces,
+			"manage_membership":       team.OrganizationAccess.ManageMembership,
 		}}
 		if err := d.Set("organization_access", organizationAccess); err != nil {
 			return fmt.Errorf("error setting organization access for team %s: %w", d.Id(), err)
@@ -237,6 +244,7 @@ func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
 			ManageProjects:        tfe.Bool(organizationAccess["manage_projects"].(bool)),
 			ReadProjects:          tfe.Bool(organizationAccess["read_projects"].(bool)),
 			ReadWorkspaces:        tfe.Bool(organizationAccess["read_workspaces"].(bool)),
+			ManageMembership:      tfe.Bool(organizationAccess["manage_membership"].(bool)),
 		}
 	}
 

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -77,6 +77,8 @@ func TestAccTFETeam_full(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.read_projects", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.read_workspaces", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_membership", "true"),
 				),
 			},
 		},
@@ -122,6 +124,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.manage_projects", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.read_workspaces", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_membership", "true"),
 				),
 			},
 			{
@@ -154,6 +158,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.read_projects", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "sso_team_id", "changed-sso-id"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_membership", "false"),
 				),
 			},
 			{
@@ -187,6 +193,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.read_projects", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "sso_team_id", ""),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_membership", "false"),
 				),
 			},
 		},
@@ -436,6 +444,9 @@ func testAccCheckTFETeamAttributes_full(
 		if !team.OrganizationAccess.ManageProjects {
 			return fmt.Errorf("OrganizationAccess.ManageProjects should be true")
 		}
+		if !team.OrganizationAccess.ManageMembership {
+			return fmt.Errorf("OrganizationAccess.ManageMembership should be true")
+		}
 		if team.SSOTeamID != "team-test-sso-id" {
 			return fmt.Errorf("Bad SSO Team ID: %s", team.SSOTeamID)
 		}
@@ -469,6 +480,9 @@ func testAccCheckTFETeamAttributes_full_update(
 		}
 		if team.OrganizationAccess.ManageProjects {
 			return fmt.Errorf("OrganizationAccess.ManageProjects should be false")
+		}
+		if team.OrganizationAccess.ManageMembership {
+			return fmt.Errorf("OrganizationAccess.ManageMembership should be false")
 		}
 
 		if team.SSOTeamID != "changed-sso-id" {
@@ -537,6 +551,7 @@ resource "tfe_team" "foobar" {
 	manage_projects = true
 	read_workspaces = true
 	read_projects = true
+	manage_membership = true
   }
   sso_team_id = "team-test-sso-id"
 }`, rInt)
@@ -566,6 +581,7 @@ resource "tfe_team" "foobar" {
 	manage_projects = false
 	read_projects = false
 	read_workspaces = false
+	manage_membership = false
   }
 
   sso_team_id = "changed-sso-id"

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -54,6 +54,7 @@ The `organization_access` block supports:
 * `manage_modules` - (Optional) Allow members to publish and delete modules in the organization's private registry.
 * `manage_run_tasks` - (Optional) Allow members to create, edit, and delete the organization's run tasks.
 * `manage_projects` - (Optional) Allow members to create and administrate all projects within the organization. Requires `manage_workspaces` to be set to `true`.
+* `manage_membership` - (Optional) Allow members to add/remove users from the organization, and to add/remove users from visible teams.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Allow the manage membership organization access setting to be set on teams by the provider

## Testing plan

1.  New teams should have manage_membership as false
2. If manage membership is omitted, it is set to false
1. Manage membership can be set or unset via the provider

## External links

- [go-tfe PR](https://github.com/hashicorp/go-tfe/pull/652 )
- [API docs](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/teams#create-a-team)
- [Permission docs](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/permissions#manage-membership)

## Output from acceptance tests

```
TF_ACC=1 go test github.com/hashicorp/terraform-provider-tfe/tfe  -run TestAccTFETeam_ -tags=integration -v
=== RUN   TestAccTFETeam_basic
--- PASS: TestAccTFETeam_basic (6.43s)
=== RUN   TestAccTFETeam_full
--- PASS: TestAccTFETeam_full (6.27s)
=== RUN   TestAccTFETeam_full_update
--- PASS: TestAccTFETeam_full_update (13.47s)
=== RUN   TestAccTFETeam_import_byId
--- PASS: TestAccTFETeam_import_byId (6.82s)
=== RUN   TestAccTFETeam_import_byId_doesNotExist
--- PASS: TestAccTFETeam_import_byId_doesNotExist (6.74s)
=== RUN   TestAccTFETeam_import_byName
--- PASS: TestAccTFETeam_import_byName (6.87s)
=== RUN   TestAccTFETeam_import_missingOrg
--- PASS: TestAccTFETeam_import_missingOrg (6.50s)
=== RUN   TestAccTFETeam_import_missingTeam
--- PASS: TestAccTFETeam_import_missingTeam (6.58s)
=== RUN   TestAccTFETeam_import_teamNameWithSpaces
--- PASS: TestAccTFETeam_import_teamNameWithSpaces (6.88s)
=== RUN   TestAccTFETeam_import_teamNameWithSlashes
--- PASS: TestAccTFETeam_import_teamNameWithSlashes (6.97s)
=== RUN   TestAccTFETeam_import_teamNameWhichLooksLikeID
--- PASS: TestAccTFETeam_import_teamNameWhichLooksLikeID (6.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	80.687s
```