### PR TITLE
Clarify why force_delete is requires with old TFE versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * `r/tfe_workspace` and `d/tfe_workspace`: Add attribute `html_url` by @brandonc ([#784](https://github.com/hashicorp/terraform-provider-tfe/pull/784))
 
 BUG FIXES:
+* r/tfe_workspace: Clarify error message shown when attempting to safe-delete a workspace on a version of TFE which does not support safe delete ([#803](https://github.com/hashicorp/terraform-provider-tfe/pull/803))
 
 ## v0.42.0 (January 31, 2023)
 

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -762,7 +762,7 @@ func resourceTFEWorkspaceDelete(d *schema.ResourceData, meta interface{}) error 
 			err = config.Client.Workspaces.DeleteByID(ctx, id)
 		} else {
 			return fmt.Errorf(
-				"Error deleting workspace %s: This workspace must be force deleted by setting force_delete=true", id)
+				"Error deleting workspace %s: This version of Terraform Enterprise does not support workspace safe-delete. Workspaces must be force deleted by setting force_delete=true", id)
 		}
 	} else if *ws.Permissions.CanForceDelete {
 		if forceDelete {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -2099,7 +2099,7 @@ func TestTFEWorkspace_delete_withoutCanForceDeletePermission(t *testing.T) {
 
 	err = resourceTFEWorkspaceDelete(rd, config)
 	if err == nil {
-		t.Fatalf("Expected an error deleting workspace with CanForceDelete=nil, force_delete=true, and %v resources", workspace.ResourceCount)
+		t.Fatalf("Expected an error deleting workspace with CanForceDelete=nil, force_delete=false, and %v resources", workspace.ResourceCount)
 	}
 
 	workspace.ResourceCount = 0
@@ -2108,7 +2108,7 @@ func TestTFEWorkspace_delete_withoutCanForceDeletePermission(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected an error deleting workspace with CanForceDelete=nil and force_delete=false")
 	}
-	expectedErrSubstring := "workspace must be force deleted by setting force_delete=true"
+	expectedErrSubstring := "This version of Terraform Enterprise does not support workspace safe-delete. Workspaces must be force deleted by setting force_delete=true"
 	if !strings.Contains(err.Error(), expectedErrSubstring) {
 		t.Fatalf("Expected error contains %s but got %s", expectedErrSubstring, err.Error())
 	}


### PR DESCRIPTION
## Description

Update failure message when attempting to safe delete a workspace on a version of TFE which does not support safe delete, to clarify why the force_delete flag is needed

## Testing plan

1. Verify that the updated error message is shown

## Output from acceptance tests

```
 go test ./...  -run TestTFEWorkspace -tags=integration -v
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestTFEWorkspace_delete_withoutCanForceDeletePermission
2023/02/16 09:52:49 [DEBUG] Delete workspace ws-testing
2023/02/16 09:52:49 [DEBUG] Delete workspace ws-testing
2023/02/16 09:52:49 [DEBUG] Delete workspace ws-testing
--- PASS: TestTFEWorkspace_delete_withoutCanForceDeletePermission (0.46s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 0.639s




...
```
