### PR TITLE
Ws lock

### DIFF
--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -163,6 +163,7 @@ func Provider() *schema.Provider {
 			"tfe_variable_set":                resourceTFEVariableSet(),
 			"tfe_workspace_variable_set":      resourceTFEWorkspaceVariableSet(),
 			"tfe_workspace_policy_set":        resourceTFEWorkspacePolicySet(),
+			"tfe_workspace_lock":              resourceTFEWorkspaceLock(),
 		},
 		ConfigureContextFunc: configure(),
 	}

--- a/tfe/resource_tfe_workspace_lock.go
+++ b/tfe/resource_tfe_workspace_lock.go
@@ -66,11 +66,6 @@ func resourceTFEWorkspaceLockRead(d *schema.ResourceData, meta interface{}) erro
 	ws, err := config.Client.Workspaces.ReadByID(ctx, wID)
 
 	if err != nil {
-		// if errors.Is(err, tfe.ErrResourceNotFound) {
-		// 	log.Printf("[DEBUG] Variable set %s no longer exists", d.Id())
-		// 	d.SetId("")
-		// 	return nil
-		// }
 		return fmt.Errorf("Error reading Workspace %s: %w", d.Id(), err)
 	}
 
@@ -79,6 +74,7 @@ func resourceTFEWorkspaceLockRead(d *schema.ResourceData, meta interface{}) erro
 		d.SetId("")
 		return nil
 	}
+	d.SetId(wID)
 
 	return nil
 }

--- a/tfe/resource_tfe_workspace_lock.go
+++ b/tfe/resource_tfe_workspace_lock.go
@@ -1,0 +1,100 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"fmt"
+	"log"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceTFEWorkspaceLock() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTFEWorkspaceLockCreate,
+		Read:   resourceTFEWorkspaceLockRead,
+		Delete: resourceTFEWorkspaceLockDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"reason": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceTFEWorkspaceLockCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(ConfiguredClient)
+
+	wID := d.Get("workspace_id").(string)
+
+	applyOptions := tfe.WorkspaceLockOptions{}
+
+	if v, ok := d.GetOk("reason"); ok {
+		applyOptions.Reason = tfe.String(v.(string))
+	}
+
+	_, err := config.Client.Workspaces.Lock(ctx, wID, applyOptions)
+	if err != nil {
+		return fmt.Errorf(
+			"Error locking workspace %s: %w", wID, err)
+	}
+
+	d.SetId(wID)
+
+	return resourceTFEWorkspaceLockRead(d, meta)
+}
+
+func resourceTFEWorkspaceLockRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(ConfiguredClient)
+
+	wID := d.Id()
+
+	log.Printf("[DEBUG] Read configuration of workspace %s", d.Id())
+	ws, err := config.Client.Workspaces.ReadByID(ctx, wID)
+
+	if err != nil {
+		// if errors.Is(err, tfe.ErrResourceNotFound) {
+		// 	log.Printf("[DEBUG] Variable set %s no longer exists", d.Id())
+		// 	d.SetId("")
+		// 	return nil
+		// }
+		return fmt.Errorf("Error reading Workspace %s: %w", d.Id(), err)
+	}
+
+	if !ws.Locked {
+		log.Printf("[DEBUG] Workspace ID %s is no longer locked", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceTFEWorkspaceLockDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(ConfiguredClient)
+
+	wID := d.Id()
+
+	log.Printf("[DEBUG] Unlock workspace (%s)", wID)
+
+	_, err := config.Client.Workspaces.Unlock(ctx, wID)
+	if err != nil {
+		return fmt.Errorf(
+			"Error unlocking workspace %s: %w", wID, err)
+	}
+
+	return nil
+}

--- a/tfe/resource_tfe_workspace_lock_test.go
+++ b/tfe/resource_tfe_workspace_lock_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFEWorkspaceLock_basic(t *testing.T) {
+	workspace := &tfe.Workspace{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspace_lock(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceAttributes(workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_lock.foobar", "id", workspace.ID),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_lock.foobar", "workspace_id", workspace.ID),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_lock.foobar", "reason", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFEWorkspace_lock(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name               = "workspace-test"
+  organization       = tfe_organization.foobar.id
+  description        = "My favorite workspace!"
+  allow_destroy_plan = false
+  auto_apply         = true
+  tag_names          = ["fav", "test"]
+}
+
+resource "tfe_workspace_lock" "foobar" {
+  workspace_id = tfe_workspace.foobar.id
+  reason       = "test"
+}
+`, rInt)
+}

--- a/tfe/resource_tfe_workspace_lock_test.go
+++ b/tfe/resource_tfe_workspace_lock_test.go
@@ -11,6 +11,7 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccTFEWorkspaceLock_basic(t *testing.T) {
@@ -27,17 +28,62 @@ func TestAccTFEWorkspaceLock_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace, testAccProvider),
-					testAccCheckTFEWorkspaceAttributes(workspace),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace_lock.foobar", "id", workspace.ID),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace_lock.foobar", "workspace_id", workspace.ID),
+					testAccCheckTFEWorkspaceLocked(workspace, true),
+					testAccCheckTFEWorkspaceLockedID(
+						"tfe_workspace.foobar", "tfe_workspace_lock.foobar"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace_lock.foobar", "reason", "test"),
 				),
 			},
+			{
+				Config: testAccTFEWorkspace_unlock(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceLocked(workspace, false),
+				),
+			},
 		},
 	})
+}
+
+func testAccCheckTFEWorkspaceLocked(
+	workspace *tfe.Workspace, locked bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if workspace.Locked != locked {
+			return fmt.Errorf("Expected workspaces lock status to be %t but got %t name", locked, workspace.Locked)
+		}
+		return nil
+	}
+}
+
+func testAccCheckTFEWorkspaceLockedID(ws, lock string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[ws]
+		if !ok {
+			return fmt.Errorf("Not found: %s", ws)
+		}
+
+		wID := rs.Primary.ID
+
+		if wID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		rs, ok = s.RootModule().Resources[lock]
+		if !ok {
+			return fmt.Errorf("Not found: %s", ws)
+		}
+
+		if wID != rs.Primary.ID {
+			return fmt.Errorf("expected lock ID to be workspace ID %s but got %s", wID, rs.Primary.ID)
+		}
+		if wID != rs.Primary.Attributes["workspace_id"] {
+			return fmt.Errorf("expected lock workspace ID to be workspace ID %s but got %s", wID, rs.Primary.Attributes["workspace_id"])
+		}
+
+		return nil
+	}
 }
 
 func testAccTFEWorkspace_lock(rInt int) string {
@@ -59,6 +105,24 @@ resource "tfe_workspace" "foobar" {
 resource "tfe_workspace_lock" "foobar" {
   workspace_id = tfe_workspace.foobar.id
   reason       = "test"
+}
+`, rInt)
+}
+
+func testAccTFEWorkspace_unlock(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name               = "workspace-test"
+  organization       = tfe_organization.foobar.id
+  description        = "My favorite workspace!"
+  allow_destroy_plan = false
+  auto_apply         = true
+  tag_names          = ["fav", "test"]
 }
 `, rInt)
 }

--- a/website/docs/r/workspace_lock.markdown
+++ b/website/docs/r/workspace_lock.markdown
@@ -1,0 +1,48 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_workspace_lock"
+description: |-
+  Lock Workspace.
+---
+
+# tfe_workspace_lock
+
+[Lock](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#locking) a workspace
+to prevent any runs from happening. When this resource is detroyed, the workspace is unlocked.
+
+## Example Usage
+
+```hcl
+resource "tfe_organization" "test" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "my-workspace-name"
+  organization = tfe_organization.test.name
+}
+
+resource "tfe_workspace_lock" "test" {
+  workspace_id = tfe_workspace.test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `tfe_workspace` - (Required) Workspace ID
+* `reason` - (Optional) Reason for locking the workspace
+
+## Attributes Reference
+
+* `id` - The ID of the Workspace locked.
+
+## Import
+
+Import an existing lock with the workspace ID.
+
+```shell
+terraform import tfe_workspace_lock.test ws-12345
+```


### PR DESCRIPTION
## Description

Add `workspace_lock` resource to lock workspaces.

Fixes #251

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-changelog)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/CONTRIBUTING.md#updating-the-documentation)_

## Testing plan

1. Acceptance test will demonstrate that this works.


## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See TESTS.md to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
TESTARGS="-run TestAccTFEWorkspaceLock_basic" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceLock_basic -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFEWorkspaceLock_basic
--- PASS: TestAccTFEWorkspaceLock_basic (33.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	33.366s
```
