### PR TITLE
Update team project access to include additional project roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 * **New Data Source**: d/tfe_organization_tags is a new data source to allow reading all workspace tags within an organization, by @rhughes1 ([#773](https://github.com/hashicorp/terraform-provider-tfe/pull/773))
 * r/workspace, d/workspace: Add `source_name` and `source_url` to workspaces ([#527](https://github.com/hashicorp/terraform-provider-tfe/pull/527))
 * `r/tfe_team`: Add `read_projects` and `read_workspaces` to the `organization_access` block. ([#796](https://github.com/hashicorp/terraform-provider-tfe/pull/796))
+* r/tfe_team_project_access and d/tfe_team_project_access: Added support for "maintain" and "write" project permissions ([#826](https://github.com/hashicorp/terraform-provider-tfe/pull/826))
 
 ENHANCEMENTS:
 * r/tfe_organization_membership: Organization Memberships can now be imported using `<ORGANIZATION NAME>/<USER EMAIL>` ([#715](https://github.com/hashicorp/terraform-provider-tfe/pull/715))

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/hashicorp/go-slug v0.10.1
-	github.com/hashicorp/go-tfe v1.19.0
+	github.com/hashicorp/go-tfe v1.20.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl/v2 v2.16.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUD
 github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-slug v0.10.1 h1:05SCRWCBpCxOeP7stQHvMgOz0raCBCekaytu8Rg/RZ4=
 github.com/hashicorp/go-slug v0.10.1/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
-github.com/hashicorp/go-tfe v1.19.0 h1:CKSrpUfpH0kTF/rC9qrDkKHNgQVHUqnlmSSLyVgVv5g=
-github.com/hashicorp/go-tfe v1.19.0/go.mod h1:sk16Tskky9E4ywt0DJN8+qalnHuc11EW45+U8+EaZRs=
+github.com/hashicorp/go-tfe v1.20.0 h1:kDxxLbVrhbZiHZp5yN5eIsCCaY2kEU5T9eO1NI8/KRg=
+github.com/hashicorp/go-tfe v1.20.0/go.mod h1:sk16Tskky9E4ywt0DJN8+qalnHuc11EW45+U8+EaZRs=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/tfe/data_source_team_project_access_test.go
+++ b/tfe/data_source_team_project_access_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestAccTFETeamProjectAccessDataSource_basic(t *testing.T) {
-	skipUnlessBeta(t)
-
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)

--- a/tfe/resource_tfe_team_project_access.go
+++ b/tfe/resource_tfe_team_project_access.go
@@ -6,11 +6,12 @@ package tfe
 import (
 	"context"
 	"errors"
+	"log"
+
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
 )
 
 func resourceTFETeamProjectAccess() *schema.Resource {
@@ -32,6 +33,8 @@ func resourceTFETeamProjectAccess() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						string(tfe.TeamProjectAccessAdmin),
+						string(tfe.TeamProjectAccessWrite),
+						string(tfe.TeamProjectAccessMaintain),
 						string(tfe.TeamProjectAccessRead),
 					},
 					false,

--- a/tfe/resource_tfe_team_project_access_test.go
+++ b/tfe/resource_tfe_team_project_access_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccTFETeamProjectAccess_admin(t *testing.T) {
+func TestAccTFETeamProjectAccess(t *testing.T) {
 	tmAccess := &tfe.TeamProjectAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
-	for _, access := range []tfe.TeamProjectAccessType{tfe.TeamProjectAccessAdmin, tfe.TeamProjectAccessRead} {
+	for _, access := range []tfe.TeamProjectAccessType{tfe.TeamProjectAccessAdmin, tfe.TeamProjectAccessMaintain, tfe.TeamProjectAccessWrite, tfe.TeamProjectAccessRead} {
 		resource.Test(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,

--- a/website/docs/r/team_project_access.html.markdown
+++ b/website/docs/r/team_project_access.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `team_id` - (Required) ID of the team to add to the project.
 * `project_id` - (Required) ID of the project to which the team will be added.
-* `access` - (Required) Type of fixed access to grant. Valid values are `admin` or `read`.
+* `access` - (Required) Type of fixed access to grant. Valid values are `admin`, `maintain`, `write`, or `read`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This adds new "maintain" and "write" access levels to the `tfe_team_project_access` resource.

## Testing plan

Sample config:

```
variable "organization" {
  type = string
}

resource "tfe_project" "this" {
  organization = var.organization
  name         = "test project"
}

resource "tfe_team" "maintain" {
  organization = var.organization
  name         = "maintain-team"
}

resource "tfe_team" "write" {
  organization = var.organization
  name         = "write-team"
}

resource "tfe_team_project_access" "maintain" {
  access     = "maintain"
  team_id    = tfe_team.maintain.id
  project_id = tfe_project.this.id
}

resource "tfe_team_project_access" "write" {
  access     = "write"
  team_id    = tfe_team.write.id
  project_id = tfe_project.this.id
}
```

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/project-team-access#project-team-access-levels)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/642)

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFETeamProjectAccess" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFETeamProjectAccess -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFETeamProjectAccessDataSource_basic
    testing.go:184: Skipping test related to a Terraform Cloud/Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFETeamProjectAccessDataSource_basic (0.00s)
=== RUN   TestAccTFETeamProjectAccess
--- PASS: TestAccTFETeamProjectAccess (41.66s)
=== RUN   TestAccTFETeamProjectAccess_import
--- PASS: TestAccTFETeamProjectAccess_import (10.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	53.010s
```
