### PR TITLE
Added some additional guidance around source_url and source_name

### DIFF
--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
    Requires `source_name` to also be set.
    **Note:** The API does not (currently) allow this to be updated after a
    workspace has been created, so modifying this value will result in the
-   workspace being replaced.
+   workspace being replaced. To disable this, use an [ignore changee](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) lifecycle meta-argument
 * `speculative_enabled` - (Optional) Whether this workspace allows speculative
   plans. Defaults to `true`. Setting this to `false` prevents Terraform Cloud
   or the Terraform Enterprise instance from running plans on pull requests,


### PR DESCRIPTION
Given that you can't update these in-place, any changes to these parameters will result in the workspace being destroyed then recreated.

Probably most people do not want to do that, so an ignore_changes lifecycle meta-argument is a good idea.
