### PR TITLE
Only set `oauth_token_id` and `github_app_installation_id` if configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 ENHANCEMENTS:
 
 BUG FIXES:
+* `r/tfe_workspace`: Only set `oauth_token_id` and `github_app_installation_id` if configured, by @moensch ([#835](https://github.com/hashicorp/terraform-provider-tfe/issues/834))
 
 ## v0.43.0 (March 23, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
 ENHANCEMENTS:
 
 BUG FIXES:
-* `r/tfe_workspace`: Only set `oauth_token_id` and `github_app_installation_id` if configured, by @moensch ([#835](https://github.com/hashicorp/terraform-provider-tfe/issues/834))
+* `r/tfe_workspace`: Only set `oauth_token_id` and `github_app_installation_id` if configured, by @moensch ([#835](https://github.com/hashicorp/terraform-provider-tfe/pull/835))
 
 ## v0.43.0 (March 23, 2023)
 

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -364,9 +364,17 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		options.VCSRepo = &tfe.VCSRepoOptions{
 			Identifier:        tfe.String(vcsRepo["identifier"].(string)),
 			IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
-			OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
-			GHAInstallationID: tfe.String(vcsRepo["github_app_installation_id"].(string)),
 			TagsRegex:         tfe.String(vcsRepo["tags_regex"].(string)),
+		}
+
+		// Only set the oauth_token_id if it is configured.
+		if oauth_token_id, ok := vcsRepo["oauth_token_id"].(string); ok && oauth_token_id != "" {
+			options.VCSRepo.OAuthTokenID = tfe.String(oauth_token_id)
+		}
+
+		// Only set the github_app_installation_id if it is configured.
+		if github_app_installation_id, ok := vcsRepo["github_app_installation_id"].(string); ok && github_app_installation_id != "" {
+			options.VCSRepo.GHAInstallationID = tfe.String(github_app_installation_id)
 		}
 
 		// Only set the branch if one is configured.

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -368,13 +368,13 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		// Only set the oauth_token_id if it is configured.
-		if oauth_token_id, ok := vcsRepo["oauth_token_id"].(string); ok && oauth_token_id != "" {
-			options.VCSRepo.OAuthTokenID = tfe.String(oauth_token_id)
+		if oauthTokenID, ok := vcsRepo["oauth_token_id"].(string); ok && oauthTokenID != "" {
+			options.VCSRepo.OAuthTokenID = tfe.String(oauthTokenID)
 		}
 
 		// Only set the github_app_installation_id if it is configured.
-		if github_app_installation_id, ok := vcsRepo["github_app_installation_id"].(string); ok && github_app_installation_id != "" {
-			options.VCSRepo.GHAInstallationID = tfe.String(github_app_installation_id)
+		if ghaInstallationID, ok := vcsRepo["github_app_installation_id"].(string); ok && ghaInstallationID != "" {
+			options.VCSRepo.GHAInstallationID = tfe.String(ghaInstallationID)
 		}
 
 		// Only set the branch if one is configured.


### PR DESCRIPTION
fixes #834

## Description

Address #834 - only set `oauth_token_id` and `github_app_installation_id` if configured. Before this change, they'd be set to an empty string.

* [x] changelog updated
* [x] No documentation change needed


## Testing plan

1.  Make a new `tfe_workspace` with `vcs_repo.oauth_token_id` explicitly set to `null`
1.  Run terraform apply in trace mode
1.  Observe apply operation fail
1.  Observe JSON POST request containing `"oauth-token-id": "",`, instead of the expected `"oauth-token-id": null,`

## External links

- Related PR where this feature was first introduced: [808](https://github.com/hashicorp/terraform-provider-tfe/pull/808)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
