### PR TITLE
Add Optional Expiry to Auth Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ FEATURES:
 * `r/tfe_team`: Add attribute `manage_membership` to `organization_access` on `tfe_team` by @JarrettSpiker ([#801](https://github.com/hashicorp/terraform-provider-tfe/pull/801))
 * **New Resource**: `r/tfe_workspace_run` manages create and destroy lifecycles in a workspace, by @uk1288 ([#786](https://github.com/hashicorp/terraform-provider-tfe/pull/786))
 * `r/tfe_variable`: Add a `readable_value` attribute, which will provide an un-redacted representation of the variable's value in plan outputs if the variable is not sensitive, and which may be referenced by downstream resources by @JarrettSpiker ([#801](https://github.com/hashicorp/terraform-provider-tfe/pull/867))
+* `r/tfe_organization_token`: Add optional `expired_at` field to organization tokens by, @juliannatetreault ([#844](https://github.com/hashicorp/terraform-provider-tfe/pull/844))
+* `r/tfe_team_token`: Add optional `expired_at` field to team tokens by, @juliannatetreault ([#844](https://github.com/hashicorp/terraform-provider-tfe/pull/844))
 
 ENHANCEMENTS:
 
@@ -14,10 +16,6 @@ BUG FIXES:
 * `r/tfe_variable`: Don't silently erase or override the `value` of a sensitive variable on changes to other attributes when `ignore_changes = [value]` is set, by @nfagerlund ([#873](https://github.com/hashicorp/terraform-provider-tfe/pull/873), fixing issue [#839](https://github.com/hashicorp/terraform-provider-tfe/issues/839))
 
 ## v0.44.1 (April 21, 2023)
-
-FEATURES:
-* `r/tfe_organization_token`: Add optional `expired_at` field to organization tokens by, @juliannatetreault ([#844](https://github.com/hashicorp/terraform-provider-tfe/pull/844))
-* `r/tfe_team_token`: Add optional `expired_at` field to team tokens by, @juliannatetreault ([#844](https://github.com/hashicorp/terraform-provider-tfe/pull/844))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ BUG FIXES:
 
 ## v0.44.1 (April 21, 2023)
 
+FEATURES:
+* `r/tfe_organization_token`: Add optional `expired_at` field to organization tokens by, @juliannatetreault ([#844](https://github.com/hashicorp/terraform-provider-tfe/pull/844))
+* `r/tfe_team_token`: Add optional `expired_at` field to team tokens by, @juliannatetreault ([#844](https://github.com/hashicorp/terraform-provider-tfe/pull/844))
+
 BUG FIXES:
 
 * Fixed a documentation bug in the new `r/tfe_no_code_module` resource, incorrectly labelling the attribute `registry_module` as `module`

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -78,13 +78,11 @@ func resourceTFEOrganizationTokenCreate(d *schema.ResourceData, meta interface{}
 	options := tfe.OrganizationTokenCreateOptions{}
 
 	// Check whether the optional expiry was provided.
-	_, expiredAtProvided := d.GetOk("expired_at")
+	expiredAt, expiredAtProvided := d.GetOk("expired_at")
 
 	// If an expiry was provided, parse it and update the options struct.
 	if expiredAtProvided {
-		expiredAt := d.Get("expired_at").(string)
-
-		expiry, err := time.Parse(time.RFC3339, expiredAt)
+		expiry, err := time.Parse(time.RFC3339, expiredAt.(string))
 
 		options.ExpiredAt = &expiry
 

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -73,6 +73,7 @@ func resourceTFEOrganizationTokenCreate(d *schema.ResourceData, meta interface{}
 		}
 		log.Printf("[DEBUG] Regenerating existing token for organization: %s", organization)
 	}
+
 	if err != nil {
 		expiredAt := d.Get("expired_at").(string)
 		return fmt.Errorf("%s must be a valid date or time", expiredAt)

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -41,6 +41,12 @@ func resourceTFEOrganizationToken() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+
+			"expired_at": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -66,6 +72,10 @@ func resourceTFEOrganizationTokenCreate(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("a token already exists for organization: %s", organization)
 		}
 		log.Printf("[DEBUG] Regenerating existing token for organization: %s", organization)
+	}
+	if err != nil {
+		expiredAt := d.Get("expired_at").(string)
+		return fmt.Errorf("%s must be a valid date or time", expiredAt)
 	}
 
 	token, err := config.Client.OrganizationTokens.Create(ctx, organization)

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -102,7 +102,6 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	expiredAt := "null"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -115,7 +114,7 @@ func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.expiry", "expired_at", expiredAt),
+						"tfe_organization_token.expiry", "expired_at", ""),
 				),
 			},
 		},
@@ -287,7 +286,6 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_organization_token" "foobar" {
   organization = tfe_organization.foobar.id
-  expired_at = null
 }
 
 resource "tfe_organization_token" "error" {

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -125,7 +125,7 @@ func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 func TestAccTFEOrganizationToken_existsWithExpiry(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	expiredAt := "2051-04-11T23:15:59+00:00"
+	expiredAt := "2051-04-11T23:15:59Z"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -308,7 +308,7 @@ resource "tfe_organization_token" "foobar" {
 
 resource "tfe_organization_token" "expiry" {
   organization  = tfe_organization.foobar.id
-  expired_at 	= "2051-04-11T23:15:59+00:00"
+  expired_at 	= "2051-04-11T23:15:59Z"
 }`, rInt)
 }
 

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -110,7 +110,7 @@ func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganizationToken_basic(rInt),
+				Config: testAccTFEOrganizationToken_existsWithoutExpiry(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -118,11 +118,6 @@ func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 						"tfe_organization_token.foobar", "organization", orgName),
 				),
 			},
-
-			{
-				Config:      testAccTFEOrganizationToken_existsWithoutExpiry(rInt),
-				ExpectError: regexp.MustCompile(`must be a valid date or time`),
-			},
 		},
 	})
 }
@@ -130,7 +125,7 @@ func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 func TestAccTFEOrganizationToken_existsWithExpiry(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	expiredAt := fmt.Sprintf("2051-04-11T23:15:59+00:00")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -138,22 +133,12 @@ func TestAccTFEOrganizationToken_existsWithExpiry(t *testing.T) {
 		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganizationToken_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEOrganizationTokenExists(
-						"tfe_organization_token.foobar", token),
-					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", orgName),
-				),
-			},
-
-			{
 				Config: testAccTFEOrganizationToken_existsWithExpiry(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.expiry", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.expiry", "organization", orgName),
+						"tfe_organization_token.expiry", "expired_at", expiredAt),
 				),
 			},
 		},

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -99,6 +99,67 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 	})
 }
 
+func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
+	token := &tfe.OrganizationToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEOrganizationToken_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEOrganizationTokenExists(
+						"tfe_organization_token.foobar", token),
+					resource.TestCheckResourceAttr(
+						"tfe_organization_token.foobar", "organization", orgName),
+				),
+			},
+
+			{
+				Config:      testAccTFEOrganizationToken_existsWithoutExpiry(rInt),
+				ExpectError: regexp.MustCompile(`must be a valid date or time`),
+			},
+		},
+	})
+}
+
+func TestAccTFEOrganizationToken_existsWithExpiry(t *testing.T) {
+	token := &tfe.OrganizationToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEOrganizationToken_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEOrganizationTokenExists(
+						"tfe_organization_token.foobar", token),
+					resource.TestCheckResourceAttr(
+						"tfe_organization_token.foobar", "organization", orgName),
+				),
+			},
+
+			{
+				Config: testAccTFEOrganizationToken_existsWithExpiry(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEOrganizationTokenExists(
+						"tfe_organization_token.expiry", token),
+					resource.TestCheckResourceAttr(
+						"tfe_organization_token.expiry", "organization", orgName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFEOrganizationToken_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -213,5 +274,38 @@ resource "tfe_organization_token" "foobar" {
 resource "tfe_organization_token" "regenerated" {
   organization     = tfe_organization.foobar.id
   force_regenerate = true
+}`, rInt)
+}
+
+func testAccTFEOrganizationToken_existsWithoutExpiry(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_organization_token" "foobar" {
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_organization_token" "error" {
+  organization = tfe_organization.foobar.id
+}`, rInt)
+}
+
+func testAccTFEOrganizationToken_existsWithExpiry(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_organization_token" "foobar" {
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_organization_token" "expiry" {
+  organization  = tfe_organization.foobar.id
+  expired_at 	= "04/11/2051"
 }`, rInt)
 }

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -102,7 +102,7 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	expiredAt := "null"
+	expiredAt := ""
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -287,7 +287,7 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_organization_token" "foobar" {
   organization = tfe_organization.foobar.id
-  expired_at = "null"
+  expired_at = ""
 }
 
 resource "tfe_organization_token" "error" {

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -102,6 +102,7 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	expiredAt := "null"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -114,7 +115,7 @@ func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.expiry", "expired_at", ""),
+						"tfe_organization_token.foobar", "expired_at", expiredAt),
 				),
 			},
 		},
@@ -286,6 +287,7 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_organization_token" "foobar" {
   organization = tfe_organization.foobar.id
+  expired_at = "null"
 }
 
 resource "tfe_organization_token" "error" {

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -306,6 +306,6 @@ resource "tfe_organization_token" "foobar" {
 
 resource "tfe_organization_token" "expiry" {
   organization  = tfe_organization.foobar.id
-  expired_at 	= "04/11/2051"
+  expired_at 	= "2051-04-11T23:15:59+00:00"
 }`, rInt)
 }

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -125,7 +125,7 @@ func TestAccTFEOrganizationToken_existsWithoutExpiry(t *testing.T) {
 func TestAccTFEOrganizationToken_existsWithExpiry(t *testing.T) {
 	token := &tfe.OrganizationToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	expiredAt := fmt.Sprintf("2051-04-11T23:15:59+00:00")
+	expiredAt := "2051-04-11T23:15:59+00:00"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/tfe/resource_tfe_team_token.go
+++ b/tfe/resource_tfe_team_token.go
@@ -74,13 +74,11 @@ func resourceTFETeamTokenCreate(d *schema.ResourceData, meta interface{}) error 
 	options := tfe.TeamTokenCreateOptions{}
 
 	// Check whether the optional expiry was provided.
-	_, expiredAtProvided := d.GetOk("expired_at")
+	expiredAt, expiredAtProvided := d.GetOk("expired_at")
 
 	// If an expiry was provided, parse it and update the options struct.
 	if expiredAtProvided {
-		expiredAt := d.Get("expired_at").(string)
-
-		expiry, err := time.Parse(time.RFC3339, expiredAt)
+		expiry, err := time.Parse(time.RFC3339, expiredAt.(string))
 
 		options.ExpiredAt = &expiry
 

--- a/tfe/resource_tfe_team_token.go
+++ b/tfe/resource_tfe_team_token.go
@@ -40,6 +40,12 @@ func resourceTFETeamToken() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+
+			"expired_at": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -62,6 +68,11 @@ func resourceTFETeamTokenCreate(d *schema.ResourceData, meta interface{}) error 
 			return fmt.Errorf("a token already exists for team: %s", teamID)
 		}
 		log.Printf("[DEBUG] Regenerating existing token for team: %s", teamID)
+	}
+
+	if err != nil {
+		expiredAt := d.Get("expired_at").(string)
+		return fmt.Errorf("%s must be a valid date or time", expiredAt)
 	}
 
 	log.Printf("[DEBUG] Create new token for team: %s", teamID)

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -91,6 +91,7 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 	token := &tfe.TeamToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	expiredAt := "null"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -103,7 +104,7 @@ func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_team_token.expiry", "expired_at", ""),
+						"tfe_team_token.expiry", "expired_at", expiredAt),
 				),
 			},
 		},
@@ -126,7 +127,7 @@ func TestAccTFETeamToken_existsWithExpiry(t *testing.T) {
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.expiry", token),
 					resource.TestCheckResourceAttr(
-						"tfe_team_token.expiry", "expired_at", expiredAt),
+						"tfe_team_token.foobar", "expired_at", expiredAt),
 				),
 			},
 		},
@@ -295,6 +296,7 @@ resource "tfe_team" "foobar" {
 
 resource "tfe_team_token" "foobar" {
   team_id = tfe_team.foobar.id
+  expired_at = "null"
 }
 
 resource "tfe_team_token" "error" {

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -98,7 +98,7 @@ func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamToken_basic(rInt),
+				Config: testAccTFETeamToken_existsWithoutExpiry(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -104,7 +104,7 @@ func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_team_token.expiry", "expired_at", expiredAt),
+						"tfe_team_token.foobar", "expired_at", expiredAt),
 				),
 			},
 		},
@@ -127,7 +127,7 @@ func TestAccTFETeamToken_existsWithExpiry(t *testing.T) {
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.expiry", token),
 					resource.TestCheckResourceAttr(
-						"tfe_team_token.foobar", "expired_at", expiredAt),
+						"tfe_team_token.expiry", "expired_at", expiredAt),
 				),
 			},
 		},

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -104,11 +104,6 @@ func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 						"tfe_team_token.foobar", token),
 				),
 			},
-
-			{
-				Config:      testAccTFETeamToken_existsWithoutForce(rInt),
-				ExpectError: regexp.MustCompile(`must be a valid date or time`),
-			},
 		},
 	})
 }
@@ -116,6 +111,7 @@ func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 func TestAccTFETeamToken_existsWithExpiry(t *testing.T) {
 	token := &tfe.TeamToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	expiredAt := fmt.Sprintf("2051-04-11T23:15:59+00:00")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -123,18 +119,12 @@ func TestAccTFETeamToken_existsWithExpiry(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamToken_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFETeamTokenExists(
-						"tfe_team_token.foobar", token),
-				),
-			},
-
-			{
-				Config: testAccTFETeamToken_existsWithForce(rInt),
+				Config: testAccTFETeamToken_existsWithExpiry(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.expiry", token),
+					resource.TestCheckResourceAttr(
+						"tfe_team_token.expiry", "expired_at", expiredAt),
 				),
 			},
 		},

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -114,7 +114,7 @@ func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 func TestAccTFETeamToken_existsWithExpiry(t *testing.T) {
 	token := &tfe.TeamToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	expiredAt := "2051-04-11T23:15:59+00:00"
+	expiredAt := "2051-04-11T23:15:59Z"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -322,7 +322,7 @@ resource "tfe_team_token" "foobar" {
 
 resource "tfe_team_token" "expiry" {
   team_id    = tfe_team.foobar.id
-  expired_at = "2051-04-11T23:15:59+00:00"
+  expired_at = "2051-04-11T23:15:59Z"
 }`, rInt)
 }
 

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -111,7 +111,7 @@ func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 func TestAccTFETeamToken_existsWithExpiry(t *testing.T) {
 	token := &tfe.TeamToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	expiredAt := fmt.Sprintf("2051-04-11T23:15:59+00:00")
+	expiredAt := "2051-04-11T23:15:59+00:00"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -91,7 +91,7 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 	token := &tfe.TeamToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	expiredAt := "null"
+	expiredAt := ""
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -296,7 +296,7 @@ resource "tfe_team" "foobar" {
 
 resource "tfe_team_token" "foobar" {
   team_id = tfe_team.foobar.id
-  expired_at = "null"
+  expired_at = ""
 }
 
 resource "tfe_team_token" "error" {

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -88,6 +88,59 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
+	token := &tfe.TeamToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamToken_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamTokenExists(
+						"tfe_team_token.foobar", token),
+				),
+			},
+
+			{
+				Config:      testAccTFETeamToken_existsWithoutForce(rInt),
+				ExpectError: regexp.MustCompile(`must be a valid date or time`),
+			},
+		},
+	})
+}
+
+func TestAccTFETeamToken_existsWithExpiry(t *testing.T) {
+	token := &tfe.TeamToken{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamToken_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamTokenExists(
+						"tfe_team_token.foobar", token),
+				),
+			},
+
+			{
+				Config: testAccTFETeamToken_existsWithForce(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamTokenExists(
+						"tfe_team_token.expiry", token),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFETeamToken_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -217,5 +270,48 @@ resource "tfe_team_token" "foobar" {
 resource "tfe_team_token" "regenerated" {
   team_id          = tfe_team.foobar.id
   force_regenerate = true
+}`, rInt)
+}
+
+func testAccTFETeamToken_existsWithoutExpiry(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar" {
+  name         = "team-test"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_team_token" "foobar" {
+  team_id = tfe_team.foobar.id
+}
+
+resource "tfe_team_token" "error" {
+  team_id = tfe_team.foobar.id
+}`, rInt)
+}
+
+func testAccTFETeamToken_existsWithExpiry(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar" {
+  name         = "team-test"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_team_token" "foobar" {
+  team_id = tfe_team.foobar.id
+}
+
+resource "tfe_team_token" "expiry" {
+  team_id    = tfe_team.foobar.id
+  expired_at = "04/11/2051"
 }`, rInt)
 }

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -296,7 +296,7 @@ resource "tfe_team" "foobar" {
 
 resource "tfe_team_token" "foobar" {
   team_id = tfe_team.foobar.id
-  expired_at = "null"
+  expired_at = null
 }
 
 resource "tfe_team_token" "error" {

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -91,7 +91,6 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 	token := &tfe.TeamToken{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	expiredAt := "null"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -104,7 +103,7 @@ func TestAccTFETeamToken_existsWithoutExpiry(t *testing.T) {
 					testAccCheckTFETeamTokenExists(
 						"tfe_team_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_team_token.expiry", "expired_at", expiredAt),
+						"tfe_team_token.expiry", "expired_at", ""),
 				),
 			},
 		},
@@ -296,7 +295,6 @@ resource "tfe_team" "foobar" {
 
 resource "tfe_team_token" "foobar" {
   team_id = tfe_team.foobar.id
-  expired_at = null
 }
 
 resource "tfe_team_token" "error" {

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -312,6 +312,6 @@ resource "tfe_team_token" "foobar" {
 
 resource "tfe_team_token" "expiry" {
   team_id    = tfe_team.foobar.id
-  expired_at = "04/11/2051"
+  expired_at = "2051-04-11T23:15:59+00:00"
 }`, rInt)
 }

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -28,19 +28,13 @@ The following arguments are supported:
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!
-* `expired_at` - (Optional) A date and time in which the organization token will expire. The expiration date must be passed in
-  iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
-
-## Attributes Reference
-
-* `id` - The ID of the token.
-* `token` - The generated token.
-* `expired_at` - The token's expiration date. The expiration date must be passed in
-iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
+* `expired_at` - (Optional) The token's expiration date. The expiration date must be a date/time string in RFC3339 
+format (e.g., "2024-12-31T23:59:59Z"). If no expiration date is supplied, the expiration date will default to null and 
+never expire.
 
 ## Example Usage
 
-Basic usage:
+When a token has an expiry:
 
 ```hcl
 resource "tfe_organization_token" "test" {
@@ -56,6 +50,11 @@ resource "tfe_organization_token" "test" {
   expired_at = time_rotating.example.id
 }
 ```
+
+## Attributes Reference
+
+* `id` - The ID of the token.
+* `token` - The generated token.
 
 ## Import
 

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!
+* `expired_at` - (Optional) A date and time in which the organization token will expire.
 
 ## Attributes Reference
 

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -28,7 +28,19 @@ The following arguments are supported:
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!
-* `expired_at` - (Optional) A date and time in which the organization token will expire.
+* `expired_at` - (Optional) A date and time in which the organization token will expire. The expiration date must be passed in
+  iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_organization_token" "test" {
+  organization = "my-org-name"
+  expired_at = "2051-04-11T23:15:59+00:00"
+}
+```
 
 ## Attributes Reference
 

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -31,6 +31,13 @@ The following arguments are supported:
 * `expired_at` - (Optional) A date and time in which the organization token will expire. The expiration date must be passed in
   iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
 
+## Attributes Reference
+
+* `id` - The ID of the token.
+* `token` - The generated token.
+* `expired_at` - The token's expiration date. The expiration date must be passed in
+iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
+
 ## Example Usage
 
 Basic usage:
@@ -49,28 +56,6 @@ resource "tfe_organization_token" "test" {
   expired_at = time_rotating.example.id
 }
 ```
-
-Generating the `expired_at` string using the date tool in unix systems (darwin):
-```
-date -Iseconds -v"+30d"
-```
-
-Generating the `expired_at` string using the date tool in unix systems (linux):
-```
-date -Iseconds -d"+30 days"
-```
-
-Generating the `expired_at` string using the `timeadd` Terraform function:
-```
-$ terraform console
-> timeadd(timestamp(), "720h")
-"2023-07-21T02:02:23Z"
-```
-
-## Attributes Reference
-
-* `id` - The ID of the token.
-* `token` - The generated token.
 
 ## Import
 

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -38,8 +38,33 @@ Basic usage:
 ```hcl
 resource "tfe_organization_token" "test" {
   organization = "my-org-name"
-  expired_at = "2051-04-11T23:15:59+00:00"
 }
+
+resource "time_rotating" "example" {
+  rotation_days = 30
+}
+
+resource "tfe_organization_token" "test" {
+  organization = data.tfe_organization.org.name
+  expired_at = time_rotating.example.id
+}
+```
+
+Generating the `expired_at` string using the date tool in unix systems (darwin):
+```
+date -Iseconds -v"+30d"
+```
+
+Generating the `expired_at` string using the date tool in unix systems (linux):
+```
+date -Iseconds -d"+30 days"
+```
+
+Generating the `expired_at` string using the `timeadd` Terraform function:
+```
+$ terraform console
+> timeadd(timestamp(), "720h")
+"2023-07-21T02:02:23Z"
 ```
 
 ## Attributes Reference

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -37,17 +37,13 @@ never expire.
 When a token has an expiry:
 
 ```hcl
-resource "tfe_organization_token" "test" {
-  organization = "my-org-name"
-}
-
 resource "time_rotating" "example" {
   rotation_days = 30
 }
 
 resource "tfe_organization_token" "test" {
   organization = data.tfe_organization.org.name
-  expired_at = time_rotating.example.id
+  expired_at = time_rotating.example.rotation_rfc3339
 }
 ```
 

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -35,6 +35,13 @@ The following arguments are supported:
 * `expired_at` - (Optional) A date and time in which the team token will expire. The expiration date must be passed in
 iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
 
+## Attributes Reference
+
+* `id` - The ID of the token.
+* `token` - The generated token.
+* `expired_at` - The token's expiration date. The expiration date must be passed in
+iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
+
 ## Example Usage
 
 Basic usage:
@@ -53,28 +60,6 @@ resource "tfe_team_token" "test" {
   expired_at = time_rotating.example.id
 }
 ```
-
-Generating the `expired_at` string using the date tool in unix systems (darwin):
-```
-date -Iseconds -v"+30d"
-```
-
-Generating the `expired_at` string using the date tool in unix systems (linux):
-```
-date -Iseconds -d"+30 days"
-```
-
-Generating the `expired_at` string using the `timeadd` Terraform function:
-```
-$ terraform console
-> timeadd(timestamp(), "720h")
-"2023-07-21T02:02:23Z"
-```
-
-## Attributes Reference
-
-* `id` - The ID of the token.
-* `token` - The generated token.
 
 ## Import
 

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -40,7 +40,7 @@ iso8601 format. If no expiration date is supplied, the expiration date will defa
 Basic usage:
 
 ```hcl
-resource "tfe_team" "test" {
+resource "tfe_team_token" "test" {
   name         = "my-team-name"
   organization = "my-org-name"
   expired_at = "2051-04-11T23:15:59+00:00"

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!
+* * `expired_at` - (Optional) A date and time in which the team token will expire.
 
 ## Attributes Reference
 

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -52,7 +52,7 @@ resource "time_rotating" "example" {
 
 resource "tfe_team_token" "test" {
   team_id = tfe_team.test.id
-  expired_at = time_rotating.example.id
+  expired_at = time_rotating.example.rotation_rfc3339
 }
 ```
 

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -41,8 +41,7 @@ Basic usage:
 
 ```hcl
 resource "tfe_team_token" "test" {
-  name         = "my-team-name"
-  organization = "my-org-name"
+  team_id = "team-id"
   expired_at = "2051-04-11T23:15:59+00:00"
 }
 ```

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -32,7 +32,20 @@ The following arguments are supported:
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!
-* * `expired_at` - (Optional) A date and time in which the team token will expire.
+* `expired_at` - (Optional) A date and time in which the team token will expire. The expiration date must be passed in
+iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_team" "test" {
+  name         = "my-team-name"
+  organization = "my-org-name"
+  expired_at = "2051-04-11T23:15:59+00:00"
+}
+```
 
 ## Attributes Reference
 

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -32,19 +32,14 @@ The following arguments are supported:
 * `force_regenerate` - (Optional) If set to `true`, a new token will be
   generated even if a token already exists. This will invalidate the existing
   token!
-* `expired_at` - (Optional) A date and time in which the team token will expire. The expiration date must be passed in
-iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
-
-## Attributes Reference
-
-* `id` - The ID of the token.
-* `token` - The generated token.
-* `expired_at` - The token's expiration date. The expiration date must be passed in
-iso8601 format. If no expiration date is supplied, the expiration date will default to null and never expire.
+* `expired_at` - (Optional) The token's expiration date. The expiration date must be a date/time string in RFC3339 
+format (e.g., "2024-12-31T23:59:59Z"). If no expiration date is supplied, the expiration date will default to null and 
+never expire.
 
 ## Example Usage
 
-Basic usage:
+When a token has an expiry:
+
 ```hcl
 resource "tfe_team" "test" {
   name         = "my-team-name"
@@ -60,6 +55,11 @@ resource "tfe_team_token" "test" {
   expired_at = time_rotating.example.id
 }
 ```
+
+## Attributes Reference
+
+* `id` - The ID of the token.
+* `token` - The generated token.
 
 ## Import
 

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -38,12 +38,37 @@ iso8601 format. If no expiration date is supplied, the expiration date will defa
 ## Example Usage
 
 Basic usage:
-
 ```hcl
-resource "tfe_team_token" "test" {
-  team_id = "team-id"
-  expired_at = "2051-04-11T23:15:59+00:00"
+resource "tfe_team" "test" {
+  name         = "my-team-name"
+  organization = "my-org-name"
 }
+
+resource "time_rotating" "example" {
+  rotation_days = 30
+}
+
+resource "tfe_team_token" "test" {
+  team_id = tfe_team.test.id
+  expired_at = time_rotating.example.id
+}
+```
+
+Generating the `expired_at` string using the date tool in unix systems (darwin):
+```
+date -Iseconds -v"+30d"
+```
+
+Generating the `expired_at` string using the date tool in unix systems (linux):
+```
+date -Iseconds -d"+30 days"
+```
+
+Generating the `expired_at` string using the `timeadd` Terraform function:
+```
+$ terraform console
+> timeadd(timestamp(), "720h")
+"2023-07-21T02:02:23Z"
 ```
 
 ## Attributes Reference


### PR DESCRIPTION
## Description
Allow an optional `expired_at` to be set on authentication API tokens via the provider.

## Testing plan

- Ensure that organization and team API tokens that omit the optional `expired_at` field still work as expected.
- Ensure that an `expired_at` can be set on organization and team API tokens and that once set, the expiration date displays in the UI (`/app/org-name/authentication-tokens`) with the expiration date that was provided.
- Ensure that an invalid `expired_at` cannot be set on organization and team API tokens and that if attempted to be set, an error is returned.

## External links

- [Related go-tfe PR](https://github.com/hashicorp/go-tfe/pull/672)
- [API documentation](https://github.com/hashicorp/terraform-docs-common/pull/321)

## Output from acceptance tests

#### `resource_tfe_organization_token_test.go` results:

```
=== RUN   TestAccTFEOrganizationToken_basic
--- PASS: TestAccTFEOrganizationToken_basic (8.99s)
PASS

Process finished with the exit code 0
...
=== RUN   TestAccTFEOrganizationToken_existsWithoutExpiry
--- PASS: TestAccTFEOrganizationToken_existsWithoutExpiry (18.02s)
PASS

Process finished with the exit code 0
...

=== RUN   TestAccTFEOrganizationToken_existsWithExpiry
--- PASS: TestAccTFEOrganizationToken_existsWithExpiry (9.48s)
PASS

Process finished with the exit code 0
```

#### `resource_tfe_team_token_test.go` results:

```
=== RUN   TestAccTFETeamToken_basic
--- PASS: TestAccTFETeamToken_basic (10.22s)
PASS

Process finished with the exit code 0
...
=== RUN   TestAccTFETeamToken_existsWithoutExpiry
--- PASS: TestAccTFETeamToken_existsWithoutExpiry (10.95s)
PASS

Process finished with the exit code 0
...
=== RUN   TestAccTFETeamToken_existsWithExpiry
--- PASS: TestAccTFETeamToken_existsWithExpiry (10.51s)
PASS

Process finished with the exit code 0
```
