### PR TITLE
TF-5353 Remove beta flag from project varsets tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ FEATURES:
 * `r/tfe_team`: Add attribute `manage_membership` to `organization_access` on `tfe_team` by @JarrettSpiker ([#801](https://github.com/hashicorp/terraform-provider-tfe/pull/801))
 
 ENHANCEMENTS:
-* Remove beta flag from `r/tfe_project_variable_set` test. Feature now generally available.
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * `r/tfe_team`: Add attribute `manage_membership` to `organization_access` on `tfe_team` by @JarrettSpiker ([#801](https://github.com/hashicorp/terraform-provider-tfe/pull/801))
 
 ENHANCEMENTS:
+* Remove beta flag from `r/tfe_project_variable_set` test. Feature now generally available.
 
 BUG FIXES:
 

--- a/tfe/resource_tfe_project_variable_set_test.go
+++ b/tfe/resource_tfe_project_variable_set_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestAccTFEProjectVariableSet_basic(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	tfeClient, err := getClientUsingEnv()


### PR DESCRIPTION
## Description

Remove beta flag from tfe_project_variable_set test.

I think that this is actually reliant on the feature flag being removed from Atlas first in this pr: https://github.com/hashicorp/atlas/pull/15420
I will run the tests again, once that is merged.

## Testing plan

1. Only test change; tests should pass.
