### PR TITLE
Fix flaky TestAccTFEProjectDataSource_basic

### DIFF
--- a/tfe/data_source_project_test.go
+++ b/tfe/data_source_project_test.go
@@ -51,6 +51,10 @@ resource "tfe_project" "foobar" {
 data "tfe_project" "foobar" {
   name         = tfe_project.foobar.name
   organization = tfe_project.foobar.organization
+  # Read the data source after creating the workspace, so counts match
+  depends_on = [
+	tfe_workspace.foobar
+  ]
 }
 
 resource "tfe_workspace" "foobar" {


### PR DESCRIPTION
## Description

This new test is flaky, because it tests the effect of the workspace resource on the project data source, but doesn't ensure that the workspace resource is processed first. Simple enough: just do that. 

## Testing plan

1.  Test passes.

## Output from acceptance tests

```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEProjectDataSource_basic -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEProjectDataSource_basic
--- PASS: TestAccTFEProjectDataSource_basic (18.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	18.409s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```
