### PR TITLE
Add a readable_value attribute to tfe_variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BREAKING CHANGES:
 FEATURES:
 * `r/tfe_team`: Add attribute `manage_membership` to `organization_access` on `tfe_team` by @JarrettSpiker ([#801](https://github.com/hashicorp/terraform-provider-tfe/pull/801))
 * **New Resource**: `r/tfe_workspace_run` manages create and destroy lifecycles in a workspace, by @uk1288 ([#786](https://github.com/hashicorp/terraform-provider-tfe/pull/786))
+* `r/tfe_variable`: Add a `readable_value` attribute, which will provide an un-redacted representation of the variable's value in plan outputs if the variable is not sensitive, and which may be referenced by downstream resources by @JarrettSpiker ([#801](https://github.com/hashicorp/terraform-provider-tfe/pull/867))
 
 ENHANCEMENTS:
 

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -234,7 +234,7 @@ func (r *resourceTFEVariable) Schema(ctx context.Context, req resource.SchemaReq
 			"readable_value": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
-				Description: "A non-sensitive read-only copy of the variable value, which can be viewed or references " +
+				Description: "A non-sensitive read-only copy of the variable value, which can be viewed or referenced " +
 					"in plan outputs without being redacted. Will only be present if the variable is not sensitive",
 				PlanModifiers: []planmodifier.String{
 					&updateReadableValuePlanModifier{},

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -40,6 +40,7 @@ type modelTFEVariable struct {
 	ID            types.String `tfsdk:"id"`
 	Key           types.String `tfsdk:"key"`
 	Value         types.String `tfsdk:"value"`
+	ReadableValue types.String `tfsdk:"readable_value"`
 	Category      types.String `tfsdk:"category"`
 	Description   types.String `tfsdk:"description"`
 	HCL           types.Bool   `tfsdk:"hcl"`
@@ -67,6 +68,9 @@ func modelFromTFEVariable(v tfe.Variable, lastValue types.String) modelTFEVariab
 	// instead, because the API never lets us read it again.
 	if v.Sensitive {
 		m.Value = lastValue
+		m.ReadableValue = types.StringNull()
+	} else {
+		m.ReadableValue = m.Value
 	}
 	return m
 }
@@ -91,6 +95,9 @@ func modelFromTFEVariableSetVariable(v tfe.VariableSetVariable, lastValue types.
 	// instead, because the API never lets us read it again.
 	if v.Sensitive {
 		m.Value = lastValue
+		m.ReadableValue = types.StringNull()
+	} else {
+		m.ReadableValue = m.Value
 	}
 	return m
 }
@@ -222,6 +229,15 @@ func (r *resourceTFEVariable) Schema(ctx context.Context, req resource.SchemaReq
 						variableSetIDRegexp,
 						"must be a valid variable set ID (varset-<RANDOM STRING>)",
 					),
+				},
+			},
+			"readable_value": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Description: "A non-sensitive read-only copy of the variable value, which can be viewed or references " +
+					"in plan outputs without being redacted. Will only be present if the variable is not sensitive",
+				PlanModifiers: []planmodifier.String{
+					&updateReadableValuePlanModifier{},
 				},
 			},
 		},
@@ -707,11 +723,46 @@ func (r *resourceTFEVariable) ImportState(ctx context.Context, req resource.Impo
 	resp.Diagnostics.Append(diags...)
 }
 
+type updateReadableValuePlanModifier struct{}
+
+func (u *updateReadableValuePlanModifier) Description(ctx2 context.Context) string {
+	return "The readable_value will match the value if sensitive is false, or be empty otherwise"
+}
+
+func (u *updateReadableValuePlanModifier) MarkdownDescription(ctx2 context.Context) string {
+	return u.Description(ctx2)
+}
+
+func (u *updateReadableValuePlanModifier) PlanModifyString(ctx2 context.Context, request planmodifier.StringRequest, response *planmodifier.StringResponse) {
+	var sensitive types.Bool
+	diags := request.Plan.GetAttribute(ctx, path.Root("sensitive"), &sensitive)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// If the variable is sensitive, unset the readable_value
+	if sensitive.ValueBool() {
+		response.PlanValue = types.StringNull()
+		return
+	}
+
+	// Otherwise, it should equal the actual value
+	var actualValue types.String
+	diags = request.Plan.GetAttribute(ctx, path.Root("value"), &actualValue)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	response.PlanValue = actualValue
+}
+
 // Compile-time interface check
 var _ resource.Resource = &resourceTFEVariable{}
 var _ resource.ResourceWithConfigure = &resourceTFEVariable{}
 var _ resource.ResourceWithUpgradeState = &resourceTFEVariable{}
 var _ resource.ResourceWithImportState = &resourceTFEVariable{}
+var _ planmodifier.String = &updateReadableValuePlanModifier{}
 
 // NewResourceVariable is a resource function for the framework provider.
 func NewResourceVariable() resource.Resource {

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -232,15 +232,11 @@ func (r *resourceTFEVariable) Schema(ctx context.Context, req resource.SchemaReq
 				},
 			},
 			"readable_value": schema.StringAttribute{
-				Optional: true,
 				Computed: true,
 				Description: "A non-sensitive read-only copy of the variable value, which can be viewed or referenced " +
 					"in plan outputs without being redacted. Will only be present if the variable is not sensitive",
 				PlanModifiers: []planmodifier.String{
 					&updateReadableValuePlanModifier{},
-				},
-				Validators: []validator.String{
-					&readableValueNotSetInConfigValidator{},
 				},
 			},
 		},
@@ -760,35 +756,12 @@ func (u *updateReadableValuePlanModifier) PlanModifyString(ctx2 context.Context,
 	response.PlanValue = actualValue
 }
 
-type readableValueNotSetInConfigValidator struct{}
-
-func (r *readableValueNotSetInConfigValidator) Description(ctx2 context.Context) string {
-	return "readable_value is computed only, and may not be set explicitly in the terraform configuration"
-}
-
-func (r *readableValueNotSetInConfigValidator) MarkdownDescription(ctx2 context.Context) string {
-	return r.Description(ctx2)
-}
-
-func (r *readableValueNotSetInConfigValidator) ValidateString(ctx2 context.Context, request validator.StringRequest, response *validator.StringResponse) {
-	if request.ConfigValue.IsUnknown() || request.ConfigValue.IsNull() {
-		return
-	}
-
-	response.Diagnostics.AddAttributeError(
-		request.Path,
-		"readable_value explicitly set",
-		"readable_value is meant to only be read from the resource, not set directly",
-	)
-}
-
 // Compile-time interface check
 var _ resource.Resource = &resourceTFEVariable{}
 var _ resource.ResourceWithConfigure = &resourceTFEVariable{}
 var _ resource.ResourceWithUpgradeState = &resourceTFEVariable{}
 var _ resource.ResourceWithImportState = &resourceTFEVariable{}
 var _ planmodifier.String = &updateReadableValuePlanModifier{}
-var _ validator.String = &readableValueNotSetInConfigValidator{}
 
 // NewResourceVariable is a resource function for the framework provider.
 func NewResourceVariable() resource.Resource {

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -724,15 +724,15 @@ func (r *resourceTFEVariable) ImportState(ctx context.Context, req resource.Impo
 
 type updateReadableValuePlanModifier struct{}
 
-func (u *updateReadableValuePlanModifier) Description(ctx2 context.Context) string {
+func (u *updateReadableValuePlanModifier) Description(ctx context.Context) string {
 	return "The readable_value will match the value if sensitive is false, or be empty otherwise"
 }
 
-func (u *updateReadableValuePlanModifier) MarkdownDescription(ctx2 context.Context) string {
-	return u.Description(ctx2)
+func (u *updateReadableValuePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return u.Description(ctx)
 }
 
-func (u *updateReadableValuePlanModifier) PlanModifyString(ctx2 context.Context, request planmodifier.StringRequest, response *planmodifier.StringResponse) {
+func (u *updateReadableValuePlanModifier) PlanModifyString(ctx context.Context, request planmodifier.StringRequest, response *planmodifier.StringResponse) {
 	var sensitive types.Bool
 	diags := request.Plan.GetAttribute(ctx, path.Root("sensitive"), &sensitive)
 	response.Diagnostics.Append(diags...)

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -239,6 +239,9 @@ func (r *resourceTFEVariable) Schema(ctx context.Context, req resource.SchemaReq
 				PlanModifiers: []planmodifier.String{
 					&updateReadableValuePlanModifier{},
 				},
+				Validators: []validator.String{
+					&readableValueNotSetInConfigValidator{},
+				},
 			},
 		},
 		Description:         "",
@@ -757,12 +760,35 @@ func (u *updateReadableValuePlanModifier) PlanModifyString(ctx2 context.Context,
 	response.PlanValue = actualValue
 }
 
+type readableValueNotSetInConfigValidator struct{}
+
+func (r *readableValueNotSetInConfigValidator) Description(ctx2 context.Context) string {
+	return "readable_value is computed only, and may not be set explicitly in the terraform configuration"
+}
+
+func (r *readableValueNotSetInConfigValidator) MarkdownDescription(ctx2 context.Context) string {
+	return r.Description(ctx2)
+}
+
+func (r *readableValueNotSetInConfigValidator) ValidateString(ctx2 context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsUnknown() || request.ConfigValue.IsNull() {
+		return
+	}
+
+	response.Diagnostics.AddAttributeError(
+		request.Path,
+		"readable_value explicitly set",
+		"readable_value is meant to only be read from the resource, not set directly",
+	)
+}
+
 // Compile-time interface check
 var _ resource.Resource = &resourceTFEVariable{}
 var _ resource.ResourceWithConfigure = &resourceTFEVariable{}
 var _ resource.ResourceWithUpgradeState = &resourceTFEVariable{}
 var _ resource.ResourceWithImportState = &resourceTFEVariable{}
 var _ planmodifier.String = &updateReadableValuePlanModifier{}
+var _ validator.String = &readableValueNotSetInConfigValidator{}
 
 // NewResourceVariable is a resource function for the framework provider.
 func NewResourceVariable() resource.Resource {

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -359,25 +359,6 @@ func TestAccTFEVariable_varset_readable_value_becomes_sensitive(t *testing.T) {
 	})
 }
 
-func TestAccTFEVariable_readable_value_explicitlySet(t *testing.T) {
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	// Test that we throw an error if the user attempts to explicitly set the readable_value in the configuration
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccCheckTFEVariableDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccTFEVariable_readablevalue_setExplicitly(rInt, variableValue1),
-				ExpectError: regexp.MustCompile(`Invalid Configuration for Read-Only Attribute`),
-			},
-		},
-	})
-}
-
 func TestAccTFEVariable_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -883,27 +864,4 @@ resource "tfe_workspace" "downstream-nonreadable" {
   organization = tfe_organization.foobar.id
 }
 `, rIntOrg, rIntVariableValue, strconv.FormatBool(sensitive))
-}
-
-func testAccTFEVariable_readablevalue_setExplicitly(rIntOrg int, rIntVariableValue int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-	name  = "tst-terraform-%d"
-	email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-	name         = "workspace-test"
-	organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable" "foobar" {
-  key          = "key_test"
-  value        = "%d"
-  readable_value = "%d"
-  description  = "some description"
-  category     = "env"
-  workspace_id = tfe_workspace.foobar.id
-}
-`, rIntOrg, rIntVariableValue, rIntVariableValue)
 }

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -243,7 +244,6 @@ func TestAccTFEVariable_readable_value_becomes_sensitive(t *testing.T) {
 
 	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	variableValue2 := variableValue1 + 42
-	variableValue3 := variableValue2 + 42
 
 	// Test that if an insensitive variable becomes sensitive, downstream resources depending on the readableValue
 	// may no longer access it, but that the value may still be used directly
@@ -268,34 +268,8 @@ func TestAccTFEVariable_readable_value_becomes_sensitive(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEVariable_readablevalue(rInt, variableValue2, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEVariableExists(
-						"tfe_variable.foobar", variable),
-					resource.TestCheckResourceAttr(
-						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue2)),
-					resource.TestCheckResourceAttr(
-						"tfe_variable.foobar", "sensitive", "true"),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.downstream-readable", "name", "downstream-readable-"),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue2)),
-				),
-			},
-			{
-				Config: testAccTFEVariable_readablevalue(rInt, variableValue3, false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEVariableExists(
-						"tfe_variable.foobar", variable),
-					resource.TestCheckResourceAttr(
-						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue3)),
-					resource.TestCheckResourceAttr(
-						"tfe_variable.foobar", "sensitive", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue3)),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue3)),
-				),
+				Config:      testAccTFEVariable_readablevalue(rInt, variableValue2, true),
+				ExpectError: regexp.MustCompile(`tfe_variable.foobar.readable_value is null`),
 			},
 		},
 	})
@@ -310,9 +284,9 @@ func TestAccTFEVariable_varset_readable_value(t *testing.T) {
 
 	// Test that downstream resources may depend on both the value and readableValue of a non-sensitive variable
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue1, false),
@@ -354,14 +328,13 @@ func TestAccTFEVariable_varset_readable_value_becomes_sensitive(t *testing.T) {
 
 	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	variableValue2 := variableValue1 + 42
-	variableValue3 := variableValue2 + 42
 
 	// Test that if an insensitive variable becomes sensitive, downstream resources depending on the readableValue
 	// may no longer access it, but that the value may still be used directly
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue1, false),
@@ -379,34 +352,8 @@ func TestAccTFEVariable_varset_readable_value_becomes_sensitive(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue2, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEVariableSetVariableExists(
-						"tfe_variable.foobar", variable),
-					resource.TestCheckResourceAttr(
-						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue2)),
-					resource.TestCheckResourceAttr(
-						"tfe_variable.foobar", "sensitive", "true"),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.downstream-readable", "name", "downstream-readable-"),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue2)),
-				),
-			},
-			{
-				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue3, false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEVariableSetVariableExists(
-						"tfe_variable.foobar", variable),
-					resource.TestCheckResourceAttr(
-						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue3)),
-					resource.TestCheckResourceAttr(
-						"tfe_variable.foobar", "sensitive", "false"),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue3)),
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue3)),
-				),
+				Config:      testAccTFEVariable_varset_readablevalue(rInt, variableValue2, true),
+				ExpectError: regexp.MustCompile(`tfe_variable.foobar.readable_value is null`),
 			},
 		},
 	})

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -359,6 +359,25 @@ func TestAccTFEVariable_varset_readable_value_becomes_sensitive(t *testing.T) {
 	})
 }
 
+func TestAccTFEVariable_readable_value_explicitlySet(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	// Test that we throw an error if the user attempts to explicitly set the readable_value in the configuration
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEVariable_readablevalue_setExplicitly(rInt, variableValue1),
+				ExpectError: regexp.MustCompile(`readable_value explicitly set`),
+			},
+		},
+	})
+}
+
 func TestAccTFEVariable_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -864,4 +883,27 @@ resource "tfe_workspace" "downstream-nonreadable" {
   organization = tfe_organization.foobar.id
 }
 `, rIntOrg, rIntVariableValue, strconv.FormatBool(sensitive))
+}
+
+func testAccTFEVariable_readablevalue_setExplicitly(rIntOrg int, rIntVariableValue int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+	name  = "tst-terraform-%d"
+	email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+	name         = "workspace-test"
+	organization = tfe_organization.foobar.id
+}
+
+resource "tfe_variable" "foobar" {
+  key          = "key_test"
+  value        = "%d"
+  readable_value = "%d"
+  description  = "some description"
+  category     = "env"
+  workspace_id = tfe_workspace.foobar.id
+}
+`, rIntOrg, rIntVariableValue, rIntVariableValue)
 }

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -301,6 +301,117 @@ func TestAccTFEVariable_readable_value_becomes_sensitive(t *testing.T) {
 	})
 }
 
+func TestAccTFEVariable_varset_readable_value(t *testing.T) {
+	variable := &tfe.VariableSetVariable{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	variableValue2 := variableValue1 + 42
+
+	// Test that downstream resources may depend on both the value and readableValue of a non-sensitive variable
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEVariableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue1, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableSetVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue1)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue1)),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue1)),
+				),
+			},
+			{
+				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue2, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableSetVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue2)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue2)),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue2)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEVariable_varset_readable_value_becomes_sensitive(t *testing.T) {
+	variable := &tfe.VariableSetVariable{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	variableValue2 := variableValue1 + 42
+	variableValue3 := variableValue2 + 42
+
+	// Test that if an insensitive variable becomes sensitive, downstream resources depending on the readableValue
+	// may no longer access it, but that the value may still be used directly
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEVariableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue1, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableSetVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue1)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue1)),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue1)),
+				),
+			},
+			{
+				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue2, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableSetVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue2)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", "downstream-readable-"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue2)),
+				),
+			},
+			{
+				Config: testAccTFEVariable_varset_readablevalue(rInt, variableValue3, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableSetVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue3)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue3)),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue3)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFEVariable_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -760,6 +871,39 @@ resource "tfe_variable" "foobar" {
   description  = "some description"
   category     = "env"
   workspace_id = tfe_workspace.foobar.id
+  sensitive    = %s
+}
+
+resource "tfe_workspace" "downstream-readable" {
+  name         = "downstream-readable-${tfe_variable.foobar.readable_value}"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_workspace" "downstream-nonreadable" {
+  name         = "downstream-nonreadable-${tfe_variable.foobar.value}"
+  organization = tfe_organization.foobar.id
+}
+`, rIntOrg, rIntVariableValue, strconv.FormatBool(sensitive))
+}
+
+func testAccTFEVariable_varset_readablevalue(rIntOrg int, rIntVariableValue int, sensitive bool) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_variable_set" "variable_set" {
+  name         = "varset-test"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_variable" "foobar" {
+  key          = "key_test"
+  value        = "%d"
+  description  = "some description"
+  category     = "env"
+  variable_set_id = tfe_variable_set.variable_set.id
   sensitive    = %s
 }
 

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -183,6 +184,117 @@ func TestAccTFEVariable_update_key_sensitive(t *testing.T) {
 						"tfe_variable.foobar", "hcl", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "sensitive", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEVariable_readable_value(t *testing.T) {
+	variable := &tfe.Variable{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	variableValue2 := variableValue1 + 42
+
+	// Test that downstream resources may depend on both the value and readableValue of a non-sensitive variable
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEVariable_readablevalue(rInt, variableValue1, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue1)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue1)),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue1)),
+				),
+			},
+			{
+				Config: testAccTFEVariable_readablevalue(rInt, variableValue2, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue2)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue2)),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue2)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEVariable_readable_value_becomes_sensitive(t *testing.T) {
+	variable := &tfe.Variable{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	variableValue2 := variableValue1 + 42
+	variableValue3 := variableValue2 + 42
+
+	// Test that if an insensitive variable becomes sensitive, downstream resources depending on the readableValue
+	// may no longer access it, but that the value may still be used directly
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEVariable_readablevalue(rInt, variableValue1, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue1)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue1)),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue1)),
+				),
+			},
+			{
+				Config: testAccTFEVariable_readablevalue(rInt, variableValue2, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue2)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", "downstream-readable-"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue2)),
+				),
+			},
+			{
+				Config: testAccTFEVariable_readablevalue(rInt, variableValue3, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEVariableExists(
+						"tfe_variable.foobar", variable),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "value", fmt.Sprintf("%d", variableValue3)),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "sensitive", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-readable", "name", fmt.Sprintf("downstream-readable-%d", variableValue3)),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.downstream-nonreadable", "name", fmt.Sprintf("downstream-nonreadable-%d", variableValue3)),
 				),
 			},
 		},
@@ -629,4 +741,36 @@ resource "tfe_variable" "vs_terraform" {
   hcl          = true
   variable_set_id = tfe_variable_set.foobar.id
 }`, rInt)
+}
+func testAccTFEVariable_readablevalue(rIntOrg int, rIntVariableValue int, sensitive bool) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+	name  = "tst-terraform-%d"
+	email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+	name         = "workspace-test"
+	organization = tfe_organization.foobar.id
+}
+
+resource "tfe_variable" "foobar" {
+  key          = "key_test"
+  value        = "%d"
+  description  = "some description"
+  category     = "env"
+  workspace_id = tfe_workspace.foobar.id
+  sensitive    = %s
+}
+
+resource "tfe_workspace" "downstream-readable" {
+  name         = "downstream-readable-${tfe_variable.foobar.readable_value}"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_workspace" "downstream-nonreadable" {
+  name         = "downstream-nonreadable-${tfe_variable.foobar.value}"
+  organization = tfe_organization.foobar.id
+}
+`, rIntOrg, rIntVariableValue, strconv.FormatBool(sensitive))
 }

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -372,7 +372,7 @@ func TestAccTFEVariable_readable_value_explicitlySet(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEVariable_readablevalue_setExplicitly(rInt, variableValue1),
-				ExpectError: regexp.MustCompile(`readable_value explicitly set`),
+				ExpectError: regexp.MustCompile(`Invalid Configuration for Read-Only Attribute`),
 			},
 		},
 	})

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -97,7 +97,7 @@ in the state.
 
 While the `value` field may be referenced in other resources, for safety it is always treated as sensitive. This means that it will always be redacted from plan outputs, and any other resource attributes which depend on it will also be redacted.
 
-The `readable_value` attribute is not sensitive, and will not be redacted. This allows other resources to reference it, while keeping their plan outputs readable.
+The `readable_value` attribute is not sensitive, and will not be redacted; instead, it will be null if the variable is sensitive. This allows other resources to reference it, while keeping their plan outputs readable.
 
 For example:
 ```


### PR DESCRIPTION
## Description

Add a readable_value attribute to the tfe_variable resource. This aims to solve the usability problem where variable values, and all values which depend on them, are redacted from plan outputs regardless of if the variable is sensitive.

This new computed property would only be set if the variable is non-sensitive, and would not be redacted from outputs. Any other resource attribute depending on it (instead of on `value` directly) would also not be redacted from plan outputs.

## Testing plan

1. Changing the value of a non-sensitive variable should update the readable_value
1. Changing the value of a sensitive variable should leave the readable_value blank
2. Changing a variable from sensitive to non-sensitive should set the readable_value
1. Changing a variable from non-sensitive to sensitive should clear the readable_value

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-5533)

## Output from acceptance tests

```
❯ TF_ACC=1 go test github.com/hashicorp/terraform-provider-tfe/tfe  -run TestAccTFEVariable_ -tags=integration -v
=== RUN   TestAccTFEVariable_basic
--- PASS: TestAccTFEVariable_basic (8.11s)
=== RUN   TestAccTFEVariable_basic_variable_set
--- PASS: TestAccTFEVariable_basic_variable_set (9.54s)
=== RUN   TestAccTFEVariable_update
--- PASS: TestAccTFEVariable_update (13.13s)
=== RUN   TestAccTFEVariable_update_key_sensitive
--- PASS: TestAccTFEVariable_update_key_sensitive (13.61s)
=== RUN   TestAccTFEVariable_readable_value
--- PASS: TestAccTFEVariable_readable_value (15.37s)
=== RUN   TestAccTFEVariable_readable_value_becomes_sensitive
--- PASS: TestAccTFEVariable_readable_value_becomes_sensitive (21.37s)
=== RUN   TestAccTFEVariable_varset_readable_value
--- PASS: TestAccTFEVariable_varset_readable_value (18.53s)
=== RUN   TestAccTFEVariable_varset_readable_value_becomes_sensitive
--- PASS: TestAccTFEVariable_varset_readable_value_becomes_sensitive (27.12s)
=== RUN   TestAccTFEVariable_import
--- PASS: TestAccTFEVariable_import (8.83s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 135.814s

```
