### PR TITLE
Use `make lint` instead of custom action

### DIFF
--- a/.github/actions/lint-provider-tfe/action.yml
+++ b/.github/actions/lint-provider-tfe/action.yml
@@ -20,8 +20,11 @@ runs:
       run: make vet
       shell: bash
 
-    - uses: golangci/golangci-lint-action@v3
-      with:
-        version: v1.50.0
-        args: "--out-${NO_FUTURE}format colored-line-number"
-        skip-pkg-cache: true
+    - name: Install golangci-lint
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/0b5709648c8ba9780e821faf16c5c2bb3262ce3e/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCILINT_VERSION
+      shell: bash
+      env:
+        GOLANGCILINT_VERSION: v1.52.2
+
+    - run: make lint
+      shell: bash

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,6 +135,7 @@ linters-settings:
       - singleCaseSwitch
       - ifElseChain
       - nestingReduce
+      - sloppyTestFuncName
   revive:
     # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: false #recommended in their configuration


### PR DESCRIPTION
At some point, the custom action stopped leaving annotations on the PR and also doesn't offer log output in the action output.