### PR TITLE
Replace some error comparisons with `errors.Is()`

### DIFF
--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -356,7 +357,7 @@ func (r *resourceTFEVariable) readWithWorkspace(ctx context.Context, req resourc
 	variable, err := r.config.Client.Variables.Read(ctx, workspaceID, variableID)
 	if err != nil {
 		// If it's gone: that's not an error, but we are done.
-		if err == tfe.ErrResourceNotFound {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
 			log.Printf("[DEBUG] Variable %s no longer exists", variableID)
 			resp.State.RemoveResource(ctx)
 		} else {
@@ -387,7 +388,7 @@ func (r *resourceTFEVariable) readWithVariableSet(ctx context.Context, req resou
 	variableSetID := data.VariableSetID.ValueString()
 	variable, err := r.config.Client.VariableSetVariables.Read(ctx, variableSetID, variableID)
 	if err != nil {
-		if err == tfe.ErrResourceNotFound {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
 			// If it's gone: that's not an error, but we are done.
 			log.Printf("[DEBUG] Variable %s no longer exists", variableID)
 			resp.State.RemoveResource(ctx)
@@ -539,7 +540,7 @@ func (r *resourceTFEVariable) deleteWithWorkspace(ctx context.Context, req resou
 	log.Printf("[DEBUG] Delete variable: %s", variableID)
 	err := r.config.Client.Variables.Delete(ctx, workspaceID, variableID)
 	// Ignore 404s for delete
-	if err != nil && err != tfe.ErrResourceNotFound {
+	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 		resp.Diagnostics.AddError(
 			"Error deleting variable",
 			fmt.Sprintf("Couldn't delete variable %s: %s", variableID, err.Error()),
@@ -563,7 +564,7 @@ func (r *resourceTFEVariable) deleteWithVariableSet(ctx context.Context, req res
 	log.Printf("[DEBUG] Delete variable: %s", variableID)
 	err := r.config.Client.VariableSetVariables.Delete(ctx, variableSetID, variableID)
 	// Ignore 404s for delete
-	if err != nil && err != tfe.ErrResourceNotFound {
+	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 		resp.Diagnostics.AddError(
 			"Error deleting variable",
 			fmt.Sprintf("Couldn't delete variable %s: %s", variableID, err.Error()),


### PR DESCRIPTION
## Description

Per a lint (that I didn't notice in the initial tfe_variable PR somehow), plain (in)equality comparison of error values can give inaccurate results with go ≥ 1.13 "wrapped" errors. I don't think there's any likely code path for these go-tfe errors to arrive wrapped, but handling errors more resiliently sounds like a good habit to get into.

## Testing plan

1.  Manage a tfe_variable with an apply.
2. Delete it manually in the TFC UI.
3. Do a terraform refresh or a terraform destroy. The run shouldn't error, because it should (deliberately) eat the 404. 

Alternately, just trust the go documentation that errors.Is does what it says it does. 

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go errors.Is() docs](https://pkg.go.dev/errors#Is)

