### PR TITLE
Attach more info about tfe_workspace_run status when apply is rejected

### DIFF
--- a/tfe/workspace_run_helpers.go
+++ b/tfe/workspace_run_helpers.go
@@ -132,7 +132,11 @@ func createWorkspaceRun(d *schema.ResourceData, meta interface{}, isDestroyRun b
 				time.Now().Format(time.UnixDate))),
 		})
 		if err != nil {
-			return fmt.Errorf("run errored while applying run %s: %w", run.ID, err)
+			refreshed, fetchErr := config.Client.Runs.Read(ctx, run.ID)
+			if fetchErr != nil {
+				err = fmt.Errorf("%w\n additionally, got an error while reading the run: %w", err, fetchErr)
+			}
+			return fmt.Errorf("run errored while applying run %s (waited til status %s, currently status %s): %w", run.ID, run.Status, refreshed.Status, err)
 		}
 	}
 

--- a/tfe/workspace_run_helpers.go
+++ b/tfe/workspace_run_helpers.go
@@ -134,7 +134,7 @@ func createWorkspaceRun(d *schema.ResourceData, meta interface{}, isDestroyRun b
 		if err != nil {
 			refreshed, fetchErr := config.Client.Runs.Read(ctx, run.ID)
 			if fetchErr != nil {
-				err = fmt.Errorf("%w\n additionally, got an error while reading the run: %w", err, fetchErr)
+				err = fmt.Errorf("%w\n additionally, got an error while reading the run: %s", err, fetchErr.Error())
 			}
 			return fmt.Errorf("run errored while applying run %s (waited til status %s, currently status %s): %w", run.ID, run.Status, refreshed.Status, err)
 		}


### PR DESCRIPTION
## Description

We're seeing periodic flappy test failures with a "run errored while applying run run-xxxxxxxxxxxxxxxx: transition not allowed" error. This commit adds some additional context logging to the site of that error, so we can investigate these failures more methodically the next time we see one.

## Testing plan

This is a logging-only PR, whose effects can only be observed during an error that ought not to be happening. You cannot test it; only the universe can test it.

## External links

- [A representative test failure](https://github.com/hashicorp/terraform-provider-tfe/actions/runs/4961833602/jobs/8879123960?pr=881)
- [(dj khaled voice) ANOTHER ONE](https://github.com/hashicorp/terraform-provider-tfe/actions/runs/4941756232/jobs/8834683874?pr=878)
