### PR TITLE
update to write to the new GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/jira-issue-sync.yml
+++ b/.github/workflows/jira-issue-sync.yml
@@ -34,7 +34,8 @@ jobs:
               "labels": ${{ toJSON(github.event.issue.labels.*.name) }}
             }
         run: |
-          echo "::set-output name=extra::$(echo '${{ env.EXTRA_FIELDS }}' '${{ inputs.issue-extra-fields }}' | jq -rcs '.[0] * .[1]')"
+          echo "extra=$(echo '${{ env.EXTRA_FIELDS }}' '${{ inputs.issue-extra-fields }}' | jq -rcs '.[0] * .[1]')" >> $GITHUB_OUTPUT       
+          
 
       # Creates a new issue, only if this is a new PR or GH Issue, and only if an existing issue is not in the branch name
       - name: Create Issue


### PR DESCRIPTION
## Description

Avoid deprecation warning for set-output. More about the deprecation: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
