### PR TITLE
Bump all GitHub Actions and pin; avoid deprecated Node 12

### DIFF
--- a/.github/actions/lint-provider-tfe/action.yml
+++ b/.github/actions/lint-provider-tfe/action.yml
@@ -7,7 +7,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go Environment
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version-file: "go.mod"
         cache: true

--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
         go-version-file: go.mod
         cache: true
@@ -44,7 +44,7 @@ runs:
 
     - name: Download artifact
       id: download-artifact
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615 # v2.27.0
       with:
         workflow_conclusion: success
         name: junit-test-summary
@@ -53,7 +53,7 @@ runs:
 
     - name: Split acceptance tests
       id: test_split
-      uses: hashicorp-forge/go-test-split-action@v1
+      uses: hashicorp-forge/go-test-split-action@796beedbdb3d1bea14cad2d3057bab5c5cf15fe5 # v1.0.2
       with:
         index: ${{ inputs.matrix_index }}
         total: ${{ inputs.matrix_total }}
@@ -81,7 +81,7 @@ runs:
         gotestsum --junitfile summary.xml --format short-verbose -- $MOD_PROVIDER $MOD_TFE $MOD_VERSION -v -timeout=30m -run "${{ steps.test_split.outputs.run }}"
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: junit-test-summary-${{ matrix.index }}
         path: summary.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: ./.github/actions/lint-provider-tfe
 
   tests:
@@ -24,13 +24,13 @@ jobs:
     steps:
       - name: Fetch Outputs
         id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@v1
+        uses: hashicorp-forge/terraform-cloud-action/outputs@v1 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
         with:
           token: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
           organization: hashicorp-v2
           workspace: tflocal-terraform-provider-tfe
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - uses: ./.github/actions/test-provider-tfe
         with:
@@ -45,12 +45,12 @@ jobs:
     needs: [ tests ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: 16
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
 
       - name: Install junit-report-merger
         run: npm install -g junit-report-merger
@@ -59,7 +59,7 @@ jobs:
         run: jrm ./ci-summary-provider.xml "junit-test-summary-0/*.xml" "junit-test-summary-1/*.xml" "junit-test-summary-2/*.xml" "junit-test-summary-3/*.xml" "junit-test-summary-4/*.xml"
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: junit-test-summary
           path: ./ci-summary-provider.xml

--- a/.github/workflows/jira-issue-sync.yml
+++ b/.github/workflows/jira-issue-sync.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login
-        uses: atlassian/gajira-login@v3.0.1
+        uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # v3.0.1
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -39,7 +39,7 @@ jobs:
       # Creates a new issue, only if this is a new PR or GH Issue, and only if an existing issue is not in the branch name
       - name: Create Issue
         if: github.event.action == 'opened' && steps.find-issue-in-branch.outputs.issue == null
-        uses: atlassian/gajira-create@v3
+        uses: atlassian/gajira-create@59e177c4f6451399df5b4911c2211104f171e669 # v3.0.1
         with:
           project: "${{ inputs.project }}"
           issuetype: "GH Issue"
@@ -50,21 +50,21 @@ jobs:
       - name: Search
         if: github.event.action != 'opened'
         id: search
-        uses: tomhjp/gh-action-jira-search@v0.2.2
+        uses: tomhjp/gh-action-jira-search@04700b457f317c3e341ce90da5a3ff4ce058f2fa # v0.2.2
         with:
           # cf[10089] is Issue Link (use JIRA API to retrieve)
           jql: 'issuetype = "GH Issue" and cf[10089] = "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
 
       - name: Sync comment
         if: github.event.action == 'created' && steps.search.outputs.issue
-        uses: atlassian/gajira-comment@v3
+        uses: atlassian/gajira-comment@v3 # TSCCR: no entry for repository "atlassian/gajira-comment"
         with:
           issue: ${{ steps.search.outputs.issue }}
           comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
 
       - name: Close issue
         if: ( github.event.action == 'closed' || github.event.action == 'deleted' ) && steps.search.outputs.issue
-        uses: brandonc/gajira-transition@master
+        uses: brandonc/gajira-transition@master # TSCCR: no entry for repository "brandonc/gajira-transition"
         with:
           issue: ${{ steps.search.outputs.issue }}
           transition: "Closed"
@@ -77,7 +77,7 @@ jobs:
 
       - name: Reopen issue
         if: github.event.action == 'reopened' && steps.search.outputs.issue
-        uses: atlassian/gajira-transition@v3
+        uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3.0.1
         with:
           issue: ${{ steps.search.outputs.issue }}
           transition: "Reopen"

--- a/.github/workflows/jira-pr-transition.yml
+++ b/.github/workflows/jira-pr-transition.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login
-        uses: atlassian/gajira-login@v3.0.1
+        uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # v3.0.1
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       - name: Find in branch name
         id: search
-        uses: atlassian/gajira-find-issue-key@v3
+        uses: atlassian/gajira-find-issue-key@v3 # TSCCR: no entry for repository "atlassian/gajira-find-issue-key"
         with:
           string: ${{ github.head_ref }}
           from: ""
@@ -34,21 +34,21 @@ jobs:
 
       - name: Transition Drafts to In Progress
         if: steps.search.outputs.issue && github.event.pull_request.draft
-        uses: atlassian/gajira-transition@v3
+        uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3.0.1
         with:
           issue: ${{ steps.search.outputs.issue }}
           transition: "In Progress"
 
       - name: Transition Opened to In Review
         if: steps.search.outputs.issue && !github.event.pull_request.draft && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
-        uses: atlassian/gajira-transition@v3
+        uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3.0.1
         with:
           issue: ${{ steps.search.outputs.issue }}
           transition: "In Review"
 
       - name: Transition Merged to Closed
         if: steps.search.outputs.issue && github.event.action == 'closed' && github.event.pull_request.merged == true
-        uses: atlassian/gajira-transition@v3
+        uses: atlassian/gajira-transition@38fc9cd61b03d6a53dd35fcccda172fe04b36de3 # v3.0.1
         with:
           issue: ${{ steps.search.outputs.issue }}
           transition: "Closed"

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: mhausenblas/mkdocs-deploy-gh-pages@d77dd03172e96abbcdb081d8c948224762033653 # 1.26
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: mkdocs.yml

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Build nightly tflocal instance
-        uses: hashicorp-forge/terraform-cloud-action/apply@v1
+        uses: hashicorp-forge/terraform-cloud-action/apply@v1 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
         with:
           token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
           organization: "hashicorp-v2"
@@ -29,13 +29,13 @@ jobs:
     steps:
       - name: Fetch Outputs
         id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@v1
+        uses: hashicorp-forge/terraform-cloud-action/outputs@v1 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
         with:
           token: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
           organization: hashicorp-v2
           workspace: tflocal-terraform-provider-tfe-nightly
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - uses: ./.github/actions/test-provider-tfe
         with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send slack notification on failure
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
         with:
           payload: |
             {
@@ -95,17 +95,17 @@ jobs:
     needs: [tests-summarize]
     if: "${{ always() }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: go.mod
           check-latest: true
           cache: true
 
       - name: Destroy nightly tflocal instance
-        uses: hashicorp-forge/terraform-cloud-action/destroy@v1
+        uses: hashicorp-forge/terraform-cloud-action/destroy@v1 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
         with:
           token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
           organization: "hashicorp-v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
   release-notes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 0
       - name: Generate Release Notes
         run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: release-notes
           path: release-notes.txt


### PR DESCRIPTION
Commit is the result of running HashiCorp's internal pinning tool, for all GitHub Actions workflows in the repo.

https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/

Note, this unsolicited PR is a courtesy and has not been tested before submission.  The PR should be evaluated and merged by its responsible team.
