### PR TITLE
[TF-5841] Use the provision-licenses role to upgrade org subscriptions in tests

### DIFF
--- a/tfe/data_source_outputs_test.go
+++ b/tfe/data_source_outputs_test.go
@@ -171,7 +171,7 @@ func createStateVersion(t *testing.T, client *tfe.Client, rInt int, fileName str
 		t.Fatal(err)
 	}
 
-	upgradeOrganizationSubscription(t, client, org)
+	upgradeOrganizationSubscription(t, org)
 
 	orgCleanup = func() {
 		if err := client.Organizations.Delete(ctx, org.Name); err != nil {


### PR DESCRIPTION
## Description

Note: This PR depends on [this PR](https://github.com/hashicorp/terraform-provider-tfe/pull/909) that sets the admin role tokens in the environment for tests.

This PR uses the new TFC Admin API roles in the tests. In particular, the role `provision-licenses` is used when the organization subscription is upgraded.

## Testing plan

* If you're testing locally, refer to the linked PR for how to test locally. If you're using oasis, make sure you have a token that has the provision-licenses role.
* All tests should pass, and specifically these tests:

```
TestAccTFEAgentPoolDataSource_basic 
TestAccTFEOrganizationMembersDataSource_basic 
TestAccTFEPolicySetDataSource_basic
TestAccTFEPolicySetDataSource_vcs
TestAccTFETeamAccessDataSource_basic
TestAccTFETeamProjectAccessDataSource_basic
TestAccTFETeamDataSource_basic 
TestAccTFETeamDataSource_ssoTeamId 
TestAccTFEAgentPool_basic
TestAccTFEAgentPool_update 
TestAccTFEAgentPool_import
TestAccTFEAgentToken_basic 
TestAccTFEPolicySetParameter_basic
TestAccTFEPolicySetParameter_update
TestAccTFEPolicySetParameter_import
TestAccTFEPolicySet_basic
TestAccTFEPolicySet_update
TestAccTFEPolicySet_updateEmpty
TestAccTFEPolicySet_updatePopulated
TestAccTFEPolicySet_updateToGlobal 
TestAccTFEPolicySet_updateToWorkspace
TestAccTFEPolicySet_vcs
TestAccTFEPolicySet_GithubApp
TestAccTFEPolicySet_updateVCSBranch
TestAccTFEPolicySet_versionedNoConflicts
TestAccTFEPolicySet_invalidName
TestAccTFEPolicySetImport
TestAccTFEWorkspacePolicySet_basic
TestAccTFEWorkspacePolicySet_incorrectImportSyntax
TestAccTFEWorkspaceRun_withApplyOnlyBlock
TestAccTFEWorkspaceRun_withBothApplyAndDestroyBlocks
TestAccTFEWorkspaceRun_invalidParams
TestAccTFEWorkspaceRun_WhenRunErrors
TestAccTFEWorkspace_operationsAndExecutionModeInteroperability
TestAccTFEWorkspace_unsetExecutionMode
```

## External links

- [Depends on this PR](https://github.com/hashicorp/terraform-provider-tfe/pull/909)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/696)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
