### PR TITLE
Set admin role tokens from the env

### DIFF
--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -4,6 +4,27 @@
 name: Test
 description: Tests terraform-provider-tfe within a matrix
 inputs:
+  admin_configuration_token:
+    description: TFC Admin API Configuration role token
+    required: true
+  admin_provision_licenses_token:
+    description: TFC Admin API Provision Licenses role token
+    required: true
+  admin_security_maintenance_token:
+    description: TFC Admin API Security Maintenance role token
+    required: true
+  admin_site_admin_token:
+    description: TFC Admin API Site Admin role token
+    required: true
+  admin_subscription_token:
+    description: TFC Admin API Subscription role token
+    required: true
+  admin_support_token:
+    description: TFC Admin API Support role token
+    required: true
+  admin_version_maintenance_token:
+    description: TFC Admin API Version Maintenance role token
+    required: true
   matrix_index:
     description: Index of the matrix strategy runner
     required: true
@@ -64,6 +85,13 @@ runs:
       env:
         TFE_HOSTNAME: "${{ inputs.hostname }}"
         TFE_TOKEN: "${{ inputs.token }}"
+        TFE_ADMIN_CONFIGURATION_TOKEN: ${{ inputs.admin_configuration_token }}
+        TFE_ADMIN_PROVISION_LICENSES_TOKEN: ${{ inputs.admin_provision_licenses_token }}
+        TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN: ${{ inputs.admin_security_maintenance_token }}
+        TFE_ADMIN_SITE_ADMIN_TOKEN: ${{ inputs.admin_site_admin_token }}
+        TFE_ADMIN_SUBSCRIPTION_TOKEN: ${{ inputs.admin_subscription_token }}
+        TFE_ADMIN_SUPPORT_TOKEN: ${{ inputs.admin_support_token }}
+        TFE_ADMIN_VERSION_MAINTENANCE_TOKEN: ${{ inputs.admin_version_maintenance_token }}
         TFE_USER1: tfe-provider-user1
         TFE_USER2: tfe-provider-user2
         TF_ACC: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Fetch Outputs
         id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@v1 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
+        uses: hashicorp-forge/terraform-cloud-action/outputs@4adbe7eea886138ac10a4c09e63c5c568aaa6672 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
         with:
           token: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
           organization: hashicorp-v2
@@ -39,6 +39,13 @@ jobs:
           hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
+          admin_configuration_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.configuration }}
+          admin_provision_licenses_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.provision-licenses }}
+          admin_security_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.security-maintenance }}
+          admin_site_admin_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.site-admin }}
+          admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
+          admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
+          admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version-maintenance }}
 
   tests-combine-summaries:
     name: Combine Test Reports

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Build nightly tflocal instance
-        uses: hashicorp-forge/terraform-cloud-action/apply@v1 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
+        uses: hashicorp-forge/terraform-cloud-action/apply@4adbe7eea886138ac10a4c09e63c5c568aaa6672 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
         with:
           token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
           organization: "hashicorp-v2"
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Fetch Outputs
         id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@v1 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
+        uses: hashicorp-forge/terraform-cloud-action/outputs@4adbe7eea886138ac10a4c09e63c5c568aaa6672 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
         with:
           token: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
           organization: hashicorp-v2
@@ -105,7 +105,7 @@ jobs:
           cache: true
 
       - name: Destroy nightly tflocal instance
-        uses: hashicorp-forge/terraform-cloud-action/destroy@v1 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
+        uses: hashicorp-forge/terraform-cloud-action/destroy@4adbe7eea886138ac10a4c09e63c5c568aaa6672 # TSCCR: no entry for repository "hashicorp-forge/terraform-cloud-action"
         with:
           token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
           organization: "hashicorp-v2"


### PR DESCRIPTION
## Description

* Set the TFC Admin API role tokens from the environment
* Bump the version of `hashicorp-forge/terraform-cloud-action/` to the version that includes a fix to outputting nested sensitive values.

## Testing plan

The tokens should be set when CI is run (e.g., https://github.com/hashicorp/terraform-provider-tfe/actions/runs/5192171587/jobs/9360961243?pr=909#step:4:14)
