### PR TITLE
r/tfe_workspace_run: Ensure wait_for_run=false results in a fire-and-forget Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+BUG FIXES:
+* `r/tfe_workspace_run`: Ensure `wait_for_run` correctly results in a fire-and-forget Run when set to `false` by @lucymhdavies ([#910](https://github.com/hashicorp/terraform-provider-tfe/pull/910)
+
+
+
 ## v0.45.0 (May 25, 2023)
 
 FEATURES:

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -190,15 +190,18 @@ The following arguments are supported:
 
 Both `apply` and `destroy` block supports:
 
-* `manual_confirm` - (Required) If set to true a human will have to manually confirm a plan in Terraform Cloud's UI to start an apply. If set to false, this resource will auto confirm the plan. The exception is the case of policy check soft-failed where a human has to perform an override by manually confirming the plan even though `manual_confirm` is set to false. Defaults to `false`.
+* `manual_confirm` - (Required) If set to true a human will have to manually confirm a plan in Terraform Cloud's UI to start an apply. If set to false, this resource will be automatically applied. Defaults to `false`.
+  * If `wait_for_run` is set to `false`, this auto-apply will be done by Terraform Cloud.
+  * If `wait_for_run` is set to `true`, the apply will be confirmed by the provider. The exception is the case of policy check soft-failed where a human has to perform an override by manually confirming the plan even though `manual_confirm` is set to false.
+  * Note that this setting will override the workspace's default apply mode. To use the workspace default apply mode, look up the setting for `auto_apply` with the `tfe_workspace` data source.
 * `retry` - (Optional) Whether or not to retry on plan or apply errors. When set to true, `retry_attempts` must also be greater than zero inorder for retries to happen. Defaults to `true`.
 * `retry_attempts` - (Optional) The number to retry attempts made after an initial error. Defaults to `3`.
 * `retry_backoff_min` - (Optional) The minimum time in seconds to backoff before attempting a retry. Defaults to `1`.
 * `retry_backoff_max` - (Optional) The maximum time in seconds to backoff before attempting a retry. Defaults to `30`.
-* `wait_for_run` - (Optional) Whether or not to wait for a run to reach completion before firing the next run. When set to false, `manual_confirm` will not be considered as run will be started with auto apply set to true . Defaults to `true`.
+* `wait_for_run` - (Optional) Whether or not to wait for a run to reach completion before considering this a success. When set to `false`, the provider considers the `tfe_workspace_run` resource to have been created immediately after the run has been queued. When set to `true`, the provider waits for a successful apply on the target workspace to have applied successfully (or if it resulted in a no-change plan). Defaults to `true`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the run created by this resource.
+* `id` - The ID of the run created by this resource. Note, if the resource was created without an `apply{}` configuration block, then this ID will not refer to a real run in Terraform Cloud.


### PR DESCRIPTION
## Description

Fix for https://github.com/hashicorp/terraform-provider-tfe/issues/908

Replacement PR for https://github.com/hashicorp/terraform-provider-tfe/pull/910

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_


## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspaceRun" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceRun -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFEWorkspaceRunTaskDataSource_basic
    testing.go:232: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTaskDataSource_basic (0.00s)
=== RUN   TestAccTFEWorkspaceRunTask_create
    testing.go:232: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTask_create (0.00s)
=== RUN   TestAccTFEWorkspaceRunTask_beta_create
    testing.go:232: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTask_beta_create (0.00s)
=== RUN   TestAccTFEWorkspaceRunTask_import
    testing.go:232: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTask_import (0.00s)
=== RUN   TestAccTFEWorkspaceRun_withApplyOnlyBlock
2023/05/30 12:09:55 [DEBUG] Configuring client for host "app.terraform.io"
2023/05/30 12:09:55 [DEBUG] Service discovery for app.terraform.io at https://app.terraform.io/.well-known/terraform.json
2023/05/30 12:09:56 [DEBUG] Attempting to fetch token from Terraform CLI configuration for hostname app.terraform.io...
    testing.go:89: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEWorkspaceRun_withApplyOnlyBlock (0.92s)
=== RUN   TestAccTFEWorkspaceRun_withBothApplyAndDestroyBlocks
2023/05/30 12:09:56 [DEBUG] Configuring client for host "app.terraform.io"
2023/05/30 12:09:56 [DEBUG] Service discovery for app.terraform.io at https://app.terraform.io/.well-known/terraform.json
2023/05/30 12:09:57 [DEBUG] Attempting to fetch token from Terraform CLI configuration for hostname app.terraform.io...
    testing.go:89: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEWorkspaceRun_withBothApplyAndDestroyBlocks (0.84s)
=== RUN   TestAccTFEWorkspaceRun_invalidParams
2023/05/30 12:09:57 [DEBUG] Configuring client for host "app.terraform.io"
2023/05/30 12:09:57 [DEBUG] Service discovery for app.terraform.io at https://app.terraform.io/.well-known/terraform.json
2023/05/30 12:09:57 [DEBUG] Attempting to fetch token from Terraform CLI configuration for hostname app.terraform.io...
    testing.go:89: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEWorkspaceRun_invalidParams (0.86s)
=== RUN   TestAccTFEWorkspaceRun_WhenRunErrors
2023/05/30 12:09:58 [DEBUG] Configuring client for host "app.terraform.io"
2023/05/30 12:09:58 [DEBUG] Service discovery for app.terraform.io at https://app.terraform.io/.well-known/terraform.json
2023/05/30 12:09:58 [DEBUG] Attempting to fetch token from Terraform CLI configuration for hostname app.terraform.io...
    testing.go:89: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEWorkspaceRun_WhenRunErrors (0.87s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-tfe/tfe	3.908s
FAIL
make: *** [testacc] Error 1
```


Which... I'm not sure if that's a problem with me running the tests, or if this is the tests failing because the functionality has changed. It seems like the former (some issue running the tests)




Tests in GitHub Actions... most pass. Only one fails, and it's got nothing to do with my change:

```
=== FAIL: tfe TestAccTFEOrganizationsDataSource_basic (7.43s)
    data_source_organizations_test.go:20: Step 2/2 error: Error running second post-apply plan: exit status 1
        
        Error: Error retrieving Organizations: resource not found
        
          with data.tfe_organizations.foobarbaz,
          on terraform_plugin_test.tf line 2, in data "tfe_organizations" "foobarbaz":
           2: data "tfe_organizations" "foobarbaz" {}
```

https://github.com/hashicorp/terraform-provider-tfe/actions/runs/5146530571/jobs/9265710677

re-ran the tests, and looks like they're fine after all
https://github.com/hashicorp/terraform-provider-tfe/actions/runs/5146530571