### PR TITLE
Incorporate missing post plan terminal statuses to ensure plan is completely processed before attempting to confirm run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BUG FIXES:
 ENHANCEMENTS:
 * `r/tfe_agent_pool`: Add attribute `organization_scoped` to set the scope of an agent pool by @hs26gill [870](https://github.com/hashicorp/terraform-provider-tfe/pull/870)
 * `d/tfe_agent_pool`: Add attribute `organization_scoped` and `allowed_workspace_ids` to retrieve agent pool scope and associated allowed workspace ids by @hs26gill [870](https://github.com/hashicorp/terraform-provider-tfe/pull/870)
+* `r/tfe_workspace_run`: Incorporate missing post plan statuses to ensure that `tfe_workspace_run` resource waits for a plan to process completely before attempting to confirm the associated run, by @uk1288 ([#921](https://github.com/hashicorp/terraform-provider-tfe/pull/921))
 
 ## v0.45.0 (May 25, 2023)
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/hashicorp/go-slug v0.11.1
-	github.com/hashicorp/go-tfe v1.28.0
+	github.com/hashicorp/go-tfe v1.29.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c h1:figwFwYep1Qnl64Y+Rc8tyQWE0xvYAN+5EX+rD40pTU=
 github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
@@ -7,6 +10,8 @@ github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
@@ -18,6 +23,7 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
+github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.4.1 h1:Uwp5tDRkPr+l/TnbHOQzp+tmJfLceOlbVucgpTz8ix4=
 github.com/go-git/go-git/v5 v5.6.1 h1:q4ZRqQl4pR/ZJHc1L5CFjGA1a10u76aV1iC+nh+bHsk=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
@@ -58,6 +64,8 @@ github.com/hashicorp/go-slug v0.11.1 h1:c6lLdQnlhUWbS5I7hw8SvfymoFuy6EmiFDedy6ir
 github.com/hashicorp/go-slug v0.11.1/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-tfe v1.28.0 h1:YQNfHz5UPMiOD2idad4GCjzG3R2ExPww741PBPqMOIU=
 github.com/hashicorp/go-tfe v1.28.0/go.mod h1:z0182DGE/63AKUaWblUVBIrt+xdSmsuuXg5AoxGqDF4=
+github.com/hashicorp/go-tfe v1.29.0 h1:hVvgoKtLAWTkXl9p/8WnItCaW65VJwqpjLZkXe8R2AM=
+github.com/hashicorp/go-tfe v1.29.0/go.mod h1:z0182DGE/63AKUaWblUVBIrt+xdSmsuuXg5AoxGqDF4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -95,8 +103,10 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -114,8 +124,10 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -129,8 +141,12 @@ github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DV
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/skeema/knownhosts v1.1.0 h1:Wvr9V0MxhjRbl3f9nMnKnFfiWTJmtECJ9Njkea3ysW0=
+github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -140,6 +156,7 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
@@ -149,6 +166,7 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -241,6 +259,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
+gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -18,31 +18,27 @@ var (
 )
 
 var planPendingStatuses = map[tfe.RunStatus]bool{
-	tfe.RunPending:        true,
-	tfe.RunPlanQueued:     true,
-	tfe.RunPlanning:       true,
-	tfe.RunCostEstimating: true,
-	tfe.RunPolicyChecking: true,
-	tfe.RunQueuing:        true,
-	tfe.RunFetching:       true,
-}
-
-var planTerminalStatuses = map[tfe.RunStatus]bool{
-	tfe.RunPlanned:            true,
-	tfe.RunPlannedAndFinished: true,
-	tfe.RunErrored:            true,
-	tfe.RunCostEstimated:      true,
-	tfe.RunPolicyChecked:      true,
-	tfe.RunPolicySoftFailed:   true,
-	tfe.RunPolicyOverride:     true,
+	tfe.RunPending:           true,
+	tfe.RunPlanQueued:        true,
+	tfe.RunPlanning:          true,
+	tfe.RunCostEstimating:    true,
+	tfe.RunPolicyChecking:    true,
+	tfe.RunQueuing:           true,
+	tfe.RunFetching:          true,
+	tfe.RunPostPlanRunning:   true,
+	tfe.RunPostPlanCompleted: true,
+	tfe.RunPrePlanRunning:    true,
+	tfe.RunPrePlanCompleted:  true,
 }
 
 var applyPendingStatuses = map[tfe.RunStatus]bool{
-	tfe.RunConfirmed:   true,
-	tfe.RunApplyQueued: true,
-	tfe.RunApplying:    true,
-	tfe.RunQueuing:     true,
-	tfe.RunFetching:    true,
+	tfe.RunConfirmed:       true,
+	tfe.RunApplyQueued:     true,
+	tfe.RunApplying:        true,
+	tfe.RunQueuing:         true,
+	tfe.RunFetching:        true,
+	tfe.RunQueuingApply:    true,
+	tfe.RunPreApplyRunning: true,
 }
 
 var applyDoneStatuses = map[tfe.RunStatus]bool{
@@ -50,10 +46,33 @@ var applyDoneStatuses = map[tfe.RunStatus]bool{
 	tfe.RunErrored: true,
 }
 
+var confirmationPendingStatuses = map[tfe.RunStatus]bool{
+	tfe.RunPostPlanCompleted: true,
+	tfe.RunPlanned:           true,
+	tfe.RunCostEstimated:     true,
+	tfe.RunPolicyChecked:     true,
+}
+
 var confirmationDoneStatuses = map[tfe.RunStatus]bool{
-	tfe.RunConfirmed:   true,
-	tfe.RunApplyQueued: true,
-	tfe.RunApplying:    true,
+	tfe.RunConfirmed:        true,
+	tfe.RunApplyQueued:      true,
+	tfe.RunApplying:         true,
+	tfe.RunPrePlanCompleted: true,
+	tfe.RunPrePlanRunning:   true,
+	tfe.RunQueuingApply:     true,
+}
+
+var policyOverridenStatuses = map[tfe.RunStatus]bool{
+	tfe.RunPolicyChecked:    true,
+	tfe.RunConfirmed:        true,
+	tfe.RunApplyQueued:      true,
+	tfe.RunApplying:         true,
+	tfe.RunPrePlanCompleted: true,
+	tfe.RunPrePlanRunning:   true,
+}
+
+var policyOverridePendingStatuses = map[tfe.RunStatus]bool{
+	tfe.RunPolicyOverride: true,
 }
 
 func resourceTFEWorkspaceRun() *schema.Resource {

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -32,13 +32,14 @@ var planPendingStatuses = map[tfe.RunStatus]bool{
 }
 
 var applyPendingStatuses = map[tfe.RunStatus]bool{
-	tfe.RunConfirmed:       true,
-	tfe.RunApplyQueued:     true,
-	tfe.RunApplying:        true,
-	tfe.RunQueuing:         true,
-	tfe.RunFetching:        true,
-	tfe.RunQueuingApply:    true,
-	tfe.RunPreApplyRunning: true,
+	tfe.RunConfirmed:         true,
+	tfe.RunApplyQueued:       true,
+	tfe.RunApplying:          true,
+	tfe.RunQueuing:           true,
+	tfe.RunFetching:          true,
+	tfe.RunQueuingApply:      true,
+	tfe.RunPreApplyRunning:   true,
+	tfe.RunPreApplyCompleted: true,
 }
 
 var applyDoneStatuses = map[tfe.RunStatus]bool{
@@ -54,15 +55,16 @@ var confirmationPendingStatuses = map[tfe.RunStatus]bool{
 }
 
 var confirmationDoneStatuses = map[tfe.RunStatus]bool{
-	tfe.RunConfirmed:        true,
-	tfe.RunApplyQueued:      true,
-	tfe.RunApplying:         true,
-	tfe.RunPrePlanCompleted: true,
-	tfe.RunPrePlanRunning:   true,
-	tfe.RunQueuingApply:     true,
+	tfe.RunConfirmed:         true,
+	tfe.RunApplyQueued:       true,
+	tfe.RunApplying:          true,
+	tfe.RunPrePlanCompleted:  true,
+	tfe.RunPrePlanRunning:    true,
+	tfe.RunQueuingApply:      true,
+	tfe.RunPreApplyCompleted: true,
 }
 
-var policyOverridenStatuses = map[tfe.RunStatus]bool{
+var policyOverriddenStatuses = map[tfe.RunStatus]bool{
 	tfe.RunPolicyChecked:    true,
 	tfe.RunConfirmed:        true,
 	tfe.RunApplyQueued:      true,

--- a/tfe/resource_tfe_workspace_run.go
+++ b/tfe/resource_tfe_workspace_run.go
@@ -17,20 +17,6 @@ var (
 	backoffMax = 3000.0
 )
 
-var planPendingStatuses = map[tfe.RunStatus]bool{
-	tfe.RunPending:           true,
-	tfe.RunPlanQueued:        true,
-	tfe.RunPlanning:          true,
-	tfe.RunCostEstimating:    true,
-	tfe.RunPolicyChecking:    true,
-	tfe.RunQueuing:           true,
-	tfe.RunFetching:          true,
-	tfe.RunPostPlanRunning:   true,
-	tfe.RunPostPlanCompleted: true,
-	tfe.RunPrePlanRunning:    true,
-	tfe.RunPrePlanCompleted:  true,
-}
-
 var applyPendingStatuses = map[tfe.RunStatus]bool{
 	tfe.RunConfirmed:         true,
 	tfe.RunApplyQueued:       true,

--- a/tfe/workspace_run_helpers_test.go
+++ b/tfe/workspace_run_helpers_test.go
@@ -81,7 +81,6 @@ func MockRunsListForWorkspaceQueue(t *testing.T, client *tfe.Client, workspaceID
 }
 
 func TestReadRunPositionInWorkspaceQueue(t *testing.T) {
-	defaultOrganization := "my-org"
 	client := testTfeClient(t, testClientOptions{})
 	MockRunsListForWorkspaceQueue(t, client, "ws-1", "ws-2")
 
@@ -114,7 +113,7 @@ func TestReadRunPositionInWorkspaceQueue(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			position, err := readRunPositionInWorkspaceQueue(
-				ConfiguredClient{Client: client, Organization: defaultOrganization},
+				client,
 				testCase.currentRunID,
 				testCase.workspace,
 				false,
@@ -224,7 +223,7 @@ func TestReadRunPositionInOrgQueue(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			position, err := readRunPositionInOrgQueue(
-				ConfiguredClient{Client: client, Organization: defaultOrganization},
+				client,
 				"run-02",
 				testCase.orgName,
 			)


### PR DESCRIPTION
## Description
The changes in this PR checks potential terminal post plan statuses to ensure that a plan has been completely processed before proceeding to confirm the associated run. The terminal status changes depending on the post plan lifecycle that a run has. For example a plan can terminate at `planned` status or `cost_estimated` or `policy_checked`.

See issue for more details: https://github.com/hashicorp/terraform-provider-tfe/issues/898

[This PR depends on go-tfe PR#712](https://github.com/hashicorp/go-tfe/pull/712)

## Testing plan

1.  _Workspace_run resource should create run as usual, the only way to produce the issue consistently is to force a run to remain in a status, e.g `policy_checked`, for a longer period of time such that workspace_run receives that status while polling the run. I achieved this by adding delays to each run state_

## External links

- [Blocked by go-tfe PR](https://github.com/hashicorp/go-tfe/pull/712)

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEWorkspaceRun" make testacc

...
```
