### PR TITLE
remove no_code beta note in docs

### DIFF
--- a/website/docs/r/no_code_module.html.markdown
+++ b/website/docs/r/no_code_module.html.markdown
@@ -9,9 +9,6 @@ description: |-
 
 Creates, updates and destroys no-code module for registry modules.
 
-**NOTE:** This resource is currently in beta and isn't generally
-available to all users. It is subject to change or be removed.
-
 ## Example Usage
 
 Basic usage:

--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -83,7 +83,6 @@ resource "tfe_registry_module" "test-no-code-provisioning-registry-module" {
   module_provider = "aws"
   name            = "vpc"
   registry_name   = "public"
-  no_code         = true
 }
 
 resource "tfe_no_code_module" "foobar" {


### PR DESCRIPTION
## Description

Remove beta note for no_code modules from the docs.


## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
