### PR TITLE
docs: Fixing issue for datasource tfe_workspace.assessments_enabled

### DIFF
--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -34,7 +34,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The workspace ID.
 * `allow_destroy_plan` - Indicates whether destroy plans can be queued on the workspace.
 * `auto_apply` - Indicates whether to automatically apply changes when a Terraform plan is successful.
-  `assessments_enabled` - (Available only in Terraform Cloud) Indicates whether health assessments such as drift detection are enabled for the workspace.
+* `assessments_enabled` - (Available only in Terraform Cloud) Indicates whether health assessments such as drift detection are enabled for the workspace.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument).
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` is set to `true`.


### PR DESCRIPTION
## Description

Due to a formatting issue in the docs of _datasource_ `tfe_workspace`

https://github.com/hashicorp/terraform-provider-tfe/blob/9057f219ff967385dccdc1a7aa6ababa57269fbd/website/docs/d/workspace.html.markdown?plain=1#L37

the attribute `assessments_enabled` became part of the description for `auto_apply` .
![Screenshot 2023-06-14 at 12 45 48](https://github.com/hashicorp/terraform-provider-tfe/assets/81589119/67a0b8df-e56d-44e0-9655-3c7f49c18005)

## Testing plan

n/a

## External links

- see: https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/workspace#auto_apply

## Output from acceptance tests

n/a

...
```
