### PR TITLE
feat: add tfe_saml_settings data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,7 @@
 ## Unreleased
 
 FEATURES:
-
-BUG FIXES:
-
-ENHANCEMENTS:
-
-DEPRECATIONS:
+* **New Resource**: `d/tfe_saml_settings` is a new data source to retrieve SAML settings from the Admin API, by @karvounis-form3 [952](https://github.com/hashicorp/terraform-provider-tfe/pull/952)
 
 ## v0.46.0 (July 3, 2023)
 

--- a/tfe/data_source_saml_settings.go
+++ b/tfe/data_source_saml_settings.go
@@ -1,0 +1,170 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &dataSourceTFESAMLSettings{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFESAMLSettings{}
+)
+
+// NewSAMLSettingsDataSource is a helper function to simplify the provider implementation.
+func NewSAMLSettingsDataSource() datasource.DataSource {
+	return &dataSourceTFESAMLSettings{}
+}
+
+// dataSourceTFESAMLSettings is the data source implementation.
+type dataSourceTFESAMLSettings struct {
+	client *tfe.Client
+}
+
+// modelTFESAMLSettings maps the data source schema data.
+type modelTFESAMLSettings struct {
+	ID                        types.String `tfsdk:"id"`
+	Enabled                   types.Bool   `tfsdk:"enabled"`
+	Debug                     types.Bool   `tfsdk:"debug"`
+	TeamManagementEnabled     types.Bool   `tfsdk:"team_management_enabled"`
+	AuthnRequestsSigned       types.Bool   `tfsdk:"authn_requests_signed"`
+	WantAssertionsSigned      types.Bool   `tfsdk:"want_assertions_signed"`
+	IDPCert                   types.String `tfsdk:"idp_cert"`
+	OldIDPCert                types.String `tfsdk:"old_idp_cert"`
+	SLOEndpointURL            types.String `tfsdk:"slo_endpoint_url"`
+	SSOEndpointURL            types.String `tfsdk:"sso_endpoint_url"`
+	AttrUsername              types.String `tfsdk:"attr_username"`
+	AttrGroups                types.String `tfsdk:"attr_groups"`
+	AttrSiteAdmin             types.String `tfsdk:"attr_site_admin"`
+	SiteAdminRole             types.String `tfsdk:"site_admin_role"`
+	SSOAPITokenSessionTimeout types.Int64  `tfsdk:"sso_api_token_session_timeout"`
+	ACSConsumerURL            types.String `tfsdk:"acs_consumer_url"`
+	MetadataURL               types.String `tfsdk:"metadata_url"`
+	Certificate               types.String `tfsdk:"certificate"`
+}
+
+// Metadata returns the data source type name.
+func (d *dataSourceTFESAMLSettings) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_saml_settings"
+}
+
+// Schema defines the schema for the data source.
+func (d *dataSourceTFESAMLSettings) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"debug": schema.BoolAttribute{
+				Computed: true,
+			},
+			"team_management_enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"authn_requests_signed": schema.BoolAttribute{
+				Computed: true,
+			},
+			"want_assertions_signed": schema.BoolAttribute{
+				Computed: true,
+			},
+			"idp_cert": schema.StringAttribute{
+				Computed: true,
+			},
+			"old_idp_cert": schema.StringAttribute{
+				Computed: true,
+			},
+			"slo_endpoint_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"sso_endpoint_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"attr_username": schema.StringAttribute{
+				Computed: true,
+			},
+			"attr_groups": schema.StringAttribute{
+				Computed: true,
+			},
+			"attr_site_admin": schema.StringAttribute{
+				Computed: true,
+			},
+			"site_admin_role": schema.StringAttribute{
+				Computed: true,
+			},
+			"sso_api_token_session_timeout": schema.Int64Attribute{
+				Computed: true,
+			},
+			"acs_consumer_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"metadata_url": schema.StringAttribute{
+				Computed: true,
+			},
+			"certificate": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *dataSourceTFESAMLSettings) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+	d.client = client.Client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *dataSourceTFESAMLSettings) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	s, err := d.client.Admin.Settings.SAML.Read(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read SAML settings", err.Error())
+	}
+
+	// Set state
+	diags := resp.State.Set(ctx, &modelTFESAMLSettings{
+		ID:                        types.StringValue(s.ID),
+		Enabled:                   types.BoolValue(s.Enabled),
+		Debug:                     types.BoolValue(s.Debug),
+		TeamManagementEnabled:     types.BoolValue(s.TeamManagementEnabled),
+		AuthnRequestsSigned:       types.BoolValue(s.AuthnRequestsSigned),
+		WantAssertionsSigned:      types.BoolValue(s.WantAssertionsSigned),
+		IDPCert:                   types.StringValue(s.IDPCert),
+		OldIDPCert:                types.StringValue(s.OldIDPCert),
+		SLOEndpointURL:            types.StringValue(s.SLOEndpointURL),
+		SSOEndpointURL:            types.StringValue(s.SSOEndpointURL),
+		AttrUsername:              types.StringValue(s.AttrUsername),
+		AttrGroups:                types.StringValue(s.AttrGroups),
+		AttrSiteAdmin:             types.StringValue(s.AttrSiteAdmin),
+		SiteAdminRole:             types.StringValue(s.SiteAdminRole),
+		SSOAPITokenSessionTimeout: types.Int64Value(int64(s.SSOAPITokenSessionTimeout)),
+		ACSConsumerURL:            types.StringValue(s.ACSConsumerURL),
+		MetadataURL:               types.StringValue(s.MetadataURL),
+		Certificate:               types.StringValue(s.Certificate),
+	})
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/tfe/data_source_saml_settings_test.go
+++ b/tfe/data_source_saml_settings_test.go
@@ -24,10 +24,6 @@ func TestAccTFESAMLSettingsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceAddress, "team_management_enabled"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "authn_requests_signed"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "want_assertions_signed"),
-					resource.TestCheckResourceAttrSet(resourceAddress, "idp_cert"),
-					resource.TestCheckResourceAttrSet(resourceAddress, "old_idp_cert"),
-					resource.TestCheckResourceAttrSet(resourceAddress, "slo_endpoint_url"),
-					resource.TestCheckResourceAttrSet(resourceAddress, "sso_endpoint_url"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "attr_username"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "attr_groups"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "attr_site_admin"),
@@ -35,7 +31,6 @@ func TestAccTFESAMLSettingsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceAddress, "sso_api_token_session_timeout"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "acs_consumer_url"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "metadata_url"),
-					resource.TestCheckResourceAttrSet(resourceAddress, "certificate"),
 				),
 			},
 		},
@@ -44,5 +39,5 @@ func TestAccTFESAMLSettingsDataSource_basic(t *testing.T) {
 }
 
 func testAccTFESAMLSettingsDataSourceConfig_basic() string {
-	return fmt.Sprintf(`data "tfe_saml_settings" "foobar" {}`)
+	return fmt.Sprint(`data "tfe_saml_settings" "foobar" {}`)
 }

--- a/tfe/data_source_saml_settings_test.go
+++ b/tfe/data_source_saml_settings_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccTFESAMLSettingsDataSource_basic(t *testing.T) {
+	resourceAddress := "data.tfe_saml_settings.foobar"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESAMLSettingsDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceAddress, "id"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "enabled"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "debug"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "team_management_enabled"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "authn_requests_signed"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "want_assertions_signed"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "idp_cert"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "old_idp_cert"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "slo_endpoint_url"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "sso_endpoint_url"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "attr_username"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "attr_groups"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "attr_site_admin"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "site_admin_role"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "sso_api_token_session_timeout"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "acs_consumer_url"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "metadata_url"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "certificate"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func testAccTFESAMLSettingsDataSourceConfig_basic() string {
+	return fmt.Sprintf(`data "tfe_saml_settings" "foobar" {}`)
+}

--- a/tfe/provider_next.go
+++ b/tfe/provider_next.go
@@ -111,7 +111,9 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 }
 
 func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+		NewSAMLSettingsDataSource,
+	}
 }
 
 func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/website/docs/d/saml_settings.html.markdown
+++ b/website/docs/d/saml_settings.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_saml_settings"
+description: |-
+  Get information on SAML Settings.
+---
+
+# Data Source: tfe_saml_settings
+
+Use this data source to get information about SAML Settings.
+
+## Example Usage
+
+```hcl
+data "tfe_saml_settings" "foo" {}
+```
+
+## Argument Reference
+
+No arguments are required for this datasource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - It is always `saml`.
+* `enabled` - Whether SAML single sign-on is enabled.
+* `debug` - Whether debug mode is enabled, which means that the SAMLResponse XML will be displayed on the login page.
+* `team_management_enabled` - Whether Terraform Enterprise is set to manage team membership.
+* `authn_requests_signed` - Whether `<samlp:AuthnRequest>` messages are signed.
+* `want_assertions_signed` - Whether `<saml:Assertion>` elements are signed.
+* `idp_cert` - PEM encoded X.509 Certificate as provided by the IdP configuration.
+* `old_idp_cert` - Previous version of the PEM encoded X.509 Certificate as provided by the IdP configuration.
+* `slo_endpoint_url` - Single Log Out URL.
+* `sso_endpoint_url` - Single Sign On URL.
+* `attr_username` - Name of the SAML attribute that determines the user's username.
+* `attr_groups` - Name of the SAML attribute that determines team membership.
+* `attr_site_admin` - Site admin access role.
+* `site_admin_role` - Site admin access role.
+* `sso_api_token_session_timeout` - Single Sign On session timeout in seconds.
+* `acs_consumer_url` - ACS Consumer (Recipient) URL.
+* `metadata_url` - Metadata (Audience) URL.
+* `certificate` - Request and assertion signing certificate.


### PR DESCRIPTION
## Description

This PR adds the datasource `tfe_saml_settings`. This change is required in order to add SAML settings support to the provider ([documentation](https://developer.hashicorp.com/terraform/enterprise/saml/configuration)). Follow up PR will be to add a resource for `tfe_saml_settings`.

## External links

- [List SAML settings API](https://developer.hashicorp.com/terraform/enterprise/api-docs/admin/settings#list-saml-settings)
- [Additions to go-tfe PR](https://github.com/hashicorp/go-tfe/pull/731)

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFESAMLSettingsDataSource_basic" make testacc

TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFESAMLSettingsDataSource_basic -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFESAMLSettingsDataSource_basic
--- PASS: TestAccTFESAMLSettingsDataSource_basic (19.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	19.853s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```
