### PR TITLE
`d/tfe_project`: Ignore case when matching project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES:
 * **New Resource**: `d/tfe_saml_settings` is a new data source to retrieve SAML settings from the Admin API, by @karvounis-form3 [952](https://github.com/hashicorp/terraform-provider-tfe/pull/952)
 
+BUG FIXES:
+* `d/tfe_project`: Ignore case when matching project name from Projects List API, by @jbonhag [958](https://github.com/hashicorp/terraform-provider-tfe/pull/958)
+
 ## v0.46.0 (July 3, 2023)
 
 FEATURES:

--- a/tfe/data_source_project.go
+++ b/tfe/data_source_project.go
@@ -9,6 +9,7 @@ package tfe
 import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -60,7 +61,8 @@ func dataSourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	for _, proj := range l.Items {
-		if proj.Name == projName {
+		// Case-insensitive uniqueness is enforced in TFC
+		if strings.ToLower(proj.Name) == strings.ToLower(projName) {
 			// Only now include workspaces to cut down on request load.
 			readOptions := &tfe.WorkspaceListOptions{
 				ProjectID: proj.ID,

--- a/tfe/data_source_project.go
+++ b/tfe/data_source_project.go
@@ -8,8 +8,9 @@ package tfe
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -62,7 +63,7 @@ func dataSourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	for _, proj := range l.Items {
 		// Case-insensitive uniqueness is enforced in TFC
-		if strings.ToLower(proj.Name) == strings.ToLower(projName) {
+		if strings.EqualFold(proj.Name, projName) {
 			// Only now include workspaces to cut down on request load.
 			readOptions := &tfe.WorkspaceListOptions{
 				ProjectID: proj.ID,


### PR DESCRIPTION
## Description

Fixes https://github.com/hashicorp/terraform-provider-tfe/issues/882.

This PR performs case-insensitive matching when reading the list of projects from the [Projects List API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/projects#list-projects) for the `tfe_project` data source.

There was a potential issue where a project would not be found in the API response when the name attribute didn't match the case of the existing project exactly. For example, given an organization with a project 'Hello There', this data source would fail to read a matching project, despite its presence in the API response:

```
data "tfe_project" "foo" {
  organization = "jbonhag"
  name         = "hello there"
}
...
╷
│ Error: could not find project jbonhag/hello there
│ 
│   with data.tfe_project.foo,
│   on main.tf line 10, in data "tfe_project" "foo":
│   10: data "tfe_project" "foo" {
│ 
╵
```

Request:

```
GET /api/v2/organizations/jbonhag/projects?filter%5Bnames%5D=hello+there
```

Response:

```
{
  "data": [
    {
      "id": "prj-cPt3Ax5iuwgaGxrp",
      "type": "projects",
      "attributes": {
        "name": "Hello There",
...
```

Because project names in TFC have to be unique without regard to case, it makes sense to match the project name case-insensitively.


_Remember to:_

- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_

- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Create a project called `Foo`
1.  Create a `tfe_project` data source with lowercase name `foo`, e.g.:

```
data "tfe_project" "foo" {
  organization = "my-org"
  name = "foo"
}

output "project_id" {
  value = data.tfe_project.foo.id
}

```

1.  Run `terraform apply`
1.  Project should be found

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/projects#list-projects)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
❯ TESTARGS="-run TestAccTFEProjectDataSource_caseInsensitive" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEProjectDataSource_caseInsensitive -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEProjectDataSource_caseInsensitive
--- PASS: TestAccTFEProjectDataSource_caseInsensitive (8.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	9.045s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```
