### PR TITLE
Add project ids to policy sets data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 * **New Resource**: `r/tfe_saml_settings` manages SAML Settings, by @karvounis-form3 [970](https://github.com/hashicorp/terraform-provider-tfe/pull/970)
 * `d/tfe_saml_settings`: Add PrivateKey (sensitive), SignatureSigningMethod, and SignatureDigestMethod attributes, by @karvounis-form3 [970](https://github.com/hashicorp/terraform-provider-tfe/pull/970)
 * **New Resource**: `r/tfe_project_policy_set` is a new resource to attach/detach an existing `project` to an existing `policy set`, by @Netra2104 [972](https://github.com/hashicorp/terraform-provider-tfe/pull/972)
+* `d/tfe_policy_set`: Add `project_ids` attribute, by @Netra2104 [974](https://github.com/hashicorp/terraform-provider-tfe/pull/974/files)
 
 NOTES:
 * The provider is now using go-tfe [v1.30.0](https://github.com/hashicorp/go-tfe/releases/tag/v1.30.0), by @karvounis-form3 [970](https://github.com/hashicorp/terraform-provider-tfe/pull/970)

--- a/tfe/data_source_policy_set.go
+++ b/tfe/data_source_policy_set.go
@@ -97,6 +97,12 @@ func dataSourceTFEPolicySet() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
+
+			"project_ids": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
 		},
 	}
 }
@@ -163,6 +169,14 @@ func dataSourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error 
 					}
 				}
 				d.Set("workspace_ids", workspaceIDs)
+
+				var projectIDs []interface{}
+				if !policySet.Global {
+					for _, project := range policySet.Projects {
+						projectIDs = append(projectIDs, project.ID)
+					}
+				}
+				d.Set("project_ids", projectIDs)
 
 				d.SetId(policySet.ID)
 

--- a/tfe/data_source_policy_set_test.go
+++ b/tfe/data_source_policy_set_test.go
@@ -45,6 +45,8 @@ func TestAccTFEPolicySetDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "workspace_ids.#", "1"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_policy_set.bar", "project_ids.#", "1"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "vcs_repo.#", "0"),
 				),
 			},
@@ -87,6 +89,8 @@ func TestAccTFEPolicySetDataSourceOPA_basic(t *testing.T) {
 						"data.tfe_policy_set.bar", "overridable", "true"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "workspace_ids.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_policy_set.bar", "project_ids.#", "1"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "vcs_repo.#", "0"),
 				),
@@ -145,6 +149,8 @@ func TestAccTFEPolicySetDataSource_vcs(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "workspace_ids.#", "0"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_policy_set.bar", "project_ids.#", "0"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "vcs_repo.#", "1"),
 				),
 			},
@@ -180,6 +186,11 @@ resource "tfe_workspace" "foobar" {
   organization = local.organization_name
 }
 
+resource "tfe_project" "foobar" {
+  name         = "project-foo-%d"
+  organization = local.organization_name
+}
+
 resource "tfe_sentinel_policy" "foo" {
   name         = "policy-foo"
   policy       = "main = rule { true }"
@@ -192,12 +203,13 @@ resource "tfe_policy_set" "foobar" {
   organization = local.organization_name
   policy_ids   = [tfe_sentinel_policy.foo.id]
   workspace_ids = [tfe_workspace.foobar.id]
+  project_ids = [tfe_project.foobar.id]
 }
 
 data "tfe_policy_set" "bar" {
   name = tfe_policy_set.foobar.name
   organization = local.organization_name
-}`, organization, rInt, rInt)
+}`, organization, rInt, rInt, rInt)
 }
 
 func testAccTFEPolicySetDataSourceConfigOPA_basic(organization string, rInt int) string {
@@ -211,6 +223,11 @@ resource "tfe_workspace" "foobar" {
   organization = local.organization_name
 }
 
+resource "tfe_project" "foobar" {
+  name         = "project-foo-%d"
+  organization = local.organization_name
+}
+
 resource "tfe_policy_set" "foobar" {
   name         = "tst-policy-set-%d"
   description  = "Policy Set"
@@ -218,13 +235,14 @@ resource "tfe_policy_set" "foobar" {
   kind         = "opa"
   overridable  = true
   workspace_ids = [tfe_workspace.foobar.id]
+  project_ids = [tfe_project.foobar.id]
 }
 
 data "tfe_policy_set" "bar" {
   name = tfe_policy_set.foobar.name
   organization = local.organization_name
   kind = "opa"
-}`, organization, rInt, rInt)
+}`, organization, rInt, rInt, rInt)
 }
 
 func testAccTFEPolicySetDataSourceConfig_vcs(organization string, rInt int) string {

--- a/tfe/data_source_policy_set_test.go
+++ b/tfe/data_source_policy_set_test.go
@@ -203,7 +203,12 @@ resource "tfe_policy_set" "foobar" {
   organization = local.organization_name
   policy_ids   = [tfe_sentinel_policy.foo.id]
   workspace_ids = [tfe_workspace.foobar.id]
-  project_ids = [tfe_project.foobar.id]
+  
+}
+
+resource "tfe_project_policy_set" "foobar" {
+	policy_set_id = tfe_policy_set.foobar.id
+	project_id = tfe_project.foobar.id
 }
 
 data "tfe_policy_set" "bar" {
@@ -235,7 +240,11 @@ resource "tfe_policy_set" "foobar" {
   kind         = "opa"
   overridable  = true
   workspace_ids = [tfe_workspace.foobar.id]
-  project_ids = [tfe_project.foobar.id]
+}
+
+resource "tfe_project_policy_set" "foobar" {
+	policy_set_id = tfe_policy_set.foobar.id
+	project_id = tfe_project.foobar.id
 }
 
 data "tfe_policy_set" "bar" {

--- a/tfe/data_source_policy_set_test.go
+++ b/tfe/data_source_policy_set_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccTFEPolicySetDataSource_basic(t *testing.T) {
+	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -136,6 +136,14 @@ func resourceTFEPolicySet() *schema.Resource {
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				ConflictsWith: []string{"global"},
 			},
+
+			"project_ids": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"global"},
+			},
 		},
 	}
 }
@@ -195,6 +203,10 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 
 	for _, workspaceID := range d.Get("workspace_ids").(*schema.Set).List() {
 		options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
+	}
+
+	for _, projectID := range d.Get("project_ids").(*schema.Set).List() {
+		options.Projects = append(options.Projects, &tfe.Project{ID: projectID.(string)})
 	}
 
 	log.Printf("[DEBUG] Create policy set %s for organization: %s", name, organization)

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -136,14 +136,6 @@ func resourceTFEPolicySet() *schema.Resource {
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				ConflictsWith: []string{"global"},
 			},
-
-			"project_ids": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Computed:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"global"},
-			},
 		},
 	}
 }
@@ -203,10 +195,6 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 
 	for _, workspaceID := range d.Get("workspace_ids").(*schema.Set).List() {
 		options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
-	}
-
-	for _, projectID := range d.Get("project_ids").(*schema.Set).List() {
-		options.Projects = append(options.Projects, &tfe.Project{ID: projectID.(string)})
 	}
 
 	log.Printf("[DEBUG] Create policy set %s for organization: %s", name, organization)

--- a/website/docs/d/policy_set.html.markdown
+++ b/website/docs/d/policy_set.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `kind` - The policy-as-code framework for the policy. Valid values are "sentinel" and "opa".
 * `overridable` - Whether users can override this policy when it fails during a run. Only valid for OPA policies.
 * `workspace_ids` - IDs of the workspaces that use the policy set.
+* `project_ids` - IDs of the projects that use the policy set.
 * `policy_ids` - IDs of the policies attached to the policy set.
 * `policies_path` - The sub-path within the attached VCS repository when using `vcs_repo`.
 * `vcs_repo` - Settings for the workspace's VCS repository.


### PR DESCRIPTION
## Description

Project ids needs to be added to the policy set data source. 

## External links

- [Related PR](https://hashicorp.atlassian.net/jira/software/c/projects/TF/boards/593?modal=detail&selectedIssue=TF-6351&assignee=626ff58e2db308007023a9d8)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
=== RUN   TestAccTFEPolicySetDataSource_basic
2023/07/26 11:13:33 [DEBUG] Configuring client for host "app.staging.terraform.io"
2023/07/26 11:13:33 [ERROR] Error reading CLI config or credentials file /Users/netra.mali/.terraformrc: open /Users/netra.mali/.terraformrc: no such file or directory
2023/07/26 11:13:33 [ERROR] Error reading CLI config or credentials file /Users/netra.mali/.terraform.d/credentials.tfrc.json: open /Users/netra.mali/.terraform.d/credentials.tfrc.json: no such file or directory
2023/07/26 11:13:33 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
--- PASS: TestAccTFEPolicySetDataSource_basic (34.69s)
PASS

=== RUN   TestAccTFEPolicySetDataSource_vcs
2023/07/26 11:14:49 [DEBUG] Configuring client for host "app.staging.terraform.io"
2023/07/26 11:14:49 [ERROR] Error reading CLI config or credentials file /Users/netra.mali/.terraformrc: open /Users/netra.mali/.terraformrc: no such file or directory
2023/07/26 11:14:49 [ERROR] Error reading CLI config or credentials file /Users/netra.mali/.terraform.d/credentials.tfrc.json: open /Users/netra.mali/.terraform.d/credentials.tfrc.json: no such file or directory
2023/07/26 11:14:49 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
    data_source_policy_set_test.go:122: Please set GITHUB_POLICY_SET_IDENTIFIER to run this test
--- SKIP: TestAccTFEPolicySetDataSource_vcs (1.79s)

Test ignored.
PASS

=== RUN   TestAccTFEPolicySetDataSource_notFound
--- PASS: TestAccTFEPolicySetDataSource_notFound (5.50s)
PASS

...
```

A small doc change to add a new attribute to the data source: project_ids

![Screenshot 2023-07-26 at 10 00 20 AM](https://github.com/hashicorp/terraform-provider-tfe/assets/42544158/5e4ca31f-455f-492e-b2c6-58ca03ca03be)

