### PR TITLE
TF-5569 add support for custom project permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ FEATURES:
 * `d/tfe_saml_settings`: Add PrivateKey (sensitive), SignatureSigningMethod, and SignatureDigestMethod attributes, by @karvounis-form3 [970](https://github.com/hashicorp/terraform-provider-tfe/pull/970)
 * **New Resource**: `r/tfe_project_policy_set` is a new resource to attach/detach an existing `project` to an existing `policy set`, by @Netra2104 [972](https://github.com/hashicorp/terraform-provider-tfe/pull/972)
 * `d/tfe_policy_set`: Add `project_ids` attribute, by @Netra2104 [974](https://github.com/hashicorp/terraform-provider-tfe/pull/974/files)
+* `r/tfe_team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes with
+various customizable permissions options to apply at the project level to the project itself and all of the workspaces therein, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
+* `d/team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
 
 NOTES:
 * The provider is now using go-tfe [v1.30.0](https://github.com/hashicorp/go-tfe/releases/tag/v1.30.0), by @karvounis-form3 [970](https://github.com/hashicorp/terraform-provider-tfe/pull/970)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ FEATURES:
 * **New Resource**: `r/tfe_project_policy_set` is a new resource to attach/detach an existing `project` to an existing `policy set`, by @Netra2104 [972](https://github.com/hashicorp/terraform-provider-tfe/pull/972)
 * `d/tfe_policy_set`: Add `project_ids` attribute, by @Netra2104 [974](https://github.com/hashicorp/terraform-provider-tfe/pull/974/files)
 * `r/tfe_team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes with
-various customizable permissions options to apply at the project level to the project itself and all of the workspaces therein, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
+various customizable permissions options to apply to a project and all of the workspaces therein, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
 * `d/team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
 
 NOTES:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/hashicorp/go-slug v0.12.0
-	github.com/hashicorp/go-tfe v1.31.1-0.20230801200939-9a03826e069f
+	github.com/hashicorp/go-tfe v1.32.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.17.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/hashicorp/go-slug v0.12.0
-	github.com/hashicorp/go-tfe v1.31.0
+	github.com/hashicorp/go-tfe v1.31.1-0.20230801200939-9a03826e069f
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c h1:figwFwYep1Qnl64Y+Rc8tyQWE0xvYAN+5EX+rD40pTU=
 github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
@@ -7,6 +10,8 @@ github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
@@ -18,6 +23,7 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
+github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.4.1 h1:Uwp5tDRkPr+l/TnbHOQzp+tmJfLceOlbVucgpTz8ix4=
 github.com/go-git/go-git/v5 v5.6.1 h1:q4ZRqQl4pR/ZJHc1L5CFjGA1a10u76aV1iC+nh+bHsk=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
@@ -60,6 +66,10 @@ github.com/hashicorp/go-tfe v1.31.0 h1:R1CokrAVBHxrsvRw1vKes7RQxTRTWcula7gjQK7Jf
 github.com/hashicorp/go-tfe v1.31.0/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
 github.com/hashicorp/go-tfe v1.31.1-0.20230801200939-9a03826e069f h1:j/8My4e8aBYIZLIT+IJPUuRCA44JE5Hm+MzL6/1oNlY=
 github.com/hashicorp/go-tfe v1.31.1-0.20230801200939-9a03826e069f/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
+github.com/hashicorp/go-tfe v1.31.1-0.20230804191300-6f876e410412 h1:II2M8hJUWfLi879Wlm1yp87xqCZBwpXeFFL2MSr7dA4=
+github.com/hashicorp/go-tfe v1.31.1-0.20230804191300-6f876e410412/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
+github.com/hashicorp/go-tfe v1.32.0 h1:wyUQJHPrqF5IwD5Y4YJFTlU3A08LXoJ2PLF7x80febU=
+github.com/hashicorp/go-tfe v1.32.0/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -97,8 +107,10 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -116,8 +128,10 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -131,8 +145,12 @@ github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DV
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/skeema/knownhosts v1.1.0 h1:Wvr9V0MxhjRbl3f9nMnKnFfiWTJmtECJ9Njkea3ysW0=
+github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -142,6 +160,7 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
@@ -151,6 +170,7 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -243,6 +263,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
+gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/hashicorp/go-slug v0.12.0 h1:y1ArGp5RFF85uvD8nq5VZug/bup/kGN5Ft4xFOQ5
 github.com/hashicorp/go-slug v0.12.0/go.mod h1:JZVtycnZZbiJ4oxpJ/zfhyfBD8XxT4f0uOSyjNLCqFY=
 github.com/hashicorp/go-tfe v1.31.0 h1:R1CokrAVBHxrsvRw1vKes7RQxTRTWcula7gjQK7Jfsk=
 github.com/hashicorp/go-tfe v1.31.0/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
+github.com/hashicorp/go-tfe v1.31.1-0.20230801200939-9a03826e069f h1:j/8My4e8aBYIZLIT+IJPUuRCA44JE5Hm+MzL6/1oNlY=
+github.com/hashicorp/go-tfe v1.31.1-0.20230801200939-9a03826e069f/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,3 @@
-github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c h1:figwFwYep1Qnl64Y+Rc8tyQWE0xvYAN+5EX+rD40pTU=
 github.com/ProtonMail/go-crypto v0.0.0-20230619160724-3fbb1f12458c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
@@ -10,8 +7,6 @@ github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
@@ -23,7 +18,6 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
-github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.4.1 h1:Uwp5tDRkPr+l/TnbHOQzp+tmJfLceOlbVucgpTz8ix4=
 github.com/go-git/go-git/v5 v5.6.1 h1:q4ZRqQl4pR/ZJHc1L5CFjGA1a10u76aV1iC+nh+bHsk=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
@@ -62,12 +56,6 @@ github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZn
 github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-slug v0.12.0 h1:y1ArGp5RFF85uvD8nq5VZug/bup/kGN5Ft4xFOQ5GPM=
 github.com/hashicorp/go-slug v0.12.0/go.mod h1:JZVtycnZZbiJ4oxpJ/zfhyfBD8XxT4f0uOSyjNLCqFY=
-github.com/hashicorp/go-tfe v1.31.0 h1:R1CokrAVBHxrsvRw1vKes7RQxTRTWcula7gjQK7Jfsk=
-github.com/hashicorp/go-tfe v1.31.0/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
-github.com/hashicorp/go-tfe v1.31.1-0.20230801200939-9a03826e069f h1:j/8My4e8aBYIZLIT+IJPUuRCA44JE5Hm+MzL6/1oNlY=
-github.com/hashicorp/go-tfe v1.31.1-0.20230801200939-9a03826e069f/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
-github.com/hashicorp/go-tfe v1.31.1-0.20230804191300-6f876e410412 h1:II2M8hJUWfLi879Wlm1yp87xqCZBwpXeFFL2MSr7dA4=
-github.com/hashicorp/go-tfe v1.31.1-0.20230804191300-6f876e410412/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
 github.com/hashicorp/go-tfe v1.32.0 h1:wyUQJHPrqF5IwD5Y4YJFTlU3A08LXoJ2PLF7x80febU=
 github.com/hashicorp/go-tfe v1.32.0/go.mod h1:vcfy2u52JQ4sYLFi941qcQXQYfUq2RjEW466tZ+m97Y=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -107,10 +95,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
-github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -128,10 +114,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -145,12 +129,8 @@ github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DV
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/skeema/knownhosts v1.1.0 h1:Wvr9V0MxhjRbl3f9nMnKnFfiWTJmtECJ9Njkea3ysW0=
-github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -160,7 +140,6 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
@@ -170,7 +149,6 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
-github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -263,7 +241,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
-gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tfe/data_source_team_project_access.go
+++ b/tfe/data_source_team_project_access.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	tfe "github.com/hashicorp/go-tfe"
@@ -30,18 +31,88 @@ func dataSourceTFETeamProjectAccess() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			"project_access": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"settings": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"teams": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"workspace_access": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"locking": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"move": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"delete": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"run_tasks": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"runs": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"sentinel_mocks": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"state_versions": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"variables": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
 func dataSourceTFETeamProjectAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(ConfiguredClient)
-
 	// Get the team ID.
 	teamID := d.Get("team_id").(string)
-
 	// Get the project
 	projectID := d.Get("project_id").(string)
+
 	proj, err := config.Client.Projects.Read(ctx, projectID)
 	if err != nil {
 		return diag.Errorf(

--- a/tfe/data_source_team_project_access_test.go
+++ b/tfe/data_source_team_project_access_test.go
@@ -37,6 +37,55 @@ func TestAccTFETeamProjectAccessDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamProjectCustomAccessDataSource_basic(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccessDataSourceConfig(org.Name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.tfe_team_project_access.foobar_custom", "id"),
+					resource.TestCheckResourceAttrSet("data.tfe_team_project_access.foobar_custom", "team_id"),
+					resource.TestCheckResourceAttrSet("data.tfe_team_project_access.foobar_custom", "project_id"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "access", "custom"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "project_access.0.settings", "delete"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.runs", "apply"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.delete", "false"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccTFETeamProjectAccessDataSourceConfig(organization string) string {
 	return fmt.Sprintf(`
 resource "tfe_team" "foobar" {
@@ -59,5 +108,45 @@ data "tfe_team_project_access" "foobar" {
   team_id      = tfe_team.foobar.id
   project_id   = tfe_project.foobar.id
   depends_on = [tfe_team_project_access.foobar]
+}`, organization, organization)
+}
+
+func testAccTFETeamProjectCustomAccessDataSourceConfig(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_team" "foobar_custom" {
+  name         = "team-test2"
+  organization = "%s"
+}
+
+resource "tfe_project" "foobar_custom" {
+  name         = "projecttest2"
+  organization = "%s"
+}
+
+resource "tfe_team_project_access" "foobar_custom" {
+  access       = "custom"
+  team_id      = tfe_team.foobar_custom.id
+  project_id   = tfe_project.foobar_custom.id
+  project_access {
+    settings = "delete"
+    teams    = "manage"
+  }
+  workspace_access {
+    state_versions = "write"
+    sentinel_mocks = "read"
+		runs					 = "apply"
+    variables      = "write"
+    create         = true
+    locking        = true
+    move           = true
+    delete         = false
+    run_tasks      = false
+  }
+}
+
+data "tfe_team_project_access" "foobar_custom" {
+  team_id      = tfe_team.foobar_custom.id
+  project_id   = tfe_project.foobar_custom.id
+  depends_on   = [tfe_team_project_access.foobar_custom]
 }`, organization, organization)
 }

--- a/tfe/resource_tfe_team_project_access.go
+++ b/tfe/resource_tfe_team_project_access.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 
 	tfe "github.com/hashicorp/go-tfe"
@@ -26,6 +27,7 @@ func resourceTFETeamProjectAccess() *schema.Resource {
 
 		SchemaVersion: 1,
 
+		CustomizeDiff: checkForCustomPermissions,
 		Schema: map[string]*schema.Schema{
 			"access": {
 				Type:     schema.TypeString,
@@ -36,6 +38,7 @@ func resourceTFETeamProjectAccess() *schema.Resource {
 						string(tfe.TeamProjectAccessWrite),
 						string(tfe.TeamProjectAccessMaintain),
 						string(tfe.TeamProjectAccessRead),
+						string(tfe.TeamProjectAccessCustom),
 					},
 					false,
 				),
@@ -55,6 +58,138 @@ func resourceTFETeamProjectAccess() *schema.Resource {
 					projectIDRegexp,
 					"must be a valid project ID (prj-<RANDOM STRING>)",
 				),
+			},
+
+			"project_access": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"settings": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.ProjectSettingsPermissionRead),
+									string(tfe.ProjectSettingsPermissionUpdate),
+									string(tfe.ProjectSettingsPermissionDelete),
+								},
+								false,
+							),
+						},
+
+						"teams": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.ProjectTeamsPermissionNone),
+									string(tfe.ProjectTeamsPermissionRead),
+									string(tfe.ProjectTeamsPermissionManage),
+								},
+								false,
+							),
+						},
+					},
+				},
+			},
+
+			"workspace_access": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"locking": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"move": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"delete": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"run_tasks": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"runs": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.WorkspaceRunsPermissionRead),
+									string(tfe.WorkspaceRunsPermissionPlan),
+									string(tfe.WorkspaceRunsPermissionApply),
+								},
+								false,
+							),
+						},
+
+						"sentinel_mocks": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.WorkspaceSentinelMocksPermissionNone),
+									string(tfe.WorkspaceSentinelMocksPermissionRead),
+								},
+								false,
+							),
+						},
+
+						"state_versions": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.WorkspaceStateVersionsPermissionNone),
+									string(tfe.WorkspaceStateVersionsPermissionReadOutputs),
+									string(tfe.WorkspaceStateVersionsPermissionRead),
+									string(tfe.WorkspaceStateVersionsPermissionWrite),
+								},
+								false,
+							),
+						},
+
+						"variables": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.WorkspaceVariablesPermissionNone),
+									string(tfe.WorkspaceVariablesPermissionRead),
+									string(tfe.WorkspaceVariablesPermissionWrite),
+								},
+								false,
+							),
+						},
+					},
+				},
 			},
 		},
 	}
@@ -83,9 +218,55 @@ func resourceTFETeamProjectAccessCreate(ctx context.Context, d *schema.ResourceD
 
 	// Create a new options struct.
 	options := tfe.TeamProjectAccessAddOptions{
-		Access:  *tfe.ProjectAccess(tfe.TeamProjectAccessType(access)),
-		Team:    tm,
-		Project: proj,
+		Access:          *tfe.ProjectAccess(tfe.TeamProjectAccessType(access)),
+		Team:            tm,
+		Project:         proj,
+		ProjectAccess:   &tfe.TeamProjectAccessProjectPermissionsOptions{},
+		WorkspaceAccess: &tfe.TeamProjectAccessWorkspacePermissionsOptions{},
+	}
+
+	if v, ok := d.GetOk("project_access.0.settings"); ok {
+		options.ProjectAccess.Settings = tfe.ProjectSettingsPermission(tfe.ProjectSettingsPermissionType(v.(string)))
+	}
+
+	if v, ok := d.GetOk("project_access.0.teams"); ok {
+		options.ProjectAccess.Teams = tfe.ProjectTeamsPermission(tfe.ProjectTeamsPermissionType(v.(string)))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.state_versions"); ok {
+		options.WorkspaceAccess.StateVersions = tfe.WorkspaceStateVersionsPermission(tfe.WorkspaceStateVersionsPermissionType(v.(string)))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.sentinel_mocks"); ok {
+		options.WorkspaceAccess.SentinelMocks = tfe.WorkspaceSentinelMocksPermission(tfe.WorkspaceSentinelMocksPermissionType(v.(string)))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.runs"); ok {
+		options.WorkspaceAccess.Runs = tfe.WorkspaceRunsPermission(tfe.WorkspaceRunsPermissionType(v.(string)))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.variables"); ok {
+		options.WorkspaceAccess.Variables = tfe.WorkspaceVariablesPermission(tfe.WorkspaceVariablesPermissionType(v.(string)))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.create"); ok {
+		options.WorkspaceAccess.Create = tfe.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.locking"); ok {
+		options.WorkspaceAccess.Locking = tfe.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.move"); ok {
+		options.WorkspaceAccess.Move = tfe.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.delete"); ok {
+		options.WorkspaceAccess.Delete = tfe.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("workspace_access.0.run_tasks"); ok {
+		options.WorkspaceAccess.RunTasks = tfe.Bool(v.(bool))
 	}
 
 	log.Printf("[DEBUG] Give team %s %s access to project: %s", tm.Name, access, proj.Name)
@@ -129,6 +310,31 @@ func resourceTFETeamProjectAccessRead(ctx context.Context, d *schema.ResourceDat
 		d.Set("project_id", "")
 	}
 
+	project_access := []map[string]interface{}{{
+		"settings": tmAccess.ProjectAccess.ProjectSettingsPermission,
+		"teams":    tmAccess.ProjectAccess.ProjectTeamsPermission,
+	}}
+
+	workspace_access := []map[string]interface{}{{
+		"state_versions": tmAccess.WorkspaceAccess.WorkspaceStateVersionsPermission,
+		"sentinel_mocks": tmAccess.WorkspaceAccess.WorkspaceSentinelMocksPermission,
+		"runs":           tmAccess.WorkspaceAccess.WorkspaceRunsPermission,
+		"variables":      tmAccess.WorkspaceAccess.WorkspaceVariablesPermission,
+		"create":         tmAccess.WorkspaceAccess.WorkspaceCreatePermission,
+		"locking":        tmAccess.WorkspaceAccess.WorkspaceLockingPermission,
+		"move":           tmAccess.WorkspaceAccess.WorkspaceMovePermission,
+		"delete":         tmAccess.WorkspaceAccess.WorkspaceDeletePermission,
+		"run_tasks":      tmAccess.WorkspaceAccess.WorkspaceRunTasksPermission,
+	}}
+
+	if err := d.Set("project_access", project_access); err != nil {
+		return diag.Errorf("Error setting configuration of team project access %s: %v", d.Id(), err)
+	}
+
+	if err := d.Set("workspace_access", workspace_access); err != nil {
+		return diag.Errorf("Error setting configuration of team workspace access %s: %v", d.Id(), err)
+	}
+
 	return nil
 }
 
@@ -136,11 +342,87 @@ func resourceTFETeamProjectAccessUpdate(ctx context.Context, d *schema.ResourceD
 	config := meta.(ConfiguredClient)
 
 	// create an options struct
-	options := tfe.TeamProjectAccessUpdateOptions{}
+	options := tfe.TeamProjectAccessUpdateOptions{
+		ProjectAccess:   &tfe.TeamProjectAccessProjectPermissionsOptions{},
+		WorkspaceAccess: &tfe.TeamProjectAccessWorkspacePermissionsOptions{},
+	}
 
 	// Set access level
 	access := d.Get("access").(string)
 	options.Access = tfe.ProjectAccess(tfe.TeamProjectAccessType(access))
+
+	if d.HasChange("project_access.0.settings") {
+		if settings, ok := d.GetOk("project_access.0.settings"); ok {
+			projectSettingsPermissionType := tfe.ProjectSettingsPermissionType(settings.(string))
+			options.ProjectAccess.Settings = &projectSettingsPermissionType
+		}
+	}
+
+	if d.HasChange("project_access.0.teams") {
+		if teams, ok := d.GetOk("project_access.0.teams"); ok {
+			projectTeamsPermissionType := tfe.ProjectTeamsPermissionType(teams.(string))
+			options.ProjectAccess.Teams = &projectTeamsPermissionType
+		}
+	}
+
+	if d.HasChange("workspace_access.0.state_versions") {
+		if state_versions, ok := d.GetOk("workspace_access.0.state_versions"); ok {
+			workspaceStateVersionsPermissionType := tfe.WorkspaceStateVersionsPermissionType(state_versions.(string))
+			options.WorkspaceAccess.StateVersions = &workspaceStateVersionsPermissionType
+		}
+	}
+
+	if d.HasChange("workspace_access.0.sentinel_mocks") {
+		if sentinel_mocks, ok := d.GetOk("workspace_access.0.sentinel_mocks"); ok {
+			workspaceSentinelMocksPermissionType := tfe.WorkspaceSentinelMocksPermissionType(sentinel_mocks.(string))
+			options.WorkspaceAccess.SentinelMocks = &workspaceSentinelMocksPermissionType
+		}
+	}
+
+	if d.HasChange("workspace_access.0.runs") {
+		if runs, ok := d.GetOk("workspace_access.0.runs"); ok {
+			workspaceRunsPermissionType := tfe.WorkspaceRunsPermissionType(runs.(string))
+			options.WorkspaceAccess.Runs = &workspaceRunsPermissionType
+		}
+	}
+
+	if d.HasChange("workspace_access.0.variables") {
+		if variables, ok := d.GetOk("workspace_access.0.variables"); ok {
+			workspaceVariablesPermissionType := tfe.WorkspaceVariablesPermissionType(variables.(string))
+			options.WorkspaceAccess.Variables = &workspaceVariablesPermissionType
+		}
+	}
+
+	if d.HasChange("workspace_access.0.create") {
+		if create, ok := d.GetOkExists("workspace_access.0.create"); ok {
+			create := tfe.Bool(create.(bool))
+			options.WorkspaceAccess.Create = create
+		}
+	}
+
+	if d.HasChange("workspace_access.0.locking") {
+		if locking, ok := d.GetOkExists("workspace_access.0.locking"); ok {
+			options.WorkspaceAccess.Locking = tfe.Bool(locking.(bool))
+		}
+	}
+
+	if d.HasChange("workspace_access.0.move") {
+		if move, ok := d.GetOkExists("workspace_access.0.move"); ok {
+			options.WorkspaceAccess.Move = tfe.Bool(move.(bool))
+		}
+	}
+
+	if d.HasChange("workspace_access.0.delete") {
+		if delete, ok := d.GetOkExists("workspace_access.0.delete"); ok {
+			options.WorkspaceAccess.Delete = tfe.Bool(delete.(bool))
+		}
+	}
+
+	if d.HasChange("workspace_access.0.run_tasks") {
+		if run_tasks, ok := d.GetOkExists("workspace_access.0.run_tasks"); ok {
+			options.WorkspaceAccess.RunTasks = tfe.Bool(run_tasks.(bool))
+		}
+	}
 
 	log.Printf("[DEBUG] Update team project access: %s", d.Id())
 	_, err := config.Client.TeamProjectAccess.Update(ctx, d.Id(), options)
@@ -149,7 +431,7 @@ func resourceTFETeamProjectAccessUpdate(ctx context.Context, d *schema.ResourceD
 			"Error updating team project access %s: %v", d.Id(), err)
 	}
 
-	return nil
+	return resourceTFETeamProjectAccessRead(ctx, d, meta)
 }
 
 func resourceTFETeamProjectAccessDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -162,6 +444,26 @@ func resourceTFETeamProjectAccessDelete(ctx context.Context, d *schema.ResourceD
 			return nil
 		}
 		return diag.Errorf("Error deleting team project access %s: %v", d.Id(), err)
+	}
+
+	return nil
+}
+
+// You cannot set custom permissions when access level is not "custom"
+func checkForCustomPermissions(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+
+	if access, ok := d.GetOk("access"); ok && access != "custom" {
+		// is an empty [] if project_access is not in the config
+		project_access := d.GetRawConfig().GetAttr("project_access").AsValueSet().Values()
+		if len(project_access) != 0 {
+			return fmt.Errorf("you can only set project_access permissions with access level custom")
+		}
+
+		// is an empty [] if project_access is not in the config
+		workspace_access := d.GetRawConfig().GetAttr("workspace_access").AsValueSet().Values()
+		if len(workspace_access) != 0 {
+			return fmt.Errorf("you can only set workspace_access permissions with access level custom")
+		}
 	}
 
 	return nil

--- a/tfe/resource_tfe_team_project_access_test.go
+++ b/tfe/resource_tfe_team_project_access_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 	"testing"
 	"time"
 
@@ -38,6 +39,39 @@ func TestAccTFETeamProjectAccess(t *testing.T) {
 	}
 }
 
+func TestAccTFETeamProjectCustomAccess(t *testing.T) {
+	tmAccess := &tfe.TeamProjectAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	access := tfe.TeamProjectAccessCustom
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccess(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "delete"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.runs", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+		},
+	})
+}
 func TestAccTFETeamProjectAccess_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -53,6 +87,151 @@ func TestAccTFETeamProjectAccess_import(t *testing.T) {
 				ResourceName:      "tfe_team_project_access.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFETeamProjectCustomAccess_import(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	tmAccess := &tfe.TeamProjectAccess{}
+	access := tfe.TeamProjectAccessCustom
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccess(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "delete"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.runs", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+			{
+				ResourceName:      "tfe_team_project_access.custom_foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFETeamProjectCustomAccess_full_update(t *testing.T) {
+	tmAccess := &tfe.TeamProjectAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	access := tfe.TeamProjectAccessCustom
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccess(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "delete"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.runs", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+			{
+				Config: testAccTFETeamProjectCustomAccess_full_update(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "none"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "none"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.runs", "apply"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFETeamProjectCustomAccess_partial_update(t *testing.T) {
+	tmAccess := &tfe.TeamProjectAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	access := tfe.TeamProjectAccessCustom
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccess(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "delete"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+			{
+				Config: testAccTFETeamProjectCustomAccess_partial_update(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					// changed access levels
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "true"),
+					// unchanged access levels
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
 			},
 		},
 	})
@@ -85,6 +264,22 @@ func testAccCheckTFETeamProjectAccessExists(
 
 		return nil
 	}
+}
+
+func TestAccTFETeamProjectCustomAccess_invalid_custom_access(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFETeamProjectCustomAccess_invalid_custom_config(rInt),
+				ExpectError: regexp.MustCompile("you can only set workspace_access permissions with access level custom"),
+			},
+		},
+	})
 }
 
 func testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess *tfe.TeamProjectAccess, access tfe.TeamProjectAccessType) resource.TestCheckFunc {
@@ -139,4 +334,141 @@ resource "tfe_team_project_access" "foobar" {
   team_id      = tfe_team.foobar.id
   project_id   = tfe_project.foobar.id
 }`, rInt, access)
+}
+
+func testAccTFETeamProjectCustomAccess(rInt int, access tfe.TeamProjectAccessType) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar_2" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar_2" {
+  name         = "team-test"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_project" "foobar_2" {
+  name         = "projecttest"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_team_project_access" "custom_foobar" {
+  access       = "%s"
+  team_id      = tfe_team.foobar_2.id
+  project_id   = tfe_project.foobar_2.id
+  project_access {
+    settings = "delete"
+    teams    = "manage"
+  }
+  workspace_access {
+    state_versions = "write"
+    sentinel_mocks = "read"
+    runs           = "read"
+    variables      = "write"
+    create         = true
+    locking        = true
+    move           = true
+    delete         = false
+    run_tasks      = false
+  }
+
+}`, rInt, access)
+}
+
+func testAccTFETeamProjectCustomAccess_full_update(rInt int, access tfe.TeamProjectAccessType) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar_2" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar_2" {
+  name         = "team-test"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_project" "foobar_2" {
+  name         = "projecttest"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_team_project_access" "custom_foobar" {
+  access       = "%s"
+  team_id      = tfe_team.foobar_2.id
+  project_id   = tfe_project.foobar_2.id
+  project_access {
+    settings = "read"
+    teams    = "none"
+  }
+  workspace_access {
+    state_versions = "read"
+    sentinel_mocks = "none"
+    runs           = "apply"
+    variables      = "read"
+    create         = false
+    locking        = false
+    move           = false
+    delete         = true
+    run_tasks      = true
+  }
+}`, rInt, access)
+}
+
+func testAccTFETeamProjectCustomAccess_partial_update(rInt int, access tfe.TeamProjectAccessType) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar_2" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar_2" {
+  name         = "team-test"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_project" "foobar_2" {
+  name         = "projecttest"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_team_project_access" "custom_foobar" {
+  access       = "%s"
+  team_id      = tfe_team.foobar_2.id
+  project_id   = tfe_project.foobar_2.id
+  project_access {
+    settings = "read"
+  }
+  workspace_access {
+    delete = true
+  }
+}`, rInt, access)
+}
+
+func testAccTFETeamProjectCustomAccess_invalid_custom_config(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar_2" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar_invalid" {
+  name         = "team-test"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_project" "foobar_invalid" {
+  name         = "projecttest"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_team_project_access" "custom_invalid" {
+  access       = "read"
+  team_id      = tfe_team.foobar_invalid.id
+  project_id   = tfe_project.foobar_invalid.id
+
+  workspace_access {
+    delete = true
+  }
+}`, rInt)
 }

--- a/website/docs/r/team_project_access.html.markdown
+++ b/website/docs/r/team_project_access.html.markdown
@@ -37,7 +37,74 @@ The following arguments are supported:
 
 * `team_id` - (Required) ID of the team to add to the project.
 * `project_id` - (Required) ID of the project to which the team will be added.
-* `access` - (Required) Type of fixed access to grant. Valid values are `admin`, `maintain`, `write`, or `read`.
+* `access` - (Required) Type of fixed access to grant. Valid values are `admin`, `maintain`, `write`, `read`, or `custom`.
+
+## Custom Access
+
+If using `custom` for `access`, you can set the levels of individual permissions
+that affect the project itself and all workspaces in the project, by using `project_access` and `workspace_access` arguments and their associated permission attributes. When using custom access, if attributes are not set they will be given a default value. Some permissions have values that are specific "strings" that denote the level of the permission, while other permissions are simple booleans.
+
+The following permissions apply to the project itself.
+
+| project-access      | Description, Default, Valid Values          | 
+|---------------------|---------------------------------------------|
+| `settings`          | The permission to grant for the project's settings. Default: `read`. Valid strings: `read`, `update`, or `delete` |
+| `teams`             | The permission to grant for the project's teams. Default: `none`, Valid strings: `none`, `read`, or `manage` |
+
+</n>
+</n>
+</n>
+
+The following permissions apply to all workpsaces (and future workspaces) in the project.
+
+| workspace-access     | Description, Default, Valid Values                    | 
+|----------------------|-------------------------------------------------------|
+| `runs`               | The permission to grant project's workspaces' runs. Default: `read`. Valid strings: `read`, `plan`, or `apply`. |
+| `sentinel-mocks`     | The permission to grant project's workspaces' Sentinel mocks. Default: `none`. Valid strings: `none`, or `read`. |
+| `state-versions`     | The permission to grant project's workspaces' state versions. Default: `none` Valid strings: `none`, `read-outputs`, `read`, or `write`.|
+| `variables`          | The permission to grant project's workspaces' variables. Default `none`. Valid strings: `none`, `read`, or `write`. |
+| `create`             | The permission to create project's workspaces in the project. Default: `false`. Valid booleans `true`, `false` |
+| `locking`            | The permission to manually lock or unlock the project's workspaces. Default `false`. Valid booleans `true`, `false` |
+| `delete`             | The permission to delete the project's workspaces. Default: `false`. Valid booleans: `true`, `false` |
+| `move`               | This permission to move workspaces into and out of the project. The team must also have permissions to the project(s) receiving the the workspace(s). Default: `false`. Valid booleans: `true`, `false` |
+| `run-tasks`          | The permission to manage run tasks within the project's workspaces. Default `false`. Valid booleans: `true`, `false` |
+
+
+## Example Usage with Custom Project Permissions
+
+```hcl
+resource "tfe_team" "dev" {
+  name         = "my-dev-team"
+  organization = "my-org-name"
+}
+
+resource "tfe_project" "test" {
+  name         = "myproject"
+  organization = "my-org-name"
+}
+
+resource "tfe_team_project_access" "custom" {
+  access       = "custom"
+  team_id      = tfe_team.dev.id
+  project_id   = tfe_project.test.id
+
+  project_access {
+    settings = "read"
+    teams    = "none"
+  }
+  workspace_access {
+    state_versions = "write"
+    sentinel_mocks = "none"
+    runs           = "apply"
+    variables      = "write"
+    create         = true
+    locking        = true
+    move           = false
+    delete         = false
+    run_tasks      = false
+  }
+}
+```
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

With the release of customizable project permissions in TFC, we want people to be able to do use the new permissions in their terraform configs as well. There are two types of customizable permissions that can be set on team_projects, `project_access` which control access to certain abilities on the project itself as well as `workspace_access` permissions which effect all workspaces inside of the project.

This pr:
* Adds a new access level Custom option
* Adds the ability to read/write/update/import the new access levels and the corresponding `workspace_access` and `project_access` permissions.
* Makes it impossible to write config that has both an non-custom access level AND `workspace_access` and `project_access` permissions. This is done by using a [CustomizeDiff Function:](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/customizing-differences) [checkForCustomPermissions](https://github.com/hashicorp/terraform-provider-tfe/pull/983/files#diff-c4af4604f75d3fb86bbf0077775b521d098610fcf7d97e9f868510dc6d70aa88R453). Due to some limitations to GetChange and GetOk (if it doesn't exist in the config, but still exists in state -- the permission attributes didn't show up as empty) I had to also use the [RawConfig function](https://github.com/hashicorp/terraform-provider-tfe/pull/983/files#diff-c4af4604f75d3fb86bbf0077775b521d098610fcf7d97e9f868510dc6d70aa88R457) which returns a `cty.Value` that I could scoop the actual value of the attribute from the actual config being processed for update.

- [x] Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_

- [x] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Example main.tf

- [ ] Test you can create a team_project_access resource with `access: "custom"` and custom permissions set.

```
terraform {
  required_providers {
    tfe = {
      version = "~> 0.46.0"
    }
  }
}

data "tfe_organization" "org" {
  name = "<name of org with business access>"
}

resource "tfe_team" "test_team" {
  name         = "a1team"
  organization = data.tfe_organization.org.name
}

resource "tfe_project" "test_project" {
  name         = "a1project"
  organization = data.tfe_organization.org.name
}

resource "tfe_team_project_access" "custom_foobar" {
  access     = "custom"
  team_id    = tfe_team.test_team.id
  project_id = tfe_project.test_project.id
  project_access {
    settings = "delete"
    teams    = "manage"
  }
  workspace_access {
    state_versions = "read"
    sentinel_mocks = "none"
    runs           = "apply"
    variables      = "write"
    create         = true
    locking        = true
    move           = true
    delete         = true
    run_tasks      = true
  }
}

```

- [x] Test that you can update the values of some of the permissions
- [x] Test that if you change `access` to `read` with the `project_access` and `workspace_access` sets that you get an error
- [x] Test that you can change `access` to `read`, remove the `project_access` and `workspace_access` sections, that you can successfully apply the update. The values of the permissions in the state file should also be updated to match the implied permissions (easiest way to see that working is to update again to `admin` access -- you should then see permissions to do ALL the things v.s. what you see for read, but [you can also check the docs for those](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/project-team-access#implied-custom-permission-levels)) 
- [x] Test that you can import a team_project_access data source of a team_project that already exists
```
data "tfe_team_project_access" "tpa" {
  team_id    = "team-a3LLXuFdT6uBj53m"
  project_id = "prj-nevQrQZiVvyc8bpr"
}
```
- [x] Test that you can destroy the team_project_access resources that you've made 

## External links

- [API documentation on Project Team Access](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/project-team-access)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/745)

## Output from acceptance tests

```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFETeamProjectCustomAccess -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
=== RUN   TestAccTFETeamProjectCustomAccessDataSource_basic
2023/08/03 11:07:57 [DEBUG] Configuring client for host "tfcdev-3519dce5.ngrok.io"
2023/08/03 11:07:57 [ERROR] Error reading CLI config or credentials file /Users/rachaelberecka/.terraformrc: open /Users/rachaelberecka/.terraformrc: no such file or directory
2023/08/03 11:07:57 [DEBUG] Service discovery for tfcdev-3519dce5.ngrok.io at https://tfcdev-3519dce5.ngrok.io/.well-known/terraform.json
--- PASS: TestAccTFETeamProjectCustomAccessDataSource_basic (19.36s)
=== RUN   TestAccTFETeamProjectCustomAccess
--- PASS: TestAccTFETeamProjectCustomAccess (16.39s)
=== RUN   TestAccTFETeamProjectCustomAccess_import
--- PASS: TestAccTFETeamProjectCustomAccess_import (17.42s)
=== RUN   TestAccTFETeamProjectCustomAccess_full_update
--- PASS: TestAccTFETeamProjectCustomAccess_full_update (20.34s)
=== RUN   TestAccTFETeamProjectCustomAccess_partial_update
--- PASS: TestAccTFETeamProjectCustomAccess_partial_update (20.97s)
=== RUN   TestAccTFETeamProjectCustomAccess_invalid_custom_access
--- PASS: TestAccTFETeamProjectCustomAccess_invalid_custom_access (1.97s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/tfe 97.006s
```

```
$ TFE_HOSTNAME=<tfcdev>TFE_TOKEN=<user token on owner's team in org>="-run TestAccTFETeamProjectCustomAccess" make testacc
...
```

## Example outputs from plans/applies

Here's the output of a create plan & apply
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # tfe_project.test_project will be created
  + resource "tfe_project" "test_project" {
      + id           = (known after apply)
      + name         = "a1project"
      + organization = "hashicorp"
    }

  # tfe_team.test_team will be created
  + resource "tfe_team" "test_team" {
      + id           = (known after apply)
      + name         = "a1team"
      + organization = "hashicorp"
      + visibility   = "secret"

      + organization_access {
          + manage_membership       = (known after apply)
          + manage_modules          = (known after apply)
          + manage_policies         = (known after apply)
          + manage_policy_overrides = (known after apply)
          + manage_projects         = (known after apply)
          + manage_providers        = (known after apply)
          + manage_run_tasks        = (known after apply)
          + manage_vcs_settings     = (known after apply)
          + manage_workspaces       = (known after apply)
          + read_projects           = (known after apply)
          + read_workspaces         = (known after apply)
        }
    }

  # tfe_team_project_access.custom_foobar will be created
  + resource "tfe_team_project_access" "custom_foobar" {
      + access     = "custom"
      + id         = (known after apply)
      + project_id = (known after apply)
      + team_id    = (known after apply)

      + project_access {
          + settings = "delete"
          + teams    = "manage"
        }

      + workspace_access {
          + create         = false
          + delete         = true
          + locking        = false
          + move           = false
          + run_tasks      = true
          + runs           = "apply"
          + sentinel_mocks = "read"
          + state_versions = "write"
          + variables      = "read"
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

first apply


Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tfe_team.test_team: Creating...
tfe_project.test_project: Creating...
tfe_team.test_team: Creation complete after 0s [id=team-fySqgKuUviv6q3iY]
tfe_project.test_project: Creation complete after 0s [id=prj-k8bhRZevJuY23gjh]
tfe_team_project_access.custom_foobar: Creating...
tfe_team_project_access.custom_foobar: Creation complete after 1s [id=tprj-R7FXUdKiDKUp9XuR]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

Example state of from team_project_access data_source:

```
    {
      "mode": "data",
      "type": "tfe_team_project_access",
      "name": "tpa",
      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "access": "custom",
            "id": "tprj-QbvzFkZVe86aGJDu",
            "project_access": [
              {
                "settings": "delete",
                "teams": "manage"
              }
            ],
            "project_id": "prj-nevQrQZiVvyc8bpr",
            "team_id": "team-a3LLXuFdT6uBj53m",
            "workspace_access": [
              {
                "create": true,
                "delete": true,
                "locking": true,
                "move": true,
                "run_tasks": true,
                "runs": "apply",
                "sentinel_mocks": "read",
                "state_versions": "write",
                "variables": "write"
              }
            ]
          },
          "sensitive_attributes": []
        }
      ]
    }
```

## Docs update Preview

<img width="1710" alt="image" src="https://github.com/hashicorp/terraform-provider-tfe/assets/12437993/4b9804b7-6d5b-48fa-9d08-775c9705d0cb">

<img width="1717" alt="image" src="https://github.com/hashicorp/terraform-provider-tfe/assets/12437993/52ea409a-a8a6-4bf3-a134-cf8e4e1d80d4">

<img width="1728" alt="image" src="https://github.com/hashicorp/terraform-provider-tfe/assets/12437993/59894002-8491-478e-b31a-c18d549fd35b">

<img width="1721" alt="image" src="https://github.com/hashicorp/terraform-provider-tfe/assets/12437993/905318d1-102f-40ff-a540-48d2e9cfe1e6">

