### PR TITLE
Add tfe_teams data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* **New Data Source**: `d/tfe_teams` is a new data source to return names and IDs of Teams in an Organization, by @isaacmcollins [992] https://github.com/hashicorp/terraform-provider-tfe/pull/992
+
 ## v0.48.0 (August 7, 2023)
 
 BUG FIXES:
@@ -14,6 +16,7 @@ FEATURES:
 * `r/tfe_team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes with
 various customizable permissions options to apply to a project and all of the workspaces therein, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
 * `d/team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
+
 
 NOTES:
 * The provider is now using go-tfe [v1.32.0](https://github.com/hashicorp/go-tfe/releases/tag/v1.32.0)

--- a/tfe/data_source_teams.go
+++ b/tfe/data_source_teams.go
@@ -1,0 +1,77 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceTFETeams() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTFETeamsRead,
+
+		Schema: map[string]*schema.Schema{
+			"organization": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"ids": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTFETeamsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(ConfiguredClient)
+	organization, err := config.schemaOrDefaultOrganization(d)
+	if err != nil {
+		return err
+	}
+
+	teams, err := config.Client.Teams.List(ctx, organization, &tfe.TeamListOptions{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving teams: %w", err)
+	}
+
+	if len(teams.Items) == 0 {
+		return fmt.Errorf("Could not find teams in  %s", organization)
+	} else {
+		options := &tfe.TeamListOptions{}
+		names := []string{}
+		ids := map[string]string{}
+		for {
+			for _, team := range teams.Items {
+				names = append(names, team.Name)
+				ids[team.Name] = team.ID
+			}
+
+			if teams.CurrentPage >= teams.TotalPages {
+				break
+			}
+
+			options.PageNumber = teams.NextPage
+
+			teams, err = config.Client.Teams.List(ctx, organization, options)
+			if err != nil {
+				return fmt.Errorf("Error retrieving teams: %w", err)
+			}
+		}
+		d.SetId(organization)
+		d.Set("names", names)
+		d.Set("ids", ids)
+	}
+	return nil
+}

--- a/tfe/data_source_teams_test.go
+++ b/tfe/data_source_teams_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccTFETeamsDataSource_basic(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String(fmt.Sprintf("tst-terraform-%d", rInt)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamsDataSourceConfig_basic_resource(rInt, org.Name),
+			},
+			{
+				Config: testAccTFETeamsDataSourceConfig_basic_data(org.Name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTFETeamsHasNames("data.tfe_teams.foobar", []string{
+						fmt.Sprintf("team-foo-%d", rInt),
+						fmt.Sprintf("team-bar-%d", rInt),
+					}),
+					testAccCheckTFETeamsHasIDs("data.tfe_teams.foobar", []string{
+						fmt.Sprintf("team-foo-%d", rInt),
+						fmt.Sprintf("team-bar-%d", rInt),
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTFETeamsHasNames(teamsData string, teamNames []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		teams, ok := s.RootModule().Resources[teamsData]
+		if !ok {
+			return fmt.Errorf("Teams data '%s' not found.", teamsData)
+		}
+		numTeamsStr := teams.Primary.Attributes["names.#"]
+		numTeams, _ := strconv.Atoi(numTeamsStr)
+
+		if numTeams < len(teamNames) {
+			return fmt.Errorf("expected %d organizations, but found %d.", len(teamNames), numTeams)
+		}
+
+		teamsMap := map[string]struct{}{}
+		for i := 0; i < numTeams; i++ {
+			teamName := teams.Primary.Attributes[fmt.Sprintf("names.%d", i)]
+			teamsMap[teamName] = struct{}{}
+		}
+
+		for _, teamName := range teamNames {
+			_, ok := teamsMap[teamName]
+			if !ok {
+				return fmt.Errorf("expected to find team name %s, but did not.", teamName)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFETeamsHasIDs(teamsData string, teamNames []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		teams, ok := s.RootModule().Resources[teamsData]
+		if !ok {
+			return fmt.Errorf("Teams data '%s' not found.", teamsData)
+		}
+
+		for _, teamName := range teamNames {
+			id := fmt.Sprintf("ids.%s", teamName)
+			_, ok := teams.Primary.Attributes[id]
+			if !ok {
+				return fmt.Errorf("expected to find team id %s, but did not.", id)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccTFETeamsDataSourceConfig_basic_resource(rInt int, organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_team" "foo" {
+  name         = "team-foo-%d"
+  organization = "%s"
+}
+
+resource "tfe_team" "bar" {
+	name         = "team-bar-%d"
+	organization = "%s"
+}`, rInt, organization, rInt, organization)
+}
+
+func testAccTFETeamsDataSourceConfig_basic_data(organization string) string {
+	return fmt.Sprintf(`
+	data "tfe_teams" "foobar" {
+		organization = "%s"
+	}`, organization)
+}

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -121,6 +121,7 @@ func Provider() *schema.Provider {
 			"tfe_slug":                    dataSourceTFESlug(),
 			"tfe_ssh_key":                 dataSourceTFESSHKey(),
 			"tfe_team":                    dataSourceTFETeam(),
+			"tfe_teams":                   dataSourceTFETeams(),
 			"tfe_team_access":             dataSourceTFETeamAccess(),
 			"tfe_team_project_access":     dataSourceTFETeamProjectAccess(),
 			"tfe_workspace":               dataSourceTFEWorkspace(),

--- a/website/docs/d/teams.html.markdown
+++ b/website/docs/d/teams.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # Data Source: tfe_teams
 
-Use this data source to get a list of Teams in an Organization and a map of their IDs.
+Use this data source to get a list of Teams in an Organization and a map of their IDs. The Teams returned may be a subset of all teams in an Organization based on the permissions of the API token.
 
 ## Example Usage
 
@@ -21,7 +21,7 @@ data "tfe_teams" "foo" {
 
 The following arguments are supported:
 
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization.
 
 ## Attributes Reference
 

--- a/website/docs/d/teams.html.markdown
+++ b/website/docs/d/teams.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_teams"
+description: |-
+  Get information on Teams.
+---
+
+# Data Source: tfe_teams
+
+Use this data source to get a list of Teams in an Organization and a map of their IDs.
+
+## Example Usage
+
+```hcl
+data "tfe_teams" "foo" {
+  organization = "my-org-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Required) Name of the organization.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+* `id` - Name of the organization.
+* `names` - A list of team names in an organization.
+* `ids` - A map of team names in an organization and their IDs.


### PR DESCRIPTION
## Description

This PR adds a new data source ```tfe_teams``` which returns a list of all Team names in an Organization and a map of Team names to their respective IDs.

Closes [#913]

## Testing plan

1. Using the config below:
```hcl
provider "tfe" {}

resource "tfe_team" "foo" {
  name         = "foo"
  organization = "test-org"
}

resource "tfe_team" "bar" {
  name         = "bar"
  organization = "test-org"
}

data "tfe_teams" "teams" {
  organization = "test-org"
}
```
2. Should yield the following results:
```hcl
names = tolist([
    "foo",
    "bar",
])
ids = tomap({
    "foo" = "foo-id"
    "bar" = "bar-id"
})
```

## External links

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)

## Output from acceptance tests
```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```