### PR TITLE
Add project_ids to variable set data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+FEATURES:
+* `d/tfe_variable_set`: Add `project_ids` attribute, by @Netra2104 [994](https://github.com/hashicorp/terraform-provider-tfe/pull/994)
+  
 ## v0.48.0 (August 7, 2023)
 
 BUG FIXES:
@@ -14,7 +17,6 @@ FEATURES:
 * `r/tfe_team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes with
 various customizable permissions options to apply to a project and all of the workspaces therein, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
 * `d/team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
-* `d/tfe_variable_set`: Add `project_ids` attribute, by @Netra2104 [994](https://github.com/hashicorp/terraform-provider-tfe/pull/994)
 
 NOTES:
 * The provider is now using go-tfe [v1.32.0](https://github.com/hashicorp/go-tfe/releases/tag/v1.32.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ FEATURES:
 * `r/tfe_team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes with
 various customizable permissions options to apply to a project and all of the workspaces therein, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
 * `d/team_project_access`: Add a `custom` option to the `access` attribute as well as `project_access` and `workspace_access` attributes, by @rberecka [983](https://github.com/hashicorp/terraform-provider-tfe/pull/983)
+* `d/tfe_variable_set`: Add `project_ids` attribute, by @Netra2104 [994](https://github.com/hashicorp/terraform-provider-tfe/pull/994)
 
 NOTES:
 * The provider is now using go-tfe [v1.32.0](https://github.com/hashicorp/go-tfe/releases/tag/v1.32.0)

--- a/tfe/data_source_variable_set.go
+++ b/tfe/data_source_variable_set.go
@@ -48,6 +48,13 @@ func dataSourceTFEVariableSet() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"project_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -103,6 +110,12 @@ func dataSourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) erro
 					variables = append(variables, variable.ID)
 				}
 				d.Set("variable_ids", variables)
+
+				var projects []interface{}
+				for _, project := range vs.Projects {
+					projects = append(projects, project.ID)
+				}
+				d.Set("project_ids", projects)
 
 				d.SetId(vs.ID)
 				return nil

--- a/tfe/data_source_variable_set_test.go
+++ b/tfe/data_source_variable_set_test.go
@@ -56,6 +56,8 @@ func TestAccTFEVariableSetsDataSource_full(t *testing.T) {
 						"data.tfe_variable_set.foobar", "workspace_ids.#", "1"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_variable_set.foobar", "variable_ids.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_variable_set.foobar", "project_ids.#", "1"),
 				),
 			},
 		},
@@ -94,11 +96,17 @@ resource "tfe_workspace" "foobar" {
   organization = tfe_organization.foobar.id
 }
 
+resource "tfe_project" "foobar" {
+  name         = "project-foo-%d"
+  organization = tfe_organization.foobar.id
+}
+
 resource "tfe_variable_set" "foobar" {
   name = "varset-foo-%d"
 	description = "a description"
 	organization = tfe_organization.foobar.id
 	workspace_ids = [tfe_workspace.foobar.id]
+	project_ids = [tfe_project.foobar.id]
 }
 
 resource "tfe_variable" "envfoo" {
@@ -112,5 +120,5 @@ data "tfe_variable_set" "foobar" {
   name = tfe_variable_set.foobar.name
 	organization = tfe_variable_set.foobar.organization
 	depends_on = [tfe_variable.envfoo]
-}`, rInt, rInt, rInt)
+}`, rInt, rInt, rInt, rInt)
 }

--- a/tfe/data_source_variable_set_test.go
+++ b/tfe/data_source_variable_set_test.go
@@ -106,7 +106,11 @@ resource "tfe_variable_set" "foobar" {
 	description = "a description"
 	organization = tfe_organization.foobar.id
 	workspace_ids = [tfe_workspace.foobar.id]
-	project_ids = [tfe_project.foobar.id]
+}
+
+resource "tfe_project_variable_set" "foobar" {
+	variable_set_id = tfe_variable_set.foobar.id
+	project_id = tfe_project.foobar.id
 }
 
 resource "tfe_variable" "envfoo" {

--- a/website/docs/d/variable_set.html.markdown
+++ b/website/docs/d/variable_set.html.markdown
@@ -36,3 +36,4 @@ The following arguments are supported:
 * `global` - Whether or not the variable set applies to all workspaces in the organization.
 * `workspace_ids` - IDs of the workspaces that use the variable set.
 * `variable_ids` - IDs of the variables attached to the variable set.
+* `project_ids` - IDs of the projects that use the variable set.


### PR DESCRIPTION
## Description

The [variable set](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/variable_set#attributes-reference) data source exports a workspace_ids attribute containing the set of workspace ids that a varset is assigned to. For completeness, we should update the TFE provider to export a list of project_ids as well.

## External links

- [Jira Ticket](https://hashicorp.atlassian.net/jira/software/c/projects/TF/boards/593?modal=detail&selectedIssue=TF-5323&assignee=626ff58e2db308007023a9d8)

## Output from acceptance tests

```
/Users/netra.mali/go/go1.19.11/bin/go tool test2json -t /Users/netra.mali/Library/Caches/JetBrains/GoLand2023.1/tmp/GoLand/___TestAccTFEVariableSetsDataSource_full_in_github_com_hashicorp_terraform_provider_tfe_tfe.test -test.v -test.paniconexit0 -test.run ^\QTestAccTFEVariableSetsDataSource_full\E$
=== RUN   TestAccTFEVariableSetsDataSource_full
--- PASS: TestAccTFEVariableSetsDataSource_full (18.74s)
PASS

```
![Screenshot 2023-08-08 at 12 08 21 PM](https://github.com/hashicorp/terraform-provider-tfe/assets/42544158/ebca2082-47b5-45b3-9245-e4d1fac7a53b)


