### PR TITLE
[TF-6330] add org membership ID attr to tfe_organization_membership

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,8 @@ _Describe why you're making this change._
 
 _Remember to:_
 
-- _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
-
-- _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_
+- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
+- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_
 
 ## Testing plan
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
 FEATURES:
+* `d/tfe_organization_membership`: Add `organization_membership_id` attribute, by @laurenolivia [997](https://github.com/hashicorp/terraform-provider-tfe/pull/997)
 * `d/tfe_variable_set`: Add `project_ids` attribute, by @Netra2104 [994](https://github.com/hashicorp/terraform-provider-tfe/pull/994)
 * **New Data Source**: `d/tfe_teams` is a new data source to return names and IDs of Teams in an Organization, by @isaacmcollins [992](https://github.com/hashicorp/terraform-provider-tfe/pull/992)
+
 ## v0.48.0 (August 7, 2023)
 
 BUG FIXES:

--- a/tfe/data_source_organization_membership.go
+++ b/tfe/data_source_organization_membership.go
@@ -37,9 +37,10 @@ func dataSourceTFEOrganizationMembership() *schema.Resource {
 			},
 
 			"organization_membership_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				AtLeastOneOf: []string{"email", "username"},
 			},
 		},
 	}

--- a/tfe/data_source_organization_membership.go
+++ b/tfe/data_source_organization_membership.go
@@ -35,6 +35,12 @@ func dataSourceTFEOrganizationMembership() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"organization_membership_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -45,17 +51,23 @@ func dataSourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interf
 	// Get the user email and organization.
 	email := d.Get("email").(string)
 	username := d.Get("username").(string)
+	orgMemberID := d.Get("organization_membership_id").(string)
 
 	organization, err := config.schemaOrDefaultOrganization(d)
 	if err != nil {
 		return err
 	}
 
-	orgMember, err := fetchOrganizationMemberByNameOrEmail(context.Background(), config.Client, organization, username, email)
-	if err != nil {
-		return fmt.Errorf("could not find organization membership for organization %s: %w", organization, err)
+	if orgMemberID == "" {
+		orgMember, err := fetchOrganizationMemberByNameOrEmail(context.Background(), config.Client, organization, username, email)
+		if err != nil {
+			return fmt.Errorf("could not find organization membership for organization %s: %w", organization, err)
+		}
+
+		d.SetId(orgMember.ID)
+	} else {
+		d.SetId(orgMemberID)
 	}
 
-	d.SetId(orgMember.ID)
 	return resourceTFEOrganizationMembershipRead(d, meta)
 }

--- a/tfe/data_source_organization_membership_test.go
+++ b/tfe/data_source_organization_membership_test.go
@@ -94,7 +94,7 @@ func TestAccTFEOrganizationMembershipDataSource_missingParams(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOrganizationMembershipDataSourceMissingParams(rInt),
-				ExpectError: regexp.MustCompile("you must specify a username, email, or organization_membership_id"),
+				ExpectError: regexp.MustCompile("`email,organization_membership_id,username` must be specified"),
 			},
 		},
 	})

--- a/tfe/data_source_organization_membership_test.go
+++ b/tfe/data_source_organization_membership_test.go
@@ -34,6 +34,18 @@ func TestAccTFEOrganizationMembershipDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.tfe_organization_membership.foobar", "user_id"),
 				),
 			},
+			{
+				Config: testAccTFEOrganizationMembershipDataSourceConfigWithOrgMemberID(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_membership.foobar", "email", "example@hashicorp.com"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_membership.foobar", "username", ""),
+					resource.TestCheckResourceAttr(
+						"data.tfe_organization_membership.foobar", "organization", orgName),
+					resource.TestCheckResourceAttrSet("data.tfe_organization_membership.foobar", "user_id"),
+				),
+			},
 		},
 	})
 }
@@ -128,5 +140,23 @@ resource "tfe_organization_membership" "foobar" {
 
 data "tfe_organization_membership" "foobar" {
   organization = tfe_organization.foobar.name
+}`, rInt)
+}
+
+func testAccTFEOrganizationMembershipDataSourceConfigWithOrgMemberID(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_organization_membership" "foobar" {
+  email        = "example@hashicorp.com"
+  organization = tfe_organization.foobar.id
+}
+
+data "tfe_organization_membership" "foobar" {
+  organization 								= tfe_organization.foobar.name
+  organization_membership_id  = tfe_organization_membership.foobar.id
 }`, rInt)
 }

--- a/tfe/data_source_organization_membership_test.go
+++ b/tfe/data_source_organization_membership_test.go
@@ -94,7 +94,7 @@ func TestAccTFEOrganizationMembershipDataSource_missingParams(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOrganizationMembershipDataSourceMissingParams(rInt),
-				ExpectError: regexp.MustCompile("you must specify a username or email"),
+				ExpectError: regexp.MustCompile("you must specify a username, email, or organization_membership_id"),
 			},
 		},
 	})

--- a/tfe/organization_members_helpers.go
+++ b/tfe/organization_members_helpers.go
@@ -47,7 +47,7 @@ func fetchOrganizationMembers(client *tfe.Client, orgName string) ([]map[string]
 
 func fetchOrganizationMemberByNameOrEmail(ctx context.Context, client *tfe.Client, organization, username, email string) (*tfe.OrganizationMembership, error) {
 	if email == "" && username == "" {
-		return nil, fmt.Errorf("you must specify a username or email")
+		return nil, fmt.Errorf("you must specify a username, email, or organization_membership_id")
 	}
 
 	options := &tfe.OrganizationMembershipListOptions{

--- a/tfe/organization_members_helpers.go
+++ b/tfe/organization_members_helpers.go
@@ -47,7 +47,7 @@ func fetchOrganizationMembers(client *tfe.Client, orgName string) ([]map[string]
 
 func fetchOrganizationMemberByNameOrEmail(ctx context.Context, client *tfe.Client, organization, username, email string) (*tfe.OrganizationMembership, error) {
 	if email == "" && username == "" {
-		return nil, fmt.Errorf("you must specify a username, email, or organization_membership_id")
+		return nil, fmt.Errorf("you must specify a username or email")
 	}
 
 	options := &tfe.OrganizationMembershipListOptions{

--- a/website/docs/d/organization_membership.html.markdown
+++ b/website/docs/d/organization_membership.html.markdown
@@ -28,10 +28,19 @@ data "tfe_organization_membership" "test" {
 
 ### Fetch by username
 
-```
+```hcl
 data "tfe_organization_membership" "test" {
   organization  = "my-org-name"
   username = "my-username"
+}
+```
+
+### Fetch by organization membership ID
+
+```hcl
+data "tfe_organization_membership" "test" {
+  organization  = "my-org-name"
+  organization_membership_id = "ou-xxxxxxxxxxx"
 }
 ```
 
@@ -39,11 +48,12 @@ data "tfe_organization_membership" "test" {
 
 The following arguments are supported:
 
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization.
 * `email` - (Optional) Email of the user.
 * `username` - (Optional) The username of the user.
+* `organization_membership_id` - (Optional) ID belonging to the organziation membership.
 
-~> **NOTE:** While `email` and `username` are optional arguments, one or the other is required.
+~> **NOTE:** While `email` and `username` are optional arguments, one or the other is required if `organization_membership_id` argument is not provided.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This PR adds the `organization_membership_id` to the `tfe_organization_membership` data source. The original feature request wanted the data source to also allow the `user_id` arg, however the Organization Membership API doesn't accept `user_id` as a query param.

_Remember to:_
- [x] Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)
- [x] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)

## Testing plan

1.  Use the `d/tfe_organization_membership` with the following arguments:
```
data "tfe_organization_membership" "test" {
  organization  = "my-org-name"
  organization_membership_id = "ou-xxxxxxxxxxx"
}
```

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://github.com/hashicorp/go-tfe/blob/main/organization_membership.go)
- [Organization Membership API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/organization-memberships#organization-memberships-api)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEOrganizationMembershipDataSource_basic" make testacc

--- PASS: TestAccTFEOrganizationMembershipDataSource_basic (17.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/tfe	(cached)
...
```

<img width="696" alt="Screenshot 2023-08-11 at 2 22 51 PM" src="https://github.com/hashicorp/terraform-provider-tfe/assets/29918071/3286e81b-450e-4f7f-9314-b28e65d29861">
