### PR TITLE
Docs: Fix missing backticks in 'tfe_registry_module' docs

### DIFF
--- a/website/docs/cdktf/csharp/r/registry_module.html.markdown
+++ b/website/docs/cdktf/csharp/r/registry_module.html.markdown
@@ -183,7 +183,7 @@ The `VcsRepo` block supports:
   string.
 * `Identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)
-  and repository in your VCS provider. The format for Azure DevOps is <organization>/<project>/\_git/<repository>.
+  and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `OauthTokenId` - (Optional) Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `GithubAppInstallationId` and can only be used if `GithubAppInstallationId` is not used.
 * `GithubAppInstallationId` - (Optional) The installation id of the Github App. This conflicts with `OauthTokenId` and can only be used if `OauthTokenId` is not used.
 

--- a/website/docs/cdktf/csharp/r/registry_module.html.markdown
+++ b/website/docs/cdktf/csharp/r/registry_module.html.markdown
@@ -179,7 +179,7 @@ The following arguments are supported:
 The `VcsRepo` block supports:
 
 * `DisplayIdentifier` - (Required) The display identifier for your VCS repository.
-  For most VCS providers outside of BitBucket Cloud, this will match the `Identifier`
+  For most VCS providers outside of BitBucket Cloud and Azure DevOps, this will match the `Identifier`
   string.
 * `Identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)

--- a/website/docs/cdktf/go/r/registry_module.html.markdown
+++ b/website/docs/cdktf/go/r/registry_module.html.markdown
@@ -202,7 +202,7 @@ The following arguments are supported:
 The `VcsRepo` block supports:
 
 * `DisplayIdentifier` - (Required) The display identifier for your VCS repository.
-  For most VCS providers outside of BitBucket Cloud, this will match the `Identifier`
+  For most VCS providers outside of BitBucket Cloud and Azure DevOps, this will match the `Identifier`
   string.
 * `Identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)

--- a/website/docs/cdktf/go/r/registry_module.html.markdown
+++ b/website/docs/cdktf/go/r/registry_module.html.markdown
@@ -206,7 +206,7 @@ The `VcsRepo` block supports:
   string.
 * `Identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)
-  and repository in your VCS provider. The format for Azure DevOps is <organization>/<project>/\_git/<repository>.
+  and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `OauthTokenId` - (Optional) Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `GithubAppInstallationId` and can only be used if `GithubAppInstallationId` is not used.
 * `GithubAppInstallationId` - (Optional) The installation id of the Github App. This conflicts with `OauthTokenId` and can only be used if `OauthTokenId` is not used.
 

--- a/website/docs/cdktf/java/r/registry_module.html.markdown
+++ b/website/docs/cdktf/java/r/registry_module.html.markdown
@@ -182,7 +182,7 @@ The following arguments are supported:
 The `vcsRepo` block supports:
 
 * `displayIdentifier` - (Required) The display identifier for your VCS repository.
-  For most VCS providers outside of BitBucket Cloud, this will match the `identifier`
+  For most VCS providers outside of BitBucket Cloud and Azure DevOps, this will match the `identifier`
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)

--- a/website/docs/cdktf/java/r/registry_module.html.markdown
+++ b/website/docs/cdktf/java/r/registry_module.html.markdown
@@ -186,7 +186,7 @@ The `vcsRepo` block supports:
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)
-  and repository in your VCS provider. The format for Azure DevOps is <organization>/<project>/\_git/<repository>.
+  and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `oauthTokenId` - (Optional) Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `githubAppInstallationId` and can only be used if `githubAppInstallationId` is not used.
 * `githubAppInstallationId` - (Optional) The installation id of the Github App. This conflicts with `oauthTokenId` and can only be used if `oauthTokenId` is not used.
 

--- a/website/docs/cdktf/python/r/registry_module.html.markdown
+++ b/website/docs/cdktf/python/r/registry_module.html.markdown
@@ -189,7 +189,7 @@ The `vcs_repo` block supports:
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)
-  and repository in your VCS provider. The format for Azure DevOps is <organization>/<project>/\_git/<repository>.
+  and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `oauth_token_id` - (Optional) Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.
 * `github_app_installation_id` - (Optional) The installation id of the Github App. This conflicts with `oauth_token_id` and can only be used if `oauth_token_id` is not used.
 

--- a/website/docs/cdktf/python/r/registry_module.html.markdown
+++ b/website/docs/cdktf/python/r/registry_module.html.markdown
@@ -185,7 +185,7 @@ The following arguments are supported:
 The `vcs_repo` block supports:
 
 * `display_identifier` - (Required) The display identifier for your VCS repository.
-  For most VCS providers outside of BitBucket Cloud, this will match the `identifier`
+  For most VCS providers outside of BitBucket Cloud and Azure DevOps, this will match the `identifier`
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)

--- a/website/docs/cdktf/typescript/r/registry_module.html.markdown
+++ b/website/docs/cdktf/typescript/r/registry_module.html.markdown
@@ -208,7 +208,7 @@ The following arguments are supported:
 The `vcsRepo` block supports:
 
 * `displayIdentifier` - (Required) The display identifier for your VCS repository.
-  For most VCS providers outside of BitBucket Cloud, this will match the `identifier`
+  For most VCS providers outside of BitBucket Cloud and Azure DevOps, this will match the `identifier`
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)

--- a/website/docs/cdktf/typescript/r/registry_module.html.markdown
+++ b/website/docs/cdktf/typescript/r/registry_module.html.markdown
@@ -212,7 +212,7 @@ The `vcsRepo` block supports:
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)
-  and repository in your VCS provider. The format for Azure DevOps is <organization>/<project>/\_git/<repository>.
+  and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `oauthTokenId` - (Optional) Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `githubAppInstallationId` and can only be used if `githubAppInstallationId` is not used.
 * `githubAppInstallationId` - (Optional) The installation id of the Github App. This conflicts with `oauthTokenId` and can only be used if `oauthTokenId` is not used.
 

--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -128,7 +128,7 @@ The following arguments are supported:
 The `vcs_repo` block supports:
 
 * `display_identifier` - (Required) The display identifier for your VCS repository.
-  For most VCS providers outside of BitBucket Cloud, this will match the `identifier`
+  For most VCS providers outside of BitBucket Cloud and Azure DevOps, this will match the `identifier`
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)

--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -132,7 +132,7 @@ The `vcs_repo` block supports:
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Server)
-  and repository in your VCS provider. The format for Azure DevOps is <organization>/<project>/\_git/<repository>.
+  and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `oauth_token_id` - (Optional) Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.
 * `github_app_installation_id` - (Optional) The installation id of the Github App. This conflicts with `oauth_token_id` and can only be used if `oauth_token_id` is not used.
 


### PR DESCRIPTION
## Description

Missing backticks in the docs for `tfe_registry_module` result in `//_git/` once rendered by a browser. The expected string is `<ado organization>/<ado project>/_git/<ado repository>` instead.
 https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/registry_module#identifier

Additionally, this PR adds Azure DevOps to the list of exceptions for VCS providers where `identifier` and `display_identifier` do not match.
