### PR TITLE
Add excluded_workspace_ids to policy sets data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 * `r/tfe_team_project_access`: Fixes a panic that occurs when the client is configured against an older TFE release, by @sebasslash [1011](https://github.com/hashicorp/terraform-provider-tfe/pull/1011)
 * The provider no longer makes two service discovery requests per provider config, by @brandonc [1034](https://github.com/hashicorp/terraform-provider-tfe/pull/1034)
+* `d/tfe_policy_set`: Add `excluded_workspace_ids` attribute, by @Netra2104 [1035](https://github.com/hashicorp/terraform-provider-tfe/pull/1035)
 
 FEATURES:
 * `d/tfe_organization_membership`: Add `organization_membership_id` attribute, by @laurenolivia [997](https://github.com/hashicorp/terraform-provider-tfe/pull/997)

--- a/internal/provider/data_source_policy_set.go
+++ b/internal/provider/data_source_policy_set.go
@@ -177,10 +177,8 @@ func dataSourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error 
 				d.Set("workspace_ids", workspaceIDs)
 
 				var excludedWorkspaceIDs []interface{}
-				if !policySet.Global {
-					for _, excludedWorkspace := range policySet.WorkspaceExclusions {
-						excludedWorkspaceIDs = append(excludedWorkspaceIDs, excludedWorkspace.ID)
-					}
+				for _, excludedWorkspace := range policySet.WorkspaceExclusions {
+					excludedWorkspaceIDs = append(excludedWorkspaceIDs, excludedWorkspace.ID)
 				}
 				d.Set("excluded_workspace_ids", excludedWorkspaceIDs)
 

--- a/internal/provider/data_source_policy_set.go
+++ b/internal/provider/data_source_policy_set.go
@@ -98,6 +98,12 @@ func dataSourceTFEPolicySet() *schema.Resource {
 				Computed: true,
 			},
 
+			"excluded_workspace_ids": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
 			"project_ids": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -169,6 +175,14 @@ func dataSourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error 
 					}
 				}
 				d.Set("workspace_ids", workspaceIDs)
+
+				var excludedWorkspaceIDs []interface{}
+				if !policySet.Global {
+					for _, excludedWorkspace := range policySet.WorkspaceExclusions {
+						excludedWorkspaceIDs = append(excludedWorkspaceIDs, excludedWorkspace.ID)
+					}
+				}
+				d.Set("excluded_workspace_ids", excludedWorkspaceIDs)
 
 				var projectIDs []interface{}
 				if !policySet.Global {

--- a/internal/provider/data_source_policy_set_test.go
+++ b/internal/provider/data_source_policy_set_test.go
@@ -217,7 +217,7 @@ resource "tfe_project_policy_set" "foobar" {
 	project_id = tfe_project.foobar.id
 }
 
-resource "tfe_workspace_policy_set_exclusion" {
+resource "tfe_workspace_policy_set_exclusion" "foobar" {
 	policy_set_id = tfe_policy_set.foobar.id
 	workspace_id = tfe_workspace.foobar.id
 }
@@ -258,7 +258,7 @@ resource "tfe_project_policy_set" "foobar" {
 	project_id = tfe_project.foobar.id
 }
 
-resource "tfe_workspace_policy_set_exclusion" {
+resource "tfe_workspace_policy_set_exclusion" "foobar" {
 	policy_set_id = tfe_policy_set.foobar.id
 	workspace_id = tfe_workspace.foobar.id
 }

--- a/internal/provider/data_source_policy_set_test.go
+++ b/internal/provider/data_source_policy_set_test.go
@@ -46,6 +46,8 @@ func TestAccTFEPolicySetDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "workspace_ids.#", "1"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_policy_set.bar", "excluded_workspace_ids.#", "1"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "project_ids.#", "1"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "vcs_repo.#", "0"),
@@ -90,6 +92,8 @@ func TestAccTFEPolicySetDataSourceOPA_basic(t *testing.T) {
 						"data.tfe_policy_set.bar", "overridable", "true"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "workspace_ids.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_policy_set.bar", "excluded_workspace_ids.#", "1"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "project_ids.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -150,6 +154,8 @@ func TestAccTFEPolicySetDataSource_vcs(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "workspace_ids.#", "0"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_policy_set.bar", "excluded_workspace_ids.#", "0"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "project_ids.#", "0"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_policy_set.bar", "vcs_repo.#", "1"),
@@ -204,12 +210,16 @@ resource "tfe_policy_set" "foobar" {
   organization = local.organization_name
   policy_ids   = [tfe_sentinel_policy.foo.id]
   workspace_ids = [tfe_workspace.foobar.id]
-  
 }
 
 resource "tfe_project_policy_set" "foobar" {
 	policy_set_id = tfe_policy_set.foobar.id
 	project_id = tfe_project.foobar.id
+}
+
+resource "tfe_workspace_policy_set_exclusion" {
+	policy_set_id = tfe_policy_set.foobar.id
+	workspace_id = tfe_workspace.foobar.id
 }
 
 data "tfe_policy_set" "bar" {
@@ -246,6 +256,11 @@ resource "tfe_policy_set" "foobar" {
 resource "tfe_project_policy_set" "foobar" {
 	policy_set_id = tfe_policy_set.foobar.id
 	project_id = tfe_project.foobar.id
+}
+
+resource "tfe_workspace_policy_set_exclusion" {
+	policy_set_id = tfe_policy_set.foobar.id
+	workspace_id = tfe_workspace.foobar.id
 }
 
 data "tfe_policy_set" "bar" {

--- a/website/docs/d/policy_set.html.markdown
+++ b/website/docs/d/policy_set.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `kind` - The policy-as-code framework for the policy. Valid values are "sentinel" and "opa".
 * `overridable` - Whether users can override this policy when it fails during a run. Only valid for OPA policies.
 * `workspace_ids` - IDs of the workspaces that use the policy set.
+* `excluded_workspace_ids` - IDs of the workspaces that do not use the policy set.
 * `project_ids` - IDs of the projects that use the policy set.
 * `policy_ids` - IDs of the policies attached to the policy set.
 * `policies_path` - The sub-path within the attached VCS repository when using `vcs_repo`.


### PR DESCRIPTION
## Description

excluded_workspace_ids needs to be added to the policy sets data source to accompany the workspace_policy_set_exclusion resource.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/1033)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
--- PASS: TestAccTFEPolicySetDataSource_basic (6.74s)
PASS

--- PASS: TestAccTFEPolicySetDataSourceOPA_basic (5.83s)
PASS

--- PASS: TestAccTFEPolicySetDataSource_notFound (2.19s)
PASS
...
```

![Screenshot 2023-09-05 at 2 05 46 PM](https://github.com/hashicorp/terraform-provider-tfe/assets/42544158/2dceb2a5-f6c2-45b5-ac56-11a38ea2c3ed)

