### PR TITLE
Netra2104/tf 7897 add policy set workspace exclusions resource

### DIFF
--- a/internal/provider/data_source_variable_set.go
+++ b/internal/provider/data_source_variable_set.go
@@ -35,6 +35,11 @@ func dataSourceTFEVariableSet() *schema.Resource {
 				Computed: true,
 			},
 
+			"enforced": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"workspace_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -88,6 +93,7 @@ func dataSourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) erro
 				d.Set("name", vs.Name)
 				d.Set("description", vs.Description)
 				d.Set("global", vs.Global)
+				d.Set("enforced", vs.Enforced)
 
 				// Only now include vars and workspaces to cut down on request load.
 				readOptions := tfe.VariableSetReadOptions{

--- a/internal/provider/data_source_variable_set_test.go
+++ b/internal/provider/data_source_variable_set_test.go
@@ -31,6 +31,8 @@ func TestAccTFEVariableSetsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_variable_set.foobar", "global", "false"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_variable_set.foobar", "enforced", "false"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_variable_set.foobar", "organization", orgName),
 				),
 			},
@@ -67,62 +69,64 @@ func TestAccTFEVariableSetsDataSource_full(t *testing.T) {
 
 func testAccTFEVariableSetsDataSourceConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "org-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_variable_set" "foobar" {
-  name = "varset-foo-%d"
-	description = "a description"
-	organization = tfe_organization.foobar.id
-}
-
-data "tfe_variable_set" "foobar" {
-  name = tfe_variable_set.foobar.name
-	organization = tfe_variable_set.foobar.organization
-}`, rInt, rInt)
+		resource "tfe_organization" "foobar" {
+			name  = "org-%d"
+			email = "admin@company.com"
+		}
+		
+		resource "tfe_variable_set" "foobar" {
+			name = "varset-foo-%d"
+			description = "a description"
+			global = false
+			enforced = false
+			organization = tfe_organization.foobar.id
+		}
+		
+		data "tfe_variable_set" "foobar" {
+			name = tfe_variable_set.foobar.name
+			organization = tfe_variable_set.foobar.organization
+		}`, rInt, rInt)
 }
 
 func testAccTFEVariableSetsDataSourceConfig_full(rInt int) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "org-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name         = "workspace-foo-%d"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_project" "foobar" {
-  name         = "project-foo-%d"
-  organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable_set" "foobar" {
-  name = "varset-foo-%d"
-	description = "a description"
-	organization = tfe_organization.foobar.id
-	workspace_ids = [tfe_workspace.foobar.id]
-}
-
-resource "tfe_project_variable_set" "foobar" {
-	variable_set_id = tfe_variable_set.foobar.id
-	project_id = tfe_project.foobar.id
-}
-
-resource "tfe_variable" "envfoo" {
-	key          = "vfoo"
-	value        = "bar"
-	category     = "env"
-	variable_set_id = tfe_variable_set.foobar.id
-}
-
-data "tfe_variable_set" "foobar" {
-  name = tfe_variable_set.foobar.name
-	organization = tfe_variable_set.foobar.organization
-	depends_on = [tfe_variable.envfoo]
-}`, rInt, rInt, rInt, rInt)
+		resource "tfe_organization" "foobar" {
+			name  = "org-%d"
+			email = "admin@company.com"
+		}
+		
+		resource "tfe_workspace" "foobar" {
+			name         = "workspace-foo-%d"
+			organization = tfe_organization.foobar.id
+		}
+		
+		resource "tfe_project" "foobar" {
+			name         = "project-foo-%d"
+			organization = tfe_organization.foobar.id
+		}
+		
+		resource "tfe_variable_set" "foobar" {
+			name = "varset-foo-%d"
+			description = "a description"
+			organization = tfe_organization.foobar.id
+			workspace_ids = [tfe_workspace.foobar.id]
+		}
+		
+		resource "tfe_project_variable_set" "foobar" {
+			variable_set_id = tfe_variable_set.foobar.id
+			project_id = tfe_project.foobar.id
+		}
+		
+		resource "tfe_variable" "envfoo" {
+			key          = "vfoo"
+			value        = "bar"
+			category     = "env"
+			variable_set_id = tfe_variable_set.foobar.id
+		}
+		
+		data "tfe_variable_set" "foobar" {
+			name = tfe_variable_set.foobar.name
+			organization = tfe_variable_set.foobar.organization
+			depends_on = [tfe_variable.envfoo]
+		}`, rInt, rInt, rInt, rInt)
 }

--- a/internal/provider/resource_tfe_variable_set.go
+++ b/internal/provider/resource_tfe_variable_set.go
@@ -42,6 +42,12 @@ func resourceTFEVariableSet() *schema.Resource {
 				ConflictsWith: []string{"workspace_ids"},
 			},
 
+			"enforced": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"organization": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -71,8 +77,9 @@ func resourceTFEVariableSetCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// Create a new options struct.
 	options := tfe.VariableSetCreateOptions{
-		Name:   tfe.String(name),
-		Global: tfe.Bool(d.Get("global").(bool)),
+		Name:     tfe.String(name),
+		Global:   tfe.Bool(d.Get("global").(bool)),
+		Enforced: tfe.Bool(d.Get("enforced").(bool)),
 	}
 
 	if description, descriptionSet := d.GetOk("description"); descriptionSet {
@@ -128,6 +135,7 @@ func resourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("name", variableSet.Name)
 	d.Set("description", variableSet.Description)
 	d.Set("global", variableSet.Global)
+	d.Set("enforced", variableSet.Enforced)
 	d.Set("organization", variableSet.Organization.Name)
 
 	var wids []interface{}
@@ -147,6 +155,7 @@ func resourceTFEVariableSetUpdate(d *schema.ResourceData, meta interface{}) erro
 			Name:        tfe.String(d.Get("name").(string)),
 			Description: tfe.String(d.Get("description").(string)),
 			Global:      tfe.Bool(d.Get("global").(bool)),
+			Enforced:    tfe.Bool(d.Get("enforced").(bool)),
 		}
 
 		log.Printf("[DEBUG] Update variable set: %s", d.Id())

--- a/internal/provider/resource_tfe_variable_set_test.go
+++ b/internal/provider/resource_tfe_variable_set_test.go
@@ -35,6 +35,8 @@ func TestAccTFEVariableSet_basic(t *testing.T) {
 						"tfe_variable_set.foobar", "description", "a test variable set"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable_set.foobar", "global", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_variable_set.foobar", "enforced", "false"),
 				),
 			},
 		},
@@ -62,6 +64,8 @@ func TestAccTFEVariableSet_full(t *testing.T) {
 						"tfe_variable_set.foobar", "description", "a test variable set"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable_set.foobar", "global", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_variable_set.foobar", "enforced", "false"),
 					testAccCheckTFEVariableSetExists(
 						"tfe_variable_set.applied", variableSet),
 					testAccCheckTFEVariableSetApplication(variableSet),
@@ -92,6 +96,8 @@ func TestAccTFEVariableSet_update(t *testing.T) {
 						"tfe_variable_set.foobar", "description", "a test variable set"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable_set.foobar", "global", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_variable_set.foobar", "enforced", "false"),
 					testAccCheckTFEVariableSetApplicationUpdate(variableSet),
 				),
 			},
@@ -108,6 +114,8 @@ func TestAccTFEVariableSet_update(t *testing.T) {
 						"tfe_variable_set.foobar", "description", "another description"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable_set.foobar", "global", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_variable_set.foobar", "enforced", "true"),
 				),
 			},
 		},
@@ -177,6 +185,9 @@ func testAccCheckTFEVariableSetAttributes(
 		if variableSet.Global != false {
 			return fmt.Errorf("Bad global: %t", variableSet.Global)
 		}
+		if variableSet.Enforced != false {
+			return fmt.Errorf("Bad enforced: %t", variableSet.Enforced)
+		}
 
 		return nil
 	}
@@ -193,6 +204,9 @@ func testAccCheckTFEVariableSetAttributesUpdate(
 		}
 		if variableSet.Global != true {
 			return fmt.Errorf("Bad global: %t", variableSet.Global)
+		}
+		if variableSet.Enforced != true {
+			return fmt.Errorf("Bad enforced: %t", variableSet.Enforced)
 		}
 
 		return nil
@@ -242,69 +256,72 @@ func testAccCheckTFEVariableSetDestroy(s *terraform.State) error {
 
 func testAccTFEVariableSet_basic(rInt int) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name = "tst-terraform-%d"
-	email = "admin@company.com"
-}
-
-resource "tfe_variable_set" "foobar" {
-  name         = "variable_set_test"
-	description  = "a test variable set"
-	global       = false
-	organization = tfe_organization.foobar.id
-}`, rInt)
+		resource "tfe_organization" "foobar" {
+			name = "tst-terraform-%d"
+			email = "admin@company.com"
+		}
+	
+		resource "tfe_variable_set" "foobar" {
+			name         = "variable_set_test"
+			description  = "a test variable set"
+			global       = false
+			enforced     = false
+			organization = tfe_organization.foobar.id
+		}`, rInt)
 }
 
 func testAccTFEVariableSet_full(rInt int) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name = "tst-terraform-%d"
-	email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name = "foobar"
-	organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable_set" "foobar" {
-  name         = "variable_set_test"
-	description  = "a test variable set"
-	global       = false
-	organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable_set" "applied" {
-  name         = "variable_set_applied"
-	description  = "a test variable set"
-	workspace_ids   = [tfe_workspace.foobar.id]
-	organization = tfe_organization.foobar.id
-}`, rInt)
+		resource "tfe_organization" "foobar" {
+			name = "tst-terraform-%d"
+			email = "admin@company.com"
+		}
+	
+		resource "tfe_workspace" "foobar" {
+			name = "foobar"
+			organization = tfe_organization.foobar.id
+		}
+		
+		resource "tfe_variable_set" "foobar" {
+			name         = "variable_set_test"
+			description  = "a test variable set"
+			global       = false
+			enforced     = false
+			organization = tfe_organization.foobar.id
+		}
+		
+		resource "tfe_variable_set" "applied" {
+			name         = "variable_set_applied"
+			description  = "a test variable set"
+			workspace_ids   = [tfe_workspace.foobar.id]
+			organization = tfe_organization.foobar.id
+		}`, rInt)
 }
 
 func testAccTFEVariableSet_update(rInt int) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "foobar" {
-  name = "foobar"
-	organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable_set" "foobar" {
-  name         = "variable_set_test_updated"
-	description  = "another description"
-	global       = true
-	organization = tfe_organization.foobar.id
-}
-
-resource "tfe_variable_set" "applied" {
-  name         = "variable_set_applied"
-	description  = "a test variable set"
-	workspace_ids   = []
-	organization = tfe_organization.foobar.id
-}`, rInt)
+		resource "tfe_organization" "foobar" {
+			name  = "tst-terraform-%d"
+			email = "admin@company.com"
+		}
+		
+		resource "tfe_workspace" "foobar" {
+			name = "foobar"
+			organization = tfe_organization.foobar.id
+		}
+		
+		resource "tfe_variable_set" "foobar" {
+			name         = "variable_set_test_updated"
+			description  = "another description"
+			global       = true
+			enforced     = true
+			organization = tfe_organization.foobar.id
+		}
+		
+		resource "tfe_variable_set" "applied" {
+			name         = "variable_set_applied"
+			description  = "a test variable set"
+			workspace_ids   = []
+			organization = tfe_organization.foobar.id
+		}`, rInt)
 }

--- a/website/docs/d/variable_set.html.markdown
+++ b/website/docs/d/variable_set.html.markdown
@@ -33,7 +33,8 @@ The following arguments are supported:
 * `organization` - Name of the organization.
 * `name` - Name of the variable set.
 * `description` - Description of the variable set.
-* `global` - Whether or not the variable set applies to all workspaces in the organization.
+* `global` - Whether the variable set applies to all workspaces in the organization.
+* `enforced` - Whether the variables in this set are able to be over-written.
 * `workspace_ids` - IDs of the workspaces that use the variable set.
 * `variable_ids` - IDs of the variables attached to the variable set.
 * `project_ids` - IDs of the projects that use the variable set.

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -94,13 +94,46 @@ resource "tfe_variable" "test-b" {
 }
 ```
 
+Creating an enforced variable set:
+
+```hcl
+resource "tfe_organization" "test" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_variable_set" "test" {
+  name         = "Global Varset"
+  description  = "Variable set applied to all workspaces."
+  enforced     = true
+  organization = tfe_organization.test.name
+}
+
+resource "tfe_variable" "test-a" {
+  key             = "seperate_variable"
+  value           = "my_value_name"
+  category        = "terraform"
+  description     = "a useful description"
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "test-b" {
+  key             = "another_variable"
+  value           = "my_value_name"
+  category        = "env"
+  description     = "an environment variable"
+  variable_set_id = tfe_variable_set.test.id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) Name of the variable set.
 * `description` - (Optional) Description of the variable set.
-* `global` - (Optional) Whether or not the variable set applies to all workspaces in the organization. Defaults to `false`.
+* `global` - (Optional) Whether the variable set applies to all workspaces in the organization. Defaults to `false`.
+* `enforced` - (Optional) Whether the variables in this set are able to be over-written. Defaults to `false`.
 * `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `workspace_ids` - **Deprecated** (Optional) IDs of the workspaces that use the variable set.
   Must not be set if `global` is set. This argument is mutually exclusive with using the resource


### PR DESCRIPTION
## Description

Variable set has a new attribute called enforced that enforces variables in a set and prevents being overwritten. Have made changes to data source and the resource in this PR.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
--- PASS: TestAccTFEVariableSet_basic (5.77s)
PASS

--- PASS: TestAccTFEVariableSet_full (5.70s)
PASS

--- PASS: TestAccTFEVariableSet_update (6.49s)
PASS

--- PASS: TestAccTFEVariableSet_import (3.90s)
PASS

=== RUN   TestAccTFEVariableSetsDataSource_basic
--- PASS: TestAccTFEVariableSetsDataSource_basic (5.97s)
PASS
```

## Documentation output

Resource:
<img width="720" alt="Screenshot 2023-09-22 at 10 38 46 AM" src="https://github.com/hashicorp/terraform-provider-tfe/assets/42544158/1c2a4025-fb50-4a3a-92b6-f36f48a53955">
<img width="742" alt="Screenshot 2023-09-22 at 10 38 52 AM" src="https://github.com/hashicorp/terraform-provider-tfe/assets/42544158/1e2497db-a9fe-4d4a-aa4a-a891b1d8c13a">

Data source:
<img width="791" alt="Screenshot 2023-09-22 at 11 10 18 AM" src="https://github.com/hashicorp/terraform-provider-tfe/assets/42544158/31a8db6a-fb01-426c-bde7-d04cd2249add">
