### PR TITLE
Remove workspace includes from policy set reads

### DIFF
--- a/internal/provider/resource_tfe_workspace_policy_set.go
+++ b/internal/provider/resource_tfe_workspace_policy_set.go
@@ -66,9 +66,7 @@ func resourceTFEWorkspacePolicySetRead(d *schema.ResourceData, meta interface{})
 	workspaceID := d.Get("workspace_id").(string)
 
 	log.Printf("[DEBUG] Read configuration of workspace policy set: %s", policySetID)
-	policySet, err := config.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
-		Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaces},
-	})
+	policySet, err := config.Client.PolicySets.Read(ctx, policySetID)
 	if err != nil {
 		if errors.Is(err, tfe.ErrResourceNotFound) {
 			log.Printf("[DEBUG] Policy set %s no longer exists", policySetID)

--- a/internal/provider/resource_tfe_workspace_policy_set_exclusion.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_exclusion.go
@@ -66,9 +66,7 @@ func resourceTFEWorkspacePolicySetExclusionRead(d *schema.ResourceData, meta int
 	workspaceExclusionsID := d.Get("workspace_id").(string)
 
 	log.Printf("[DEBUG] Read configuration of excluded workspace policy set: %s", policySetID)
-	policySet, err := config.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
-		Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaceExclusions},
-	})
+	policySet, err := config.Client.PolicySets.Read(ctx, policySetID)
 	if err != nil {
 		if errors.Is(err, tfe.ErrResourceNotFound) {
 			log.Printf("[DEBUG] Policy set %s no longer exists", policySetID)

--- a/internal/provider/resource_tfe_workspace_policy_set_exclusion_test.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_exclusion_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -102,9 +101,7 @@ func testAccCheckTFEWorkspacePolicySetExclusionExists(n string) resource.TestChe
 			return fmt.Errorf("no excluded workspace id set")
 		}
 
-		policySet, err := config.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
-			Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaces},
-		})
+		policySet, err := config.Client.PolicySets.Read(ctx, policySetID)
 		if err != nil {
 			return fmt.Errorf("error reading polciy set %s: %w", policySetID, err)
 		}

--- a/internal/provider/resource_tfe_workspace_policy_set_test.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -100,9 +99,7 @@ func testAccCheckTFEWorkspacePolicySetExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No workspace id set")
 		}
 
-		policySet, err := config.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
-			Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaces},
-		})
+		policySet, err := config.Client.PolicySets.Read(ctx, policySetID)
 		if err != nil {
 			return fmt.Errorf("error reading polciy set %s: %w", policySetID, err)
 		}


### PR DESCRIPTION
## Description

This is an experiment to speed up policy set refreshes by removing the `include=workspaces` query param from those calls. It takes extra time to serialize the full workspace record on the backend and it doesn't seem like any workspace data besides the id is necessary to manage these workspace <-> policy set relationships in the provider.

Note that we _do_ still need need the workspace response here, so we can find a workspace associated with the policy set by name:

https://github.com/hashicorp/terraform-provider-tfe/blob/ac43481f0d1eec64f21b41d4e83fd397b3758ca3/internal/provider/resource_tfe_workspace_policy_set.go#L139

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ ❯ ENABLE_BETA=1 TFE_ADMIN_PROVISION_LICENSES_TOKEN=xxx TFE_HOSTNAME=xxx TFE_TOKEN=xxx TESTARGS="-run TestAccTFEWorkspacePolicySet" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspacePolicySet -timeout 15m
=== RUN   TestAccTFEWorkspacePolicySetExclusion_basic
--- PASS: TestAccTFEWorkspacePolicySetExclusion_basic (7.01s)
=== RUN   TestAccTFEWorkspacePolicySetExclusion_incorrectImportSyntax
--- PASS: TestAccTFEWorkspacePolicySetExclusion_incorrectImportSyntax (5.80s)
=== RUN   TestAccTFEWorkspacePolicySet_basic
--- PASS: TestAccTFEWorkspacePolicySet_basic (7.29s)
=== RUN   TestAccTFEWorkspacePolicySet_incorrectImportSyntax
--- PASS: TestAccTFEWorkspacePolicySet_incorrectImportSyntax (5.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	26.028s
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```
