### PR TITLE
Fix Terraform 1.6 compat by finishing GetMetadata implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.49.2 (October 4, 2023)
+
+BUG FIXES:
+* `d/tfe_outputs`: Fix incompatibility with the newly-released Terraform 1.6, which would result in a "Data Source Not Implemented" error.
+
 ## v0.49.1 (October 2, 2023)
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Declare the provider in your configuration and `terraform init` will automatical
 terraform {
   required_providers {
     tfe = {
-      version = "~> 0.49.1"
+      version = "~> 0.49.2"
     }
   }
 }
@@ -45,7 +45,7 @@ The above snippet using `required_providers` is for Terraform 0.13+; if you are 
 
 ```hcl
 provider "tfe" {
-  version = "~> 0.48.0"
+  version = "~> 0.49.2"
   ...
 }
 ```

--- a/internal/provider/plugin_provider.go
+++ b/internal/provider/plugin_provider.go
@@ -45,7 +45,16 @@ type providerMeta struct {
 }
 
 func (p *pluginProviderServer) GetMetadata(ctx context.Context, req *tfprotov5.GetMetadataRequest) (*tfprotov5.GetMetadataResponse, error) {
-	return &tfprotov5.GetMetadataResponse{}, nil
+	return &tfprotov5.GetMetadataResponse{
+		ServerCapabilities: &tfprotov5.ServerCapabilities{
+			GetProviderSchemaOptional: true,
+		},
+		DataSources: []tfprotov5.DataSourceMetadata{
+			{
+				TypeName: "tfe_outputs",
+			},
+		},
+	}, nil
 }
 
 func (p *pluginProviderServer) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProviderSchemaRequest) (*tfprotov5.GetProviderSchemaResponse, error) {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -75,7 +75,7 @@ automatically installed by `terraform init` in the future:
 terraform {
   required_providers {
     tfe = {
-      version = "~> 0.49.1"
+      version = "~> 0.49.2"
     }
   }
 }
@@ -88,7 +88,7 @@ The above snippet using `required_providers` is for Terraform 0.13+; if you are 
 
 ```hcl
 provider "tfe" {
-  version = "~> 0.49.1"
+  version = "~> 0.49.2"
   ...
 }
 ```
@@ -101,7 +101,7 @@ For more information on provider installation and constraining provider versions
 provider "tfe" {
   hostname = var.hostname # Optional, defaults to Terraform Cloud `app.terraform.io`
   token    = var.token
-  version  = "~> 0.48.0"
+  version  = "~> 0.49.2"
 }
 
 # Create an organization


### PR DESCRIPTION
## Description

Fixes #1088 
 
Providers implemented using the `terraform-plugin-go` library above version 0.19 or so must implement GetMetadata(), as part of supporting an optional memory usage improvement. See
https://github.com/hashicorp/terraform-plugin-sdk/issues/1234 for the start of a breadcrumb trail with more details about this whole effort.

Almost nobody actually implements providers using terraform-plugin-go, but we do! It's one of our THREE muxed-together providers, because we once needed to do something that was impossible in the SDK before the new framework existed. It's used for ONE data source, `tfe_outputs`.

This function was added (with a blank return value) in https://github.com/hashicorp/terraform-provider-tfe/pull/1046 and no one noticed a problem, presumably because acceptance tests were running with a Terraform version that didn't exercise the new memory-saving code path, instead just calling GetProviderSchema however many times.

But, Terraform 1.6 *does* exercise it, and it turns out a blank value causes it to bail out early with a not-found for the tfe_outputs data source.

This commit adds our lonely data source to the low-level provider's metadata, which fixes the issue. Longer-term, we should... probably migrate that data source to the framework and delete that whole third provider.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Make a lil config that exercises at least one element from EACH internal provider server, just to really make sure!!!

Swap in your own organization and workspace names as needed, but here, try this: 

```terraform
terraform {
  required_providers {
    tfe = {
      source = "hashicorp/tfe"
      version = "0.49.1"
    }
  }
}

provider "tfe" {
  hostname = "app.terraform.io"
  organization = "nicktech"
}

data "tfe_outputs" "radish" {
    workspace = "horse-radish"
}

data "tfe_workspace" "radish" {
    name = "horse-radish"
}

output "outs" {
    value = data.tfe_outputs.radish.nonsensitive_values
}

output "outers" {
    value = data.tfe_workspace.radish.id
}

resource tfe_variable "oddish" {
    workspace_id = data.tfe_workspace.radish.id
    key = "extraneous"
    value = "vaaalllllluuuuueeeeee"
    category = "terraform"
}
```

2. Try and apply it with Terraform 1.6.0. The tfe_outputs data source will blow up with a Not Implemented! (But, it works in 1.5 if you try that.)

```
╷
│ Error: Data Source Not Implemented
│
│   with data.tfe_outputs.radish,
│   on main.tf line 17, in data "tfe_outputs" "radish":
│   17: data "tfe_outputs" "radish" {
│
│ The combined provider does not implement the requested data source type. This is always an issue in the provider
│ implementation and should be reported to the provider developers.
│
│ Missing data source type: tfe_outputs
╵
```

3. Build this branch of the provider, set your dev overrides to use your local build artifact, and do an apply with 1.6. Everything works! 

Since I always forget how to do dev overrides: 

`TF_CLI_CONFIG_FILE=~/.terraformrc-dev-overrides`

```terraform
# In ~/.terraformrc-dev-overrides: 
provider_installation {
  dev_overrides {
    "hashicorp/tfe" = "/Users/nick/Documents/code/terraform-provider-tfe"
    "nfagerlund/fakerancher" = "/Users/nick/Documents/code/terraform-provider-fakerancher"
  }

  # For all other providers, install them directly from their origin provider
  # registries as normal. If you omit this, Terraform will _only_ use
  # the dev_overrides block, and so no other providers will be available.
  direct {}
}
```

## Output from acceptance tests

I work here, so see CI output.