### PR TITLE
docs: organization_scoped should be set to false when using tfe_agent_pool_allowed_workspaces

### DIFF
--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the agent pool.
 * `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
-* `organization_scoped` - (Optional) Whether or not the agent pool is scoped to all workspaces in the organization. Defaults to `true`.
+* `organization_scoped` - (Optional) Whether or not the agent pool is scoped to all workspaces in the organization. Defaults to `true`. Should be `false` when limiting workspaces that can use the agent pool with the [tfe_agent_pool_allowed_workspaces](agent_pool_allowed_workspaces.html) resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/agent_pool_allowed_workspaces.html.markdown
+++ b/website/docs/r/agent_pool_allowed_workspaces.html.markdown
@@ -23,20 +23,20 @@ resource "tfe_organization" "test-organization" {
   email = "admin@company.com"
 }
 
-resource "tfe_workspace" "test" {
+resource "tfe_workspace" "test-workspace" {
   name         = "my-workspace-name"
-  organization = tfe_organization.test.name
+  organization = tfe_organization.test-organization.name
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {
-  name         = "my-agent-pool-name"
-  organization = tfe_organization.test-organization.name
-  organization_scoped = true
+  name                = "my-agent-pool-name"
+  organization        = tfe_organization.test-organization.name
+  organization_scoped = false
 }
 
-resource "tfe_agent_pool_allowed_workspaces" "foobar" {
-  agent_pool_id = tfe_agent_pool.foobar.id
-  allowed_workspace_ids = [tfe_workspace.test.id]
+resource "tfe_agent_pool_allowed_workspaces" "test-allowed-workspaces" {
+  agent_pool_id         = tfe_agent_pool.test-agent-pool.id
+  allowed_workspace_ids = [tfe_workspace.test-workspace.id]
 }
 ```
 


### PR DESCRIPTION
## Description

In order to show a realistic example of using `tfe_agent_pool_allowed_workspaces`, `organization_scoped` should be set to `false`. I also updated a couple of references in that example to make it apply-able.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Copy example from agent_pool_allowed_workspaces page
1.  Run `terraform apply`
1.  Config should not error

Example copied here for easy testing:

```hcl
resource "tfe_organization" "test-organization" {
  name  = "my-org-name"
  email = "admin@company.com"
}

resource "tfe_workspace" "test-workspace" {
  name         = "my-workspace-name"
  organization = tfe_organization.test-organization.name
}

resource "tfe_agent_pool" "test-agent-pool" {
  name                = "my-agent-pool-name"
  organization        = tfe_organization.test-organization.name
  organization_scoped = false
}

resource "tfe_agent_pool_allowed_workspaces" "test-allowed-workspaces" {
  agent_pool_id         = tfe_agent_pool.test-agent-pool.id
  allowed_workspace_ids = [tfe_workspace.test-workspace.id]
}
```
