### PR TITLE
Add ValidateFunc to resc TFE_Project name

### DIFF
--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -13,6 +13,7 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var projectIDRegexp = regexp.MustCompile("^prj-[a-zA-Z0-9]{16}$")
@@ -31,6 +32,11 @@ func resourceTFEProject() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(3, 36),
+					validation.StringMatch(regexp.MustCompile(`\A[\w\_\- ]+\z`),
+						"can only include letters, numbers, spaces, -, and _."),
+				),
 			},
 
 			"organization": {

--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -34,7 +34,7 @@ func resourceTFEProject() *schema.Resource {
 				Required: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(3, 36),
-					validation.StringMatch(regexp.MustCompile(`\A[\w\_\- ]+\z`),
+					validation.StringMatch(regexp.MustCompile(`\A[\w\-][\w\- ]+[\w\-]\z`),
 						"can only include letters, numbers, spaces, -, and _."),
 				),
 			},

--- a/internal/provider/resource_tfe_project_test.go
+++ b/internal/provider/resource_tfe_project_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 	"testing"
 	"time"
 
@@ -35,6 +36,26 @@ func TestAccTFEProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_project.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProject_invalidName(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEProject_invalidNameChar(rInt),
+				ExpectError: regexp.MustCompile(`can only include letters, numbers, spaces, -, and _.`),
+			},
+			{
+				Config:      testAccTFEProject_invalidNameLen(rInt),
+				ExpectError: regexp.MustCompile(`expected length of name to be in the range \(3 - 36\),`),
 			},
 		},
 	})
@@ -125,6 +146,31 @@ resource "tfe_organization" "foobar" {
 resource "tfe_project" "foobar" {
   organization = tfe_organization.foobar.name
   name = "projecttest"
+}`, rInt)
+}
+
+func testAccTFEProject_invalidNameChar(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_project" "foobar" {
+  organization = tfe_organization.foobar.name
+  name = "invalidchar#"
+}`, rInt)
+}
+func testAccTFEProject_invalidNameLen(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_project" "foobar" {
+  organization = tfe_organization.foobar.name
+  name = "aa"
 }`, rInt)
 }
 


### PR DESCRIPTION
## Description

Added TFE Project name validation to check for length and allowed characters at plan stage. The API docs specify a Project name can only include letters, numbers, spaces, -, and _. It must be at least 3 characters long and no more than 36 characters long.

Closes #1043 

## Testing plan
 ```TESTARGS="-run TestAccTFEProject_invalidName" make testacc```

## Output from acceptance tests
```
% TESTARGS="-run TestAccTFEProject_invalidName" make testacc 
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEProject_invalidName -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
=== RUN   TestAccTFEProject_invalidName
--- PASS: TestAccTFEProject_invalidName (1.08s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   3.375s
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```
