### PR TITLE
[TF-9605] Add Private Registry Module Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 <!-- Add CHANGELOG entry to this section for any PR awaiting the next release -->
 <!-- Please also include if this is a Bug Fix, Enhancement, or Feature -->
 
+FEATURES:
+* `d/tfe_registry_module`: Add `vcs_repo.tags` and `vcs_repo.branch` attributes to allow configuration of `publishing_mechanism`. Add `test_config` to support running tests on `branch`-based registry modules, by @hashimoon [1096](https://github.com/hashicorp/terraform-provider-tfe/pull/1096)
+
 ## v0.50.0
 
 FEATURES:

--- a/internal/provider/resource_tfe_registry_module.go
+++ b/internal/provider/resource_tfe_registry_module.go
@@ -47,6 +47,10 @@ func resourceTFERegistryModule() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"publishing_mechanism": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"vcs_repo": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -78,6 +82,14 @@ func resourceTFERegistryModule() *schema.Resource {
 							ConflictsWith: []string{"vcs_repo.0.oauth_token_id"},
 							AtLeastOneOf:  []string{"vcs_repo.0.oauth_token_id", "vcs_repo.0.github_app_installation_id"},
 						},
+						"branch": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tags": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -104,6 +116,18 @@ func resourceTFERegistryModule() *schema.Resource {
 					true,
 				),
 			},
+			"test_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tests_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -113,6 +137,15 @@ func resourceTFERegistryModuleCreateWithVCS(v interface{}, meta interface{}, d *
 	// Create module with VCS repo configuration block.
 	options := tfe.RegistryModuleCreateWithVCSConnectionOptions{}
 	vcsRepo := v.([]interface{})[0].(map[string]interface{})
+	var testConfig map[string]interface{}
+
+	if tc, ok := d.GetOk("test_config"); ok {
+		if tc.([]interface{})[0] == nil {
+			return nil, fmt.Errorf("tests_enabled must be provided when configuring a test_config")
+		}
+
+		testConfig = tc.([]interface{})[0].(map[string]interface{})
+	}
 
 	orgName, err := config.schemaOrDefaultOrganization(d)
 	if err != nil {
@@ -126,8 +159,25 @@ func resourceTFERegistryModuleCreateWithVCS(v interface{}, meta interface{}, d *
 		OrganizationName:  tfe.String(orgName),
 	}
 
+	tags, tagsOk := vcsRepo["tags"].(bool)
+	branch, branchOk := vcsRepo["branch"].(string)
+
+	if tagsOk && tags && branchOk && branch != "" {
+		return nil, fmt.Errorf("tags must be set to false when a branch is provided")
+	}
+
+	if branchOk && branch != "" {
+		options.VCSRepo.Branch = tfe.String(branch)
+	}
+
 	if vcsRepo["oauth_token_id"] != nil && vcsRepo["oauth_token_id"].(string) != "" {
 		options.VCSRepo.OAuthTokenID = tfe.String(vcsRepo["oauth_token_id"].(string))
+	}
+
+	if testsEnabled, ok := testConfig["tests_enabled"].(bool); ok {
+		options.TestConfig = &tfe.RegistryModuleTestConfigOptions{
+			TestsEnabled: tfe.Bool(testsEnabled),
+		}
 	}
 
 	log.Printf("[DEBUG] Create registry module from repository %s", *options.VCSRepo.Identifier)
@@ -174,7 +224,6 @@ func resourceTFERegistryModuleCreateWithoutVCS(meta interface{}, d *schema.Resou
 
 func resourceTFERegistryModuleCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
-
 	var registryModule *tfe.RegistryModule
 	var err error
 
@@ -242,6 +291,40 @@ func resourceTFERegistryModuleUpdate(d *schema.ResourceData, meta interface{}) e
 		RegistryName: tfe.RegistryName(d.Get("registry_name").(string)),
 	}
 
+	if v, ok := d.GetOk("vcs_repo"); ok { //nolint:nestif
+		vcsRepo := v.([]interface{})[0].(map[string]interface{})
+		options.VCSRepo = &tfe.RegistryModuleVCSRepoUpdateOptions{}
+
+		tags, tagsOk := vcsRepo["tags"].(bool)
+		branch, branchOk := vcsRepo["branch"].(string)
+
+		if tagsOk && tags && branchOk && branch != "" {
+			return fmt.Errorf("tags must be set to false when a branch is provided")
+		}
+
+		if tagsOk {
+			options.VCSRepo.Tags = tfe.Bool(tags)
+		}
+
+		if branchOk {
+			options.VCSRepo.Branch = tfe.String(branch)
+		}
+	}
+
+	if v, ok := d.GetOk("test_config"); ok {
+		if v.([]interface{})[0] == nil {
+			return fmt.Errorf("tests_enabled must be provided when configuring a test_config")
+		}
+
+		testConfig := v.([]interface{})[0].(map[string]interface{})
+
+		options.TestConfig = &tfe.RegistryModuleTestConfigOptions{}
+
+		if testsEnabled, ok := testConfig["tests_enabled"].(bool); ok {
+			options.TestConfig.TestsEnabled = tfe.Bool(testsEnabled)
+		}
+	}
+
 	err = resource.Retry(time.Duration(5)*time.Minute, func() *resource.RetryError {
 		registryModule, err = config.Client.RegistryModules.Update(ctx, rmID, options)
 		if err != nil {
@@ -291,6 +374,7 @@ func resourceTFERegistryModuleRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("namespace", registryModule.Namespace)
 	d.Set("registry_name", registryModule.RegistryName)
 	d.Set("no_code", registryModule.NoCode)
+	d.Set("publishing_mechanism", registryModule.PublishingMechanism)
 
 	// Set VCS repo options.
 	var vcsRepo []interface{}
@@ -300,10 +384,23 @@ func resourceTFERegistryModuleRead(d *schema.ResourceData, meta interface{}) err
 			"oauth_token_id":             registryModule.VCSRepo.OAuthTokenID,
 			"github_app_installation_id": registryModule.VCSRepo.GHAInstallationID,
 			"display_identifier":         registryModule.VCSRepo.DisplayIdentifier,
+			"branch":                     registryModule.VCSRepo.Branch,
+			"tags":                       registryModule.VCSRepo.Tags,
 		}
 		vcsRepo = append(vcsRepo, vcsConfig)
 
 		d.Set("vcs_repo", vcsRepo)
+	}
+
+	var testConfig []interface{}
+	if registryModule.TestConfig != nil {
+		testConfigValues := map[string]interface{}{
+			"tests_enabled": registryModule.TestConfig.TestsEnabled,
+		}
+
+		testConfig = append(testConfig, testConfigValues)
+
+		d.Set("test_config", testConfig)
 	}
 
 	return nil

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -66,6 +67,10 @@ func TestAccTFERegistryModule_vcs(t *testing.T) {
 						"tfe_registry_module.foobar", "vcs_repo.0.identifier", envGithubRegistryModuleIdentifer),
 					resource.TestCheckResourceAttrSet(
 						"tfe_registry_module.foobar", "vcs_repo.0.oauth_token_id"),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "vcs_repo.0.branch", ""),
+					resource.TestCheckResourceAttr(
+						"tfe_registry_module.foobar", "vcs_repo.0.tags", "true"),
 				),
 			},
 		},
@@ -397,6 +402,272 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat(t *testing.T) 
 	})
 }
 
+func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_vcsBranch(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "branch"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", "main"),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsBranchWithTests(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "branch"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", "main"),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsBranch(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "branch"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", "main"),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "git_tag"),
+					resource.TestCheckNoResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", ""),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsBranch(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "branch"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", "main"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWithTests(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_vcsBranchWithTests(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "branch"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", "main"),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsBranch(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "branch"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", "main"),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "git_tag"),
+					resource.TestCheckNoResourceAttr("tfe_registry_module.foobar", "test_config.0"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_vcsTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "git_tag"),
+					resource.TestCheckNoResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", ""),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsBranch(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "branch"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", "main"),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsBranchWithTests(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "branch"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", "main"),
+				),
+			},
+			{
+				Config: testAccTFERegistryModule_vcsTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "git_tag"),
+					resource.TestCheckNoResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_invalidTestConfigOnCreate(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_vcsInvalidBranch(rInt),
+				ExpectError: regexp.MustCompile(`tests_enabled must be provided when configuring a test_config`),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_invalidTestConfigOnUpdate(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_vcsTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "git_tag"),
+					resource.TestCheckNoResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", ""),
+				),
+			},
+			{
+				Config:      testAccTFERegistryModule_vcsInvalidBranch(rInt),
+				ExpectError: regexp.MustCompile(`tests_enabled must be provided when configuring a test_config`),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_branchAndInvalidTagsOnCreate(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_vcsBranchWithInvalidTests(rInt),
+				ExpectError: regexp.MustCompile(`tests_enabled must be provided when configuring a test_config`),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_branchAndTagsEnabledOnCreate(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFERegistryModule_vcsBranchWithTestsAndTagsEnabled(rInt),
+				ExpectError: regexp.MustCompile(`tags must be set to false when a branch is provided`),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModule_branchAndTagsEnabledOnUpdate(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckTFERegistryModule(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModule_vcsTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "publishing_mechanism", "git_tag"),
+					resource.TestCheckNoResourceAttr("tfe_registry_module.foobar", "test_config.0.tests_enabled"),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.tags", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("tfe_registry_module.foobar", "vcs_repo.0.branch", ""),
+				),
+			},
+			{
+				Config:      testAccTFERegistryModule_vcsBranchWithTestsAndTagsEnabled(rInt),
+				ExpectError: regexp.MustCompile(`tags must be set to false when a branch is provided`),
+			},
+		},
+	})
+}
+
 func TestAccTFERegistryModuleImport_nonVCSPrivateRM(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -703,6 +974,7 @@ func testAccTFERegistryModule_vcs(rInt int) string {
 resource "tfe_organization" "foobar" {
  name  = "tst-terraform-%d"
  email = "admin@company.com"
+
 }
 
 resource "tfe_oauth_client" "foobar" {
@@ -718,6 +990,209 @@ resource "tfe_registry_module" "foobar" {
    display_identifier = "%s"
    identifier         = "%s"
    oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+   tags               = true
+ }
+}`,
+		rInt,
+		envGithubToken,
+		envGithubRegistryModuleIdentifer,
+		envGithubRegistryModuleIdentifer)
+}
+
+func testAccTFERegistryModule_vcsBranch(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "foobar" {
+ organization     = tfe_organization.foobar.name
+ api_url          = "https://api.github.com"
+ http_url         = "https://github.com"
+ oauth_token      = "%s"
+ service_provider = "github"
+}
+
+resource "tfe_registry_module" "foobar" {
+ organization     = tfe_organization.foobar.name
+ vcs_repo {
+   display_identifier = "%s"
+   identifier         = "%s"
+   oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+   branch             = "main"
+   tags				  = false
+ }
+
+ test_config {
+   tests_enabled = false
+ }
+}`,
+		rInt,
+		envGithubToken,
+		envGithubRegistryModuleIdentifer,
+		envGithubRegistryModuleIdentifer)
+}
+func testAccTFERegistryModule_vcsInvalidBranch(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "foobar" {
+ organization     = tfe_organization.foobar.name
+ api_url          = "https://api.github.com"
+ http_url         = "https://github.com"
+ oauth_token      = "%s"
+ service_provider = "github"
+}
+
+resource "tfe_registry_module" "foobar" {
+ organization     = tfe_organization.foobar.name
+ vcs_repo {
+   display_identifier = "%s"
+   identifier         = "%s"
+   oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+   branch             = "main"
+   tags				  = false 
+ }
+
+ test_config {
+ }
+}`,
+		rInt,
+		envGithubToken,
+		envGithubRegistryModuleIdentifer,
+		envGithubRegistryModuleIdentifer)
+}
+func testAccTFERegistryModule_vcsBranchWithTests(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "foobar" {
+ organization     = tfe_organization.foobar.name
+ api_url          = "https://api.github.com"
+ http_url         = "https://github.com"
+ oauth_token      = "%s"
+ service_provider = "github"
+}
+
+resource "tfe_registry_module" "foobar" {
+ organization     = tfe_organization.foobar.name
+ vcs_repo {
+   display_identifier = "%s"
+   identifier         = "%s"
+   oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+   branch             = "main"
+   tags				  = false
+ }
+
+ test_config {
+   tests_enabled = true
+ }
+}`,
+		rInt,
+		envGithubToken,
+		envGithubRegistryModuleIdentifer,
+		envGithubRegistryModuleIdentifer)
+}
+
+func testAccTFERegistryModule_vcsBranchWithInvalidTests(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "foobar" {
+ organization     = tfe_organization.foobar.name
+ api_url          = "https://api.github.com"
+ http_url         = "https://github.com"
+ oauth_token      = "%s"
+ service_provider = "github"
+}
+
+resource "tfe_registry_module" "foobar" {
+ organization     = tfe_organization.foobar.name
+ vcs_repo {
+   display_identifier = "%s"
+   identifier         = "%s"
+   oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+   branch             = "main"
+   tags				  = false
+ }
+
+ test_config {
+ }
+}`,
+		rInt,
+		envGithubToken,
+		envGithubRegistryModuleIdentifer,
+		envGithubRegistryModuleIdentifer)
+}
+
+func testAccTFERegistryModule_vcsBranchWithTestsAndTagsEnabled(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "foobar" {
+ organization     = tfe_organization.foobar.name
+ api_url          = "https://api.github.com"
+ http_url         = "https://github.com"
+ oauth_token      = "%s"
+ service_provider = "github"
+}
+
+resource "tfe_registry_module" "foobar" {
+ organization     = tfe_organization.foobar.name
+ vcs_repo {
+   display_identifier = "%s"
+   identifier         = "%s"
+   oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+   branch             = "main"
+   tags				  = true
+ }
+
+ test_config {
+   tests_enabled = true
+ }
+}`,
+		rInt,
+		envGithubToken,
+		envGithubRegistryModuleIdentifer,
+		envGithubRegistryModuleIdentifer)
+}
+
+func testAccTFERegistryModule_vcsTags(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "foobar" {
+ organization     = tfe_organization.foobar.name
+ api_url          = "https://api.github.com"
+ http_url         = "https://github.com"
+ oauth_token      = "%s"
+ service_provider = "github"
+}
+
+resource "tfe_registry_module" "foobar" {
+ organization     = tfe_organization.foobar.name
+ vcs_repo {
+   display_identifier = "%s"
+   identifier         = "%s"
+   oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+   tags               = true
+   branch 			  = ""
  }
 }`,
 		rInt,

--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -36,6 +36,36 @@ resource "tfe_registry_module" "test-registry-module" {
 }
 ```
 
+Create private registry module with tests enabled:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "test-oauth-client" {
+  organization     = tfe_organization.test-organization.name
+  api_url          = "https://api.github.com"
+  http_url         = "https://github.com"
+  oauth_token      = "my-vcs-provider-token"
+  service_provider = "github"
+}
+
+resource "tfe_registry_module" "test-registry-module" {
+  test_config {
+    tests_enabled = true
+  }
+
+  vcs_repo {
+    display_identifier = "my-org-name/terraform-provider-name"
+    identifier         = "my-org-name/terraform-provider-name"
+    oauth_token_id     = tfe_oauth_client.test-oauth-client.oauth_token_id
+    branch             = "main"
+  }
+}
+```
+
 Create private registry module with GitHub App:
 
 ```hcl
@@ -125,6 +155,9 @@ The following arguments are supported:
 * `namespace` - (Optional) The namespace of a public registry module. It can be used if `module_provider` is set and `registry_name` is public.
 * `registry_name` - (Optional) Whether the registry module is private or public. It can be used if `module_provider` is set.
 
+The `test_config` block supports
+* `tests_enabled` - (Optional) Specifies whether tests run for the registry module. Tests are only supported for branch-based publishing.
+
 The `vcs_repo` block supports:
 
 * `display_identifier` - (Required) The display identifier for your VCS repository.
@@ -135,6 +168,8 @@ The `vcs_repo` block supports:
   and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `oauth_token_id` - (Optional) Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.
 * `github_app_installation_id` - (Optional) The installation id of the Github App. This conflicts with `oauth_token_id` and can only be used if `oauth_token_id` is not used.
+* `branch` - (Optional) The git branch used for publishing when using branch-based publishing for the registry module. When a `branch` is set, `tags` will be returned as `false`.
+* `tags` - (Optional) Specifies whether tag based publishing is enabled for the registry module. When `tags` is set to `true`, the `branch` must be set to an empty value.
 
 ## Attributes Reference
 
@@ -143,6 +178,7 @@ The `vcs_repo` block supports:
 * `name` - The name of registry module.
 * `organization` - The name of the organization associated with the registry module.
 * `namespace` - The namespace of the module. For private modules this is the name of the organization that owns the module.
+* `publishing_mechanism` - The publishing mechanism used when releasing new versions of the module.
 * `registry_name` - The registry name of the registry module depicting whether the registry module is private or public.
 * `no_code` - **Deprecated** The property that will enable or disable a module as no-code provisioning ready.
 Use the tfe_no_code_module resource instead.


### PR DESCRIPTION
## Description

Add the following attributes to `RegistryModule` to support testing
- `publishing_mechanism`
- `vcs_repo.branch`
- `vcs_repo.tags`
- `test_config.tests_enabled`

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Create a `RegistryModule`
1. Confirm the `publishing_mechanism` is `git_tag`
1. Set `vcs_repo.branch` to a branch on the git repository
1. Set `vcs_repo.tags` to `false`
1. Set `test_config.tests_enabled` to `true`
1. Perform changes
1. Confirm the `publishing_mechanism` is `branch`
1. Enjoy your registry module with tests enabled

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe#TestConfig)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/registry/test)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFERegistryModuleImport" make testacc

?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	0.137s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	0.181s [no tests to run]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFERegistryModule_vcs
--- PASS: TestAccTFERegistryModule_vcs (7.89s)
=== RUN   TestAccTFERegistryModule_GitHubApp
    provider_test.go:230: Please set GITHUB_APP_INSTALLATION_ID to run this test
--- SKIP: TestAccTFERegistryModule_GitHubApp (0.00s)
=== RUN   TestAccTFERegistryModule_emptyVCSRepo
--- PASS: TestAccTFERegistryModule_emptyVCSRepo (0.13s)
=== RUN   TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName
--- PASS: TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName (4.48s)
=== RUN   TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName
--- PASS: TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName (4.35s)
=== RUN   TestAccTFERegistryModule_publicRegistryModule
--- PASS: TestAccTFERegistryModule_publicRegistryModule (4.92s)
=== RUN   TestAccTFERegistryModule_noCodeModule
--- PASS: TestAccTFERegistryModule_noCodeModule (4.95s)
=== RUN   TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat
--- PASS: TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat (8.42s)
=== RUN   TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat
--- PASS: TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat (8.14s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch (19.21s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWithTests
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWithTests (9.25s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags (14.34s)
=== RUN   TestAccTFERegistryModuleImport_nonVCSPrivateRM
--- PASS: TestAccTFERegistryModuleImport_nonVCSPrivateRM (4.95s)
=== RUN   TestAccTFERegistryModuleImport_publicRM
--- PASS: TestAccTFERegistryModuleImport_publicRM (4.49s)
=== RUN   TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider
--- PASS: TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider (0.14s)
=== RUN   TestAccTFERegistryModule_invalidRegistryName
--- PASS: TestAccTFERegistryModule_invalidRegistryName (0.27s)
=== RUN   TestAccTFERegistryModule_invalidWithModuleProviderAndNoName
--- PASS: TestAccTFERegistryModule_invalidWithModuleProviderAndNoName (0.11s)
=== RUN   TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization
--- PASS: TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization (0.11s)
=== RUN   TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName
--- PASS: TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName (0.11s)
=== RUN   TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider
--- PASS: TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider (0.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	96.758s

...
```
