### PR TITLE
fix(tfe_policy): update query if changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+BUG FIXES:
+* `r/tfe_policy`: Fix the provider ignoring updates to the `query` field and pretending it issued an API call when it didn't.
+
 ## v0.49.2 (October 4, 2023)
 
 BUG FIXES:

--- a/internal/provider/resource_tfe_policy.go
+++ b/internal/provider/resource_tfe_policy.go
@@ -288,7 +288,7 @@ func resourceTFEPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		if query, ok := d.HasChange("query"); ok {
+		if query, ok := d.GetOk("query"); ok {
 			options.Query = tfe.String(query.(string))
 		}
 

--- a/internal/provider/resource_tfe_policy.go
+++ b/internal/provider/resource_tfe_policy.go
@@ -264,7 +264,7 @@ func resourceTFEPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
 
 	// nolint:nestif
-	if d.HasChange("description") || d.HasChange("enforce_mode") {
+	if d.HasChange("description") || d.HasChange("enforce_mode") || d.HasChange("query") {
 		// Create a new options struct.
 		options := tfe.PolicyUpdateOptions{}
 
@@ -286,6 +286,10 @@ func resourceTFEPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 					Mode: tfe.EnforcementMode(tfe.EnforcementLevel(d.Get("enforce_mode").(string))),
 				},
 			}
+		}
+
+		if query, ok := d.HasChange("query"); ok {
+			options.Query = tfe.String(query.(string))
 		}
 
 		log.Printf("[DEBUG] Update configuration for %s policy: %s", vKind, d.Id())

--- a/internal/provider/resource_tfe_policy_test.go
+++ b/internal/provider/resource_tfe_policy_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAccTFEPolicy_basic(t *testing.T) {
-	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +51,6 @@ func TestAccTFEPolicy_basic(t *testing.T) {
 }
 
 func TestAccTFEPolicy_basicWithDefaults(t *testing.T) {
-	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +89,6 @@ func TestAccTFEPolicy_basicWithDefaults(t *testing.T) {
 }
 
 func TestAccTFEPolicyOPA_basic(t *testing.T) {
-	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +129,6 @@ func TestAccTFEPolicyOPA_basic(t *testing.T) {
 }
 
 func TestAccTFEPolicy_update(t *testing.T) {
-	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -244,7 +240,6 @@ func TestAccTFEPolicy_unsetEnforce(t *testing.T) {
 }
 
 func TestAccTFEPolicyOPA_update(t *testing.T) {
-	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)
@@ -304,7 +299,6 @@ func TestAccTFEPolicyOPA_update(t *testing.T) {
 }
 
 func TestAccTFEPolicy_import(t *testing.T) {
-	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description

I tried to update the `query` of a policy, and it didn't update - but the state thought it did! 🤦 

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

I'm not going to spend the time to test this independently - it's too much effort. If it builds, someone else can try testing this. It's rather upsetting that this sort of bug is even possible in this Terraform provider.

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/policies#update-a-policy)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

Feel free to do this.

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._