### PR TITLE
Fix flaky TFESAMLSettings resource tests, add comments

### DIFF
--- a/internal/provider/data_source_saml_settings_test.go
+++ b/internal/provider/data_source_saml_settings_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+// FLAKE ALERT: SAML settings are a singleton resource shared by the entire TFE
+// instance, and any test touching them is at high risk to flake.
+// This test is fine, because it only checks that the attributes have SOME
+// value. Testing for any _particular_ value would not be viable, because
+// `resource_tfe_saml_settings_test.go` exists. See that file for more color on
+// this.
 func TestAccTFESAMLSettingsDataSource_basic(t *testing.T) {
 	resourceAddress := "data.tfe_saml_settings.foobar"
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_tfe_saml_settings_test.go
+++ b/internal/provider/resource_tfe_saml_settings_test.go
@@ -16,212 +16,225 @@ import (
 
 const testResourceName = "tfe_saml_settings.foobar"
 
-func TestAccTFESAMLSettings_basic(t *testing.T) {
-	s := tfe.AdminSAMLSetting{
-		IDPCert:        "testIDPCertBasic",
-		SLOEndpointURL: "https://foobar.com/slo_endpoint_url",
-		SSOEndpointURL: "https://foobar.com/sso_endpoint_url",
-	}
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccTFESAMLSettingsDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFESAMLSettings_basic(s),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(testResourceName, "debug", "false"),
-					resource.TestCheckResourceAttr(testResourceName, "authn_requests_signed", "false"),
-					resource.TestCheckResourceAttr(testResourceName, "want_assertions_signed", "false"),
-					resource.TestCheckResourceAttr(testResourceName, "team_management_enabled", "false"),
-					resource.TestCheckResourceAttr(testResourceName, "idp_cert", s.IDPCert),
-					resource.TestCheckResourceAttr(testResourceName, "slo_endpoint_url", s.SLOEndpointURL),
-					resource.TestCheckResourceAttr(testResourceName, "sso_endpoint_url", s.SSOEndpointURL),
-					resource.TestCheckResourceAttr(testResourceName, "attr_username", samlDefaultAttrUsername),
-					resource.TestCheckResourceAttr(testResourceName, "attr_site_admin", samlDefaultAttrSiteAdmin),
-					resource.TestCheckResourceAttr(testResourceName, "attr_groups", samlDefaultAttrGroups),
-					resource.TestCheckResourceAttr(testResourceName, "site_admin_role", samlDefaultSiteAdminRole),
-					resource.TestCheckResourceAttr(testResourceName, "sso_api_token_session_timeout", strconv.Itoa(int(samlDefaultSSOAPITokenSessionTimeoutSeconds))),
-					resource.TestCheckResourceAttrSet(testResourceName, "acs_consumer_url"),
-					resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
-					resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", samlSignatureMethodSHA256),
-					resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", samlSignatureMethodSHA256),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFESAMLSettings_full(t *testing.T) {
-	s := tfe.AdminSAMLSetting{
-		IDPCert:                   "testIDPCertFull",
-		SLOEndpointURL:            "https://foobar.com/slo_endpoint_url",
-		SSOEndpointURL:            "https://foobar.com/sso_endpoint_url",
-		Debug:                     true,
-		AuthnRequestsSigned:       true,
-		WantAssertionsSigned:      true,
-		TeamManagementEnabled:     false,
-		AttrUsername:              "Foo" + samlDefaultAttrUsername,
-		AttrSiteAdmin:             "Foo" + samlDefaultAttrSiteAdmin,
-		AttrGroups:                "Foo" + samlDefaultAttrGroups,
-		SiteAdminRole:             "foo-" + samlDefaultSiteAdminRole,
-		SSOAPITokenSessionTimeout: 1101100,
-		Certificate:               "TestCertificateFull",
-		PrivateKey:                "TestPrivateKeyFull",
-		SignatureSigningMethod:    samlSignatureMethodSHA1,
-		SignatureDigestMethod:     samlSignatureMethodSHA256,
-	}
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccTFESAMLSettingsDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFESAMLSettings_full(s),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(testResourceName, "debug", strconv.FormatBool(s.Debug)),
-					resource.TestCheckResourceAttr(testResourceName, "authn_requests_signed", strconv.FormatBool(s.AuthnRequestsSigned)),
-					resource.TestCheckResourceAttr(testResourceName, "want_assertions_signed", strconv.FormatBool(s.WantAssertionsSigned)),
-					resource.TestCheckResourceAttr(testResourceName, "team_management_enabled", strconv.FormatBool(s.TeamManagementEnabled)),
-					resource.TestCheckResourceAttr(testResourceName, "idp_cert", s.IDPCert),
-					resource.TestCheckResourceAttr(testResourceName, "slo_endpoint_url", s.SLOEndpointURL),
-					resource.TestCheckResourceAttr(testResourceName, "sso_endpoint_url", s.SSOEndpointURL),
-					resource.TestCheckResourceAttr(testResourceName, "attr_username", s.AttrUsername),
-					resource.TestCheckResourceAttr(testResourceName, "attr_site_admin", s.AttrSiteAdmin),
-					resource.TestCheckResourceAttr(testResourceName, "attr_groups", s.AttrGroups),
-					resource.TestCheckResourceAttr(testResourceName, "site_admin_role", s.SiteAdminRole),
-					resource.TestCheckResourceAttr(testResourceName, "sso_api_token_session_timeout", strconv.Itoa(s.SSOAPITokenSessionTimeout)),
-					resource.TestCheckResourceAttrSet(testResourceName, "acs_consumer_url"),
-					resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
-					resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", s.SignatureSigningMethod),
-					resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", s.SignatureDigestMethod),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFESAMLSettings_update(t *testing.T) {
-	s := tfe.AdminSAMLSetting{
-		IDPCert:        "testIDPCertUpdateInit",
-		SLOEndpointURL: "https://foobar.com/slo_endpoint_url",
-		SSOEndpointURL: "https://foobar.com/sso_endpoint_url",
-	}
-	updatedSetting := tfe.AdminSAMLSetting{
-		IDPCert:                   "testIDPCertUpdateInit",
-		SLOEndpointURL:            "https://foobar-updated.com/slo_endpoint_url",
-		SSOEndpointURL:            "https://foobar-updated.com/sso_endpoint_url",
-		Debug:                     true,
-		AuthnRequestsSigned:       true,
-		WantAssertionsSigned:      true,
-		TeamManagementEnabled:     false,
-		AttrUsername:              "FooUpdate" + samlDefaultAttrUsername,
-		AttrSiteAdmin:             "FooUpdate" + samlDefaultAttrSiteAdmin,
-		AttrGroups:                "FooUpdate" + samlDefaultAttrGroups,
-		SiteAdminRole:             "foo-update-" + samlDefaultSiteAdminRole,
-		SSOAPITokenSessionTimeout: 1234567,
-		Certificate:               "TestCertificateUpdate",
-		PrivateKey:                "TestPrivateKeyUpdate",
-		SignatureSigningMethod:    samlSignatureMethodSHA1,
-		SignatureDigestMethod:     samlSignatureMethodSHA256,
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccTFESAMLSettingsDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFESAMLSettings_basic(s),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(testResourceName, "debug", "false"),
-					resource.TestCheckResourceAttr(testResourceName, "authn_requests_signed", "false"),
-					resource.TestCheckResourceAttr(testResourceName, "want_assertions_signed", "false"),
-					resource.TestCheckResourceAttr(testResourceName, "team_management_enabled", "false"),
-					resource.TestCheckResourceAttr(testResourceName, "idp_cert", s.IDPCert),
-					resource.TestCheckResourceAttr(testResourceName, "slo_endpoint_url", s.SLOEndpointURL),
-					resource.TestCheckResourceAttr(testResourceName, "sso_endpoint_url", s.SSOEndpointURL),
-					resource.TestCheckResourceAttr(testResourceName, "attr_username", samlDefaultAttrUsername),
-					resource.TestCheckResourceAttr(testResourceName, "attr_site_admin", samlDefaultAttrSiteAdmin),
-					resource.TestCheckResourceAttr(testResourceName, "attr_groups", samlDefaultAttrGroups),
-					resource.TestCheckResourceAttr(testResourceName, "site_admin_role", samlDefaultSiteAdminRole),
-					resource.TestCheckResourceAttr(testResourceName, "sso_api_token_session_timeout", strconv.Itoa(int(samlDefaultSSOAPITokenSessionTimeoutSeconds))),
-					resource.TestCheckResourceAttrSet(testResourceName, "acs_consumer_url"),
-					resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
-					resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", samlSignatureMethodSHA256),
-					resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", samlSignatureMethodSHA256),
-				),
-			},
-			{
-				Config: testAccTFESAMLSettings_full(updatedSetting),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(testResourceName, "debug", strconv.FormatBool(updatedSetting.Debug)),
-					resource.TestCheckResourceAttr(testResourceName, "authn_requests_signed", strconv.FormatBool(updatedSetting.AuthnRequestsSigned)),
-					resource.TestCheckResourceAttr(testResourceName, "want_assertions_signed", strconv.FormatBool(updatedSetting.WantAssertionsSigned)),
-					resource.TestCheckResourceAttr(testResourceName, "team_management_enabled", strconv.FormatBool(updatedSetting.TeamManagementEnabled)),
-					resource.TestCheckResourceAttr(testResourceName, "idp_cert", updatedSetting.IDPCert),
-					resource.TestCheckResourceAttr(testResourceName, "slo_endpoint_url", updatedSetting.SLOEndpointURL),
-					resource.TestCheckResourceAttr(testResourceName, "sso_endpoint_url", updatedSetting.SSOEndpointURL),
-					resource.TestCheckResourceAttr(testResourceName, "attr_username", updatedSetting.AttrUsername),
-					resource.TestCheckResourceAttr(testResourceName, "attr_site_admin", updatedSetting.AttrSiteAdmin),
-					resource.TestCheckResourceAttr(testResourceName, "attr_groups", updatedSetting.AttrGroups),
-					resource.TestCheckResourceAttr(testResourceName, "site_admin_role", updatedSetting.SiteAdminRole),
-					resource.TestCheckResourceAttr(testResourceName, "sso_api_token_session_timeout", strconv.Itoa(updatedSetting.SSOAPITokenSessionTimeout)),
-					resource.TestCheckResourceAttrSet(testResourceName, "acs_consumer_url"),
-					resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
-					resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", updatedSetting.SignatureSigningMethod),
-					resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", updatedSetting.SignatureDigestMethod),
-				),
-			},
-		},
-	})
-}
-
-func TestAccTFESAMLSettings_import(t *testing.T) {
-	idpCert := "testIDPCertImport"
-	slo := "https://foobar-import.com/slo_endpoint_url"
-	sso := "https://foobar-import.com/sso_endpoint_url"
-	s := tfe.AdminSAMLSetting{
-		IDPCert:        idpCert,
-		SLOEndpointURL: slo,
-		SSOEndpointURL: sso,
-	}
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccTFESAMLSettingsDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFESAMLSettings_basic(s),
-			},
-			{
-				ResourceName: testResourceName,
-				ImportState:  true,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					if len(s) != 1 {
-						return fmt.Errorf("expected 1 state: %+v", s)
-					}
-					rs := s[0]
-					if rs.Attributes["private_key"] != "" {
-						return fmt.Errorf("expected private_key attribute to not be set, received: %s", rs.Attributes["private_key"])
-					}
-					if rs.Attributes["idp_cert"] != idpCert {
-						return fmt.Errorf("expected idp_cert attribute to be equal to %s, received: %s", idpCert, rs.Attributes["idp_cert"])
-					}
-					if rs.Attributes["slo_endpoint_url"] != slo {
-						return fmt.Errorf("expected slo_endpoint_url attribute to be equal to %s, received: %s", slo, rs.Attributes["slo_endpoint_url"])
-					}
-					if rs.Attributes["sso_endpoint_url"] != sso {
-						return fmt.Errorf("expected sso_endpoint_url attribute to be equal to %s, received: %s", sso, rs.Attributes["sso_endpoint_url"])
-					}
-					return nil
+// FLAKE ALERT: SAML settings are a singleton resource shared by the entire TFE
+// instance, and any test touching them is at high risk to flake.
+// In order for these tests to be safe, the following requirements MUST be met:
+//  1. All test cases for this resource must run within a SINGLE test func, using
+//     t.Run to separate the individual test cases.
+//  2. The inner sub-tests must not call t.Parallel.
+//
+// If these tests are split into multiple test funcs and they get allocated to
+// different test runner partitions in CI, then they will inevitably flake, as
+// tests running concurrently in different containers will be competing to set
+// the same shared global state in the TFE instance.
+func TestAccTFESAMLSettings_omnibus(t *testing.T) {
+	t.Run("basic SAML settings resource", func(t *testing.T) {
+		s := tfe.AdminSAMLSetting{
+			IDPCert:        "testIDPCertBasic",
+			SLOEndpointURL: "https://foobar.com/slo_endpoint_url",
+			SSOEndpointURL: "https://foobar.com/sso_endpoint_url",
+		}
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESAMLSettingsDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESAMLSettings_basic(s),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
+						resource.TestCheckResourceAttr(testResourceName, "debug", "false"),
+						resource.TestCheckResourceAttr(testResourceName, "authn_requests_signed", "false"),
+						resource.TestCheckResourceAttr(testResourceName, "want_assertions_signed", "false"),
+						resource.TestCheckResourceAttr(testResourceName, "team_management_enabled", "false"),
+						resource.TestCheckResourceAttr(testResourceName, "idp_cert", s.IDPCert),
+						resource.TestCheckResourceAttr(testResourceName, "slo_endpoint_url", s.SLOEndpointURL),
+						resource.TestCheckResourceAttr(testResourceName, "sso_endpoint_url", s.SSOEndpointURL),
+						resource.TestCheckResourceAttr(testResourceName, "attr_username", samlDefaultAttrUsername),
+						resource.TestCheckResourceAttr(testResourceName, "attr_site_admin", samlDefaultAttrSiteAdmin),
+						resource.TestCheckResourceAttr(testResourceName, "attr_groups", samlDefaultAttrGroups),
+						resource.TestCheckResourceAttr(testResourceName, "site_admin_role", samlDefaultSiteAdminRole),
+						resource.TestCheckResourceAttr(testResourceName, "sso_api_token_session_timeout", strconv.Itoa(int(samlDefaultSSOAPITokenSessionTimeoutSeconds))),
+						resource.TestCheckResourceAttrSet(testResourceName, "acs_consumer_url"),
+						resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
+						resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", samlSignatureMethodSHA256),
+						resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", samlSignatureMethodSHA256),
+					),
 				},
 			},
-		},
+		})
+	})
+
+	t.Run("full SAML settings resource", func(t *testing.T) {
+		s := tfe.AdminSAMLSetting{
+			IDPCert:                   "testIDPCertFull",
+			SLOEndpointURL:            "https://foobar.com/slo_endpoint_url",
+			SSOEndpointURL:            "https://foobar.com/sso_endpoint_url",
+			Debug:                     true,
+			AuthnRequestsSigned:       true,
+			WantAssertionsSigned:      true,
+			TeamManagementEnabled:     false,
+			AttrUsername:              "Foo" + samlDefaultAttrUsername,
+			AttrSiteAdmin:             "Foo" + samlDefaultAttrSiteAdmin,
+			AttrGroups:                "Foo" + samlDefaultAttrGroups,
+			SiteAdminRole:             "foo-" + samlDefaultSiteAdminRole,
+			SSOAPITokenSessionTimeout: 1101100,
+			Certificate:               "TestCertificateFull",
+			PrivateKey:                "TestPrivateKeyFull",
+			SignatureSigningMethod:    samlSignatureMethodSHA1,
+			SignatureDigestMethod:     samlSignatureMethodSHA256,
+		}
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESAMLSettingsDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESAMLSettings_full(s),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
+						resource.TestCheckResourceAttr(testResourceName, "debug", strconv.FormatBool(s.Debug)),
+						resource.TestCheckResourceAttr(testResourceName, "authn_requests_signed", strconv.FormatBool(s.AuthnRequestsSigned)),
+						resource.TestCheckResourceAttr(testResourceName, "want_assertions_signed", strconv.FormatBool(s.WantAssertionsSigned)),
+						resource.TestCheckResourceAttr(testResourceName, "team_management_enabled", strconv.FormatBool(s.TeamManagementEnabled)),
+						resource.TestCheckResourceAttr(testResourceName, "idp_cert", s.IDPCert),
+						resource.TestCheckResourceAttr(testResourceName, "slo_endpoint_url", s.SLOEndpointURL),
+						resource.TestCheckResourceAttr(testResourceName, "sso_endpoint_url", s.SSOEndpointURL),
+						resource.TestCheckResourceAttr(testResourceName, "attr_username", s.AttrUsername),
+						resource.TestCheckResourceAttr(testResourceName, "attr_site_admin", s.AttrSiteAdmin),
+						resource.TestCheckResourceAttr(testResourceName, "attr_groups", s.AttrGroups),
+						resource.TestCheckResourceAttr(testResourceName, "site_admin_role", s.SiteAdminRole),
+						resource.TestCheckResourceAttr(testResourceName, "sso_api_token_session_timeout", strconv.Itoa(s.SSOAPITokenSessionTimeout)),
+						resource.TestCheckResourceAttrSet(testResourceName, "acs_consumer_url"),
+						resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
+						resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", s.SignatureSigningMethod),
+						resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", s.SignatureDigestMethod),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("SAML settings update", func(t *testing.T) {
+		s := tfe.AdminSAMLSetting{
+			IDPCert:        "testIDPCertUpdateInit",
+			SLOEndpointURL: "https://foobar.com/slo_endpoint_url",
+			SSOEndpointURL: "https://foobar.com/sso_endpoint_url",
+		}
+		updatedSetting := tfe.AdminSAMLSetting{
+			IDPCert:                   "testIDPCertUpdateInit",
+			SLOEndpointURL:            "https://foobar-updated.com/slo_endpoint_url",
+			SSOEndpointURL:            "https://foobar-updated.com/sso_endpoint_url",
+			Debug:                     true,
+			AuthnRequestsSigned:       true,
+			WantAssertionsSigned:      true,
+			TeamManagementEnabled:     false,
+			AttrUsername:              "FooUpdate" + samlDefaultAttrUsername,
+			AttrSiteAdmin:             "FooUpdate" + samlDefaultAttrSiteAdmin,
+			AttrGroups:                "FooUpdate" + samlDefaultAttrGroups,
+			SiteAdminRole:             "foo-update-" + samlDefaultSiteAdminRole,
+			SSOAPITokenSessionTimeout: 1234567,
+			Certificate:               "TestCertificateUpdate",
+			PrivateKey:                "TestPrivateKeyUpdate",
+			SignatureSigningMethod:    samlSignatureMethodSHA1,
+			SignatureDigestMethod:     samlSignatureMethodSHA256,
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESAMLSettingsDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESAMLSettings_basic(s),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
+						resource.TestCheckResourceAttr(testResourceName, "debug", "false"),
+						resource.TestCheckResourceAttr(testResourceName, "authn_requests_signed", "false"),
+						resource.TestCheckResourceAttr(testResourceName, "want_assertions_signed", "false"),
+						resource.TestCheckResourceAttr(testResourceName, "team_management_enabled", "false"),
+						resource.TestCheckResourceAttr(testResourceName, "idp_cert", s.IDPCert),
+						resource.TestCheckResourceAttr(testResourceName, "slo_endpoint_url", s.SLOEndpointURL),
+						resource.TestCheckResourceAttr(testResourceName, "sso_endpoint_url", s.SSOEndpointURL),
+						resource.TestCheckResourceAttr(testResourceName, "attr_username", samlDefaultAttrUsername),
+						resource.TestCheckResourceAttr(testResourceName, "attr_site_admin", samlDefaultAttrSiteAdmin),
+						resource.TestCheckResourceAttr(testResourceName, "attr_groups", samlDefaultAttrGroups),
+						resource.TestCheckResourceAttr(testResourceName, "site_admin_role", samlDefaultSiteAdminRole),
+						resource.TestCheckResourceAttr(testResourceName, "sso_api_token_session_timeout", strconv.Itoa(int(samlDefaultSSOAPITokenSessionTimeoutSeconds))),
+						resource.TestCheckResourceAttrSet(testResourceName, "acs_consumer_url"),
+						resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
+						resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", samlSignatureMethodSHA256),
+						resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", samlSignatureMethodSHA256),
+					),
+				},
+				{
+					Config: testAccTFESAMLSettings_full(updatedSetting),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(testResourceName, "enabled", "true"),
+						resource.TestCheckResourceAttr(testResourceName, "debug", strconv.FormatBool(updatedSetting.Debug)),
+						resource.TestCheckResourceAttr(testResourceName, "authn_requests_signed", strconv.FormatBool(updatedSetting.AuthnRequestsSigned)),
+						resource.TestCheckResourceAttr(testResourceName, "want_assertions_signed", strconv.FormatBool(updatedSetting.WantAssertionsSigned)),
+						resource.TestCheckResourceAttr(testResourceName, "team_management_enabled", strconv.FormatBool(updatedSetting.TeamManagementEnabled)),
+						resource.TestCheckResourceAttr(testResourceName, "idp_cert", updatedSetting.IDPCert),
+						resource.TestCheckResourceAttr(testResourceName, "slo_endpoint_url", updatedSetting.SLOEndpointURL),
+						resource.TestCheckResourceAttr(testResourceName, "sso_endpoint_url", updatedSetting.SSOEndpointURL),
+						resource.TestCheckResourceAttr(testResourceName, "attr_username", updatedSetting.AttrUsername),
+						resource.TestCheckResourceAttr(testResourceName, "attr_site_admin", updatedSetting.AttrSiteAdmin),
+						resource.TestCheckResourceAttr(testResourceName, "attr_groups", updatedSetting.AttrGroups),
+						resource.TestCheckResourceAttr(testResourceName, "site_admin_role", updatedSetting.SiteAdminRole),
+						resource.TestCheckResourceAttr(testResourceName, "sso_api_token_session_timeout", strconv.Itoa(updatedSetting.SSOAPITokenSessionTimeout)),
+						resource.TestCheckResourceAttrSet(testResourceName, "acs_consumer_url"),
+						resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
+						resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", updatedSetting.SignatureSigningMethod),
+						resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", updatedSetting.SignatureDigestMethod),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("SAML settings import", func(t *testing.T) {
+		idpCert := "testIDPCertImport"
+		slo := "https://foobar-import.com/slo_endpoint_url"
+		sso := "https://foobar-import.com/sso_endpoint_url"
+		s := tfe.AdminSAMLSetting{
+			IDPCert:        idpCert,
+			SLOEndpointURL: slo,
+			SSOEndpointURL: sso,
+		}
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESAMLSettingsDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESAMLSettings_basic(s),
+				},
+				{
+					ResourceName: testResourceName,
+					ImportState:  true,
+					ImportStateCheck: func(s []*terraform.InstanceState) error {
+						if len(s) != 1 {
+							return fmt.Errorf("expected 1 state: %+v", s)
+						}
+						rs := s[0]
+						if rs.Attributes["private_key"] != "" {
+							return fmt.Errorf("expected private_key attribute to not be set, received: %s", rs.Attributes["private_key"])
+						}
+						if rs.Attributes["idp_cert"] != idpCert {
+							return fmt.Errorf("expected idp_cert attribute to be equal to %s, received: %s", idpCert, rs.Attributes["idp_cert"])
+						}
+						if rs.Attributes["slo_endpoint_url"] != slo {
+							return fmt.Errorf("expected slo_endpoint_url attribute to be equal to %s, received: %s", slo, rs.Attributes["slo_endpoint_url"])
+						}
+						if rs.Attributes["sso_endpoint_url"] != sso {
+							return fmt.Errorf("expected sso_endpoint_url attribute to be equal to %s, received: %s", sso, rs.Attributes["sso_endpoint_url"])
+						}
+						return nil
+					},
+				},
+			},
+		})
 	})
 }
 


### PR DESCRIPTION
## Description

These tests flake violently, because they're competing for control of global singleton state. The flakes show a distinctive pattern: they only flake when at least two of the resource test funcs end up on separate test runner partitions in CI, and re-running a single one failed partition alone always succeeds (because there's no concurrent competition anymore).

The fix is to make sure all of these tests ALWAYS run in serial on a single test runner partition. Smooshing into a single outer func and calling t.Run without t.Parallel seems like it should fit the bill.

changelog N/A, docs N/A (aside from code comments) 

## Testing plan

1.  It doesn't flake in CI. 

## Output from acceptance tests

N/A (problem only occurs in parallelized CI)