### PR TITLE
[TF-10363] skip SAML resource tests when CI runs

### DIFF
--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -46,6 +46,7 @@ inputs:
   list_tests:
     description: Accepts regex rules to either include or exclude specific tests from running in either CI or nightly workflows.
     required: false
+    default: "."
 
 runs:
   using: composite

--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -83,6 +83,7 @@ runs:
         index: ${{ inputs.matrix_index }}
         total: ${{ inputs.matrix_total }}
         junit-summary: ./ci-summary-provider.xml
+        # When tests are split and run concurrently, lists_tests arg in ci.yml will skip the TestAccTFESAMLSettings_omnibus test suite
         list: ${{ inputs.list_tests }}
 
     - name: Run Tests

--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -43,6 +43,9 @@ inputs:
   enterprise:
     description: Test enterprise features (`hostname` must be running in ON_PREM mode)
     required: false
+  list_tests:
+    description: Accepts regex rules to either include or exclude specific tests from running in either CI or nightly workflows.
+    required: false
 
 runs:
   using: composite
@@ -79,6 +82,7 @@ runs:
         index: ${{ inputs.matrix_index }}
         total: ${{ inputs.matrix_total }}
         junit-summary: ./ci-summary-provider.xml
+        list: ${{ inputs.list_tests }}
 
     - name: Run Tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
           admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
           admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
           admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version-maintenance }}
+          # Run terminal cmd 'go help testflag' to learn more about -list flag
+          # action.yml uses https://github.com/hashicorp-forge/go-test-split-action/blob/main/action.yml to split acceptance tests
+          # which runs against all tests using the list arg
+          # lists_tests regex is used to skip the TestAccTFESAMLSettings_omnibus test suite for CI tests only
           list_tests: "[^(TestAccTFESAMLSettings_omnibus)]"
 
   tests-combine-summaries:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
           admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
           admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version-maintenance }}
-          list_tests: "!^TestAccTFESAMLSettings_omnibus"
+          list_tests: "[^(TestAccTFESAMLSettings_omnibus)]"
 
   tests-combine-summaries:
     name: Combine Test Reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
           admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
           admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version-maintenance }}
+          list_tests: "!^TestAccTFESAMLSettings_omnibus"
 
   tests-combine-summaries:
     name: Combine Test Reports

--- a/internal/provider/resource_tfe_saml_settings_test.go
+++ b/internal/provider/resource_tfe_saml_settings_test.go
@@ -27,6 +27,9 @@ const testResourceName = "tfe_saml_settings.foobar"
 // different test runner partitions in CI, then they will inevitably flake, as
 // tests running concurrently in different containers will be competing to set
 // the same shared global state in the TFE instance.
+
+// TestAccTFESAMLSettings_omnibus test suite is skipped in the CI, and will only run in TFE Nightly workflow
+// Should this test name ever change, you will also need to update the regex in ci.yml
 func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 	t.Run("basic SAML settings resource", func(t *testing.T) {
 		s := tfe.AdminSAMLSetting{


### PR DESCRIPTION
## Description

Skip `tfe_saml_settings` resource tests in CI workflow.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Invoke CI test suite
2. Verify that `TestAccTFESAMLSettings_omnibus` does not appear in logs
3. OR run `go test ./... -list` in terminal and list of tests that output should not include `TestAccTFESAMLSettings_omnibus`

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
