### PR TITLE
Fix flaky `TestAccTFEVariableSetsDataSource_full`

### DIFF
--- a/internal/provider/data_source_variable_set_test.go
+++ b/internal/provider/data_source_variable_set_test.go
@@ -127,6 +127,6 @@ func testAccTFEVariableSetsDataSourceConfig_full(rInt int) string {
 		data "tfe_variable_set" "foobar" {
 			name = tfe_variable_set.foobar.name
 			organization = tfe_variable_set.foobar.organization
-			depends_on = [tfe_variable.envfoo]
+			depends_on = [tfe_variable.envfoo, tfe_project_variable_set.foobar]
 		}`, rInt, rInt, rInt, rInt)
 }


### PR DESCRIPTION
## Description

This test was checking that the varset was connected to the project, but that connection is managed by a separate resource that was not a declared or inferred dependency of the data source. So, random chance determined whether the varset had been connected to the project yet by the time the data source was read.

The fix is to declare the dependency.

Changelog / docs updates are N/A.

## Testing plan

1.  Test passes reliably in CI. 

A representative failure, from last night's nightlies: 

![Check 5/5 error: data.tfe_variable_set.foobar: Attribute 'project_ids.#' expected "1", got "0"](https://github.com/hashicorp/terraform-provider-tfe/assets/484309/ec498bf8-cd25-4bda-b7f6-95dbd2e1520b)

## External links

- [How not to flake](https://hashicorp.atlassian.net/wiki/spaces/TFENG/pages/2453340359/How+To+Avoid+Test+Flakiness) (confluence link, internal users only, sorry community friends)

## Output from acceptance tests

see CI