### PR TITLE
Fix nil pointer dereference segfault in tfe_variable resource

### DIFF
--- a/internal/provider/resource_tfe_variable.go
+++ b/internal/provider/resource_tfe_variable.go
@@ -479,6 +479,7 @@ func (r *resourceTFEVariable) updateWithWorkspace(ctx context.Context, req resou
 			"Error updating variable",
 			fmt.Sprintf("Couldn't update variable %s: %s", variableID, err.Error()),
 		)
+		return
 	}
 	// Update state
 	result := modelFromTFEVariable(*variable, plan.Value)
@@ -524,6 +525,7 @@ func (r *resourceTFEVariable) updateWithVariableSet(ctx context.Context, req res
 			"Error updating variable",
 			fmt.Sprintf("Couldn't update variable %s: %s", variableID, err.Error()),
 		)
+		return
 	}
 	// Update state
 	result := modelFromTFEVariableSetVariable(*variable, plan.Value)


### PR DESCRIPTION
## Description 

If go-tfe returns a non-nil err, you can't ever treat the `*tfe.Variable` pointer it returns as though it's valid. But in the Update path for this resource, I forgot to do an early return on client error, and thus we'd immediately try to dereference that variable pointer and do a segfault.

Easiest way to reproduce this bug is to apply a config that creates a non-sensitive variable, manually create a second variable, then try to change the `key` of the config variable to conflict with the key of the manual variable.

All the other crud methods were fine — Create and Read both had appropriate early returns, and Delete doesn't need it because it doesn't do anything after appending to diags. I'm guessing I must have implemented Update after Delete and gotten confused.

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_ **N/A**

## Testing plan

1. Make a workspace.
2. Edit, then apply this config. 
3. Manually, create a second var in the workspace called `original_nome` (note spelling)
4. Edit config to change `key = "original_nome"` so that it'll conflict with the manually created var on update.
5. Apply.
6. Profit (by which I mean segfault).
7. Set up your dev overrides to point at a build from this branch.
8. Apply again.
9. Profit (by which I mean, get a nice error output and no segfault). 

```terraform
terraform {
  required_providers {
    tfe = {
      source = "hashicorp/tfe"
      version = "0.49.2"
    }
  }
}

provider "tfe" {
}

resource tfe_variable "use_case_name" {
    key = "original_name"
    value = "hey??"
    sensitive = false
    workspace_id = "xxx" # YOUR WORKSPACE HERE
    category = "terraform"
    description = "nope?"
}
```

## External links

The jira is IPL-5220.

## Output from acceptance tests

Tests are unchanged, we weren't testing for this case and probably shouldn't bother. 