### PR TITLE
Upgrade go-tfe to v1.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES:
 * `r/tfe_policy_set`: Fix detecting spurious changes on every run when providing file contents with `tfe_slug`. This may require an updated version of tfc-agent for the full fix to take effect. Fixed by upgrading go-slug to v0.13.1 [1123](https://github.com/hashicorp/terraform-provider-tfe/pull/1123)
 * `r/tfe_variable`: Fix nil pointer dereference segfault on client error during Update operations, by @nfagerlund [1131](https://github.com/hashicorp/terraform-provider-tfe/1131)
 * provider: Fix an issue where the request body is not preserved during certain retry scenarios, by @sebasslash [1135](https://github.com/hashicorp/terraform-provider-tfe/pull/1135)
+* provider: Fix a build failure for 32 bit linux architectures by @brandonc [1139](https://github.com/hashicorp/terraform-provider-tfe/pull/1139)
 
 ## v0.49.2 (October 4, 2023)
 

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
-	github.com/hashicorp/go-slug v0.13.1
-	github.com/hashicorp/go-tfe v1.39.1
+	github.com/hashicorp/go-slug v0.13.2
+	github.com/hashicorp/go-tfe v1.39.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,10 +58,10 @@ github.com/hashicorp/go-plugin v1.5.1 h1:oGm7cWBaYIp3lJpx1RUEfLWophprE2EV/KUeqBY
 github.com/hashicorp/go-plugin v1.5.1/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
 github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT9yvm0e+Nd5M=
 github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
-github.com/hashicorp/go-slug v0.13.1 h1:2it55HK4vVXsBoCgUQ7Y2ADQpBaU1ge25VRp1wzZpTM=
-github.com/hashicorp/go-slug v0.13.1/go.mod h1:RA4C+ezyC2nDsiPM5+1djqagveBBJdSN/fM2QCUziYQ=
-github.com/hashicorp/go-tfe v1.39.1 h1:UZF9Avfg2tRlYFuRArktWRkAgwe6I0Vp/ZVhCt/nuv8=
-github.com/hashicorp/go-tfe v1.39.1/go.mod h1:/+MNl/OTw26MYEJDnc2utP43QwBgOLrbOQaug6VbeCY=
+github.com/hashicorp/go-slug v0.13.2 h1:ArlarJ8w1Rinx4P1N6Sr00t+GmjJWtYZuSEDYPQBErA=
+github.com/hashicorp/go-slug v0.13.2/go.mod h1:RA4C+ezyC2nDsiPM5+1djqagveBBJdSN/fM2QCUziYQ=
+github.com/hashicorp/go-tfe v1.39.2 h1:2RrFa6UWEJghQVl248Avd9TJE+ii3NqDD75jBEcr/Tg=
+github.com/hashicorp/go-tfe v1.39.2/go.mod h1:pc7+wHCH26BaoFP5txiKkM7Coi5PmB9VwNfnnT2XpKE=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=


### PR DESCRIPTION
## Description
Fixes release workflow build error. See go-tfe [release notes](https://github.com/hashicorp/go-tfe/releases/tag/v1.39.2). 
