### PR TITLE
[r/tfe_workspace] Support `organization_default` value for the `execution_mode` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 FEATURES:
 * `d/tfe_registry_module`: Add `vcs_repo.tags` and `vcs_repo.branch` attributes to allow configuration of `publishing_mechanism`. Add `test_config` to support running tests on `branch`-based registry modules, by @hashimoon [1096](https://github.com/hashicorp/terraform-provider-tfe/pull/1096)
+* `r/tfe_workspace`: Support `organization_default` value for the `execution_mode` argument, by @tmatilai [1143](https://github.com/hashicorp/terraform-provider-tfe/pull/1143)
 
 ## v0.50.0
 

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -63,11 +63,12 @@ The following arguments are supported:
 * `auto_apply_run_trigger` - (Optional) Whether to automatically apply changes for runs that were created by run triggers from another workspace. Defaults to `false`.
 * `description` - (Optional) A description for the workspace.
 * `execution_mode` - (Optional) Which [execution mode](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#execution-mode)
-  to use. Using Terraform Cloud, valid values are `remote`, `local` or`agent`.
-  Defaults to `remote`. Using Terraform Enterprise, only `remote`and `local`
-  execution modes are valid.  When set to `local`, the workspace will be used
-  for state storage only. This value _must not_ be provided if `operations`
-  is provided.
+  to use. Using Terraform Cloud, valid values are `remote`, `local`, `agent` or
+  `organization_default`. Defaults to `remote`. Using Terraform Enterprise,
+  only `remote` and `local` execution modes are valid. When set to
+  `organization_default`, the default execution mode of the organization is
+  used. When set to `local`, the workspace will be used for state storage only.
+  This value _must not_ be provided if `operations` is provided.
 * `file_triggers_enabled` - (Optional) Whether to filter runs based on the changed files
   in a VCS push. Defaults to `true`. If enabled, the working directory and
   trigger prefixes describe a set of paths which must contain changes for a


### PR DESCRIPTION
## Description

When the `execution_mode` is set to `organization_default`, the default execution mode of the organization is used.

The API is not very nice to be used with Terraform, and the UX with a separate `setting_overwrites` block feels equally clumsy. But YMMV, so feel free to judge.

Fixes #1118

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

```terraform
resource "tfe_workspace" "test" {
  name = "test"

  execution_mode = "organization_default"
}
```

## External links

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe#WorkspaceSettingOverwrites)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
