### PR TITLE
Added note to tfe_outputs docs about enabling remote state sharing

### DIFF
--- a/website/docs/d/outputs.html.markdown
+++ b/website/docs/d/outputs.html.markdown
@@ -9,6 +9,8 @@ description: |-
 This data source is used to retrieve the state outputs for a given workspace.
 It enables output values in one Terraform configuration to be used in another.
 
+~> **IMPORTANT:** For the `tfe_outputs` data source to function correctly, the target workspace (from which you are retrieving the outputs) must have remote state sharing enabled.
+
 ~> **NOTE:** The `values` attribute is preemptively marked [sensitive](https://developer.hashicorp.com/terraform/language/values/outputs#sensitive-suppressing-values-in-cli-output) and is only populated after a run completes on the associated workspace. Use the `nonsensitive_values` attribute to access the subset of the outputs
 that are known to be non-sensitive.
 


### PR DESCRIPTION
## Description

This update revises the `tfe_outputs` documentation to explicitly state the necessity of enabling remote state sharing. The absence of this requirement can led to confusion, as code executes without errors until you try to use the outputs, as detailed in [Issue #1124](https://github.com/hashicorp/terraform-provider-tfe/issues/1124). This amendment aims to prevent such misunderstandings and streamline user experience.


- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_