### PR TITLE
[d/tfe_organization] Make name argument optional if configured for the provider [COMBINED]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 FEATURES:
 * `d/tfe_registry_module`: Add `vcs_repo.tags` and `vcs_repo.branch` attributes to allow configuration of `publishing_mechanism`. Add `test_config` to support running tests on `branch`-based registry modules, by @hashimoon [1096](https://github.com/hashicorp/terraform-provider-tfe/pull/1096)
+
+ENHANCEMENTS:
 * `d/tfe_organization`: Make `name` argument optional if configured for the provider, by @tmatilai [1133](https://github.com/hashicorp/terraform-provider-tfe/pull/1133)
 
 ## v0.50.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 FEATURES:
 * `d/tfe_registry_module`: Add `vcs_repo.tags` and `vcs_repo.branch` attributes to allow configuration of `publishing_mechanism`. Add `test_config` to support running tests on `branch`-based registry modules, by @hashimoon [1096](https://github.com/hashicorp/terraform-provider-tfe/pull/1096)
+* `d/tfe_organization`: Make `name` argument optional if configured for the provider, by @tmatilai [1133](https://github.com/hashicorp/terraform-provider-tfe/pull/1133)
 
 ## v0.50.0
 

--- a/internal/provider/data_source_organization.go
+++ b/internal/provider/data_source_organization.go
@@ -18,7 +18,7 @@ func dataSourceTFEOrganization() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"external_id": {
@@ -88,6 +88,7 @@ func dataSourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Setting Organization Attributes")
 	d.SetId(org.ExternalID)
+	d.Set("name", org.Name)
 	d.Set("external_id", org.ExternalID)
 	d.Set("collaborator_auth_policy", org.CollaboratorAuthPolicy)
 	d.Set("cost_estimation_enabled", org.CostEstimationEnabled)

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -20,13 +20,12 @@ data "tfe_organization" "foo" {
 ## Argument Reference
 
 The following arguments are supported:
-* `name` - (Required) Name of the organization.
+* `name` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `name` - Name of the organization.
 * `email` - Admin email address.
 * `external_id` - An identifier for the organization.
 * `assessments_enforced` - (Available only in Terraform Cloud) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.


### PR DESCRIPTION
## Description

This PR is a rebased copy of #1133 by @tmatilai, with an added test written by me. 

### Original description

> The `organization` argument of all (?) other resources and data sources is already optional if defined in the provider configuration. This PR makes the `tfe_organization` data source to behave the same with the `name` argument.
>
> It actually already fetched the "current" organization with `name = ""`, but the `name` attribute was not written back to the data source.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

```terraform
provider "tfe" {
  organization = "example"
}

data "tfe_organization" "current" {}
```
