### PR TITLE
Add resource and data sources for private registry GPG keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ FEATURES:
 * **New Resource**: `r/tfe_organization_default_execution_mode` is a new resource to set the `default_execution_mode` and `default_agent_pool_id` for an organization, by @SwiftEngineer [1137](https://github.com/hashicorp/terraform-provider-tfe/pull/1137)'
 * `r/tfe_workspace`: Now uses the organization's `default_execution_mode` and `default_agent_pool_id` as the default `execution_mode`, by @SwiftEngineer [1137](https://github.com/hashicorp/terraform-provider-tfe/pull/1137)'
 * **New Resource**: `r/tfe_registry_gpg_key` is a new resource for managing private registry GPG keys, by @tmatilai
+* **New Data Source**: `d/tfe_registry_gpg_key` is a new data source to retrieve a private registry GPG key, by @tmatilai
 
 ENHANCEMENTS:
 * `d/tfe_organization`: Make `name` argument optional if configured for the provider, by @tmatilai [1133](https://github.com/hashicorp/terraform-provider-tfe/pull/1133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ FEATURES:
 * `d/tfe_registry_module`: Add `vcs_repo.tags` and `vcs_repo.branch` attributes to allow configuration of `publishing_mechanism`. Add `test_config` to support running tests on `branch`-based registry modules, by @hashimoon [1096](https://github.com/hashicorp/terraform-provider-tfe/pull/1096)
 * **New Resource**: `r/tfe_organization_default_execution_mode` is a new resource to set the `default_execution_mode` and `default_agent_pool_id` for an organization, by @SwiftEngineer [1137](https://github.com/hashicorp/terraform-provider-tfe/pull/1137)'
 * `r/tfe_workspace`: Now uses the organization's `default_execution_mode` and `default_agent_pool_id` as the default `execution_mode`, by @SwiftEngineer [1137](https://github.com/hashicorp/terraform-provider-tfe/pull/1137)'
-* **New Resource**: `r/tfe_registry_gpg_key` is a new resource for managing private registry GPG keys, by @tmatilai
-* **New Data Source**: `d/tfe_registry_gpg_key` is a new data source to retrieve a private registry GPG key, by @tmatilai
-* **New Data Source**: `d/tfe_registry_gpg_keys` is a new data source to retrieve all private registry GPG keys of an organization, by @tmatilai
+* **New Resource**: `r/tfe_registry_gpg_key` is a new resource for managing private registry GPG keys, by @tmatilai [1160](https://github.com/hashicorp/terraform-provider-tfe/pull/1160)
+* **New Data Source**: `d/tfe_registry_gpg_key` is a new data source to retrieve a private registry GPG key, by @tmatilai [1160](https://github.com/hashicorp/terraform-provider-tfe/pull/1160)
+* **New Data Source**: `d/tfe_registry_gpg_keys` is a new data source to retrieve all private registry GPG keys of an organization, by @tmatilai [1160](https://github.com/hashicorp/terraform-provider-tfe/pull/1160)
 
 ENHANCEMENTS:
 * `d/tfe_organization`: Make `name` argument optional if configured for the provider, by @tmatilai [1133](https://github.com/hashicorp/terraform-provider-tfe/pull/1133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ FEATURES:
 * `r/tfe_workspace`: Now uses the organization's `default_execution_mode` and `default_agent_pool_id` as the default `execution_mode`, by @SwiftEngineer [1137](https://github.com/hashicorp/terraform-provider-tfe/pull/1137)'
 * **New Resource**: `r/tfe_registry_gpg_key` is a new resource for managing private registry GPG keys, by @tmatilai
 * **New Data Source**: `d/tfe_registry_gpg_key` is a new data source to retrieve a private registry GPG key, by @tmatilai
+* **New Data Source**: `d/tfe_registry_gpg_keys` is a new data source to retrieve all private registry GPG keys of an organization, by @tmatilai
 
 ENHANCEMENTS:
 * `d/tfe_organization`: Make `name` argument optional if configured for the provider, by @tmatilai [1133](https://github.com/hashicorp/terraform-provider-tfe/pull/1133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ FEATURES:
 * `d/tfe_registry_module`: Add `vcs_repo.tags` and `vcs_repo.branch` attributes to allow configuration of `publishing_mechanism`. Add `test_config` to support running tests on `branch`-based registry modules, by @hashimoon [1096](https://github.com/hashicorp/terraform-provider-tfe/pull/1096)
 * **New Resource**: `r/tfe_organization_default_execution_mode` is a new resource to set the `default_execution_mode` and `default_agent_pool_id` for an organization, by @SwiftEngineer [1137](https://github.com/hashicorp/terraform-provider-tfe/pull/1137)'
 * `r/tfe_workspace`: Now uses the organization's `default_execution_mode` and `default_agent_pool_id` as the default `execution_mode`, by @SwiftEngineer [1137](https://github.com/hashicorp/terraform-provider-tfe/pull/1137)'
+* **New Resource**: `r/tfe_registry_gpg_key` is a new resource for managing private registry GPG keys, by @tmatilai
 
 ENHANCEMENTS:
 * `d/tfe_organization`: Make `name` argument optional if configured for the provider, by @tmatilai [1133](https://github.com/hashicorp/terraform-provider-tfe/pull/1133)

--- a/internal/provider/attribute_helpers.go
+++ b/internal/provider/attribute_helpers.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// AttrGettable is a small enabler for helper functions that need to read one
+// attribute of a Configuration, Plan, or State.
+type AttrGettable interface {
+	GetAttribute(ctx context.Context, path path.Path, target interface{}) diag.Diagnostics
+}
+
+// dataOrDefaultOrganization returns the value of the "organization" attribute
+// from the Config/Plan/State data, defaulting to the provier configuration.
+// If neither is set, an error is returned.
+func (c *ConfiguredClient) dataOrDefaultOrganization(ctx context.Context, data AttrGettable, target *string) diag.Diagnostics {
+	schemaPath := path.Root("organization")
+
+	var organization types.String
+	diags := data.GetAttribute(ctx, schemaPath, &organization)
+	if diags.HasError() {
+		return diags
+	}
+
+	if !organization.IsNull() && !organization.IsUnknown() {
+		*target = organization.ValueString()
+	} else if c.Organization == "" {
+		diags.AddAttributeError(schemaPath, "No organization was specified on the resource or provider", "")
+	} else {
+		*target = c.Organization
+	}
+
+	return diags
+}

--- a/internal/provider/data_source_registry_gpg_key.go
+++ b/internal/provider/data_source_registry_gpg_key.go
@@ -1,0 +1,119 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &dataSourceTFERegistryGPGKey{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFERegistryGPGKey{}
+)
+
+// NewRegistryGPGKeyDataSource is a helper function to simplify the provider implementation.
+func NewRegistryGPGKeyDataSource() datasource.DataSource {
+	return &dataSourceTFERegistryGPGKey{}
+}
+
+// dataSourceTFERegistryGPGKey is the data source implementation.
+type dataSourceTFERegistryGPGKey struct {
+	config ConfiguredClient
+}
+
+// Metadata returns the data source type name.
+func (d *dataSourceTFERegistryGPGKey) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_registry_gpg_key"
+}
+
+// Schema defines the schema for the data source.
+func (d *dataSourceTFERegistryGPGKey) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source can be used to retrieve a private registry GPG key.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required: true,
+			},
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"ascii_armor": schema.StringAttribute{
+				Description: "ASCII-armored representation of the GPG key.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "The time when the GPG key was created.",
+				Computed:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "The time when the GPG key was last updated.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *dataSourceTFERegistryGPGKey) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+	d.config = client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *dataSourceTFERegistryGPGKey) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data modelTFERegistryGPGKey
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var organization string
+	resp.Diagnostics.Append(d.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keyID := tfe.GPGKeyID{
+		RegistryName: "private",
+		Namespace:    organization,
+		KeyID:        data.ID.ValueString(),
+	}
+
+	tflog.Debug(ctx, "Reading private registry GPG key")
+	key, err := d.config.Client.GPGKeys.Read(ctx, keyID)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read private registry GPG key", err.Error())
+		return
+	}
+
+	data = modelFromTFEVGPGKey(key)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_registry_gpg_key_test.go
+++ b/internal/provider/data_source_registry_gpg_key_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFERegistryGPGKeyDataSource_basic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryGPGKeyDataSourceConfig(orgName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.tfe_registry_gpg_key.foobar", "organization", orgName),
+					resource.TestCheckResourceAttrSet("data.tfe_registry_gpg_key.foobar", "id"),
+					resource.TestCheckResourceAttrSet("data.tfe_registry_gpg_key.foobar", "ascii_armor"),
+					resource.TestCheckResourceAttrSet("data.tfe_registry_gpg_key.foobar", "created_at"),
+					resource.TestCheckResourceAttrSet("data.tfe_registry_gpg_key.foobar", "updated_at")),
+			},
+		},
+	})
+}
+
+func testAccTFERegistryGPGKeyDataSourceConfig(orgName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "tfe_registry_gpg_key" "foobar" {
+  organization = tfe_organization.foobar.name
+
+  id = tfe_registry_gpg_key.foobar.id
+}
+`, testAccTFERegistryGPGKeyResourceConfig(orgName))
+}

--- a/internal/provider/data_source_registry_gpg_keys.go
+++ b/internal/provider/data_source_registry_gpg_keys.go
@@ -1,0 +1,146 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &dataSourceTFERegistryGPGKeys{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFERegistryGPGKeys{}
+)
+
+// NewRegistryGPGKeysDataSource is a helper function to simplify the provider implementation.
+func NewRegistryGPGKeysDataSource() datasource.DataSource {
+	return &dataSourceTFERegistryGPGKeys{}
+}
+
+// dataSourceTFERegistryGPGKeys is the data source implementation.
+type dataSourceTFERegistryGPGKeys struct {
+	config ConfiguredClient
+}
+
+// modelTFERegistryGPGKeys maps the data source schema data.
+type modelTFERegistryGPGKeys struct {
+	ID           types.String             `tfsdk:"id"`
+	Organization types.String             `tfsdk:"organization"`
+	Keys         []modelTFERegistryGPGKey `tfsdk:"keys"`
+}
+
+// Metadata returns the data source type name.
+func (d *dataSourceTFERegistryGPGKeys) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_registry_gpg_keys"
+}
+
+// Schema defines the schema for the data source.
+func (d *dataSourceTFERegistryGPGKeys) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source can be used to retrieve all private registry GPG keys of an organization.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"keys": schema.ListAttribute{
+				Description: "List of GPG keys in the organization.",
+				Computed:    true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"id":           types.StringType,
+						"organization": types.StringType,
+						"ascii_armor":  types.StringType,
+						"created_at":   types.StringType,
+						"updated_at":   types.StringType,
+					},
+				},
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *dataSourceTFERegistryGPGKeys) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+	d.config = client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *dataSourceTFERegistryGPGKeys) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data modelTFERegistryGPGKeys
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var organization string
+	resp.Diagnostics.Append(d.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	options := tfe.GPGKeyListOptions{
+		Namespaces: []string{organization},
+	}
+	tflog.Debug(ctx, "Listing private registry GPG keys")
+	keyList, err := d.config.Client.GPGKeys.ListPrivate(ctx, options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to list private registry GPG keys", err.Error())
+		return
+	}
+
+	data.ID = types.StringValue(organization)
+	data.Organization = types.StringValue(organization)
+	data.Keys = []modelTFERegistryGPGKey{}
+
+	for {
+		for _, key := range keyList.Items {
+			data.Keys = append(data.Keys, modelFromTFEVGPGKey(key))
+		}
+
+		if keyList.CurrentPage >= keyList.TotalPages {
+			break
+		}
+		options.PageNumber = keyList.NextPage
+
+		tflog.Debug(ctx, "Listing private registry GPG keys")
+		keyList, err = d.config.Client.GPGKeys.ListPrivate(ctx, options)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to list private registry GPG keys", err.Error())
+			return
+		}
+	}
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_registry_gpg_keys_test.go
+++ b/internal/provider/data_source_registry_gpg_keys_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFERegistryGPGKeysDataSource_basic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryGPGKeysDataSourceConfig(orgName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_registry_gpg_keys.all", "organization", orgName),
+					resource.TestCheckResourceAttr(
+						"data.tfe_registry_gpg_keys.all", "keys.#", "1"),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_registry_gpg_keys.all", "keys.0.id"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_registry_gpg_keys.all", "keys.0.organization", orgName),
+					resource.TestCheckResourceAttrSet(
+						"data.tfe_registry_gpg_keys.all", "keys.0.ascii_armor"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryGPGKeysDataSource_basicNoKeys(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryGPGKeysDataSourceConfig_noKeys(orgName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_registry_gpg_keys.all", "organization", orgName),
+					resource.TestCheckResourceAttr(
+						"data.tfe_registry_gpg_keys.all", "keys.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFERegistryGPGKeysDataSourceConfig(orgName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "tfe_registry_gpg_keys" "all" {
+  organization = tfe_organization.foobar.name
+
+  depends_on = [tfe_registry_gpg_key.foobar]
+}
+`, testAccTFERegistryGPGKeyResourceConfig(orgName))
+}
+
+func testAccTFERegistryGPGKeysDataSourceConfig_noKeys(orgName string) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "%s"
+  email = "admin@tfe.local"
+}
+
+data "tfe_registry_gpg_keys" "all" {
+  organization = tfe_organization.foobar.name
+}
+`, orgName)
+}

--- a/internal/provider/gpg_key.go
+++ b/internal/provider/gpg_key.go
@@ -15,7 +15,7 @@ import (
 type modelTFERegistryGPGKey struct {
 	ID           types.String `tfsdk:"id"`
 	Organization types.String `tfsdk:"organization"`
-	AsciiArmor   types.String `tfsdk:"ascii_armor"`
+	ASCIIArmor   types.String `tfsdk:"ascii_armor"`
 	CreatedAt    types.String `tfsdk:"created_at"`
 	UpdatedAt    types.String `tfsdk:"updated_at"`
 }
@@ -26,7 +26,7 @@ func modelFromTFEVGPGKey(v *tfe.GPGKey) modelTFERegistryGPGKey {
 	return modelTFERegistryGPGKey{
 		ID:           types.StringValue(v.KeyID),
 		Organization: types.StringValue(v.Namespace),
-		AsciiArmor:   types.StringValue(v.AsciiArmor),
+		ASCIIArmor:   types.StringValue(v.AsciiArmor),
 		CreatedAt:    types.StringValue(v.CreatedAt.Format(time.RFC3339)),
 		UpdatedAt:    types.StringValue(v.UpdatedAt.Format(time.RFC3339)),
 	}

--- a/internal/provider/gpg_key.go
+++ b/internal/provider/gpg_key.go
@@ -1,0 +1,33 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// modelTFERegistryGPGKey maps the resource or data source schema data to a
+// struct.
+type modelTFERegistryGPGKey struct {
+	ID           types.String `tfsdk:"id"`
+	Organization types.String `tfsdk:"organization"`
+	AsciiArmor   types.String `tfsdk:"ascii_armor"`
+	CreatedAt    types.String `tfsdk:"created_at"`
+	UpdatedAt    types.String `tfsdk:"updated_at"`
+}
+
+// modelFromTFEVGPGKey builds a modelTFERegistryGPGKey struct from a
+// tfe.GPGKey value.
+func modelFromTFEVGPGKey(v *tfe.GPGKey) modelTFERegistryGPGKey {
+	return modelTFERegistryGPGKey{
+		ID:           types.StringValue(v.KeyID),
+		Organization: types.StringValue(v.Namespace),
+		AsciiArmor:   types.StringValue(v.AsciiArmor),
+		CreatedAt:    types.StringValue(v.CreatedAt.Format(time.RFC3339)),
+		UpdatedAt:    types.StringValue(v.UpdatedAt.Format(time.RFC3339)),
+	}
+}

--- a/internal/provider/provider_custom_diffs.go
+++ b/internal/provider/provider_custom_diffs.go
@@ -2,7 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -13,11 +17,31 @@ func customizeDiffIfProviderDefaultOrganizationChanged(c context.Context, diff *
 	plannedOrg := diff.Get("organization").(string)
 
 	if configOrg.IsNull() && config.Organization != plannedOrg {
-		// There is no organization configured on the resource, yet it is different from
-		// the state organization. We must conclude that the provider default organization changed.
+		// There is no organization configured on the resource, yet the provider org is different from
+		// the planned organization. We must conclude that the provider default organization changed.
 		if err := diff.SetNew("organization", config.Organization); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func modifyPlanForDefaultOrganizationChange(ctx context.Context, providerDefaultOrg string, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	orgPath := path.Root("organization")
+
+	var configOrg, plannedOrg *string
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, orgPath, &configOrg)...)
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, orgPath, &plannedOrg)...)
+
+	if configOrg == nil && plannedOrg != nil && providerDefaultOrg != *plannedOrg {
+		// There is no organization configured on the resource, yet the provider org is different from
+		// the planned organization value. We must conclude that the provider default organization changed.
+		resp.Diagnostics.AddWarning(fmt.Sprintf("plannedOrg = %q, providerOrg = %q", *plannedOrg, providerDefaultOrg), "")
+		resp.Plan.SetAttribute(ctx, orgPath, types.StringValue(providerDefaultOrg))
+		resp.RequiresReplace.Append(orgPath)
+	}
 }

--- a/internal/provider/provider_custom_diffs.go
+++ b/internal/provider/provider_custom_diffs.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -40,7 +39,6 @@ func modifyPlanForDefaultOrganizationChange(ctx context.Context, providerDefault
 	if configOrg == nil && plannedOrg != nil && providerDefaultOrg != *plannedOrg {
 		// There is no organization configured on the resource, yet the provider org is different from
 		// the planned organization value. We must conclude that the provider default organization changed.
-		resp.Diagnostics.AddWarning(fmt.Sprintf("plannedOrg = %q, providerOrg = %q", *plannedOrg, providerDefaultOrg), "")
 		resp.Plan.SetAttribute(ctx, orgPath, types.StringValue(providerDefaultOrg))
 		resp.RequiresReplace.Append(orgPath)
 	}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -119,6 +119,7 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 
 func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewRegistryGPGKeyResource,
 		NewResourceVariable,
 		NewSAMLSettingsResource,
 	}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -113,6 +113,7 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 
 func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewRegistryGPGKeyDataSource,
 		NewSAMLSettingsDataSource,
 	}
 }

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -114,6 +114,7 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewRegistryGPGKeyDataSource,
+		NewRegistryGPGKeysDataSource,
 		NewSAMLSettingsDataSource,
 	}
 }

--- a/internal/provider/resource_tfe_registry_gpg_key.go
+++ b/internal/provider/resource_tfe_registry_gpg_key.go
@@ -177,40 +177,11 @@ func (r *resourceTFERegistryGPGKey) Read(ctx context.Context, req resource.ReadR
 }
 
 func (r *resourceTFERegistryGPGKey) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan modelTFERegistryGPGKey
-	var state modelTFERegistryGPGKey
-
-	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	keyID := tfe.GPGKeyID{
-		RegistryName: "private",
-		Namespace:    state.Organization.ValueString(), // The old namespace
-		KeyID:        plan.ID.ValueString(),
-	}
-	options := tfe.GPGKeyUpdateOptions{
-		Type:      "gpg-keys",
-		Namespace: plan.Organization.ValueString(), // The new namespace
-	}
-
-	tflog.Debug(ctx, "Updating private registry GPG key")
-	key, err := r.config.Client.GPGKeys.Update(ctx, keyID, options)
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to update private registry GPG key", err.Error())
-		return
-	}
-
-	result := modelFromTFEVGPGKey(key)
-
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+	// If the resource does not support modification and should always be recreated on
+	// configuration value updates, the Update logic can be left empty and ensure all
+	// configurable schema attributes implement the resource.RequiresReplace()
+	// attribute plan modifier.
+	resp.Diagnostics.AddError("Update not supported", "The update operation is not supported on this resource. This is a bug in the provider.")
 }
 
 func (r *resourceTFERegistryGPGKey) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource_tfe_registry_gpg_key.go
+++ b/internal/provider/resource_tfe_registry_gpg_key.go
@@ -117,7 +117,7 @@ func (r *resourceTFERegistryGPGKey) Create(ctx context.Context, req resource.Cre
 	options := tfe.GPGKeyCreateOptions{
 		Type:       "gpg-keys",
 		Namespace:  organization,
-		AsciiArmor: plan.AsciiArmor.ValueString(),
+		AsciiArmor: plan.ASCIIArmor.ValueString(),
 	}
 
 	tflog.Debug(ctx, "Creating private registry GPG key")

--- a/internal/provider/resource_tfe_registry_gpg_key.go
+++ b/internal/provider/resource_tfe_registry_gpg_key.go
@@ -1,0 +1,249 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &resourceTFERegistryGPGKey{}
+var _ resource.ResourceWithConfigure = &resourceTFERegistryGPGKey{}
+var _ resource.ResourceWithImportState = &resourceTFERegistryGPGKey{}
+
+func NewRegistryGPGKeyResource() resource.Resource {
+	return &resourceTFERegistryGPGKey{}
+}
+
+// resourceTFERegistryGPGKey implements the tfe_registry_gpg_key resource type
+type resourceTFERegistryGPGKey struct {
+	config ConfiguredClient
+}
+
+func (r *resourceTFERegistryGPGKey) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_registry_gpg_key"
+}
+
+func (r *resourceTFERegistryGPGKey) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a public key of the GPG key pair used to sign releases of private providers in the private registry.",
+		Version:     1,
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "ID of the GPG key.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			"ascii_armor": schema.StringAttribute{
+				Description: "ASCII-armored representation of the GPG key.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Description: "The time when the GPG key was created.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "The time when the GPG key was last updated.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFERegistryGPGKey) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	r.config = client
+}
+
+func (r *resourceTFERegistryGPGKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTFERegistryGPGKey
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Plan, &organization)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	options := tfe.GPGKeyCreateOptions{
+		Type:       "gpg-keys",
+		Namespace:  organization,
+		AsciiArmor: plan.AsciiArmor.ValueString(),
+	}
+
+	tflog.Debug(ctx, "Creating private registry GPG key")
+	key, err := r.config.Client.GPGKeys.Create(ctx, "private", options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create private registry GPG key", err.Error())
+		return
+	}
+
+	result := modelFromTFEVGPGKey(key)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceTFERegistryGPGKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFERegistryGPGKey
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.State, &organization)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keyID := tfe.GPGKeyID{
+		RegistryName: "private",
+		Namespace:    organization,
+		KeyID:        state.ID.ValueString(),
+	}
+
+	tflog.Debug(ctx, "Reading private registry GPG key")
+	key, err := r.config.Client.GPGKeys.Read(ctx, keyID)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read private registry GPG key", err.Error())
+		return
+	}
+
+	result := modelFromTFEVGPGKey(key)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceTFERegistryGPGKey) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan modelTFERegistryGPGKey
+	var state modelTFERegistryGPGKey
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keyID := tfe.GPGKeyID{
+		RegistryName: "private",
+		Namespace:    state.Organization.ValueString(), // The old namespace
+		KeyID:        plan.ID.ValueString(),
+	}
+	options := tfe.GPGKeyUpdateOptions{
+		Type:      "gpg-keys",
+		Namespace: plan.Organization.ValueString(), // The new namespace
+	}
+
+	tflog.Debug(ctx, "Updating private registry GPG key")
+	key, err := r.config.Client.GPGKeys.Update(ctx, keyID, options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to update private registry GPG key", err.Error())
+		return
+	}
+
+	result := modelFromTFEVGPGKey(key)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceTFERegistryGPGKey) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFERegistryGPGKey
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keyID := tfe.GPGKeyID{
+		RegistryName: "private",
+		Namespace:    state.Organization.ValueString(),
+		KeyID:        state.ID.ValueString(),
+	}
+
+	tflog.Debug(ctx, "Deleting private registry GPG key")
+	err := r.config.Client.GPGKeys.Delete(ctx, keyID)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to delete private registry GPG key", err.Error())
+		return
+	}
+}
+
+func (r *resourceTFERegistryGPGKey) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	s := strings.SplitN(req.ID, "/", 2)
+	if len(s) != 2 {
+		resp.Diagnostics.AddError(
+			"Error importing variable",
+			fmt.Sprintf("Invalid variable import format: %s (expected <ORGANIZATION>/<KEY ID>)", req.ID),
+		)
+		return
+	}
+	org := s[0]
+	id := s[1]
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization"), org)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+}

--- a/internal/provider/resource_tfe_registry_gpg_key_test.go
+++ b/internal/provider/resource_tfe_registry_gpg_key_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFERegistryGPGKeyResource_basic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryGPGKeyResourceConfig(orgName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_registry_gpg_key.foobar", "id", testGPGKeyID),
+					resource.TestCheckResourceAttr("tfe_registry_gpg_key.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr("tfe_registry_gpg_key.foobar", "ascii_armor", testGPGKeyArmor+"\n"),
+					resource.TestCheckResourceAttrSet("tfe_registry_gpg_key.foobar", "created_at"),
+					resource.TestCheckResourceAttrSet("tfe_registry_gpg_key.foobar", "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFERegistryGPGKeyResourceConfig(orgName string) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "%s"
+  email = "admin@tfe.local"
+}
+
+resource "tfe_registry_gpg_key" "foobar" {
+  organization = tfe_organization.foobar.name
+
+  ascii_armor = <<ASCII_ARMOR
+%s
+ASCII_ARMOR
+}
+`, orgName, testGPGKeyArmor)
+}
+
+const testGPGKeyID string = "13DFECCA3B58CE4A"
+
+const testGPGKeyArmor string = `
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBGKnWEYBEACsTJ9HEUrXBaBvQvXZAXEIMWloG96MVAdCj547jJviSS4TqMIQ
+EST2pzDq7lEpqL+JkW3ptyLEAeQs6gJJeuhODGm2EcxjJ9/JM4ZH+p9zq2wBeXVe
+0XJcP3HD8/7MesjMyGSsoX7tR7TcIhs5Y7zS+/L1xnoReYUsBgC6QdqjQwkuntaq
+2y6yxdYG4gVlxb4yA0Ga6Qfy0VGIKjbCdPqCRyJ76YHE3t+Skq9oDCOV3VSiwKsU
+V/ivf/MVZ1GyE03anW0+poVK38Ekogsd2+34uEjusbuoJGmHzh/20IDS8VnxQHIY
+qdVwcZrW+a3O6nexL4dJJGMfXMbCdS87FxpSnC1FDGMSJ2c5cxlMuKuDboTpbRy5
+Dd80p6voJQcLcpr0hKYIwwDGJYE336KMFqf/apCc6HbCFfN8kCYg3K7+4yganRWu
+h/9qIhP0QaYOYEQl4RdjJTSyJSP3srAJ3F5OmrAhRXlHlLo1p00zxFxG7ZcJER6l
++uRubtL9WN2kgGbr9NDJbz/HeOTjJhCASdQuzstcL8RrFMDftE/P2K8LnkxUNIbT
+dhZtwvkhnyIwOZIHwsQddeJboeHD445SlHJ+4vFsPKRTuNu5u9GhVSyZhoHmdeH0
+FheD8p43+BKZ7KmD4xd+zfCQE1xO2cO9ZrCNV2hs9UVFbgZfjokqWkuHJQARAQAB
+tBNmb28gPGFkbWluQHRmZS5jb20+iQJRBBMBCAA7FiEE/2esSrAATXzEQSanE9/s
+yjtYzkoFAmKnWEYCGwMFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQE9/s
+yjtYzkq01g/9EgnW0NBD4DdtQSHg5jya0lx5iNHLK+umwL2x7abcSQ9iTIylhbHP
++he6jS/p4yzK7Gf7S+W3D9EZ58KrTMhu85iLr0uZ947pEbC0kDlQGkIfiK0CAyq2
+IDj1RFgmeM0E2LkPOYCM+JPeBC9nZduFMYY9eFhCZXJ3ua1DP37ZBdZbjuImbiQ5
+abt75a89NbQI3KRaACzqEjFpRYuoxbh8RznkTFf57AFzt4yMWy+4l47GSXTE8boS
+1P7ZOfvJPuh2RRN9sSe0eTPCYnnSxPPo0LvgqSnLSk9yc65nkPZmlSXVdswV5Le+
+7LlKG+rTwXljfGwLmj0VNn2gGCKe5IHs8FKt3parSiQOu4MXHCHshSQDEvXyIugJ
+i2V2pcw4Hi6f2Znh3YYJamL6fDwCpDcTOCxZbvFi4OuBzbWcDLP1k52k3ZyYce92
+1CK84HWtoRseNlVt1rieClPZH5T4b0HMPBWKK39/r+RABJDAfdGtn2ulKXK2JugH
+AYXlhY9xh9+r1O7tsqExGkEYnp7nI0ArauJhIUWZybpGpPYP99kK4F64E4DRu1si
+/3eeYoqKY1jAHoebRzn3XcRg5kro/lJYQQIhT4fHt5sAc/e8gDdaQaDPIftsmu7K
+w4e6pMyztiMfRw7w0ZSjGlPsl0NiXA3nuG966gx4Bnx/ddJIHrghAi25Ag0EYqdY
+RgEQAOGONFP+z45+9gvnT1yd9sJLqxYhtj5QRxKkXkLARPd0Yjdyff/lVd1YPtZ7
+slLuEGlBDKdB6aIeu3b1C95Ie3qbTIwIp6ZYKGqUEwGW/0sPtBqqXanVrQkrY4ho
+lqejgPraFgF6sDGrSxG7b8W985NJwKcm8Lx1/x4ZwvpUrQlCL4UajJcECmjVqU/e
+ofjWZFZl7eR2oYh2BBzvA8mwkVKXs6kTGWLkK7VDeR2lCRl2fk4+5DydbOMIZXxT
+jmYR8iu2Mr+gt//VmvvBjlFMI05kwD9iG3SRYBwpYEXETKCE12KKqcbhP/bwahIB
+bcsaQkoky9jgtp7tizduPOkjkGhT9kF8L1O0VGxek40L7+QIDEnVHMAH5hSLmgau
+vJF+Bd0W/TRZbmAJXoWPreftVTmWH7xH4N7v+3dvWziIJPt+N/1HHeZXBojJJAVk
+6C+t1KpsSwGzzOjdsQVCklT7D4PmWtzz6FAjImPSbk5LbiVWis/lH+SEVZS4sG7j
+pR3vRjUZTjCi/8CmHTjiWXL7g9kkt//a5Av3iArQq0pv0QNPG/uPeN2QTnkz5DAo
+kM/qUx/G59i8AfEH2myh9oPCOzb3yFOsK9G/2Sy05cfdLozddHwt+hJVPx1Od9Nr
+HAJMQspr9AaZPB9FnAa0Bv/RNEGJv6LJwzVWJkezL2wQAZdlABEBAAGJAjYEGAEI
+ACAWIQT/Z6xKsABNfMRBJqcT3+zKO1jOSgUCYqdYRgIbDAAKCRAT3+zKO1jOSq9E
+D/4hlNaCwY/etk7ZvMe4pupQATzrZF58d2qjx4niMd3CvCWmbrWMmoNxBjECXc8H
+kp+0NURFFc/wiCn/Q6dhrMxKVCpsWpHA1Doi/vtzQtM081Ib6uIX6L6liyUexW1l
+tvJwPurqJJVBW3ikOjICCnv70tp2zaS47uQjyFGTnzglIU961EXCWdNjH1vm8bFJ
+BxXN87gHXhUUw8GZ3d2V75TAJIEqRVV+eI4flXcJ4Ld+Zbt2EiMwtQ05XCc8bgsc
+QzZFizw936bC5Py7Iu6aEaShFlZlz8LgYcId32UYh5PG1xGNZv0C9Z/PJECx5zcx
+RJszDpm3erpmdkkJf9UBuhjjTdQ9gheFjZRDi/rVJ0JPVxD7HTzEAWd5MqFXqh0V
+j2xG1FhtfxSaMf9rsJjtwewLPyZylSuz2erz1j80Hx3Q6eSIDsNjnDTtfh9Z8gXz
+gvF7mSC0lZu/RvDSRyHfCw4zCQ04HieIvq3hZLy+QS11ykJTSKAePKk77EmwtoLd
+Je9n9FCKhLknUp1/dsu0lsznvttOLwYy6xFP4JNPgiq6iYlVHs417oib67DrGlsI
+3Ki44OESW/vL3WAC091TOF4OYgGw+TMauB8SxZo0PLXrIwKeBsQEB4tf6bX66OvJ
+UFpas2r53xTaraRDpu6+u66hLY+/XV9Uf5YzETuPQnX/nw==
+=bBSS
+-----END PGP PUBLIC KEY BLOCK-----
+`

--- a/internal/provider/resource_tfe_variable.go
+++ b/internal/provider/resource_tfe_variable.go
@@ -12,7 +12,6 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -245,12 +244,6 @@ func (r *resourceTFEVariable) Schema(ctx context.Context, req resource.SchemaReq
 		DeprecationMessage:  "",
 		Version:             1,
 	}
-}
-
-// AttrGettable is a small enabler for helper functions that need to read one
-// attribute of a Plan or State.
-type AttrGettable interface {
-	GetAttribute(ctx context.Context, path path.Path, target interface{}) diag.Diagnostics
 }
 
 // isWorkspaceVariable is a helper function for switching between tfe_variable's

--- a/website/docs/d/registry_gpg_key.html.markdown
+++ b/website/docs/d/registry_gpg_key.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_registry_gpg_key"
+description: |-
+  Get information on a private registry GPG key.
+---
+
+# Data Source: tfe_registry_gpg_key
+
+Use this data source to get information about a private registry GPG key.
+
+## Example Usage
+
+```hcl
+data "tfe_registry_gpg_key" "example" {
+  organization = "my-org-name"
+  id           = "13DFECCA3B58CE4A"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) ID of the GPG key.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
+
+## Attributes Reference
+
+* `ascii_armor` - ASCII-armored representation of the GPG key.
+* `created_at` - The time when the GPG key was created.
+* `updated_at` - The time when the GPG key was last updated.

--- a/website/docs/d/registry_gpg_keys.html.markdown
+++ b/website/docs/d/registry_gpg_keys.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_registry_gpg_keys"
+description: |-
+  Get information on private registry GPG keys of an organization.
+---
+
+# Data Source: tfe_registry_gpg_key
+
+Use this data source to get information about all private registry GPG keys of an organization.
+
+## Example Usage
+
+```hcl
+data "tfe_registry_gpg_keys" "all" {
+  organization = "my-org-name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
+
+## Attributes Reference
+
+* `keys` - List of GPG keys in the organization. Each element contains the following attributes:
+  * `id` - ID of the GPG key.
+  * `organization` - Name of the organization.
+  * `ascii_armor` - ASCII-armored representation of the GPG key.
+  * `created_at` - The time when the GPG key was created.
+  * `updated_at` - The time when the GPG key was last updated.

--- a/website/docs/r/registry_gpg_key.html.markdown
+++ b/website/docs/r/registry_gpg_key.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_registry_gpg_key"
+description: |-
+  Manages private registry GPG keys.
+---
+
+# tfe_registry_gpg_key
+
+Manages a public key of the GPG key pair used to sign releases of private providers in the private registry.
+
+The provided GPG key must be ASCII-armored, i.e. starting with:
+"`-----BEGIN PGP PUBLIC KEY BLOCK-----\n\n...`".
+
+## Example Usage
+
+```hcl
+resource "tfe_registry_gpg_key" "example" {
+  organization = "my-org-name"
+  ascii_armor  = file("my-public-key.asc")
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ascii_armor` - (Required) ASCII-armored representation of the GPG key.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
+
+## Attributes Reference
+
+* `id` - ID of the GPG key.
+* `created_at` - The time when the GPG key was created.
+* `updated_at` - The time when the GPG key was last updated.
+
+## Import
+
+Keys can be imported; use `<ORGANIZATION NAME>/<KEY ID>` as the import ID. For
+example:
+
+```shell
+terraform import tfe_registry_gpg_key.example my-org-name/34365D9472D7468F
+```


### PR DESCRIPTION
## Description

Add `tfe_registry_gpg_key` resource and data source, and `tfe_registry_gpg_keys` data source, for managing and retrieving private registry GPG keys.

Related to  #584.

## Testing plan

Create and retrieve GPG keys with the new resource and data sources.

<details><summary>Example configuration</summary>

```terraform
resource "tfe_organization" "foobar" {
  name  = "foobar"
  email = "admin@tfe.local"
}

resource "tfe_registry_gpg_key" "foobar" {
  organization = tfe_organization.foobar.name

  ascii_armor = <<ASCII_ARMOR
-----BEGIN PGP PUBLIC KEY BLOCK-----

mQINBGKnWEYBEACsTJ9HEUrXBaBvQvXZAXEIMWloG96MVAdCj547jJviSS4TqMIQ
EST2pzDq7lEpqL+JkW3ptyLEAeQs6gJJeuhODGm2EcxjJ9/JM4ZH+p9zq2wBeXVe
0XJcP3HD8/7MesjMyGSsoX7tR7TcIhs5Y7zS+/L1xnoReYUsBgC6QdqjQwkuntaq
2y6yxdYG4gVlxb4yA0Ga6Qfy0VGIKjbCdPqCRyJ76YHE3t+Skq9oDCOV3VSiwKsU
V/ivf/MVZ1GyE03anW0+poVK38Ekogsd2+34uEjusbuoJGmHzh/20IDS8VnxQHIY
qdVwcZrW+a3O6nexL4dJJGMfXMbCdS87FxpSnC1FDGMSJ2c5cxlMuKuDboTpbRy5
Dd80p6voJQcLcpr0hKYIwwDGJYE336KMFqf/apCc6HbCFfN8kCYg3K7+4yganRWu
h/9qIhP0QaYOYEQl4RdjJTSyJSP3srAJ3F5OmrAhRXlHlLo1p00zxFxG7ZcJER6l
+uRubtL9WN2kgGbr9NDJbz/HeOTjJhCASdQuzstcL8RrFMDftE/P2K8LnkxUNIbT
dhZtwvkhnyIwOZIHwsQddeJboeHD445SlHJ+4vFsPKRTuNu5u9GhVSyZhoHmdeH0
FheD8p43+BKZ7KmD4xd+zfCQE1xO2cO9ZrCNV2hs9UVFbgZfjokqWkuHJQARAQAB
tBNmb28gPGFkbWluQHRmZS5jb20+iQJRBBMBCAA7FiEE/2esSrAATXzEQSanE9/s
yjtYzkoFAmKnWEYCGwMFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQE9/s
yjtYzkq01g/9EgnW0NBD4DdtQSHg5jya0lx5iNHLK+umwL2x7abcSQ9iTIylhbHP
+he6jS/p4yzK7Gf7S+W3D9EZ58KrTMhu85iLr0uZ947pEbC0kDlQGkIfiK0CAyq2
IDj1RFgmeM0E2LkPOYCM+JPeBC9nZduFMYY9eFhCZXJ3ua1DP37ZBdZbjuImbiQ5
abt75a89NbQI3KRaACzqEjFpRYuoxbh8RznkTFf57AFzt4yMWy+4l47GSXTE8boS
1P7ZOfvJPuh2RRN9sSe0eTPCYnnSxPPo0LvgqSnLSk9yc65nkPZmlSXVdswV5Le+
7LlKG+rTwXljfGwLmj0VNn2gGCKe5IHs8FKt3parSiQOu4MXHCHshSQDEvXyIugJ
i2V2pcw4Hi6f2Znh3YYJamL6fDwCpDcTOCxZbvFi4OuBzbWcDLP1k52k3ZyYce92
1CK84HWtoRseNlVt1rieClPZH5T4b0HMPBWKK39/r+RABJDAfdGtn2ulKXK2JugH
AYXlhY9xh9+r1O7tsqExGkEYnp7nI0ArauJhIUWZybpGpPYP99kK4F64E4DRu1si
/3eeYoqKY1jAHoebRzn3XcRg5kro/lJYQQIhT4fHt5sAc/e8gDdaQaDPIftsmu7K
w4e6pMyztiMfRw7w0ZSjGlPsl0NiXA3nuG966gx4Bnx/ddJIHrghAi25Ag0EYqdY
RgEQAOGONFP+z45+9gvnT1yd9sJLqxYhtj5QRxKkXkLARPd0Yjdyff/lVd1YPtZ7
slLuEGlBDKdB6aIeu3b1C95Ie3qbTIwIp6ZYKGqUEwGW/0sPtBqqXanVrQkrY4ho
lqejgPraFgF6sDGrSxG7b8W985NJwKcm8Lx1/x4ZwvpUrQlCL4UajJcECmjVqU/e
ofjWZFZl7eR2oYh2BBzvA8mwkVKXs6kTGWLkK7VDeR2lCRl2fk4+5DydbOMIZXxT
jmYR8iu2Mr+gt//VmvvBjlFMI05kwD9iG3SRYBwpYEXETKCE12KKqcbhP/bwahIB
bcsaQkoky9jgtp7tizduPOkjkGhT9kF8L1O0VGxek40L7+QIDEnVHMAH5hSLmgau
vJF+Bd0W/TRZbmAJXoWPreftVTmWH7xH4N7v+3dvWziIJPt+N/1HHeZXBojJJAVk
6C+t1KpsSwGzzOjdsQVCklT7D4PmWtzz6FAjImPSbk5LbiVWis/lH+SEVZS4sG7j
pR3vRjUZTjCi/8CmHTjiWXL7g9kkt//a5Av3iArQq0pv0QNPG/uPeN2QTnkz5DAo
kM/qUx/G59i8AfEH2myh9oPCOzb3yFOsK9G/2Sy05cfdLozddHwt+hJVPx1Od9Nr
HAJMQspr9AaZPB9FnAa0Bv/RNEGJv6LJwzVWJkezL2wQAZdlABEBAAGJAjYEGAEI
ACAWIQT/Z6xKsABNfMRBJqcT3+zKO1jOSgUCYqdYRgIbDAAKCRAT3+zKO1jOSq9E
D/4hlNaCwY/etk7ZvMe4pupQATzrZF58d2qjx4niMd3CvCWmbrWMmoNxBjECXc8H
kp+0NURFFc/wiCn/Q6dhrMxKVCpsWpHA1Doi/vtzQtM081Ib6uIX6L6liyUexW1l
tvJwPurqJJVBW3ikOjICCnv70tp2zaS47uQjyFGTnzglIU961EXCWdNjH1vm8bFJ
BxXN87gHXhUUw8GZ3d2V75TAJIEqRVV+eI4flXcJ4Ld+Zbt2EiMwtQ05XCc8bgsc
QzZFizw936bC5Py7Iu6aEaShFlZlz8LgYcId32UYh5PG1xGNZv0C9Z/PJECx5zcx
RJszDpm3erpmdkkJf9UBuhjjTdQ9gheFjZRDi/rVJ0JPVxD7HTzEAWd5MqFXqh0V
j2xG1FhtfxSaMf9rsJjtwewLPyZylSuz2erz1j80Hx3Q6eSIDsNjnDTtfh9Z8gXz
gvF7mSC0lZu/RvDSRyHfCw4zCQ04HieIvq3hZLy+QS11ykJTSKAePKk77EmwtoLd
Je9n9FCKhLknUp1/dsu0lsznvttOLwYy6xFP4JNPgiq6iYlVHs417oib67DrGlsI
3Ki44OESW/vL3WAC091TOF4OYgGw+TMauB8SxZo0PLXrIwKeBsQEB4tf6bX66OvJ
UFpas2r53xTaraRDpu6+u66hLY+/XV9Uf5YzETuPQnX/nw==
=bBSS
-----END PGP PUBLIC KEY BLOCK-----
ASCII_ARMOR
}

data "tfe_registry_gpg_key" "foobar" {
  organization = tfe_organization.foobar.name

  id = tfe_registry_gpg_key.foobar.id
}

data "tfe_registry_gpg_keys" "all" {
  organization = tfe_organization.foobar.name

  depends_on = [tfe_registry_gpg_key.foobar]
}
```

</details>


## External links

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe#GPGKeys)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/gpg-keys)

## Output from acceptance tests

```
$ make testacc TESTARGS='-run=TestAccTFERegistryGPGKey'
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run=TestAccTFERegistryGPGKey -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/client     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/logging    (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
=== RUN   TestAccTFERegistryGPGKeyDataSource_basic
--- PASS: TestAccTFERegistryGPGKeyDataSource_basic (4.29s)
=== RUN   TestAccTFERegistryGPGKeysDataSource_basic
--- PASS: TestAccTFERegistryGPGKeysDataSource_basic (3.69s)
=== RUN   TestAccTFERegistryGPGKeysDataSource_basicNoKeys
--- PASS: TestAccTFERegistryGPGKeysDataSource_basicNoKeys (2.80s)
=== RUN   TestAccTFERegistryGPGKeyResource_basic
--- PASS: TestAccTFERegistryGPGKeyResource_basic (2.74s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   13.854s
```
