### PR TITLE
Fix 'no changes detected' when provider default organization changes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - gosec #https://github.com/securego/gosec
     - predeclared #https://github.com/nishanths/predeclared
     - unconvert #https://github.com/mdempsky/unconvert
-    - wrapcheck #https://github.com/tomarrell/wrapcheck
 
 issues:
   exclude-rules:
@@ -101,19 +100,6 @@ issues:
       -|resource_tfe_run_trigger|resource_tfe_team_access|resource_tfe_organization_membership|resource_tfe_policy_set|resource_tfe_team_member|
       -|resource_tfe_workspace|resource_tfe_team_organization_member|resource_tfe_variable_set|resource_tfe_team_project_access)\.go
     text: "SA1019"
-  - linters:
-      - wrapcheck
-    path: (config_unix|data_source_slug|data_source_workspace|provider|resource_tfe_variable|resource_tfe_workspace|provider_test)\.go
-    text: "error returned from external package is unwrapped"
-  - linters:
-      - wrapcheck
-    path: (logging|plugin_provider|resource_tfe_oauth_client|resource_tfe_organization|resource_tfe_terraform_version|workspace_helpers|resource_tfe_agent_pool_test|
-      -|resource_tfe_agent_token_test|resource_tfe_notification_configuration_test|resource_tfe_oauth_client_test|resource_tfe_organization_membership_test|
-      -|resource_tfe_organization_test|resource_tfe_organization_token_test|resource_tfe_policy_set_parameter_test|resource_tfe_policy_set_test|resource_tfe_registry_module_test|
-      -|resource_tfe_run_trigger_test|resource_tfe_sentinel_policy_test|resource_tfe_ssh_key_test|resource_tfe_team_access_test|resource_tfe_team_member_test|
-      -|resource_tfe_team_member_test|resource_tfe_team_organization_member_test|resource_tfe_team_test|resource_tfe_team_token_test|resource_tfe_terraform_version_test|
-      -|resource_tfe_variable_set_test|resource_tfe_workspace_test|resource_tfe_team_members_test|resource_tfe_team_members_test|resource_tfe_variable_test)\.go
-    text: "error returned from interface method should be wrapped"
 linters-settings:
   # errcheck:
   #   # https://github.com/kisielk/errcheck#excluding-functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BREAKING CHANGES:
 
 BUG FIXES:
 * `r/tfe_policy`: Fix the provider ignoring updates to the `query` field, by @skeggse [1108](https://github.com/hashicorp/terraform-provider-tfe/pull/1108)
+* Fix the undetected change when modifying the `organization` default in the provider configuration by @brandonc [1152](https://github.com/hashicorp/terraform-provider-tfe/issue/1152)
 
 FEATURES:
 * `d/tfe_registry_module`: Add `vcs_repo.tags` and `vcs_repo.branch` attributes to allow configuration of `publishing_mechanism`. Add `test_config` to support running tests on `branch`-based registry modules, by @hashimoon [1096](https://github.com/hashicorp/terraform-provider-tfe/pull/1096)

--- a/internal/provider/provider_custom_diffs.go
+++ b/internal/provider/provider_custom_diffs.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func customizeDiffIfProviderDefaultOrganizationChanged(c context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	config := meta.(ConfiguredClient)
+
+	configOrg := diff.GetRawConfig().GetAttr("organization")
+	plannedOrg := diff.Get("organization").(string)
+
+	if configOrg.IsNull() && config.Organization != plannedOrg {
+		// There is no organization configured on the resource, yet it is different from
+		// the state organization. We must conclude that the provider default organization changed.
+		if err := diff.SetNew("organization", config.Organization); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/provider/resource_tfe_admin_organization_settings.go
+++ b/internal/provider/resource_tfe_admin_organization_settings.go
@@ -19,6 +19,8 @@ func resourceTFEAdminOrganizationSettings() *schema.Resource {
 		Update: resourceTFEAdminOrganizationSettingsUpdate,
 		Delete: resourceTFEAdminOrganizationSettingsDelete,
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_agent_pool.go
+++ b/internal/provider/resource_tfe_agent_pool.go
@@ -23,6 +23,8 @@ func resourceTFEAgentPool() *schema.Resource {
 			StateContext: resourceTFEAgentPoolImporter,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_no_code_module.go
+++ b/internal/provider/resource_tfe_no_code_module.go
@@ -25,6 +25,8 @@ func resourceTFENoCodeModule() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_oauth_client.go
+++ b/internal/provider/resource_tfe_oauth_client.go
@@ -18,6 +18,8 @@ func resourceTFEOAuthClient() *schema.Resource {
 		Read:   resourceTFEOAuthClientRead,
 		Delete: resourceTFEOAuthClientDelete,
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_organization_default_execution_mode.go
+++ b/internal/provider/resource_tfe_organization_default_execution_mode.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
 )
 
 func resourceTFEOrganizationDefaultExecutionMode() *schema.Resource {
@@ -18,6 +19,8 @@ func resourceTFEOrganizationDefaultExecutionMode() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceTFEOrganizationDefaultExecutionModeImporter,
 		},
+
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
 
 		Schema: map[string]*schema.Schema{
 			"organization": {

--- a/internal/provider/resource_tfe_organization_membership.go
+++ b/internal/provider/resource_tfe_organization_membership.go
@@ -22,6 +22,8 @@ func resourceTFEOrganizationMembership() *schema.Resource {
 			StateContext: resourceTFEOrganizationMembershipImporter,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"email": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_organization_module_sharing.go
+++ b/internal/provider/resource_tfe_organization_module_sharing.go
@@ -19,6 +19,9 @@ func resourceTFEOrganizationModuleSharing() *schema.Resource {
 		Read:               resourceTFEOrganizationModuleSharingRead,
 		Update:             resourceTFEOrganizationModuleSharingUpdate,
 		Delete:             resourceTFEOrganizationModuleSharingDelete,
+
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_organization_run_task.go
+++ b/internal/provider/resource_tfe_organization_run_task.go
@@ -24,6 +24,8 @@ func resourceTFEOrganizationRunTask() *schema.Resource {
 			StateContext: resourceTFEOrganizationRunTaskImporter,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_organization_token.go
+++ b/internal/provider/resource_tfe_organization_token.go
@@ -23,6 +23,8 @@ func resourceTFEOrganizationToken() *schema.Resource {
 			StateContext: resourceTFEOrganizationTokenImporter,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_policy.go
+++ b/internal/provider/resource_tfe_policy.go
@@ -26,6 +26,8 @@ func resourceTFEPolicy() *schema.Resource {
 			StateContext: resourceTFEPolicyImporter,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Description: "The name of the policy",

--- a/internal/provider/resource_tfe_policy_set.go
+++ b/internal/provider/resource_tfe_policy_set.go
@@ -23,6 +23,8 @@ func resourceTFEPolicySet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -28,6 +28,8 @@ func resourceTFEProject() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_registry_module.go
+++ b/internal/provider/resource_tfe_registry_module.go
@@ -26,6 +26,8 @@ func resourceTFERegistryModule() *schema.Resource {
 			StateContext: resourceTFERegistryModuleImporter,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -974,7 +974,6 @@ func testAccTFERegistryModule_vcs(rInt int) string {
 resource "tfe_organization" "foobar" {
  name  = "tst-terraform-%d"
  email = "admin@company.com"
-
 }
 
 resource "tfe_oauth_client" "foobar" {
@@ -986,6 +985,7 @@ resource "tfe_oauth_client" "foobar" {
 }
 
 resource "tfe_registry_module" "foobar" {
+ organization = tfe_organization.foobar.name
  vcs_repo {
    display_identifier = "%s"
    identifier         = "%s"
@@ -1055,7 +1055,7 @@ resource "tfe_registry_module" "foobar" {
    identifier         = "%s"
    oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
    branch             = "main"
-   tags				  = false 
+   tags				  = false
  }
 
  test_config {

--- a/internal/provider/resource_tfe_sentinel_policy.go
+++ b/internal/provider/resource_tfe_sentinel_policy.go
@@ -25,6 +25,8 @@ func resourceTFESentinelPolicy() *schema.Resource {
 			StateContext: resourceTFESentinelPolicyImporter,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_ssh_key.go
+++ b/internal/provider/resource_tfe_ssh_key.go
@@ -18,6 +18,8 @@ func resourceTFESSHKey() *schema.Resource {
 		Update: resourceTFESSHKeyUpdate,
 		Delete: resourceTFESSHKeyDelete,
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_variable_set.go
+++ b/internal/provider/resource_tfe_variable_set.go
@@ -24,6 +24,8 @@ func resourceTFEVariableSet() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -63,6 +63,10 @@ func resourceTFEWorkspace() *schema.Resource {
 				return err
 			}
 
+			if err := customizeDiffIfProviderDefaultOrganizationChanged(c, d, meta); err != nil {
+				return err
+			}
+
 			return nil
 		},
 


### PR DESCRIPTION
## Description

Closes #1152 

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Create a workspace or any other resource that has an "organization" argument using a default org from the provider
2. Change the organization string in the provider config
3. Resources will now will be replaced. Previously, no change would be detected.

## Output from acceptance tests

I couldn't think of a way to automate the testing of this customized diff. Ideas?