### PR TITLE
'organization' resource schema should always be computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# UNRELEASED
+
+BUG FIXES:
+* Fixed default provider organization usage for `r/tfe_admin_organization_settings`, by @brandonc [1183](https://github.com/hashicorp/terraform-provider-tfe/pull/1183)
+
 # v0.51.0
 
 DEPRECATIONS and BREAKING CHANGES:

--- a/internal/provider/resource_tfe_admin_organization_settings.go
+++ b/internal/provider/resource_tfe_admin_organization_settings.go
@@ -26,6 +26,7 @@ func resourceTFEAdminOrganizationSettings() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"access_beta_tools": {
 				Type:     schema.TypeBool,

--- a/website/docs/r/admin_organization_settings.markdown
+++ b/website/docs/r/admin_organization_settings.markdown
@@ -63,7 +63,3 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `sso_enabled` - True if SSO is enabled in this organization
-
-## Import
-
-This resource does not manage the creation of an organization and there is no need to import it.


### PR DESCRIPTION
## Description

Fixes #1182 -- all other resources are marked computed except for this one

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_

## Testing plan

```
provider "tfe" {
  organization = "hashicorp"
}

resource "tfe_admin_organization_settings" "test-company" {
  workspace_limit       = 0
  access_beta_tools     = false
  global_module_sharing = false
}
```

This config should work when applied. Also supports changing the provider default, which forced re-create

