### PR TITLE
Fixes older TFE, tfe_workspace_settings always unsets execution_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 * Fixed default provider organization usage for `r/tfe_admin_organization_settings`, by @brandonc [1183](https://github.com/hashicorp/terraform-provider-tfe/pull/1183)
-* `/r/tfe_workspace_settings`: Fix compatibility with older versions Terraform Enterprise when using agent execution by @brandonc [1193](https://github.com/hashicorp/terraform-provider-tfe/pull/1193)
+* `/r/tfe_workspace_settings`: Fix compatibility with older versions of Terraform Enterprise when using agent execution by @brandonc [1193](https://github.com/hashicorp/terraform-provider-tfe/pull/1193)
 
 # v0.51.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 * Fixed default provider organization usage for `r/tfe_admin_organization_settings`, by @brandonc [1183](https://github.com/hashicorp/terraform-provider-tfe/pull/1183)
+* `/r/tfe_workspace_settings`: Fix compatibility with older versions Terraform Enterprise when using agent execution by @brandonc [1193](https://github.com/hashicorp/terraform-provider-tfe/pull/1193)
 
 # v0.51.0
 

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -166,9 +166,11 @@ func (m unknownIfExecutionModeUnset) PlanModifyString(ctx context.Context, req p
 		if configured.ExecutionMode.IsNull() && overwritesState[0].ExecutionMode.ValueBool() {
 			resp.PlanValue = types.StringUnknown()
 		}
-	} else if req.Path.Equal(path.Root("execution_mode")) {
+	} else if configured.ExecutionMode.IsNull() && req.Path.Equal(path.Root("execution_mode")) {
 		// TFE does not support overwrites so default the execution mode to "remote"
 		resp.PlanValue = types.StringValue("remote")
+	} else if configured.AgentPoolID.IsNull() && req.Path.Equal(path.Root("agent_pool_id")) {
+		resp.PlanValue = types.StringNull()
 	}
 }
 


### PR DESCRIPTION
## Description

I made a mistake with `tfe_workspace_settings` compatibility. The "unknownIfExecutionModeUnset" plan modifier was supposed to actually check for unsetting before changing the planned value of execution_mode when it had no overwrites to consult.

Tested on TFC and TFE v202308-1

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] ~_Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_~

## Testing plan

1. Use this config. Run terraform apply twice. It works fine on the last couple of TFE releases (this is why there are no acceptance tests) but on v202308-1 the second plan fails

<details><summary>Sample Config</summary>

<pre>
terraform {
  required_providers {
    tfe = {
      source = "hashicorp/tfe"
      version = "0.51.0"
    }
  }
}

provider "tfe" {
}

resource tfe_organization "org" {
  name = "test-IPL5516-tfe"
  email = "bcroft@hashicorp.com"
}

// 1
resource "tfe_agent_pool" "pool" {
  name         = "pool"
  organization = tfe_organization.org.id
  organization_scoped = false
}

// 2
resource "tfe_workspace" "test" {
  name         = "test-123360"
  organization = tfe_organization.org.id
}

// 3
resource "tfe_agent_pool_allowed_workspaces" "pool" {
  agent_pool_id = tfe_agent_pool.pool.id
  allowed_workspace_ids = [for key, value in tfe_workspace.test.*.id : value]
}

// 4
resource "tfe_workspace_settings" "test-settings" {
  execution_mode = "agent"
  agent_pool_id = tfe_agent_pool_allowed_workspaces.pool.agent_pool_id
  workspace_id   = tfe_workspace.test.id
}
</pre>
</details>

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

