### PR TITLE
r/tfe_workspace: Fix panic when `trigger_prefixes = [""]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ FEATURES:
 * **New Data Source**: `d/tfe_registry_provider` is a new data source to retrieve information about a public or private provider in the private registry, by @tmatilai [1185](https://github.com/hashicorp/terraform-provider-tfe/pull/1185)
 * **New Data Source**: `d/tfe_registry_providers` is a new data source to retrieve information about public and private providers in the private registry, by @tmatilai [1185](https://github.com/hashicorp/terraform-provider-tfe/pull/1185)
 
+BUG FIXES:
+
+* `r/tfe_workspace`: Fix panic on creation when `trigger_prefixes = [""]`, by @nfagerlund [1214](https://github.com/hashicorp/terraform-provider-tfe/pull/1214)
+
 ## v0.51.1
 
 BUG FIXES:

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -373,7 +373,9 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 
 	if tps, ok := d.GetOk("trigger_prefixes"); ok {
 		for _, tp := range tps.([]interface{}) {
-			options.TriggerPrefixes = append(options.TriggerPrefixes, tp.(string))
+			if val, ok := tp.(string); ok {
+				options.TriggerPrefixes = append(options.TriggerPrefixes, val)
+			}
 		}
 	} else {
 		options.TriggerPrefixes = nil


### PR DESCRIPTION
## Description

A customer reported this panic via support. Sebastian clued me in that this is an extremely cursed known behavior in sdkv2, where it munges a list of strings containing one empty string into a list containing a single nil, so you must do a type assert on the inner elements.

Note that the Update function already did exactly this (around line 655 or so)! So there was no panic if you changed trigger_prefixes to the fatal value after the resource already existed.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Config:

```terraform
provider "tfe" {
  hostname = <YOURS>
}

resource "tfe_workspace" "ex-splodo" {
  auto_apply                    = true
  file_triggers_enabled         = true
  name                          = "jan24-trigger-prefixes-panic-repro"
  organization                  = <YOURS>
  queue_all_runs                = true
  structured_run_output_enabled = true
  terraform_version             = "1.5.1"
  trigger_prefixes              = [""] # <-- RIGHT HERE, THIS IS THE GUY
}
```

Try to create the resource with a tf apply; should panic as soon as you say "yes" after the plan.

## External links

- [Prior art PR that @sebasslash dug up](https://github.com/hashicorp/terraform-provider-tfe/pull/628)

## Output from acceptance tests

I'm internal, just check CI.