### PR TITLE
docs: update no_code_module.html.markdown

### DIFF
--- a/website/docs/r/no_code_module.html.markdown
+++ b/website/docs/r/no_code_module.html.markdown
@@ -26,7 +26,7 @@ resource "tfe_registry_module" "foobar" {
 }
 
 resource "tfe_no_code_module" "foobar" {
-	organization = tfe_organization.foobar.id
+	organization = tfe_organization.foobar.name
 	registry_module = tfe_registry_module.foobar.id
 }
 ```
@@ -46,7 +46,7 @@ resource "tfe_registry_module" "foobar" {
 }
 
 resource "tfe_no_code_module" "foobar" {
-	organization = tfe_organization.foobar.id
+	organization = tfe_organization.foobar.name
 	registry_module = tfe_registry_module.foobar.id
 
 	variable_options {


### PR DESCRIPTION
fix tfe_no_code_module to use tfe_organization.foobar.name value instead of id value.

## Description

tfe_no_code_module resource example uses id value for tfe_organization resource, which results in an error while applying the code. Using name value instead results in successful apply. Updated the docs to reflect this.
