### PR TITLE
Docs: Fix typo in 'tfe_team_project_access'

### DIFF
--- a/website/docs/cdktf/csharp/r/team_project_access.html.markdown
+++ b/website/docs/cdktf/csharp/r/team_project_access.html.markdown
@@ -69,7 +69,7 @@ The following permissions apply to the project itself.
 </n>
 </n>
 
-The following permissions apply to all workpsaces (and future workspaces) in the project.
+The following permissions apply to all workspaces (and future workspaces) in the project.
 
 | workspace_access     | Description, Default, Valid Values                    |
 |----------------------|-------------------------------------------------------|

--- a/website/docs/cdktf/go/r/team_project_access.html.markdown
+++ b/website/docs/cdktf/go/r/team_project_access.html.markdown
@@ -74,7 +74,7 @@ The following permissions apply to the project itself.
 </n>
 </n>
 
-The following permissions apply to all workpsaces (and future workspaces) in the project.
+The following permissions apply to all workspaces (and future workspaces) in the project.
 
 | workspace_access     | Description, Default, Valid Values                    |
 |----------------------|-------------------------------------------------------|

--- a/website/docs/cdktf/java/r/team_project_access.html.markdown
+++ b/website/docs/cdktf/java/r/team_project_access.html.markdown
@@ -70,7 +70,7 @@ The following permissions apply to the project itself.
 </n>
 </n>
 
-The following permissions apply to all workpsaces (and future workspaces) in the project.
+The following permissions apply to all workspaces (and future workspaces) in the project.
 
 | workspace_access     | Description, Default, Valid Values                    |
 |----------------------|-------------------------------------------------------|

--- a/website/docs/cdktf/python/r/team_project_access.html.markdown
+++ b/website/docs/cdktf/python/r/team_project_access.html.markdown
@@ -70,7 +70,7 @@ The following permissions apply to the project itself.
 </n>
 </n>
 
-The following permissions apply to all workpsaces (and future workspaces) in the project.
+The following permissions apply to all workspaces (and future workspaces) in the project.
 
 | workspace_access     | Description, Default, Valid Values                    |
 |----------------------|-------------------------------------------------------|

--- a/website/docs/cdktf/typescript/r/team_project_access.html.markdown
+++ b/website/docs/cdktf/typescript/r/team_project_access.html.markdown
@@ -73,7 +73,7 @@ The following permissions apply to the project itself.
 </n>
 </n>
 
-The following permissions apply to all workpsaces (and future workspaces) in the project.
+The following permissions apply to all workspaces (and future workspaces) in the project.
 
 | workspace_access     | Description, Default, Valid Values                    |
 |----------------------|-------------------------------------------------------|

--- a/website/docs/r/team_project_access.html.markdown
+++ b/website/docs/r/team_project_access.html.markdown
@@ -55,7 +55,7 @@ The following permissions apply to the project itself.
 </n>
 </n>
 
-The following permissions apply to all workpsaces (and future workspaces) in the project.
+The following permissions apply to all workspaces (and future workspaces) in the project.
 
 | workspace_access     | Description, Default, Valid Values                    |
 |----------------------|-------------------------------------------------------|


### PR DESCRIPTION
## Description

Docs for `tfe_team_project_access` contain the following typo:


>The following permissions apply to all _workpsaces_


_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
