### PR TITLE
Data source no-code module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * **New Resource**: `r/tfe_registry_provider` is a new resource for managing public and private providers in the private registry, by @tmatilai [1185](https://github.com/hashicorp/terraform-provider-tfe/pull/1185)
 * **New Data Source**: `d/tfe_registry_provider` is a new data source to retrieve information about a public or private provider in the private registry, by @tmatilai [1185](https://github.com/hashicorp/terraform-provider-tfe/pull/1185)
 * **New Data Source**: `d/tfe_registry_providers` is a new data source to retrieve information about public and private providers in the private registry, by @tmatilai [1185](https://github.com/hashicorp/terraform-provider-tfe/pull/1185)
+* **New Data Source**: `d/tfe_no_code_module` is a new data source to retrieve information about a no-code module, by @catsby [1242](https://github.com/hashicorp/terraform-provider-tfe/pull/1242)
 * **New Resource**: `r/tfe_sentinel_version` adds the ability for admins to configure settings for sentinel versions ([#1202](https://github.com/hashicorp/terraform-provider-tfe/pull/1202))
 * **New Resource**: `r/tfe_opa_version` adds the ability for admins to configure settings for OPA versions ([#1202](https://github.com/hashicorp/terraform-provider-tfe/pull/1202))
 

--- a/internal/provider/data_source_no_code_module.go
+++ b/internal/provider/data_source_no_code_module.go
@@ -140,7 +140,7 @@ func modelFromTFENoCodeModule(v *tfe.RegistryNoCodeModule) modelNoCodeModule {
 	return modelNoCodeModule{
 		ID:               types.StringValue(v.ID),
 		Organization:     types.StringValue(v.Organization.Name),
-		RegistryModuleID: types.StringValue(string(v.RegistryModule.ID)),
+		RegistryModuleID: types.StringValue(v.RegistryModule.ID),
 		Namespace:        types.StringValue(v.RegistryModule.Namespace),
 		VersionPin:       types.StringValue(v.VersionPin),
 		Enabled:          types.BoolValue(v.Enabled),

--- a/internal/provider/data_source_no_code_module.go
+++ b/internal/provider/data_source_no_code_module.go
@@ -16,9 +16,8 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ datasource.DataSource                   = &dataSourceTFENoCodeModule{}
-	_ datasource.DataSourceWithConfigure      = &dataSourceTFENoCodeModule{}
-	_ datasource.DataSourceWithValidateConfig = &dataSourceTFENoCodeModule{}
+	_ datasource.DataSource              = &dataSourceTFENoCodeModule{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFENoCodeModule{}
 )
 
 // NewNoCodeModuleDataSource is a helper function to simplify the implementation.
@@ -76,17 +75,6 @@ func (d *dataSourceTFENoCodeModule) Schema(_ context.Context, _ datasource.Schem
 				Computed:    true,
 			},
 		},
-	}
-}
-
-func (d *dataSourceTFENoCodeModule) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	var config modelNoCodeModule
-
-	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-
-	if resp.Diagnostics.HasError() {
-		return
 	}
 }
 

--- a/internal/provider/data_source_no_code_module.go
+++ b/internal/provider/data_source_no_code_module.go
@@ -57,7 +57,6 @@ func (d *dataSourceTFENoCodeModule) Schema(_ context.Context, _ datasource.Schem
 			},
 			"organization": schema.StringAttribute{
 				Description: "Name of the organization.",
-				Optional:    true,
 				Computed:    true,
 			},
 			"namespace": schema.StringAttribute{

--- a/internal/provider/data_source_no_code_module.go
+++ b/internal/provider/data_source_no_code_module.go
@@ -1,0 +1,196 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource                   = &dataSourceTFENoCodeModuleProvider{}
+	_ datasource.DataSourceWithConfigure      = &dataSourceTFENoCodeModuleProvider{}
+	_ datasource.DataSourceWithValidateConfig = &dataSourceTFENoCodeModuleProvider{}
+)
+
+// NewNoCodeModuleDataSource is a helper function to simplify the provider implementation.
+func NewNoCodeModuleDataSource() datasource.DataSource {
+	return &dataSourceTFENoCodeModuleProvider{}
+}
+
+// dataSourceTFENoCodeModuleProvider is the data source implementation.
+type dataSourceTFENoCodeModuleProvider struct {
+	config ConfiguredClient
+}
+
+// Metadata returns the data source type name.
+func (d *dataSourceTFENoCodeModuleProvider) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_no_code_module"
+}
+
+// need:
+//  :organization_name
+//  :registry_name
+//  :namespace
+//  :name
+//  :provider
+
+// Schema defines the schema for the data source.
+func (d *dataSourceTFENoCodeModuleProvider) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source can be used to retrieve a public or private provider from the private registry.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "ID of the provider.",
+				Computed:    true,
+			},
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"registry_name": schema.StringAttribute{
+				Description: "Whether this is a publicly maintained provider or private. Must be either `public` or `private`.",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						string(tfe.PrivateRegistry),
+						string(tfe.PublicRegistry),
+					),
+				},
+			},
+			"namespace": schema.StringAttribute{
+				Description: "The namespace of the provider. For private providers this is the same as the oraganization.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the provider.",
+				Required:    true,
+			},
+			"provider": schema.StringAttribute{
+				Description: "Name of the provider.",
+				Required:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "The time when the provider was created.",
+				Computed:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "The time when the provider was last updated.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *dataSourceTFENoCodeModuleProvider) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	var config modelTFERegistryProvider
+	// TODO: Remove hardcode
+	config.Provider = types.StringValue("aws")
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.RegistryName.ValueString() == "public" && config.Namespace.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("namespace"),
+			"Missing Attribute Configuration",
+			"Expected namespace to be configured when registry_name is \"public\".",
+		)
+	} else if (config.RegistryName.IsNull() || config.RegistryName.ValueString() == "private") && !config.Namespace.IsNull() && !config.Namespace.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("namespace"),
+			"Invalid Attribute Combination",
+			"The namespace attribute cannot be configured when registry_name is \"private\".",
+		)
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *dataSourceTFENoCodeModuleProvider) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+	d.config = client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *dataSourceTFENoCodeModuleProvider) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data modelTFERegistryProvider
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var organization string
+	resp.Diagnostics.Append(d.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var registryName string
+	if data.RegistryName.IsNull() {
+		registryName = "private"
+	} else {
+		registryName = data.RegistryName.ValueString()
+	}
+
+	var namespace string
+	if registryName == "private" {
+		namespace = organization
+	} else {
+		namespace = data.Namespace.ValueString()
+	}
+
+	providerID := tfe.RegistryProviderID{
+		OrganizationName: organization,
+		RegistryName:     tfe.RegistryName(registryName),
+		Namespace:        namespace,
+		Name:             data.Name.ValueString(),
+	}
+
+	options := tfe.RegistryProviderReadOptions{}
+
+	tflog.Debug(ctx, "Reading private registry provider")
+	provider, err := d.config.Client.RegistryProviders.Read(ctx, providerID, &options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read private registry provider", err.Error())
+		return
+	}
+
+	data = modelFromTFERegistryProvider(provider)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_no_code_module_test.go
+++ b/internal/provider/data_source_no_code_module_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFENoCodeModuleDataSource_public(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFENoCodeModuleDataSourceConfig_public(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "id"),
+					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "registry_name", "public"),
+					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "namespace", "hashicorp"),
+					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "name", "aws"),
+					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "created_at"),
+					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+// func TestAccTFENoCodeModuleDataSource_private(t *testing.T) {
+// 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+// 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:                 func() { testAccPreCheck(t) },
+// 		ProtoV5ProviderFactories: testAccMuxedProviders,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccTFENoCodeModuleDataSourceConfig_private(orgName),
+// 				Check: resource.ComposeAggregateTestCheckFunc(
+// 					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "id"),
+// 					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "organization", orgName),
+// 					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "registry_name", "private"),
+// 					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "namespace", orgName),
+// 					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "name", "example"),
+// 					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "created_at"),
+// 					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "updated_at"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+// need:
+//
+//	:organization_name
+//	:registry_name
+//	:namespace
+//	:name
+//	:provider
+//
+// # namespace = tfe_organization.foobar.name  namespace is same as org
+// name?
+func testAccTFENoCodeModuleDataSourceConfig_public(rInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "no_code_module" "foobar" {
+  organization = tfe_organization.foobar.name
+  registry_name = "public"
+  name          = tfe_no_code_module.foobar.name
+  provider = tfe_registry_provider.foobar.name
+}
+`, testAccTFENoCodeModule_basic(rInt))
+}
+
+// func testAccTFENoCodeModuleDataSourceConfig_private(orgName string) string {
+// 	return fmt.Sprintf(`
+// %s
+
+// data "tfe_registry_provider" "foobar" {
+//   organization = tfe_organization.foobar.name
+
+//   name = tfe_registry_provider.foobar.name
+// }
+// `, testAccTFENoCodeModuleResourceConfig_private(orgName))
+// }

--- a/internal/provider/data_source_no_code_module_test.go
+++ b/internal/provider/data_source_no_code_module_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccTFENoCodeModuleDataSource_public(t *testing.T) {
+	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
@@ -23,74 +24,22 @@ func TestAccTFENoCodeModuleDataSource_public(t *testing.T) {
 			{
 				Config: testAccTFENoCodeModuleDataSourceConfig_public(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "id"),
-					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "organization", orgName),
-					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "registry_name", "public"),
-					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "namespace", "hashicorp"),
-					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "name", "aws"),
-					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "created_at"),
-					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "updated_at"),
+					resource.TestCheckResourceAttrSet("data.tfe_no_code_module.foobar", "id"),
+					resource.TestCheckResourceAttr("data.tfe_no_code_module.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr("data.tfe_no_code_module.foobar", "enabled", "true"),
+					resource.TestCheckResourceAttrSet("data.tfe_no_code_module.foobar", "registry_module_id"),
 				),
 			},
 		},
 	})
 }
 
-// func TestAccTFENoCodeModuleDataSource_private(t *testing.T) {
-// 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-// 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-// 	resource.Test(t, resource.TestCase{
-// 		PreCheck:                 func() { testAccPreCheck(t) },
-// 		ProtoV5ProviderFactories: testAccMuxedProviders,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccTFENoCodeModuleDataSourceConfig_private(orgName),
-// 				Check: resource.ComposeAggregateTestCheckFunc(
-// 					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "id"),
-// 					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "organization", orgName),
-// 					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "registry_name", "private"),
-// 					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "namespace", orgName),
-// 					resource.TestCheckResourceAttr("tfe_registry_provider.foobar", "name", "example"),
-// 					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "created_at"),
-// 					resource.TestCheckResourceAttrSet("tfe_registry_provider.foobar", "updated_at"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
-
-// need:
-//
-//	:organization_name
-//	:registry_name
-//	:namespace
-//	:name
-//	:provider
-//
-// # namespace = tfe_organization.foobar.name  namespace is same as org
-// name?
 func testAccTFENoCodeModuleDataSourceConfig_public(rInt int) string {
 	return fmt.Sprintf(`
 %s
 
-data "no_code_module" "foobar" {
-  organization = tfe_organization.foobar.name
-  registry_name = "public"
-  name          = tfe_no_code_module.foobar.name
-  provider = tfe_registry_provider.foobar.name
+data "tfe_no_code_module" "foobar" {
+		id = tfe_no_code_module.foobar.id
 }
 `, testAccTFENoCodeModule_basic(rInt))
 }
-
-// func testAccTFENoCodeModuleDataSourceConfig_private(orgName string) string {
-// 	return fmt.Sprintf(`
-// %s
-
-// data "tfe_registry_provider" "foobar" {
-//   organization = tfe_organization.foobar.name
-
-//   name = tfe_registry_provider.foobar.name
-// }
-// `, testAccTFENoCodeModuleResourceConfig_private(orgName))
-// }

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -126,8 +126,8 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewRegistryGPGKeyDataSource,
 		NewRegistryGPGKeysDataSource,
 		NewRegistryProviderDataSource,
-		NewNoCodeModuleDataSource,
 		NewRegistryProvidersDataSource,
+		NewNoCodeModuleDataSource,
 		NewSAMLSettingsDataSource,
 	}
 }

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -126,6 +126,7 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewRegistryGPGKeyDataSource,
 		NewRegistryGPGKeysDataSource,
 		NewRegistryProviderDataSource,
+		NewNoCodeModuleDataSource,
 		NewRegistryProvidersDataSource,
 		NewSAMLSettingsDataSource,
 	}

--- a/website/docs/d/no_code_module.html.markdown
+++ b/website/docs/d/no_code_module.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_no_code_module"
+description: |-
+  Get information on a no-code module.
+---
+
+# Data Source: tfe_registry_provider
+
+Use this data source to read the details of an existing No-Code-Allowed module.
+
+## Example Usage
+
+```hcl
+resource "tfe_no_code_module" "foobar" {
+	organization = tfe_organization.foobar.id
+	registry_module = tfe_registry_module.foobar.id
+}
+
+data "tfe_no_code_module" "foobar" {
+	id = tfe_no_code_module.foobar.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) ID of the no-code module. 
+
+## Attributes Reference
+
+* `id` - ID of the no-code module.
+* `organization` - Organization name that the no-code module belongs to.
+* `namespace` - Namespace name that the no-code module belongs to.
+* `registry_module_id` - ID of the registry module for the no-code module. 
+* `version_pin` - Version number the no-code module is pinned to.
+* `enabled` - Indicates if this no-code module is currently enabled


### PR DESCRIPTION
## Description

This PR adds a new data source `tfe_no_code_module` for getting basic info on a single no-code module.



_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Have an existing no-code provisioning module
1.  Get it's ID (either with the API or visiting the no-code module's settings on app.terraform.io)
1.  Use the ID in the data sources' ID field
1.  Enjoy?

## External links

API Docs:

- https://developer.hashicorp.com/terraform/cloud-docs/api-docs/no-code-provisioning#read-a-no-code-module-s-properties

## Output from acceptance tests

```
$ ENABLE_BETA=1 TESTARGS="-run=TestAccTFENoCodeModuleDataSource_public -v" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run=TestAccTFENoCodeModuleDataSource_public -v -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/client     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/logging    (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
=== RUN   TestAccTFENoCodeModuleDataSource_public
--- PASS: TestAccTFENoCodeModuleDataSource_public (4.19s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   (cached)
```

