### PR TITLE
Adds `ignore_additional_tag_names` to tfe_workspace resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+FEATURES:
+* `r/tfe_workspace`: Add `ignore_additional_tag_names` which explicitly ignores tag_names _not_ defined by config to exist on the workspace without being overwritten when the resource is refreshed, by @brandonc and @mbillow
+
 ## v0.52.0
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## UNRELEASED
 
 FEATURES:
-* `r/tfe_workspace`: Add `ignore_additional_tag_names` which explicitly ignores tag_names _not_ defined by config to exist on the workspace without being overwritten when the resource is refreshed, by @brandonc and @mbillow
+* `r/tfe_workspace`: Add `ignore_additional_tag_names` which explicitly ignores `tag_names` _not_ defined by config so they will not be overwritten by the configured tags, by @brandonc and @mbillow [1254](https://github.com/hashicorp/terraform-provider-tfe/pull/1254)
 
 ## v0.52.0
 

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -209,6 +209,11 @@ func resourceTFEWorkspace() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"ignore_additional_tag_names": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"terraform_version": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -529,8 +534,11 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("agent_pool_id", agentPoolID)
 
 	var tagNames []interface{}
+	managedTags := d.Get("tag_names").(*schema.Set)
 	for _, tagName := range workspace.TagNames {
-		tagNames = append(tagNames, tagName)
+		if managedTags.Contains(tagName) || !d.Get("ignore_additional_tag_names").(bool) {
+			tagNames = append(tagNames, tagName)
+		}
 	}
 	d.Set("tag_names", tagNames)
 

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -113,7 +113,7 @@ The following arguments are supported:
   workspace will display their output as text logs.
 * `ssh_key_id` - (Optional) The ID of an SSH key to assign to the workspace.
 * `tag_names` - (Optional) A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens.
-* `terraform_version` - (Optional) The version of Terraform to use for this
+* `ignore_additional_tag_names` - (Optional) A boolean value that, when set to true, allows additional unmanaged tags to be applied to this workspace outside of terraform without being overwritten by `tag_names` config. This creates exceptional behavior in terraform with respect to `tag_names` and is not recommended.
   workspace. This can be either an exact version or a
   [version constraint](https://developer.hashicorp.com/terraform/language/expressions/version-constraints)
   (like `~> 1.0.0`); if you specify a constraint, the workspace will always use

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -113,7 +113,12 @@ The following arguments are supported:
   workspace will display their output as text logs.
 * `ssh_key_id` - (Optional) The ID of an SSH key to assign to the workspace.
 * `tag_names` - (Optional) A list of tag names for this workspace. Note that tags must only contain lowercase letters, numbers, colons, or hyphens.
-* `ignore_additional_tag_names` - (Optional) A boolean value that, when set to true, allows additional unmanaged tags to be applied to this workspace outside of terraform without being overwritten by `tag_names` config. This creates exceptional behavior in terraform with respect to `tag_names` and is not recommended.
+* `ignore_additional_tag_names` - (Optional) Explicitly ignores `tag_names`
+_not_ defined by config so they will not be overwritten by the configured
+tags. This creates exceptional behavior in terraform with respect
+to `tag_names` and is not recommended. This value must be applied before it
+will be used.
+* `terraform_version` - (Optional) The version of Terraform to use for this
   workspace. This can be either an exact version or a
   [version constraint](https://developer.hashicorp.com/terraform/language/expressions/version-constraints)
   (like `~> 1.0.0`); if you specify a constraint, the workspace will always use


### PR DESCRIPTION
## Description

A boolean value that, when set to true, allows additional unmanaged tags to be applied to this workspace outside of terraform without being overwritten by `tag_names` config. This creates exceptional behavior in terraform with respect to `tag_names` and is generally not recommended. But given that the alternative is to ignore all updates to tags after they are created, or not be able to mix unmanaged and managed tags at all, it seems like a reasonable feature until we separate the tag resource altogether
