### PR TITLE
[IPL-5689] Revert the fix for no changes detected when provider default org changes on Registry Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 FEATURES:
 * `r/tfe_workspace`: Add `ignore_additional_tag_names` which explicitly ignores `tag_names` _not_ defined by config so they will not be overwritten by the configured tags, by @brandonc and @mbillow [1254](https://github.com/hashicorp/terraform-provider-tfe/pull/1254)
 
+BUG FIXES:
+
+* `r/tfe_registry_module`: Fix registry module always triggering re-creation when an organization is not present, by @hashimoon [1263](https://github.com/hashicorp/terraform-provider-tfe/pull/1263)
+
 ## v0.52.0
 
 FEATURES:

--- a/internal/provider/resource_tfe_registry_module.go
+++ b/internal/provider/resource_tfe_registry_module.go
@@ -31,8 +31,6 @@ func resourceTFERegistryModule() *schema.Resource {
 			StateContext: resourceTFERegistryModuleImporter,
 		},
 
-		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
-
 		Schema: map[string]*schema.Schema{
 			"organization": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This fixes a bug that always forced a registry module to always be recreated when a default organization is not provided..

## Description

_Describe why you're making this change._

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan
1. Perform 
````
terraform apply
````
with the below code (fill out your values for identifiers and oauth_token_id):


````
terraform {
  required_providers {
    tfe = {
      source = "hashicorp/tfe"
      version = "0.49.0"
    }
  }
}
resource "tfe_registry_module" "test-registry-module" {
  vcs_repo {
    display_identifier = "your/display-identifier"
    identifier         = "your/identifier"
    oauth_token_id     = "ot-oauth-token-id"
  }
}
````
2. Change the version of the provider to 0.51.0
3. Perform 
````
terraform init -upgrade
````
4. Perform
````
terraform plan
````
*Expected behavior*
Since the resource is not changed but only the version of the provider the resource should not be recreated.


## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
