### PR TITLE
[TF-13376] Refactor registry module delete method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ BUG FIXES:
 * `r/tfe_workspace`: Change the error message returned when a workspace cannot be safe-deleted to reflect that the error can happen when the latest state is still being processed @uturunku1 [1274](https://github.com/hashicorp/terraform-provider-tfe/pull/1274)
 
 
+ENHANCEMENTS:
+* `r/tfe_registry_module`: Update `Delete` method to call `DeleteByName` when `module_provider` is not present, and `DeleteProvider` when `module_provider` exists @laurenolivia[1267](https://github.com/hashicorp/terraform-provider-tfe/pull/1267)
+
 ## v0.52.0
 
 FEATURES:

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -803,6 +803,7 @@ func TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(t *test
 		},
 	})
 }
+
 func testAccCheckTFERegistryModuleExists(n string, rmID tfe.RegistryModuleID, registryModule *tfe.RegistryModule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(ConfiguredClient)


### PR DESCRIPTION
## Description

The Registry Module `Delete` API deprecated and replaced three endpoints (see [docs](https://developer.hashicorp.com/terraform/enterprise/api-docs/private-registry/modules#delete-a-module)). This ticket is a follow-on, after refactoring the API calls in go-tfe ([PR](https://github.com/hashicorp/go-tfe/pull/847)) and releasing those changes in [v1.45.0](https://github.com/hashicorp/go-tfe/releases/tag/v1.45.0).

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Create two registry module resources
2.  Make `Name` attr for both resources identical
3.  Make `Provider` attr for both resources different
4.  Delete one registry module
5. Verify the resource was deleted

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
