### PR TITLE
adjust notification configuration test to not check for url string pr…

### DIFF
--- a/internal/provider/resource_tfe_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_notification_configuration_test.go
@@ -703,10 +703,6 @@ func testAccCheckTFENotificationConfigurationAttributesSlack(notificationConfigu
 			return fmt.Errorf("Bad triggers: %v", notificationConfiguration.Triggers)
 		}
 
-		if notificationConfiguration.URL != "http://example.com" {
-			return fmt.Errorf("Bad URL: %s", notificationConfiguration.URL)
-		}
-
 		return nil
 	}
 }


### PR DESCRIPTION
…esence when the notification type is slack. The API made recent changes to stop exposing the url due to security concerns. I am okay deleting this specific check for the string url because if the URL was missing, the validation method validateSchemaAttributesForDestinationTypeSlack would be fail with the following error: URL is required with destination type of slack

More on the Notification Configuration API change: https://github.com/hashicorp/atlas/pull/18520

## Description

_Describe why you're making this change._

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
