### PR TITLE
TF-11504 Project description added

### DIFF
--- a/internal/provider/data_source_project.go
+++ b/internal/provider/data_source_project.go
@@ -28,6 +28,11 @@ func dataSourceTFEProject() *schema.Resource {
 				Required: true,
 			},
 
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"organization": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -92,6 +97,7 @@ func dataSourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta 
 			}
 
 			d.Set("workspace_ids", workspaces)
+			d.Set("description", proj.Description)
 			d.SetId(proj.ID)
 			return nil
 		}

--- a/internal/provider/data_source_project_test.go
+++ b/internal/provider/data_source_project_test.go
@@ -26,6 +26,8 @@ func TestAccTFEProjectDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_project.foobar", "name", fmt.Sprintf("project-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
+						"data.tfe_project.foobar", "description", fmt.Sprintf("project description")),
+					resource.TestCheckResourceAttr(
 						"data.tfe_project.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_project.foobar", "id"),
 					resource.TestCheckResourceAttr(
@@ -67,6 +69,7 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_project" "foobar" {
   name         = "project-test-%d"
+  description  = "project description"
   organization = tfe_organization.foobar.id
 }
 

--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -46,6 +46,11 @@ func resourceTFEProject() *schema.Resource {
 				),
 			},
 
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"organization": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -66,7 +71,8 @@ func resourceTFEProjectCreate(ctx context.Context, d *schema.ResourceData, meta 
 	name := d.Get("name").(string)
 
 	options := tfe.ProjectCreateOptions{
-		Name: name,
+		Name:        name,
+		Description: tfe.String(d.Get("description").(string)),
 	}
 
 	log.Printf("[DEBUG] Create new project: %s", name)
@@ -95,6 +101,7 @@ func resourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	d.Set("name", project.Name)
+	d.Set("description", project.Description)
 	d.Set("organization", project.Organization.Name)
 
 	return nil
@@ -104,7 +111,8 @@ func resourceTFEProjectUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	config := meta.(ConfiguredClient)
 
 	options := tfe.ProjectUpdateOptions{
-		Name: tfe.String(d.Get("name").(string)),
+		Name:        tfe.String(d.Get("name").(string)),
+		Description: tfe.String(d.Get("description").(string)),
 	}
 
 	log.Printf("[DEBUG] Update configuration of project: %s", d.Id())

--- a/internal/provider/resource_tfe_project_test.go
+++ b/internal/provider/resource_tfe_project_test.go
@@ -34,6 +34,8 @@ func TestAccTFEProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_project.foobar", "name", "projecttest"),
 					resource.TestCheckResourceAttr(
+						"tfe_project.foobar", "description", "project description"),
+					resource.TestCheckResourceAttr(
 						"tfe_project.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 				),
 			},
@@ -78,6 +80,8 @@ func TestAccTFEProject_update(t *testing.T) {
 					testAccCheckTFEProjectAttributes(project),
 					resource.TestCheckResourceAttr(
 						"tfe_project.foobar", "name", "projecttest"),
+					resource.TestCheckResourceAttr(
+						"tfe_project.foobar", "description", "project description"),
 				),
 			},
 			{
@@ -88,6 +92,8 @@ func TestAccTFEProject_update(t *testing.T) {
 					testAccCheckTFEProjectAttributesUpdated(project),
 					resource.TestCheckResourceAttr(
 						"tfe_project.foobar", "name", "project updated"),
+					resource.TestCheckResourceAttr(
+						"tfe_project.foobar", "description", "project description updated"),
 				),
 			},
 		},
@@ -133,6 +139,7 @@ resource "tfe_organization" "foobar" {
 resource "tfe_project" "foobar" {
   organization = tfe_organization.foobar.name
   name = "project updated"
+  description = "project description updated"
 }`, rInt)
 }
 
@@ -146,6 +153,7 @@ resource "tfe_organization" "foobar" {
 resource "tfe_project" "foobar" {
   organization = tfe_organization.foobar.name
   name = "projecttest"
+  description = "project description"
 }`, rInt)
 }
 


### PR DESCRIPTION
## Description

Description attribute is added to projects in atlas. 

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Integration tests

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Related PR](https://github.com/hashicorp/atlas/pull/18568)
- [Related PR](https://github.com/hashicorp/atlas/pull/18494)
- [go-tfe]( https://github.com/hashicorp/go-tfe/pull/861)
- [Jira](https://hashicorp.atlassian.net/browse/TF-11504)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
=== RUN   TestAccTFEProject_basic
--- PASS: TestAccTFEProject_basic (6.15s)
PASS

=== RUN   TestAccTFEProject_update
--- PASS: TestAccTFEProject_update (6.52s)
PASS

datasource:
=== RUN   TestAccTFEProjectDataSource_basic
--- PASS: TestAccTFEProjectDataSource_basic (8.07s)
PASS
```
<img width="1106" alt="Screenshot 2024-03-01 at 9 55 15 AM" src="https://github.com/hashicorp/terraform-provider-tfe/assets/104793044/ecc33fc4-6f7a-440b-99b9-853c6740fc94">


