### PR TITLE
Migrate tfe_organization_run_task to plugin model 

### DIFF
--- a/internal/provider/data_source_organization_run_task_test.go
+++ b/internal/provider/data_source_organization_run_task_test.go
@@ -26,8 +26,8 @@ func TestAccTFEOrganizationRunTaskDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationRunTaskDataSourceConfig(org.Name, rInt, runTasksURL(), runTasksHMACKey()),

--- a/internal/provider/data_source_workspace_run_task_test.go
+++ b/internal/provider/data_source_workspace_run_task_test.go
@@ -26,8 +26,8 @@ func TestAccTFEWorkspaceRunTaskDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceRunTaskDataSourceConfig(org.Name, rInt, runTasksURL()),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -120,7 +120,6 @@ func Provider() *schema.Provider {
 			"tfe_organization_default_settings":  resourceTFEOrganizationDefaultSettings(),
 			"tfe_organization_membership":        resourceTFEOrganizationMembership(),
 			"tfe_organization_module_sharing":    resourceTFEOrganizationModuleSharing(),
-			"tfe_organization_run_task":          resourceTFEOrganizationRunTask(),
 			"tfe_organization_token":             resourceTFEOrganizationToken(),
 			"tfe_policy":                         resourceTFEPolicy(),
 			"tfe_policy_set":                     resourceTFEPolicySet(),

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -139,5 +139,6 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewResourceVariable,
 		NewSAMLSettingsResource,
 		NewResourceWorkspaceSettings,
+		NewOrganizationRunTaskResource,
 	}
 }

--- a/internal/provider/resource_tfe_organization_run_task.go
+++ b/internal/provider/resource_tfe_organization_run_task.go
@@ -66,6 +66,11 @@ func (r *resourceOrgRunTask) Metadata(_ context.Context, req resource.MetadataRe
 	resp.TypeName = req.ProviderTypeName + "_organization_run_task"
 }
 
+func (r *resourceOrgRunTask) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// If a Run Tasks uses the default organization, then if the deafault org. changes, it should trigger a modification
+	modifyPlanForDefaultOrganizationChange(ctx, r.config.Organization, req.State, req.Config, req.Plan, resp)
+}
+
 // Configure implements resource.ResourceWithConfigure
 func (r *resourceOrgRunTask) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.

--- a/internal/provider/resource_tfe_organization_run_task.go
+++ b/internal/provider/resource_tfe_organization_run_task.go
@@ -1,209 +1,296 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// NOTE: This is a legacy resource and should be migrated to the Plugin
-// Framework if substantial modifications are planned. See
-// docs/new-resources.md if planning to use this code as boilerplate for
-// a new resource.
-
 package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	customValidators "github.com/hashicorp/terraform-provider-tfe/internal/provider/validators"
 )
 
-func resourceTFEOrganizationRunTask() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceTFEOrganizationRunTaskCreate,
-		Read:   resourceTFEOrganizationRunTaskRead,
-		Delete: resourceTFEOrganizationRunTaskDelete,
-		Update: resourceTFEOrganizationRunTaskUpdate,
-		Importer: &schema.ResourceImporter{
-			StateContext: resourceTFEOrganizationRunTaskImporter,
-		},
-
-		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
-
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-
-			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"url": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
-			},
-
-			"category": {
-				Type:     schema.TypeString,
-				Default:  "task",
-				Optional: true,
-			},
-
-			"hmac_key": {
-				Type:      schema.TypeString,
-				Sensitive: true,
-				Default:   "",
-				Optional:  true,
-			},
-
-			"enabled": {
-				Type:     schema.TypeBool,
-				Default:  true,
-				Optional: true,
-			},
-
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-		},
-	}
+type resourceOrgRunTask struct {
+	config ConfiguredClient
 }
 
-func resourceTFEOrganizationRunTaskCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
-
-	// Get the task name and organization.
-	name := d.Get("name").(string)
-	organization, err := config.schemaOrDefaultOrganization(d)
-	if err != nil {
-		return err
-	}
-
-	// Create a new options struct.
-	options := tfe.RunTaskCreateOptions{
-		Name:        name,
-		URL:         d.Get("url").(string),
-		Category:    d.Get("category").(string),
-		HMACKey:     tfe.String(d.Get("hmac_key").(string)),
-		Enabled:     tfe.Bool(d.Get("enabled").(bool)),
-		Description: tfe.String(d.Get("description").(string)),
-	}
-
-	log.Printf("[DEBUG] Create task %s for organization: %s", name, organization)
-	task, err := config.Client.RunTasks.Create(ctx, organization, options)
-	if err != nil {
-		return fmt.Errorf(
-			"Error creating task %s for organization %s: %w", name, organization, err)
-	}
-
-	d.SetId(task.ID)
-
-	return resourceTFEOrganizationRunTaskRead(d, meta)
+func NewOrganizationRunTaskResource() resource.Resource {
+	return &resourceOrgRunTask{}
 }
 
-func resourceTFEOrganizationRunTaskDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(ConfiguredClient)
-
-	log.Printf("[DEBUG] Delete task: %s", d.Id())
-	err := client.Client.RunTasks.Delete(ctx, d.Id())
-	if err != nil {
-		if isErrResourceNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("Error deleting task %s: %w", d.Id(), err)
-	}
-
-	return nil
+type modelTFEOrganizationRunTaskV0 struct {
+	Category     types.String `tfsdk:"category"`
+	Description  types.String `tfsdk:"description"`
+	Enabled      types.Bool   `tfsdk:"enabled"`
+	HMACKey      types.String `tfsdk:"hmac_key"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Organization types.String `tfsdk:"organization"`
+	URL          types.String `tfsdk:"url"`
 }
 
-func resourceTFEOrganizationRunTaskUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(ConfiguredClient)
-
-	// Setup the options struct
-	options := tfe.RunTaskUpdateOptions{}
-	if d.HasChange("name") {
-		options.Name = tfe.String(d.Get("name").(string))
-	}
-	if d.HasChange("url") {
-		options.URL = tfe.String(d.Get("url").(string))
-	}
-	if d.HasChange("category") {
-		options.Category = tfe.String(d.Get("category").(string))
-	}
-	if d.HasChange("enabled") {
-		options.Enabled = tfe.Bool(d.Get("enabled").(bool))
-	}
-	if d.HasChange("hmac_key") {
-		options.HMACKey = tfe.String(d.Get("hmac_key").(string))
-	}
-	if d.HasChange("description") {
-		options.Description = tfe.String(d.Get("description").(string))
+func modelFromTFEOrganizationRunTask(v *tfe.RunTask, hmacKey types.String) modelTFEOrganizationRunTaskV0 {
+	result := modelTFEOrganizationRunTaskV0{
+		Category:     types.StringValue(v.Category),
+		Description:  types.StringValue(v.Description),
+		Enabled:      types.BoolValue(v.Enabled),
+		HMACKey:      types.StringValue(""), // This value is never emitted by the API so we inject it later
+		ID:           types.StringValue(v.ID),
+		Name:         types.StringValue(v.Name),
+		Organization: types.StringValue(v.Organization.Name),
+		URL:          types.StringValue(v.URL),
 	}
 
-	log.Printf("[DEBUG] Update configuration of task: %s", d.Id())
-	task, err := client.Client.RunTasks.Update(ctx, d.Id(), options)
-	if err != nil {
-		return fmt.Errorf("Error updating task %s: %w", d.Id(), err)
+	if len(hmacKey.String()) > 0 {
+		result.HMACKey = hmacKey
 	}
 
-	d.SetId(task.ID)
-
-	return resourceTFEOrganizationRunTaskRead(d, meta)
+	return result
 }
 
-func resourceTFEOrganizationRunTaskRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(ConfiguredClient)
-
-	log.Printf("[DEBUG] Read configuration of task: %s", d.Id())
-	task, err := client.Client.RunTasks.Read(ctx, d.Id())
-
-	if err != nil {
-		if isErrResourceNotFound(err) {
-			log.Printf("[DEBUG] Task %s does not exist", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error reading configuration of task %s: %w", d.Id(), err)
-	}
-
-	// Update the config.
-	d.Set("name", task.Name)
-	d.Set("url", task.URL)
-	d.Set("category", task.Category)
-	d.Set("enabled", task.Enabled)
-	// The HMAC Key is always empty from the API so all we can do is
-	// echo the request's key to the response
-	d.Set("hmac_key", tfe.String(d.Get("hmac_key").(string)))
-	d.Set("description", task.Description)
-	return nil
+func (r *resourceOrgRunTask) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_organization_run_task"
 }
 
-func resourceTFEOrganizationRunTaskImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(ConfiguredClient)
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceOrgRunTask) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
 
-	s := strings.Split(d.Id(), "/")
-	if len(s) != 2 {
-		return nil, fmt.Errorf(
-			"invalid task input format: %s (expected <ORGANIZATION>/<TASK NAME>)",
-			d.Id(),
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
 		)
 	}
+	r.config = client
+}
 
-	task, err := fetchOrganizationRunTask(s[1], s[0], client.Client)
-	if err != nil {
-		return nil, err
+func (r *resourceOrgRunTask) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service-generated identifier for the task",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"organization": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				// From ForceNew: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"url": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					customValidators.IsURLWithHTTPorHTTPS(),
+				},
+			},
+			"category": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("task"),
+			},
+			"hmac_key": schema.StringAttribute{
+				Sensitive: true,
+				Optional:  true,
+				Computed:  true,
+				Default:   stringdefault.StaticString(""),
+			},
+			"enabled": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(true),
+			},
+			"description": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+		},
+	}
+}
+
+func (r *resourceOrgRunTask) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFEOrganizationRunTaskV0
+
+	// Read Terraform current state into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	d.Set("organization", task.Organization.Name)
-	d.SetId(task.ID)
+	taskID := state.ID.ValueString()
 
-	return []*schema.ResourceData{d}, nil
+	tflog.Debug(ctx, "Reading organization run task")
+	task, err := r.config.Client.RunTasks.Read(ctx, taskID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading Organization Run Task", "Could not read Organization Run Task, unexpected error: "+err.Error())
+		return
+	}
+
+	result := modelFromTFEOrganizationRunTask(task, state.HMACKey)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceOrgRunTask) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTFEOrganizationRunTaskV0
+
+	// Read Terraform planned changes into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Plan, &organization)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	options := tfe.RunTaskCreateOptions{
+		Name:        plan.Name.ValueString(),
+		URL:         plan.URL.ValueString(),
+		Category:    plan.Category.ValueString(),
+		HMACKey:     plan.HMACKey.ValueStringPointer(),
+		Enabled:     plan.Enabled.ValueBoolPointer(),
+		Description: plan.Description.ValueStringPointer(),
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Create task %s for organization: %s", options.Name, organization))
+	task, err := r.config.Client.RunTasks.Create(ctx, organization, options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create organization task", err.Error())
+		return
+	}
+
+	result := modelFromTFEOrganizationRunTask(task, plan.HMACKey)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceOrgRunTask) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan modelTFEOrganizationRunTaskV0
+
+	// Read Terraform planned changes into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state modelTFEOrganizationRunTaskV0
+	// Read Terraform state into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	options := tfe.RunTaskUpdateOptions{
+		Name:        plan.Name.ValueStringPointer(),
+		URL:         plan.URL.ValueStringPointer(),
+		Category:    plan.Category.ValueStringPointer(),
+		Enabled:     plan.Enabled.ValueBoolPointer(),
+		Description: plan.Description.ValueStringPointer(),
+	}
+
+	// HMAC Key is a write-only value so we should only send it if
+	// it really has changed.
+	if plan.HMACKey.ValueString() != state.HMACKey.ValueString() {
+		options.HMACKey = plan.HMACKey.ValueStringPointer()
+	}
+
+	taskID := plan.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Update task %s", taskID))
+	task, err := r.config.Client.RunTasks.Update(ctx, taskID, options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to update organization task", err.Error())
+		return
+	}
+
+	result := modelFromTFEOrganizationRunTask(task, plan.HMACKey)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceOrgRunTask) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFEOrganizationRunTaskV0
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	taskID := state.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Delete task %s", taskID))
+	err := r.config.Client.RunTasks.Delete(ctx, taskID)
+	// Ignore 404s for delete
+	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
+		resp.Diagnostics.AddError(
+			"Error deleting organization run task",
+			fmt.Sprintf("Couldn't delete organization run task %s: %s", taskID, err.Error()),
+		)
+	}
+	// Resource is implicitly deleted from resp.State if diagnostics have no errors.
+}
+
+func (r *resourceOrgRunTask) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	s := strings.SplitN(req.ID, "/", 2)
+	if len(s) != 2 {
+		resp.Diagnostics.AddError(
+			"Error importing organization run task",
+			fmt.Sprintf("Invalid task input format: %s (expected <ORGANIZATION>/<TASK NAME>)", req.ID),
+		)
+		return
+	}
+
+	taskName := s[1]
+	orgName := s[0]
+
+	if task, err := fetchOrganizationRunTask(taskName, orgName, r.config.Client); err != nil {
+		resp.Diagnostics.AddError(
+			"Error importing organization run task",
+			err.Error(),
+		)
+	} else if task == nil {
+		resp.Diagnostics.AddError(
+			"Error importing organization run task",
+			"Task does not exist or has no details",
+		)
+	} else {
+		// We can never import the HMACkey (Write-only) so assume it's the default (empty)
+		result := modelFromTFEOrganizationRunTask(task, types.StringValue(""))
+		resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+	}
 }

--- a/internal/provider/resource_tfe_organization_run_task.go
+++ b/internal/provider/resource_tfe_organization_run_task.go
@@ -28,6 +28,11 @@ type resourceOrgRunTask struct {
 	config ConfiguredClient
 }
 
+var _ resource.Resource = &resourceOrgRunTask{}
+var _ resource.ResourceWithConfigure = &resourceOrgRunTask{}
+var _ resource.ResourceWithImportState = &resourceOrgRunTask{}
+var _ resource.ResourceWithModifyPlan = &resourceOrgRunTask{}
+
 func NewOrganizationRunTaskResource() resource.Resource {
 	return &resourceOrgRunTask{}
 }

--- a/internal/provider/resource_tfe_organization_run_task_test.go
+++ b/internal/provider/resource_tfe_organization_run_task_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestAccTFEOrganizationRunTask_validateSchemaAttributeUrl(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOrganizationRunTask_basic("org", 1, "", ""),
@@ -56,9 +56,9 @@ func TestAccTFEOrganizationRunTask_create(t *testing.T) {
 	hmacKey := runTasksHMACKey()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationRunTaskDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationRunTaskDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationRunTask_basic(org.Name, rInt, runTasksURL(), hmacKey),
@@ -101,9 +101,9 @@ func TestAccTFEOrganizationRunTask_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationRunTask_basic(org.Name, rInt, runTasksURL(), runTasksHMACKey()),

--- a/internal/provider/resource_tfe_workspace_run_task_test.go
+++ b/internal/provider/resource_tfe_workspace_run_task_test.go
@@ -26,9 +26,9 @@ func TestAccTFEWorkspaceRunTask_create(t *testing.T) {
 	workspaceTask := &tfe.WorkspaceRunTask{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceRunTaskDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceRunTaskDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceRunTask_basic(org.Name, runTasksURL()),
@@ -61,9 +61,9 @@ func TestAccTFEWorkspaceRunTask_import(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceRunTask_basic(org.Name, runTasksURL()),

--- a/internal/provider/validators/is_url_https.go
+++ b/internal/provider/validators/is_url_https.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	oldValidation "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type isURLWithHTTPorHTTPSValidator struct{}
+
+func (v isURLWithHTTPorHTTPSValidator) Description(_ context.Context) string {
+	return "string is a valid HTTP or HTTPS URL"
+}
+
+func (v isURLWithHTTPorHTTPSValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v isURLWithHTTPorHTTPSValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	if _, errs := oldValidation.IsURLWithHTTPorHTTPS(value, value); errs != nil {
+		for _, err := range errs {
+			response.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+				request.Path,
+				"Invalid Attribute Value",
+				err.Error(),
+			))
+		}
+	}
+}
+func IsURLWithHTTPorHTTPS() validator.String {
+	return isURLWithHTTPorHTTPSValidator{}
+}


### PR DESCRIPTION
## Description

Requires #1291 to be merged first

This commit migrates the tfe_organization_run_task resource to the newer
plugin model. It uses a schema v0 as there is no difference in schema.

Later changes will migrate the other resource and data source objects.

As this is a no-op as far as customer changes go, no changelog is required.

## Testing plan

1. This should be a noop. so all acceptance and unit tests will pass.

### Manually tested

* Create a `tfe_resource_run_task` resource with the existing provider
* Then re-run terraform plan using the newer version, which includes this PR
* Note that no state changes will be present. Again, this should be a noop

## External links

N/A

## Output from acceptance tests

Local testing...

```
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
=== RUN   TestAccTFEOrganizationRunTaskDataSource_basic
2024/03/18 14:25:51 [DEBUG] Configuring client for host "REDACTED"
2024/03/18 14:25:51 [WARN] Unable to read CLI config or credentials file REDACTED: open REDACTED: no such file or directory
2024/03/18 14:25:51 [DEBUG] Service discovery for REDACTED
--- PASS: TestAccTFEOrganizationRunTaskDataSource_basic (8.34s)
=== RUN   TestAccTFEOrganizationRunTask_validateSchemaAttributeUrl
--- PASS: TestAccTFEOrganizationRunTask_validateSchemaAttributeUrl (0.24s)
=== RUN   TestAccTFEOrganizationRunTask_create
--- PASS: TestAccTFEOrganizationRunTask_create (9.24s)
=== RUN   TestAccTFEOrganizationRunTask_import
--- PASS: TestAccTFEOrganizationRunTask_import (6.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	25.378s
```
