### PR TITLE
Bump nightly instance job timeout to 20m

### DIFF
--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   instance:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Build nightly tflocal instance
         uses: hashicorp-forge/terraform-cloud-action/apply@4adbe7eea886138ac10a4c09e63c5c568aaa6672 # main


### PR DESCRIPTION
Timeouts are resulting workflow failures since runs are taking longer than 10m to complete. 
