### PR TITLE
Migrate tfe_workspace_run_task to plugin model

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -143,7 +143,6 @@ func Provider() *schema.Provider {
 			"tfe_team_token":                     resourceTFETeamToken(),
 			"tfe_terraform_version":              resourceTFETerraformVersion(),
 			"tfe_workspace":                      resourceTFEWorkspace(),
-			"tfe_workspace_run_task":             resourceTFEWorkspaceRunTask(),
 			"tfe_variable_set":                   resourceTFEVariableSet(),
 			"tfe_workspace_policy_set":           resourceTFEWorkspacePolicySet(),
 			"tfe_workspace_policy_set_exclusion": resourceTFEWorkspacePolicySetExclusion(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -191,9 +191,3 @@ var descriptions = map[string]string{
 	"organization": "The organization to apply to a resource if one is not defined on\n" +
 		"the resource itself",
 }
-
-// A commonly used helper method to check if the error
-// returned was tfe.ErrResourceNotFound
-func isErrResourceNotFound(err error) bool {
-	return errors.Is(err, tfe.ErrResourceNotFound)
-}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -134,11 +134,12 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 
 func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		NewOrganizationRunTaskResource,
 		NewRegistryGPGKeyResource,
 		NewRegistryProviderResource,
 		NewResourceVariable,
-		NewSAMLSettingsResource,
 		NewResourceWorkspaceSettings,
-		NewOrganizationRunTaskResource,
+		NewSAMLSettingsResource,
+		NewWorkspaceRunTaskResource,
 	}
 }


### PR DESCRIPTION
## Description

This commit migrates the tfe_workspace_run_task resource to the newer
plugin model. It uses a schema v0 as there is no difference in schema.

Later changes will migrate the other data source objects.

As this is a no-op as far as customer changes go, no changelog is required.

## Testing plan

1. This should be a noop. so all acceptance and unit tests will pass.

### Manually tested

* Create a `tfe_workspace_run_task` resource with the existing provider
* Then re-run terraform plan using the newer version, which includes this PR
* Note that no state changes will be present. Again, this should be a noop

## External links

N/A as this is an internal refactor

## Output from acceptance tests

```
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
=== RUN   TestAccTFEWorkspaceRunTaskDataSource_basic
2024/03/27 11:38:59 [DEBUG] Configuring client for host REDACTED
2024/03/27 11:38:59 [DEBUG] Service discovery for REDACTED
--- PASS: TestAccTFEWorkspaceRunTaskDataSource_basic (11.35s)
=== RUN   TestAccTFEWorkspaceRunTask_validateSchemaAttributes
--- PASS: TestAccTFEWorkspaceRunTask_validateSchemaAttributes (0.17s)
=== RUN   TestAccTFEWorkspaceRunTask_create
--- PASS: TestAccTFEWorkspaceRunTask_create (11.20s)
=== RUN   TestAccTFEWorkspaceRunTask_import
--- PASS: TestAccTFEWorkspaceRunTask_import (9.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	33.628s
```
