### PR TITLE
correct resource name in import doc

### DIFF
--- a/website/docs/r/organization_default_settings.html.markdown
+++ b/website/docs/r/organization_default_settings.html.markdown
@@ -54,5 +54,5 @@ The following arguments are supported:
 Organization default execution mode can be imported; use `<ORGANIZATION NAME>` as the import ID. For example:
 
 ```shell
-terraform import tfe_organization_default_execution_mode.test my-org-name
+terraform import tfe_organization_default_settings.test my-org-name
 ```


### PR DESCRIPTION
## Description

correct resource name typo in `tfe_organization_default_settings` import doc

Issue https://github.com/hashicorp/terraform-provider-tfe/issues/1220

