### PR TITLE
[TF-14896] Add rule to ignore linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,6 +100,10 @@ issues:
       -|resource_tfe_run_trigger|resource_tfe_team_access|resource_tfe_organization_membership|resource_tfe_policy_set|resource_tfe_team_member|
       -|resource_tfe_workspace|resource_tfe_team_organization_member|resource_tfe_variable_set|resource_tfe_team_project_access)\.go
     text: "SA1019"
+  linters:
+      - staticcheck
+    path: resource_tfe_workspace_run_task\.go
+    text: "SA1019: v.Stage is deprecated: Use Stages property instead"    
 linters-settings:
   # errcheck:
   #   # https://github.com/kisielk/errcheck#excluding-functions

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,7 +100,7 @@ issues:
       -|resource_tfe_run_trigger|resource_tfe_team_access|resource_tfe_organization_membership|resource_tfe_policy_set|resource_tfe_team_member|
       -|resource_tfe_workspace|resource_tfe_team_organization_member|resource_tfe_variable_set|resource_tfe_team_project_access)\.go
     text: "SA1019"
-  linters:
+  - linters:
       - staticcheck
     path: resource_tfe_workspace_run_task\.go
     text: "SA1019: v.Stage is deprecated: Use Stages property instead"    


### PR DESCRIPTION
## Description

This PR adds a rule to prevent CI linters from blocking a merge where WorkspaceRunTask.Stage is used. The `Stage` field was only recently deprecated. 

See how it is currently used [here](https://github.com/hashicorp/terraform-provider-tfe/blob/main/internal/provider/resource_tfe_workspace_run_task.go#L84).

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
