### PR TITLE
Adding LICENSE File to TF Provider Release Archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,9 @@
 
 archives:
   - files:
-      # Ensure only built binary is archived
-      - 'none*'
+      # Ensure only built binary and license file are archived
+      - src: 'LICENSE'
+        dst: 'LICENSE.txt'
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 before:


### PR DESCRIPTION
Update in accordance with: [[Memo] TF-034: Adding LICENSE File to Terraform Provider Release Archives](https://go.hashi.co/memo/tf-034)