### PR TITLE
chore: ignore linter complaints for deprecated policy.Enforce

### DIFF
--- a/internal/provider/resource_tfe_policy.go
+++ b/internal/provider/resource_tfe_policy.go
@@ -194,7 +194,7 @@ func createOPAPolicyOptions(options *tfe.PolicyCreateOptions, d *schema.Resource
 		enforceOpts.Mode = tfe.EnforcementMode(tfe.EnforcementLevel(v.(string)))
 	}
 
-	options.Enforce = []*tfe.EnforcementOptions{enforceOpts}
+	options.Enforce = []*tfe.EnforcementOptions{enforceOpts} //nolint:staticcheck // this is still used by TFE versions older than 202306-1
 
 	vQuery, ok := d.GetOk("query")
 	if !ok {
@@ -218,7 +218,7 @@ func createSentinelPolicyOptions(options *tfe.PolicyCreateOptions, d *schema.Res
 		enforceOpts.Mode = tfe.EnforcementMode(tfe.EnforcementLevel(v.(string)))
 	}
 
-	options.Enforce = []*tfe.EnforcementOptions{enforceOpts}
+	options.Enforce = []*tfe.EnforcementOptions{enforceOpts} //nolint:staticcheck // this is still used by TFE versions older than 202306-1
 	return options
 }
 
@@ -254,6 +254,7 @@ func resourceTFEPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", policy.Description)
 	d.Set("kind", policy.Kind)
 
+	//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 	if len(policy.Enforce) == 1 {
 		d.Set("enforce_mode", string(policy.Enforce[0].Mode))
 	}
@@ -287,6 +288,7 @@ func resourceTFEPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		if d.HasChange("enforce_mode") {
+			//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 			options.Enforce = []*tfe.EnforcementOptions{
 				{
 					Path: tfe.String(path),

--- a/internal/provider/resource_tfe_policy_test.go
+++ b/internal/provider/resource_tfe_policy_test.go
@@ -404,6 +404,7 @@ func testAccCheckTFEPolicyAttributes(
 			return fmt.Errorf("Bad name: %s", policy.Name)
 		}
 
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		if policy.Enforce[0].Mode != "hard-mandatory" {
 			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
 		}
@@ -419,6 +420,7 @@ func testAccCheckTFEOPAPolicyAttributes(
 			return fmt.Errorf("Bad name: %s", policy.Name)
 		}
 
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		if policy.Enforce[0].Mode != "mandatory" {
 			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
 		}
@@ -438,10 +440,12 @@ func testAccCheckTFEDefaultPolicyAttributes(policy *tfe.Policy) resource.TestChe
 		}
 
 		switch policy.Kind {
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		case tfe.Sentinel:
 			if policy.Enforce[0].Mode != "soft-mandatory" {
 				return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
 			}
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		case tfe.OPA:
 			if policy.Enforce[0].Mode != "advisory" {
 				return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
@@ -458,6 +462,7 @@ func testAccCheckTFEPolicyAttributesUpdated(
 			return fmt.Errorf("Bad name: %s", policy.Name)
 		}
 
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		if policy.Enforce[0].Mode != "soft-mandatory" {
 			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
 		}
@@ -473,6 +478,7 @@ func testAccCheckTFEOPAPolicyAttributesUpdatedQuery(
 			return fmt.Errorf("Bad name: %s", policy.Name)
 		}
 
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		if policy.Enforce[0].Mode != "mandatory" {
 			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
 		}
@@ -492,6 +498,7 @@ func testAccCheckTFEOPAPolicyAttributesUpdatedAll(
 			return fmt.Errorf("Bad name: %s", policy.Name)
 		}
 
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		if policy.Enforce[0].Mode != "advisory" {
 			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
 		}

--- a/internal/provider/resource_tfe_sentinel_policy.go
+++ b/internal/provider/resource_tfe_sentinel_policy.go
@@ -136,6 +136,7 @@ func resourceTFESentinelPolicyRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("name", policy.Name)
 	d.Set("description", policy.Description)
 
+	//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 	if len(policy.Enforce) == 1 {
 		d.Set("enforce_mode", string(policy.Enforce[0].Mode))
 	}
@@ -161,6 +162,7 @@ func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if d.HasChange("enforce_mode") {
+			//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 			options.Enforce = []*tfe.EnforcementOptions{
 				{
 					Path: tfe.String(d.Get("name").(string) + ".sentinel"),

--- a/internal/provider/resource_tfe_sentinel_policy_test.go
+++ b/internal/provider/resource_tfe_sentinel_policy_test.go
@@ -147,6 +147,7 @@ func testAccCheckTFESentinelPolicyAttributes(
 			return fmt.Errorf("Bad name: %s", policy.Name)
 		}
 
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		if policy.Enforce[0].Mode != "hard-mandatory" {
 			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
 		}
@@ -162,6 +163,7 @@ func testAccCheckTFESentinelPolicyAttributesUpdated(
 			return fmt.Errorf("Bad name: %s", policy.Name)
 		}
 
+		//nolint:staticcheck // this is still used by TFE versions older than 202306-1
 		if policy.Enforce[0].Mode != "soft-mandatory" {
 			return fmt.Errorf("Bad enforce mode: %s", policy.Enforce[0].Mode)
 		}


### PR DESCRIPTION
(cherry picked from commit 32c3d86dce16e5d38f7bb6f39d5820d5b2ed4733)

## Description

Because of the changes made to the go-tfe policy.Enforce, we're getting linter errors on this deprecated array. We've created a ticket with the compliance team to look at how we can make this backwards compatible with older versions of TFE, in the meantime we're going to ignore these errors

_Remember to:_

N/A~Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)~
N/A~Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)~

## External links

- [Compliance ticket](https://hashicorp.atlassian.net/browse/TF-15241)
