### PR TITLE
Updated project name limit from 36 to 40 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ ENHANCEMENTS:
 FEATURES:
 * `r/tfe_team`: Add attributes `manage_teams`, `manage_organization_access`, and `access_secret_teams` to `organization_access` on `tfe_team` by @juliannatetreault [#1313](https://github.com/hashicorp/terraform-provider-tfe/pull/1313)
 
+ENHANCEMENTS:
+* `r/tfe_project`: Increase the Project name length from 36 to 40 characters @hs26gill [#1351](https://github.com/hashicorp/terraform-provider-tfe/pull/1351)
+
 ## v0.54.0
 
 ENHANCEMENTS:

--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -40,7 +40,7 @@ func resourceTFEProject() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.All(
-					validation.StringLenBetween(3, 36),
+					validation.StringLenBetween(3, 40),
 					validation.StringMatch(regexp.MustCompile(`\A[\w\-][\w\- ]+[\w\-]\z`),
 						"can only include letters, numbers, spaces, -, and _."),
 				),

--- a/internal/provider/resource_tfe_project_test.go
+++ b/internal/provider/resource_tfe_project_test.go
@@ -57,7 +57,7 @@ func TestAccTFEProject_invalidName(t *testing.T) {
 			},
 			{
 				Config:      testAccTFEProject_invalidNameLen(rInt),
-				ExpectError: regexp.MustCompile(`expected length of name to be in the range \(3 - 36\),`),
+				ExpectError: regexp.MustCompile(`expected length of name to be in the range \(3 - 40\),`),
 			},
 		},
 	})


### PR DESCRIPTION
## Description

This PR increases the project name character length from 36 to 40 character.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Covered by integration tests

## External links

- [Related PR](https://hashicorp.atlassian.net/browse/TF-11739)
