### PR TITLE
prevent constant diff even after a successful apply of resource_tfe_registry_module resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ ENHANCEMENTS:
 * `d/tfe_workspace`: Add an `auto_destroy_at` attribute for reading a scheduled auto-destroy, by @notchairmk [1354](https://github.com/hashicorp/terraform-provider-tfe/pull/1354)
 * `r/tfe_registry_module`: Add `initial_version` support for Branch Based Modules by @aaabdelgany [#1363](https://github.com/hashicorp/terraform-provider-tfe/pull/1363)
 
+BUG FIXES:
+* `r/tfe_registry_module`: Prevents constant diff after a successful apply when `tags` and `tests_enabled` is not set by @Uk1288 [#1357](https://github.com/hashicorp/terraform-provider-tfe/pull/1357)
+
 ## v0.55.0
 
 FEATURES:

--- a/internal/provider/resource_tfe_registry_module.go
+++ b/internal/provider/resource_tfe_registry_module.go
@@ -95,6 +95,7 @@ func resourceTFERegistryModule() *schema.Resource {
 						"tags": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -125,11 +126,13 @@ func resourceTFERegistryModule() *schema.Resource {
 			"test_config": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"tests_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},


### PR DESCRIPTION
## Description

This PR prevents constant diff even after a successful apply of `resource_tfe_registry_module` resource. It also fixes the following cases:

- when `tags` is set to true and `branch` is specified, the API ignores `tags` value and uses the specified `branch`. This leads to a constant diff attempt. Solution added is to match the API by verifying that either `branch` or `tags` is set but not both
- previously, the `tags` value was never sent during the Create request, this PR ensures that the specified `tags` value is always sent in the request
- `test_config` was only updated into state when the test config response is non-empty leading to never unsetting the value in state. Added fix to always update the test_config state to reflect api response.
- adds some tests to catch previously failing cases
- fix panic that occurs while logging errors during registry module create

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_

## Testing plan

1.  _Some configs like below resulted in constant diff even after a successful apply_
```
resource "tfe_registry_module" "test-without-test-config-block" {
 vcs_repo {
    display_identifier = "Uk1288/terraform-aws-simple-s3-cdn"
    identifier         = "Uk1288/terraform-aws-simple-s3-cdn"
    oauth_token_id     = "ot-123"
    branch             = "main"
    tags             = false
    # branch             = ""
    # tags               = true
  }
}

resource "tfe_registry_module" "bare-module" {
  vcs_repo {
    oauth_token_id     = "ot-123"
    display_identifier = "Uk1288/terraform-google-cloud-dns"
    identifier         = "Uk1288/terraform-google-cloud-dns"
  }
}

resource "tfe_registry_module" "test-with-tags-and-branch-disabled" {
 vcs_repo {
    display_identifier = "Uk1288/terraform-aws-simple-s3-cdn"
    identifier         = "Uk1288/terraform-aws-simple-s3-cdn"
    oauth_token_id     = "ot-123"
    tags             = false
    branch         = ""
  }
}

```
1.  _Applying tfe_registry_module config combo should no longer result in constant diff,_


```
$ TESTARGS="-run TestAccTFERegistryModule" make testacc

=== RUN   TestAccTFERegistryModule_vcs
--- PASS: TestAccTFERegistryModule_vcs (7.69s)
=== RUN   TestAccTFERegistryModule_GitHubApp
--- PASS: TestAccTFERegistryModule_GitHubApp (4.32s)
=== RUN   TestAccTFERegistryModule_emptyVCSRepo
--- PASS: TestAccTFERegistryModule_emptyVCSRepo (0.19s)
=== RUN   TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName
--- PASS: TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName (4.29s)
=== RUN   TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName
--- PASS: TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName (4.11s)
=== RUN   TestAccTFERegistryModule_publicRegistryModule
--- PASS: TestAccTFERegistryModule_publicRegistryModule (4.14s)
=== RUN   TestAccTFERegistryModule_vcsRepoWithTagField
--- PASS: TestAccTFERegistryModule_vcsRepoWithTagField (6.30s)
=== RUN   TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat
--- PASS: TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat (7.75s)
=== RUN   TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat
--- PASS: TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat (6.87s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch (16.40s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWithTests
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWithTests (11.21s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags (13.98s)
=== RUN   TestAccTFERegistryModule_invalidTestConfigOnCreate
--- PASS: TestAccTFERegistryModule_invalidTestConfigOnCreate (3.28s)
=== RUN   TestAccTFERegistryModule_invalidTestConfigOnUpdate
--- PASS: TestAccTFERegistryModule_invalidTestConfigOnUpdate (7.02s)
=== RUN   TestAccTFERegistryModule_branchAndInvalidTagsOnCreate
--- PASS: TestAccTFERegistryModule_branchAndInvalidTagsOnCreate (2.94s)
=== RUN   TestAccTFERegistryModule_branchAndTagsEnabledOnCreate
--- PASS: TestAccTFERegistryModule_branchAndTagsEnabledOnCreate (2.76s)
=== RUN   TestAccTFERegistryModule_branchAndTagsDisabledOnCreate
--- PASS: TestAccTFERegistryModule_branchAndTagsDisabledOnCreate (2.81s)
=== RUN   TestAccTFERegistryModule_branchAndTagsEnabledOnUpdate
--- PASS: TestAccTFERegistryModule_branchAndTagsEnabledOnUpdate (7.02s)
=== RUN   TestAccTFERegistryModule_branchAndTagsDisabledOnUpdate
--- PASS: TestAccTFERegistryModule_branchAndTagsDisabledOnUpdate (7.31s)
=== RUN   TestAccTFERegistryModuleImport_nonVCSPrivateRM
--- PASS: TestAccTFERegistryModuleImport_nonVCSPrivateRM (4.23s)
=== RUN   TestAccTFERegistryModuleImport_publicRM
--- PASS: TestAccTFERegistryModuleImport_publicRM (4.33s)
=== RUN   TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider
--- PASS: TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider (0.15s)
=== RUN   TestAccTFERegistryModule_invalidRegistryName
--- PASS: TestAccTFERegistryModule_invalidRegistryName (0.32s)
=== RUN   TestAccTFERegistryModule_invalidWithModuleProviderAndNoName
--- PASS: TestAccTFERegistryModule_invalidWithModuleProviderAndNoName (0.13s)
=== RUN   TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization
--- PASS: TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization (0.13s)
=== RUN   TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName
--- PASS: TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName (0.12s)
=== RUN   TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider
--- PASS: TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider (0.12s)
```

unrelated failure for nocode

=== RUN   TestAccTFERegistryModule_noCodeModule
    resource_tfe_registry_module_test.go:343: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating registry module vpc: resource not found
        
          with tfe_registry_module.foobar,
          on terraform_plugin_test.tf line 8, in resource "tfe_registry_module" "foobar":
           8: resource "tfe_registry_module" "foobar" {
        
--- FAIL: TestAccTFERegistryModule_noCodeModule (2.23s)