### PR TITLE
[#TF-15257] add manage-agent-pools to team organization access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+FEATURES:
+* `r/tfe_team`: Add attribute `manage_agent_pools` to `organization_access` on `tfe_team` by @emlanctot [#1358](https://github.com/hashicorp/terraform-provider-tfe/pull/1358)
+
 ## v0.56.0
 
 ENHANCEMENTS:

--- a/internal/provider/resource_tfe_team.go
+++ b/internal/provider/resource_tfe_team.go
@@ -120,6 +120,11 @@ func resourceTFETeam() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"manage_agent_pools": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -173,6 +178,7 @@ func resourceTFETeamCreate(d *schema.ResourceData, meta interface{}) error {
 			ManageTeams:              tfe.Bool(organizationAccess["manage_teams"].(bool)),
 			ManageOrganizationAccess: tfe.Bool(organizationAccess["manage_organization_access"].(bool)),
 			AccessSecretTeams:        tfe.Bool(organizationAccess["access_secret_teams"].(bool)),
+			ManageAgentPools:         tfe.Bool(organizationAccess["manage_agent_pools"].(bool)),
 		}
 	}
 
@@ -236,6 +242,7 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 			"manage_teams":               team.OrganizationAccess.ManageTeams,
 			"manage_organization_access": team.OrganizationAccess.ManageOrganizationAccess,
 			"access_secret_teams":        team.OrganizationAccess.AccessSecretTeams,
+			"manage_agent_pools":         team.OrganizationAccess.ManageAgentPools,
 		}}
 		if err := d.Set("organization_access", organizationAccess); err != nil {
 			return fmt.Errorf("error setting organization access for team %s: %w", d.Id(), err)
@@ -276,6 +283,7 @@ func resourceTFETeamUpdate(d *schema.ResourceData, meta interface{}) error {
 			ManageTeams:              tfe.Bool(organizationAccess["manage_teams"].(bool)),
 			ManageOrganizationAccess: tfe.Bool(organizationAccess["manage_organization_access"].(bool)),
 			AccessSecretTeams:        tfe.Bool(organizationAccess["access_secret_teams"].(bool)),
+			ManageAgentPools:         tfe.Bool(organizationAccess["manage_agent_pools"].(bool)),
 		}
 	}
 

--- a/internal/provider/resource_tfe_team_test.go
+++ b/internal/provider/resource_tfe_team_test.go
@@ -85,6 +85,8 @@ func TestAccTFETeam_full(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.manage_organization_access", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.access_secret_teams", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_agent_pools", "true"),
 				),
 			},
 		},
@@ -138,6 +140,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.manage_organization_access", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.access_secret_teams", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_agent_pools", "true"),
 				),
 			},
 			{
@@ -178,6 +182,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.manage_organization_access", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.access_secret_teams", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_agent_pools", "false"),
 				),
 			},
 			{
@@ -219,6 +225,8 @@ func TestAccTFETeam_full_update(t *testing.T) {
 						"tfe_team.foobar", "organization_access.0.manage_organization_access", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "organization_access.0.access_secret_teams", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_agent_pools", "false"),
 				),
 			},
 		},
@@ -480,6 +488,9 @@ func testAccCheckTFETeamAttributes_full(
 		if !team.OrganizationAccess.AccessSecretTeams {
 			return fmt.Errorf("OrganizationAccess.AccessSecretTeams should be true")
 		}
+		if !team.OrganizationAccess.ManageAgentPools {
+			return fmt.Errorf("OrganizationAccess.ManageAgentPools should be true")
+		}
 
 		if team.SSOTeamID != "team-test-sso-id" {
 			return fmt.Errorf("Bad SSO Team ID: %s", team.SSOTeamID)
@@ -526,6 +537,9 @@ func testAccCheckTFETeamAttributes_full_update(
 		}
 		if team.OrganizationAccess.AccessSecretTeams {
 			return fmt.Errorf("OrganizationAccess.AccessSecretTeams should be false")
+		}
+		if team.OrganizationAccess.ManageAgentPools {
+			return fmt.Errorf("OrganizationAccess.ManageAgentPools should be false")
 		}
 
 		if team.SSOTeamID != "changed-sso-id" {
@@ -598,6 +612,7 @@ resource "tfe_team" "foobar" {
 	manage_teams = true
 	manage_organization_access = true
 	access_secret_teams = true
+	manage_agent_pools = true
   }
   sso_team_id = "team-test-sso-id"
 }`, rInt)
@@ -631,6 +646,7 @@ resource "tfe_team" "foobar" {
 	manage_teams = false
 	manage_organization_access = false
 	access_secret_teams = false
+	manage_agent_pools = false
   }
 
   sso_team_id = "changed-sso-id"

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -58,6 +58,7 @@ The `organization_access` block supports:
 * `manage_teams` - (Optional) Allow members to create, update, and delete teams.
 * `manage_organization_access` - (Optional) Allow members to update the organization access settings of teams.
 * `access_secret_teams` - (Optional) Allow members access to secret teams up to the level of permissions granted by their team permissions setting.
+* `manage_secret_teams` - (Optional) Allows members to create, edit, and delete agent pools within their organization.
 
 ## Attributes Reference
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -24,7 +24,7 @@ Organization Permission usage:
 
 ```hcl
 resource "tfe_team" "test" {
-  name         = "my-team-name"
+  name         = "my-team-name
   organization = "my-org-name"
   organization_access {
     manage_vcs_settings = true
@@ -58,7 +58,7 @@ The `organization_access` block supports:
 * `manage_teams` - (Optional) Allow members to create, update, and delete teams.
 * `manage_organization_access` - (Optional) Allow members to update the organization access settings of teams.
 * `access_secret_teams` - (Optional) Allow members access to secret teams up to the level of permissions granted by their team permissions setting.
-* `manage_secret_teams` - (Optional) Allows members to create, edit, and delete agent pools within their organization.
+* `manage_agent_pools` - (Optional) Allows members to create, edit, and delete agent pools within their organization.
 
 ## Attributes Reference
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -58,7 +58,7 @@ The `organization_access` block supports:
 * `manage_teams` - (Optional) Allow members to create, update, and delete teams.
 * `manage_organization_access` - (Optional) Allow members to update the organization access settings of teams.
 * `access_secret_teams` - (Optional) Allow members access to secret teams up to the level of permissions granted by their team permissions setting.
-* `manage_agent_pools` - (Optional) Allows members to create, edit, and delete agent pools within their organization.
+* `manage_agent_pools` - (Optional) Allow members to create, edit, and delete agent pools within their organization.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

This PR adds support that will allow the manage_agent_pools organization access setting to be set on teams via the provider.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. `manage_agent_pools` should default to false for new teams.
2. If `manage_agent_pools` is omitted, they should default to false.
3. `manage_agent_pools` should be able to be set or unset via the provider.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe PR](https://github.com/hashicorp/go-tfe/pull/901)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-15257)


## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
