### PR TITLE
Support initial_version for creating branch based modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 * `r/tfe_oauth_client`: Add Bitbucket Data Center support with the `bitbucket_data_center` option for `service_provider` by @zainq11 [#1303](https://github.com/hashicorp/terraform-provider-tfe/pull/1304)
+* `r/tfe_registry_module`: Add `initial_version` support for Branch Based Modules by @aaabdelgany [#1363](https://github.com/hashicorp/terraform-provider-tfe/pull/1363)
 
 ## v0.55.0
 

--- a/internal/provider/resource_tfe_registry_module.go
+++ b/internal/provider/resource_tfe_registry_module.go
@@ -134,6 +134,10 @@ func resourceTFERegistryModule() *schema.Resource {
 					},
 				},
 			},
+			"initial_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -167,6 +171,7 @@ func resourceTFERegistryModuleCreateWithVCS(v interface{}, meta interface{}, d *
 
 	tags, tagsOk := vcsRepo["tags"].(bool)
 	branch, branchOk := vcsRepo["branch"].(string)
+	initialVersion, initialVersionOk := d.GetOk("initial_version")
 
 	if tagsOk && tags && branchOk && branch != "" {
 		return nil, fmt.Errorf("tags must be set to false when a branch is provided")
@@ -174,6 +179,9 @@ func resourceTFERegistryModuleCreateWithVCS(v interface{}, meta interface{}, d *
 
 	if branchOk && branch != "" {
 		options.VCSRepo.Branch = tfe.String(branch)
+		if initialVersionOk && initialVersion.(string) != "" {
+			options.InitialVersion = tfe.String(initialVersion.(string))
+		}
 	}
 
 	if vcsRepo["oauth_token_id"] != nil && vcsRepo["oauth_token_id"].(string) != "" {

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -403,7 +403,6 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat(t *testing.T) 
 }
 
 func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -463,7 +462,6 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch(t
 }
 
 func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWithTests(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -505,7 +503,6 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWi
 }
 
 func TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -556,7 +553,6 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags(t *
 }
 
 func TestAccTFERegistryModule_invalidTestConfigOnCreate(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -575,7 +571,6 @@ func TestAccTFERegistryModule_invalidTestConfigOnCreate(t *testing.T) {
 }
 
 func TestAccTFERegistryModule_invalidTestConfigOnUpdate(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -603,7 +598,6 @@ func TestAccTFERegistryModule_invalidTestConfigOnUpdate(t *testing.T) {
 }
 
 func TestAccTFERegistryModule_branchAndInvalidTagsOnCreate(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -622,7 +616,6 @@ func TestAccTFERegistryModule_branchAndInvalidTagsOnCreate(t *testing.T) {
 }
 
 func TestAccTFERegistryModule_branchAndTagsEnabledOnCreate(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -641,7 +634,6 @@ func TestAccTFERegistryModule_branchAndTagsEnabledOnCreate(t *testing.T) {
 }
 
 func TestAccTFERegistryModule_branchAndTagsEnabledOnUpdate(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
@@ -1025,6 +1017,8 @@ resource "tfe_registry_module" "foobar" {
    tags				  = false
  }
 
+ initial_version = "1.0.0"
+
  test_config {
    tests_enabled = false
  }
@@ -1059,6 +1053,8 @@ resource "tfe_registry_module" "foobar" {
    tags				  = false
  }
 
+ initial_version = "1.0.0"
+
  test_config {
  }
 }`,
@@ -1091,6 +1087,8 @@ resource "tfe_registry_module" "foobar" {
    branch             = "main"
    tags				  = false
  }
+
+ initial_version = "1.0.0"
 
  test_config {
    tests_enabled = true
@@ -1127,6 +1125,8 @@ resource "tfe_registry_module" "foobar" {
    tags				  = false
  }
 
+ initial_version = "1.0.0"
+
  test_config {
  }
 }`,
@@ -1160,6 +1160,8 @@ resource "tfe_registry_module" "foobar" {
    branch             = "main"
    tags				  = true
  }
+
+ initial_version = "1.0.0"
 
  test_config {
    tests_enabled = true

--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -154,6 +154,7 @@ The following arguments are supported:
 * `organization` - (Optional) The name of the organization associated with the registry module. It must be set if `module_provider` is used, or if `vcs_repo` is used via a GitHub App.
 * `namespace` - (Optional) The namespace of a public registry module. It can be used if `module_provider` is set and `registry_name` is public.
 * `registry_name` - (Optional) Whether the registry module is private or public. It can be used if `module_provider` is set.
+* `initial_version` - (Optional) This specifies the initial version for a branch based module. It can be used if `vcs_repo.branch` is set. If it is omitted, the initial modules version will default to `0.0.0`.
 
 The `test_config` block supports
 * `tests_enabled` - (Optional) Specifies whether tests run for the registry module. Tests are only supported for branch-based publishing.


### PR DESCRIPTION
## Description

Support for specifying a branch based modules `initialVersion` is missing from the tfe provider - if it is missing, we default to a version of `0.0.0`. This PR addresses that by adding support for an `initial_version` string. This PR also removes the `skipUnlessBeta` flag from the tf test and branch based modules tests.
_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan
```
resource "tfe_organization" "foobar" {
 name  = "tst-terraform-%d"
 email = "admin@company.com"
}

resource "tfe_oauth_client" "foobar" {
 organization     = tfe_organization.foobar.name
 api_url          = "https://api.github.com"
 http_url         = "https://github.com"
 oauth_token      = "%s"
 service_provider = "github"
}

resource "tfe_registry_module" "foobar" {
 organization     = tfe_organization.foobar.name
 vcs_repo {
   display_identifier = "%s"
   identifier         = "%s"
   oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
   branch             = "main"
   tags				  = false
 }

 initial_version = "1.0.0"

 test_config {
   tests_enabled = false
 }
```

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

https://pkg.go.dev/github.com/hashicorp/go-tfe@v1.53.0#RegistryModuleCreateWithVCSConnectionOptions.VCSRepo

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFERegistryModule -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	0.239s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	0.120s [no tests to run]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFERegistryModule_vcs
--- PASS: TestAccTFERegistryModule_vcs (8.36s)
=== RUN   TestAccTFERegistryModule_GitHubApp
    provider_test.go:230: Please set GITHUB_APP_INSTALLATION_ID to run this test
--- SKIP: TestAccTFERegistryModule_GitHubApp (0.00s)
=== RUN   TestAccTFERegistryModule_emptyVCSRepo
--- PASS: TestAccTFERegistryModule_emptyVCSRepo (0.16s)
=== RUN   TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName
--- PASS: TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName (4.87s)
=== RUN   TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName
--- PASS: TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName (5.04s)
=== RUN   TestAccTFERegistryModule_publicRegistryModule
--- PASS: TestAccTFERegistryModule_publicRegistryModule (5.01s)
=== RUN   TestAccTFERegistryModule_noCodeModule
--- PASS: TestAccTFERegistryModule_noCodeModule (5.36s)
=== RUN   TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat
--- PASS: TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat (8.07s)
=== RUN   TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat
--- PASS: TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat (7.53s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch (18.82s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWithTests
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWithTests (13.04s)
=== RUN   TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags
--- PASS: TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags (16.78s)
=== RUN   TestAccTFERegistryModule_invalidTestConfigOnCreate
--- PASS: TestAccTFERegistryModule_invalidTestConfigOnCreate (3.22s)
=== RUN   TestAccTFERegistryModule_invalidTestConfigOnUpdate
--- PASS: TestAccTFERegistryModule_invalidTestConfigOnUpdate (8.05s)
=== RUN   TestAccTFERegistryModule_branchAndInvalidTagsOnCreate
--- PASS: TestAccTFERegistryModule_branchAndInvalidTagsOnCreate (3.15s)
=== RUN   TestAccTFERegistryModule_branchAndTagsEnabledOnCreate
--- PASS: TestAccTFERegistryModule_branchAndTagsEnabledOnCreate (3.20s)
=== RUN   TestAccTFERegistryModule_branchAndTagsEnabledOnUpdate
--- PASS: TestAccTFERegistryModule_branchAndTagsEnabledOnUpdate (8.09s)
=== RUN   TestAccTFERegistryModuleImport_nonVCSPrivateRM
--- PASS: TestAccTFERegistryModuleImport_nonVCSPrivateRM (5.46s)
=== RUN   TestAccTFERegistryModuleImport_publicRM
--- PASS: TestAccTFERegistryModuleImport_publicRM (5.24s)
=== RUN   TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider
--- PASS: TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider (0.17s)
=== RUN   TestAccTFERegistryModule_invalidRegistryName
--- PASS: TestAccTFERegistryModule_invalidRegistryName (0.34s)
=== RUN   TestAccTFERegistryModule_invalidWithModuleProviderAndNoName
--- PASS: TestAccTFERegistryModule_invalidWithModuleProviderAndNoName (0.13s)
=== RUN   TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization
--- PASS: TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization (0.13s)
=== RUN   TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName
--- PASS: TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName (0.13s)
=== RUN   TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider
--- PASS: TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider (0.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	131.113s
...
```
