### PR TITLE
Add insight to name argument of tfe_project about length

### DIFF
--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -30,6 +30,8 @@ resource "tfe_project" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the project.
+    *  TFE versions v202404-2 and earlier support between 3-36 characters
+    *  TFE versions v202405-1 and later support between 3-40 characters
 * `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `description` - (Optional) A description for the project.
 


### PR DESCRIPTION
## Description

_Describe why you're making this change._

version 0.56.0 of the TFE provider adds support for creating a project with a name that is of 40 characters in length, but only `202405-1 and later` version of TFE support this. I've added a notation to the docs to bring clarity of about this to all users.

_Remember to:_

- [N/A] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [X] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
