### PR TITLE
New resource: tfe_stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ provider_tfe_override.tfrc
 
 # mkdocs build output
 site/
+.envrc

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-slug v0.15.2
-	github.com/hashicorp/go-tfe v1.57.0
-	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/go-tfe v1.58.0
+	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.19.1 // indirect
 	github.com/hashicorp/terraform-plugin-framework v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -66,13 +66,13 @@ github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISH
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-slug v0.15.2 h1:/ioIpE4bWVN/d7pG2qMrax0a7xe9vOA66S+fz7fZmGY=
 github.com/hashicorp/go-slug v0.15.2/go.mod h1:THWVTAXwJEinbsp4/bBRcmbaO5EYNLTqxbG4tZ3gCYQ=
-github.com/hashicorp/go-tfe v1.57.0 h1:sggR6C4CrtNAJqoCRNoZwBQnRfnWuImR6xbg2sUAbiU=
-github.com/hashicorp/go-tfe v1.57.0/go.mod h1:XnTtBj3tVQ4uFkcFsv8Grn+O1CVcIcceL1uc2AgUcaU=
+github.com/hashicorp/go-tfe v1.58.0 h1:aJXrStDBG+YJLkgDYswfNiKTRHQxKqT/9C1VuvujRkE=
+github.com/hashicorp/go-tfe v1.58.0/go.mod h1:XnTtBj3tVQ4uFkcFsv8Grn+O1CVcIcceL1uc2AgUcaU=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.6.3 h1:yE/r1yJvWbtrJ0STwScgEnCanb0U9v7zp0Gbkmcoxqs=
 github.com/hashicorp/hc-install v0.6.3/go.mod h1:KamGdbodYzlufbWh4r9NRo8y6GLHWZP2GBtdnms1Ln0=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -145,6 +145,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewDataRetentionPolicyResource,
 		NewResourceWorkspaceSettings,
 		NewSAMLSettingsResource,
+		NewStackResource,
 		NewTestVariableResource,
 		NewWorkspaceRunTaskResource,
 	}

--- a/internal/provider/resource_tfe_stack.go
+++ b/internal/provider/resource_tfe_stack.go
@@ -1,0 +1,269 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &resourceTFEStack{}
+var _ resource.ResourceWithConfigure = &resourceTFEStack{}
+var _ resource.ResourceWithImportState = &resourceTFEStack{}
+
+func NewStackResource() resource.Resource {
+	return &resourceTFEStack{}
+}
+
+// resourceTFEStack implements the tfe_stack resource type
+type resourceTFEStack struct {
+	config ConfiguredClient
+}
+
+func (r *resourceTFEStack) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_stack"
+}
+
+func (r *resourceTFEStack) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	pathVCSRepoOAuthTokenID := path.Expressions{
+		path.MatchRelative().AtParent().AtName("oauth_token_id"),
+	}
+	pathGHAInstallationID := path.Expressions{
+		path.MatchRelative().AtParent().AtName("github_app_installation_id"),
+	}
+
+	resp.Schema = schema.Schema{
+		Description: "Defines a Stack resource. Note that a Stack cannot be destroyed if it contains deployments that have underlying managed resources.",
+		Version:     1,
+
+		Blocks: map[string]schema.Block{
+			"vcs_repo": schema.SingleNestedBlock{
+				Description: "VCS repository configuration for the Stack.",
+				Attributes: map[string]schema.Attribute{
+					"identifier": schema.StringAttribute{
+						Description: "Identifier of the VCS repository.",
+						Required:    true,
+					},
+					"branch": schema.StringAttribute{
+						Description: "The repository branch that Terraform should use. This defaults to the respository's default branch (e.g. main).",
+						Optional:    true,
+					},
+					"github_app_installation_id": schema.StringAttribute{
+						Description: "The installation ID of the GitHub App. This conflicts with `oauth_token_id` and can only be used if `oauth_token_id` is not used.",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.AtLeastOneOf(pathVCSRepoOAuthTokenID...),
+							stringvalidator.ConflictsWith(pathVCSRepoOAuthTokenID...),
+						},
+					},
+					"oauth_token_id": schema.StringAttribute{
+						Description: "The VCS Connection to use. This ID can be obtained from a `tfe_oauth_client` resource. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.AtLeastOneOf(pathGHAInstallationID...),
+							stringvalidator.ConflictsWith(pathGHAInstallationID...),
+						},
+					},
+				},
+			},
+		},
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "ID of the Stack.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"project_id": schema.StringAttribute{
+				Description: "ID of the project that the Stack belongs to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the Stack",
+				Required:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "Description of the Stack",
+				Optional:    true,
+			},
+			"deployment_names": schema.SetAttribute{
+				Description: "The time when the Stack was created.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "The time when the stack was created.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "The time when the stack was last updated.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFEStack) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	r.config = client
+}
+
+func (r *resourceTFEStack) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTFEStack
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	options := tfe.StackCreateOptions{
+		Name: plan.Name.ValueString(),
+		VCSRepo: &tfe.StackVCSRepo{
+			Identifier:        plan.VCSRepo.Identifier.ValueString(),
+			Branch:            plan.VCSRepo.Branch.ValueString(),
+			GHAInstallationID: plan.VCSRepo.GHAInstallationID.ValueString(),
+			OAuthTokenID:      plan.VCSRepo.OAuthTokenID.ValueString(),
+		},
+		Project: &tfe.Project{
+			ID: plan.ProjectID.ValueString(),
+		},
+	}
+
+	if !plan.Description.IsNull() {
+		options.Description = tfe.String(plan.Description.ValueString())
+	}
+
+	tflog.Debug(ctx, "Creating stack")
+	stack, err := r.config.Client.Stacks.Create(ctx, options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create stack", err.Error())
+		return
+	}
+
+	result := modelFromTFEStack(stack)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceTFEStack) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFEStack
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading stack %q", state.ID.ValueString()))
+	stack, err := r.config.Client.Stacks.Read(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read stack", err.Error())
+		return
+	}
+
+	result := modelFromTFEStack(stack)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceTFEStack) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan modelTFEStack
+	var state modelTFEStack
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	options := tfe.StackUpdateOptions{
+		Name:        tfe.String(plan.Name.ValueString()),
+		Description: tfe.String(plan.Description.ValueString()),
+		VCSRepo: &tfe.StackVCSRepo{
+			Identifier:        plan.VCSRepo.Identifier.ValueString(),
+			Branch:            plan.VCSRepo.Branch.ValueString(),
+			GHAInstallationID: plan.VCSRepo.GHAInstallationID.ValueString(),
+			OAuthTokenID:      plan.VCSRepo.OAuthTokenID.ValueString(),
+		},
+	}
+
+	tflog.Debug(ctx, "Updating stack")
+	stack, err := r.config.Client.Stacks.Update(ctx, state.ID.ValueString(), options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to update stack", err.Error())
+		return
+	}
+
+	result := modelFromTFEStack(stack)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func (r *resourceTFEStack) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFEStack
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Deleting stack")
+	err := r.config.Client.Stacks.Delete(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to delete stack", err.Error())
+		return
+	}
+}
+
+func (r *resourceTFEStack) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+}

--- a/internal/provider/resource_tfe_stack_test.go
+++ b/internal/provider/resource_tfe_stack_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTFEStackResource_basic(t *testing.T) {
+	skipUnlessBeta(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "brandonc/pet-nulls-stack"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "id"),
+					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "project_id"),
+					resource.TestCheckResourceAttr("tfe_stack.foobar", "name", "example-stack"),
+					resource.TestCheckResourceAttr("tfe_stack.foobar", "description", "Just an ordinary stack"),
+					resource.TestCheckResourceAttr("tfe_stack.foobar", "vcs_repo.identifier", "brandonc/pet-nulls-stack"),
+					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "vcs_repo.oauth_token_id"),
+					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "created_at"),
+					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "updated_at"),
+				),
+			},
+			{
+				ResourceName:      "tfe_stack.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTFEStackResourceConfig(orgName, ghToken, ghRepoIdentifier string) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "%s"
+  email = "admin@tfe.local"
+}
+
+resource "tfe_project" "example" {
+	name         = "example"
+	organization = tfe_organization.foobar.name
+}
+
+resource "tfe_oauth_client" "foobar" {
+  organization     = tfe_organization.foobar.name
+  api_url          = "https://api.github.com"
+  http_url         = "https://github.com"
+  oauth_token      = "%s"
+  service_provider = "github"
+}
+
+resource "tfe_stack" "foobar" {
+	name        = "example-stack"
+	description = "Just an ordinary stack"
+  project_id  = tfe_project.example.id
+
+	vcs_repo {
+    identifier         = "%s"
+    oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+  }
+}
+`, orgName, ghToken, ghRepoIdentifier)
+}

--- a/internal/provider/stack.go
+++ b/internal/provider/stack.go
@@ -1,0 +1,73 @@
+package provider
+
+import (
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type modelTFEStackVCSRepo struct {
+	Identifier        types.String `tfsdk:"identifier"`
+	Branch            types.String `tfsdk:"branch"`
+	GHAInstallationID types.String `tfsdk:"github_app_installation_id"`
+	OAuthTokenID      types.String `tfsdk:"oauth_token_id"`
+}
+
+// modelTFEStack maps the resource or data source schema data to a
+// struct.
+type modelTFEStack struct {
+	ID              types.String          `tfsdk:"id"`
+	ProjectID       types.String          `tfsdk:"project_id"`
+	Name            types.String          `tfsdk:"name"`
+	Description     types.String          `tfsdk:"description"`
+	DeploymentNames types.Set             `tfsdk:"deployment_names"`
+	VCSRepo         *modelTFEStackVCSRepo `tfsdk:"vcs_repo"`
+	CreatedAt       types.String          `tfsdk:"created_at"`
+	UpdatedAt       types.String          `tfsdk:"updated_at"`
+}
+
+// modelFromTFEStack builds a modelTFEStack struct from a
+// tfe.Stack value.“
+func modelFromTFEStack(v *tfe.Stack) modelTFEStack {
+	names := make([]attr.Value, len(v.DeploymentNames))
+	for i, name := range v.DeploymentNames {
+		names[i] = types.StringValue(name)
+	}
+
+	result := modelTFEStack{
+		ID:              types.StringValue(v.ID),
+		ProjectID:       types.StringValue(v.Project.ID),
+		Name:            types.StringValue(v.Name),
+		Description:     types.StringNull(),
+		DeploymentNames: types.SetValueMust(types.StringType, names),
+		VCSRepo: &modelTFEStackVCSRepo{
+			Identifier:        types.StringValue(v.VCSRepo.Identifier),
+			Branch:            types.StringNull(),
+			GHAInstallationID: types.StringNull(),
+			OAuthTokenID:      types.StringNull(),
+		},
+
+		CreatedAt: types.StringValue(v.CreatedAt.Format(time.RFC3339)),
+		UpdatedAt: types.StringValue(v.UpdatedAt.Format(time.RFC3339)),
+	}
+
+	if v.Description != "" {
+		result.Description = types.StringValue(v.Description)
+	}
+
+	if v.VCSRepo.GHAInstallationID != "" {
+		result.VCSRepo.GHAInstallationID = types.StringValue(v.VCSRepo.GHAInstallationID)
+	}
+
+	if v.VCSRepo.OAuthTokenID != "" {
+		result.VCSRepo.OAuthTokenID = types.StringValue(v.VCSRepo.OAuthTokenID)
+	}
+
+	if v.VCSRepo.Branch != "" {
+		result.VCSRepo.Branch = types.StringValue(v.VCSRepo.Branch)
+	}
+
+	return result
+}

--- a/website/docs/r/stack.html.markdown.md
+++ b/website/docs/r/stack.html.markdown.md
@@ -1,0 +1,77 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_stack"
+description: |-
+  Manages Stacks.
+---
+
+# tfe_stack
+
+Defines a Stack resource.
+
+~> **NOTE:** Stacks support in the hashicorp/tfe provider is currently available on a pre-release basis and should be considered beta software and subject to change. One notable aspect of this resource is that a stack may not be destroyed until all resources within its deployments have been destroyed.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_oauth_client" "test" {
+  organization     = "my-example-org"
+  api_url          = "https://api.github.com"
+  http_url         = "https://github.com"
+  oauth_token      = var.github_token
+  service_provider = "github"
+}
+
+data "tfe_organization" "organization" {
+  name = "my-example-org"
+}
+
+resource "tfe_stack" "test-stack" {
+  name         = "my-stack"
+  description  = "A Terraform Stack using two components with two environments"
+  project_id   = data.tfe_organization.organization.default_project_id
+
+  vcs_repo {
+    branch         = "main"
+    identifier     = "my-github-org/stack-repo"
+    oauth_token_id = tfe_oauth_client.test.oauth_token_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the stack.
+* `project_id` - (Required) ID of the project where the stack should be created.
+* `description` - (Optional) Description of the stack
+* `vcs_repo` - (Required) Settings for the stack's VCS repository.
+<!--
+NOTE: This is a proposed schema for allowing force-delete actions on a stack. Force delete is not implemented yet so I've commented it out for now.
+
+* `force_delete` - (Optional) If this argument is true, the stack will be deleted during destroy plans even if it contains deployments that have managed resources. You may need to apply this change to the stack before running terraform destroy. Without this argument, all resources managed by stacks deployments need to be destroyed before the stack may be destroyed.-->
+
+The `vcs_repo` block supports:
+
+* `identifier` - (Required) A reference to your VCS repository in the format `<vcs organization>/<repository>` where `<vcs organization>` and `<repository>` refer to the organization and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
+* `branch` - (Optional) The repository branch that Terraform will execute from. This defaults to the repository's default branch (e.g. main).
+* `github_app_installation_id` - (Optional) The installation id of the Github App. This conflicts with `oauth_token_id` and can only be used if `oauth_token_id` is not used.
+* `oauth_token_id` - (Optional) The VCS Connection (OAuth Connection + Token) to use. This ID can be obtained from a `tfe_oauth_client` resource. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.
+
+## Attributes Reference
+
+* `id` - The stack ID.
+* `deployment_names` - A set of names of the deployments in the last configuration fetched for this stack. This attribute will be empty when the resource is created and will remain empty until a configuration is fetched.
+
+## Import
+
+Stacks can be imported by ID, which can be found on the stack's settings tab in the UI
+
+Example:
+
+```shell
+terraform import tfe_stack.test-stack st-9cs9Vf6Z49Zzrk1t
+```

--- a/website/docs/r/stack.html.markdown.md
+++ b/website/docs/r/stack.html.markdown.md
@@ -47,8 +47,8 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the stack.
 * `project_id` - (Required) ID of the project where the stack should be created.
-* `description` - (Optional) Description of the stack
 * `vcs_repo` - (Required) Settings for the stack's VCS repository.
+* `description` - (Optional) Description of the stack
 <!--
 NOTE: This is a proposed schema for allowing force-delete actions on a stack. Force delete is not implemented yet so I've commented it out for now.
 
@@ -64,7 +64,7 @@ The `vcs_repo` block supports:
 ## Attributes Reference
 
 * `id` - The stack ID.
-* `deployment_names` - A set of names of the deployments in the last configuration fetched for this stack. This attribute will be empty when the resource is created and will remain empty until a configuration is fetched.
+* `deployment_names` - The set of deployment names used in the last configuration for this stack. This attribute will be empty when the resource is created and will remain empty until a configuration is fetched.
 
 ## Import
 


### PR DESCRIPTION
## Description

Adds BETA support for Stacks as tfe_stack

See documentation for details.

NOTE: This should not be merged until the linked go-tfe PR is released.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

<details><summary>Details</summary>
<p>

<code>
provider "tfe" {
}

resource "tfe_project" "example" {
  name = "example-project"
  organization = "example-org"
}

resource "tfe_oauth_client" "gh" {
  organization = "example-org"
  name = "gh-example"
  api_url          = "https://api.github.com"
  http_url         = "https://github.com"
  oauth_token      = "ghp_SECRET_TOKEN"
  service_provider = "github"
  organization_scoped = true
}

resource "tfe_stack" "example" {
  name = "example-renamed"
  description = "the worst stack ever"
  project_id = tfe_project.example.id
  
  vcs_repo {
    identifier = "hashicorp-guides/pet-nulls-stack"
    oauth_token_id = tfe_oauth_client.gh.oauth_token_id
    branch = "main"
  }
}

</code>

</p>
</details> 

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe PR](https://github.com/hashicorp/go-tfe/pull/920)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ ENABLE_BETA=1 make testacc TESTARGS='-run TestAccTFEStackResource_basic -v'
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEStackResource_basic -v -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFEStackResource_basic
--- PASS: TestAccTFEStackResource_basic (15.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	16.048s
...
```
