### PR TITLE
Bump date for instances of `skipUnlessAfterDate` related to GH Token Issue

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -213,7 +213,7 @@ func TestConfigureEnvOrganization(t *testing.T) {
 // The TFE Provider tests use these environment variables, which are set in the
 // GitHub Action workflow file .github/workflows/ci.yml.
 func testAccGithubPreCheck(t *testing.T) {
-	skipUnlessAfterDate(t, time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC))
+	skipUnlessAfterDate(t, time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC))
 
 	if envGithubToken == "" {
 		t.Skip("Please set GITHUB_TOKEN to run this test")

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -1072,7 +1072,7 @@ func testAccCheckTFERegistryModuleDestroy(s *terraform.State) error {
 }
 
 func testAccPreCheckTFERegistryModule(t *testing.T) {
-	skipUnlessAfterDate(t, time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC))
+	skipUnlessAfterDate(t, time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC))
 
 	if envGithubToken == "" {
 		t.Skip("Please set GITHUB_TOKEN to run this test")


### PR DESCRIPTION
Removes instances of `skipUnlessAfterDate` related to previously broken github token 