### PR TITLE
Remove resource ID validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ FEATURES:
 * `d/tfe_organization_run_task_global_settings`: Add a datasource to retrieve the global settings of Run tasks, by @glennsarti [#1328](https://github.com/hashicorp/terraform-provider-tfe/pull/1330)
 * `r/tfe_organization_run_task_global_settings`: Add a resource to manage the global settings of Run tasks, by @glennsarti [#1328](https://github.com/hashicorp/terraform-provider-tfe/pull/1330)
 * `r/tfe_notification_configuration`: Add `workspace:auto_destroy_reminder` and `workspace:auto_destroy_run_results` as allowed notification configuration trigger types, by @notchairmk [#1394](https://github.com/hashicorp/terraform-provider-tfe/pull/1394)
+* `r/tfe_workspace_settings`: Remove workspace and agent pool ID validations, by @joekarl [1418](https://github.com/hashicorp/terraform-provider-tfe/pull/1418)
+* `r/tfe_team_project_access`: Remove project ID validation, by @joekarl [1418](https://github.com/hashicorp/terraform-provider-tfe/pull/1418)
 
 DEPRECATIONS and BREAKING CHANGES:
 * `r/_workspace_run_task`: The `stage` attribute has been deprecated in favor of the `stages` attribute, by @glennsarti [#1328](https://github.com/hashicorp/terraform-provider-tfe/pull/1330)

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -5,9 +5,7 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -24,14 +22,6 @@ type frameworkProvider struct{}
 
 // Compile-time interface check
 var _ provider.Provider = &frameworkProvider{}
-
-// Can be used to construct ID regexp patterns
-var base58Alphabet = "[1-9A-HJ-NP-Za-km-z]"
-
-// IDPattern constructs a regexp pattern for HCP Terraform with the given prefix
-func IDPattern(prefix string) *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("^%s-%s{16}$", prefix, base58Alphabet))
-}
 
 // FrameworkProviderConfig is a helper type for extracting the provider
 // configuration from the provider block.

--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -21,8 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var projectIDRegexp = regexp.MustCompile("^prj-[a-zA-Z0-9]{16}$")
-
 func resourceTFEProject() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceTFEProjectCreate,

--- a/internal/provider/resource_tfe_team_project_access.go
+++ b/internal/provider/resource_tfe_team_project_access.go
@@ -59,10 +59,6 @@ func resourceTFETeamProjectAccess() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringMatch(
-					projectIDRegexp,
-					"must be a valid project ID (prj-<RANDOM STRING>)",
-				),
 			},
 
 			"project_access": {

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -202,12 +202,6 @@ func (r *workspaceSettings) Schema(ctx context.Context, req resource.SchemaReque
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						IDPattern("ws"),
-						"must be a valid workspace ID (ws-<RANDOM STRING>)",
-					),
-				},
 			},
 
 			"execution_mode": schema.StringAttribute{
@@ -227,12 +221,6 @@ func (r *workspaceSettings) Schema(ctx context.Context, req resource.SchemaReque
 				PlanModifiers: []planmodifier.String{
 					unknownIfExecutionModeUnset{},
 					validateAgentExecutionMode{},
-				},
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						IDPattern("apool"),
-						"must be a valid workspace ID (apool-<RANDOM STRING>)",
-					),
 				},
 			},
 


### PR DESCRIPTION
## Description

TFC/E is making changes to ID formats and as the API does its own ID validation the validations here were superfluous.
Removing in favor of letting the API return errors.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. There should be no validations on project/workspace/agent pool IDs, arbitrary strings should be accepted

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
