### PR TITLE
Plan to recompute html_url when name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * `r/tfe_stack` initial support for this BETA feature was released in v0.57.0 but the documentation link was broken and it was not mentioned in the release notes. NOTE: This resource is subject to change and has limited support in HCP Terraform.
 * `d/tfe_github_app_installation` the documentation link for this resource was incorrectly named tfe_github_installation
 
+BUG FIXES:
+* `r/tfe_workspace` html_url is now planned to be recomputed when `name` changes. Previously, changed values would show up on the next plan, by @brandonc [1422](https://github.com/hashicorp/terraform-provider-tfe/issues/1422)
+
 ## v0.57.0
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+## Unreleased
+
+BUG FIXES:
+* `r/tfe_workspace` html_url is now planned to be recomputed when `name` changes. Previously, changed values would show up on the next plan, by @brandonc [1422](https://github.com/hashicorp/terraform-provider-tfe/issues/1422)
+
 ## v0.57.1
 
 * `r/tfe_stack` initial support for this BETA feature was released in v0.57.0 but the documentation link was broken and it was not mentioned in the release notes. NOTE: This resource is subject to change and has limited support in HCP Terraform.
 * `d/tfe_github_app_installation` the documentation link for this resource was incorrectly named tfe_github_installation
-
-BUG FIXES:
-* `r/tfe_workspace` html_url is now planned to be recomputed when `name` changes. Previously, changed values would show up on the next plan, by @brandonc [1422](https://github.com/hashicorp/terraform-provider-tfe/issues/1422)
 
 ## v0.57.0
 

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -67,6 +67,12 @@ func resourceTFEWorkspace() *schema.Resource {
 				return err
 			}
 
+			if d.HasChange("name") {
+				if err := d.SetNewComputed("html_url"); err != nil {
+					return err
+				}
+			}
+
 			return nil
 		},
 


### PR DESCRIPTION
## Description

tfe_workspace html_url attribute is not planned to be recomputed when the name changes, causing the attribute to lag behind the name update apply.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Example config:

```
provider "tfe" {}

resource "tfe_workspace" "a_new_workspace" {
  organization = "bcroft"
  name                = "ws-1"
  queue_all_runs      = false
  assessments_enabled = false
}

output "workspace-url" {
  value = tfe_workspace.a_new_workspace.html_url
}
```

To test, change the name of the workspace and re-apply. The output would not be modified until the next apply.

## External links

Closes #1422 

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

BEFORE:
```
$ TESTARGS="-run TestAccTFEWorkspace_HTMLURL" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspace_HTMLURL -timeout 15m
=== RUN   TestAccTFEWorkspace_HTMLURL
    resource_tfe_workspace_test.go:211: Step 2/2 error: Check failed: Check 2/3 error: tfe_workspace.foobar: Attribute 'html_url' expected "https://tfcdev-4483a00f.ngrok.app/app/tst-terraform-5248518972218429698/workspaces/workspace-test", got "https://tfcdev-4483a00f.ngrok.app/app/tst-terraform-5248518972218429698/workspaces/workspace-test-renamed"
--- FAIL: TestAccTFEWorkspace_HTMLURL (7.68s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-tfe/internal/provider	8.286s
FAIL
make: *** [testacc] Error 1
```

AFTER:
```
$ TESTARGS="-run TestAccTFEWorkspace_HTMLURL" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspace_HTMLURL -timeout 15m
=== RUN   TestAccTFEWorkspace_HTMLURL
--- PASS: TestAccTFEWorkspace_HTMLURL (9.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	9.925s
```
