### PR TITLE
d/tfe_project: Output workspace names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 ENHANCEMENTS:
-* `d/tfe_project`: Add `workspace_names` attribute, by @1natedawg [1429]([https://github.com/hashicorp/terraform-provider-tfe/pull/1271](https://github.com/hashicorp/terraform-provider-tfe/pull/1429))
+* `d/tfe_project`: Add `workspace_names` attribute, by @1natedawg [#1429](https://github.com/hashicorp/terraform-provider-tfe/pull/1429)
 
 ## v0.57.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+ENHANCEMENTS:
+* `d/tfe_project`: Add `workspace_names` attribute, by @1natedawg [1429]([https://github.com/hashicorp/terraform-provider-tfe/pull/1271](https://github.com/hashicorp/terraform-provider-tfe/pull/1429))
+
 ## v0.57.1
 
 * `r/tfe_stack` initial support for this BETA feature was released in v0.57.0 but the documentation link was broken and it was not mentioned in the release notes. NOTE: This resource is subject to change and has limited support in HCP Terraform.

--- a/internal/provider/data_source_project.go
+++ b/internal/provider/data_source_project.go
@@ -44,6 +44,13 @@ func dataSourceTFEProject() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"workspace_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -76,7 +83,7 @@ func dataSourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta 
 				ProjectID: proj.ID,
 			}
 			var workspaces []interface{}
-
+			var workspaceNames []interface{}
 			for {
 				wl, err := config.Client.Workspaces.List(ctx, orgName, readOptions)
 				if err != nil {
@@ -85,6 +92,7 @@ func dataSourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta 
 
 				for _, workspace := range wl.Items {
 					workspaces = append(workspaces, workspace.ID)
+					workspaceNames = append(workspaceNames, workspace.Name)
 				}
 
 				// Exit the loop when we've seen all pages.
@@ -97,6 +105,7 @@ func dataSourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta 
 			}
 
 			d.Set("workspace_ids", workspaces)
+			d.Set("workspace_names", workspaceNames)
 			d.Set("description", proj.Description)
 			d.SetId(proj.ID)
 			return nil

--- a/internal/provider/data_source_project_test.go
+++ b/internal/provider/data_source_project_test.go
@@ -32,6 +32,8 @@ func TestAccTFEProjectDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.tfe_project.foobar", "id"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_project.foobar", "workspace_ids.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_project.foobar", "workspace_names.#", "1"),
 				),
 			},
 		},

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -9,6 +9,8 @@ Get information on a Project.
 
 Use this data source to get information about a project.
 
+~> **NOTE:** The `workspace_ids` and `workspace_names` attributes are not guaranteed to return values in the same order, so they cannot be reliably mapped to one another. To map workspace names to IDs reliably, it is recommended to pass those names into the `tfe_workspace_ids` data source.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -31,3 +31,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The project ID.
 * `workspace_ids` - IDs of the workspaces that are associated with the project.
+* `workspace_names` - Names of the workspaces that are associated with the project.


### PR DESCRIPTION
## Description

This PR is to emit the names of all the workspaces within a project. My use case is is follows:
- I have a known project name and want to act on certain workspaces within it (based on a workspace name suffix)
- I can use tfe_project to look up the IDs of all the workspaces in that project
- I don't have a clean way to look up those workspaces by ID to get their names

So, this allows me to capture the workspace names within a project and act on them. If there is a better alternative, let me know!

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Create a project called `foo`
2. Create a `tfe_project` data source with name `foo`, e.g.:
``` 
data "tfe_project" "foo" {
  organization = "my-org"
  name = "foo"
}

output "project" {
  value = data.tfe_project.foo
}
```
3. Run `terraform plan`/`terraform apply`
4. Output should contain a list called `workspace_names` in addition to the attributes that were already there.




## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
TESTARGS="-run TestAccTFEProjectDataSource_caseInsensitive" make testacc                                                   [13:00:03]
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEProjectDataSource_caseInsensitive -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/client     0.838s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/logging    0.749s [no tests to run]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/validators        [no test files]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
=== RUN   TestAccTFEProjectDataSource_caseInsensitive
--- PASS: TestAccTFEProjectDataSource_caseInsensitive (5.01s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   5.817s

...
```
