### PR TITLE
Remove 'secret' default from `tfe_team` because it requires explicit or owner access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+## BREAKING CHANGES
+
+* `r/tfe_team`: Default "secret" visibility has been removed from tfe_team because it now requires explicit or owner access. The default, "organization", is now computed by the platform. by @brandonc [#1439](https://github.com/hashicorp/terraform-provider-tfe/pull/1439)
+
 ## v0.58.0
 
 ENHANCEMENTS:

--- a/internal/provider/resource_tfe_team.go
+++ b/internal/provider/resource_tfe_team.go
@@ -131,7 +131,7 @@ func resourceTFETeam() *schema.Resource {
 			"visibility": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "secret",
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"secret",
 					"organization",

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the team.
 * `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
-* `visibility` - (Optional) The visibility of the team ("secret" or "organization"). Defaults to "secret".
+* `visibility` - (Optional) The visibility of the team ("secret" or "organization")
 * `organization_access` - (Optional) Settings for the team's [organization access](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/permissions#organization-permissions).
 * `sso_team_id` - (Optional) Unique Identifier to control [team membership](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) via SAML. Defaults to `null`
 * `allow_member_token_management` - (Optional) Used by Owners and users with "Manage Teams" permissions to control whether team members can manage team tokens. Defaults to `true`.


### PR DESCRIPTION
## Description

Interacting with secret teams was recently changed to require explicit access or owner access. This default, when used in conjunction with an unprivileged token, conflicts with the computed default. In that scenario, the default would continuously conflict with the platform on each plan.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Ensure you cannot interact with secret teams (no owner token, no explicit access to secret teams)
2. Apply this config
3. Without this change, each subsequent plan shows an update that is never applied

```
resource "tfe_team" "admin" {
  name        = "TF-project-admins"
}
```

