### PR TITLE
Update registry_module.html.markdown

### DIFF
--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -166,7 +166,7 @@ The `vcs_repo` block supports:
   string.
 * `identifier` - (Required) A reference to your VCS repository in the format
   `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Data Center)
-  and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
+  and repository in your VCS provider. Expects the same pattern of `terraform-PROVIDER-NAME` for publishing modules to the public registry. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
 * `oauth_token_id` - (Optional) Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.
 * `github_app_installation_id` - (Optional) The installation id of the Github App. This conflicts with `oauth_token_id` and can only be used if `oauth_token_id` is not used.
 * `branch` - (Optional) The git branch used for publishing when using branch-based publishing for the registry module. When a `branch` is set, `tags` will be returned as `false`.


### PR DESCRIPTION
Add in sentence about expected naming pattern for `vcs{}` block in generic VCS repos.

## Description

After attempting to use the `tfe` provider to populate an HCP terraform PMR with some VCS backed modules I noticed that the naming convention of the VCS backed repo has to follow the `terraform-PROVIDER-NAME` pattern for modules in the public registry. 

This is not documented in the provider documentation. Adding it to help others avoid the frustration I experienced.

For example the following code will not work:

```
resource "tfe_registry_module" "key_pair" {
  organization    = var.organization
  name            = "key-pair"
  vcs_repo {
    display_identifier = "root/key-pair"
    identifier         = "root/key-pair"
    oauth_token_id     = tfe_oauth_client.gitlab.oauth_token_id
  }
}
```

The `display_identifier` and `identifier` attributes need to follow the public module registry naming convention as shown below.

This is the expected naming convention that will allow the VCS connection to work:
```
resource "tfe_registry_module" "key_pair" {
  organization    = var.organization
  name            = "key-pair"
  vcs_repo {
    display_identifier = "root/terraform-aws-key-pair"
    identifier         = "root/terraform-aws-key-pair"
    oauth_token_id     = tfe_oauth_client.gitlab.oauth_token_id
    branch             = "main"
  }
}
```