### PR TITLE
Use the stages attribute for the Workspace Run Task resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * `r/tfe_team`: Default "secret" visibility has been removed from tfe_team because it now requires explicit or owner access. The default, "organization", is now computed by the platform. by @brandonc [#1439](https://github.com/hashicorp/terraform-provider-tfe/pull/1439)
 
+BUG FIXES:
+* `r/tfe_workspace_run_task`: The Workspace Run Task resource will use the stages attribute by @glennsarti [#1459](https://github.com/hashicorp/terraform-provider-tfe/pull/1459)
+
 ## v0.58.0
 
 ENHANCEMENTS:

--- a/internal/provider/client_capabilites.go
+++ b/internal/provider/client_capabilites.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+type capabilitiesResolver interface {
+	IsCloud() bool
+	RemoteTFEVersion() string
+}
+
+func newDefaultCapabilityResolver(client *tfe.Client) capabilitiesResolver {
+	return &defaultCapabilityResolver{
+		client: client,
+	}
+}
+
+type defaultCapabilityResolver struct {
+	client *tfe.Client
+}
+
+func (r *defaultCapabilityResolver) IsCloud() bool {
+	return r.client.IsCloud()
+}
+
+func (r *defaultCapabilityResolver) RemoteTFEVersion() string {
+	return r.client.RemoteTFEVersion()
+}

--- a/internal/provider/client_capabilites_test.go
+++ b/internal/provider/client_capabilites_test.go
@@ -1,0 +1,25 @@
+package provider
+
+var _ capabilitiesResolver = &staticCapabilityResolver{}
+
+// A mock capability resolver used for testing to set specific capabilities
+type staticCapabilityResolver struct {
+	isCloud bool
+	tfeVer  string
+}
+
+func (r *staticCapabilityResolver) IsCloud() bool {
+	return r.isCloud
+}
+
+func (r *staticCapabilityResolver) RemoteTFEVersion() string {
+	return r.tfeVer
+}
+
+func (r *staticCapabilityResolver) SetIsCloud(val bool) {
+	r.isCloud = val
+}
+
+func (r *staticCapabilityResolver) SetRemoteTFEVersion(val string) {
+	r.tfeVer = val
+}

--- a/internal/provider/resource_tfe_workspace_run_task.go
+++ b/internal/provider/resource_tfe_workspace_run_task.go
@@ -51,8 +51,9 @@ func sentenceList(items []string, prefix string, suffix string, conjunction stri
 }
 
 type resourceWorkspaceRunTask struct {
-	config       ConfiguredClient
-	capabilities capabilitiesResolver
+	config         ConfiguredClient
+	capabilities   capabilitiesResolver
+	supportsStages *bool
 }
 
 var _ resource.Resource = &resourceWorkspaceRunTask{}
@@ -326,7 +327,11 @@ func (r *resourceWorkspaceRunTask) supportsStagesProperty() bool {
 	//
 	// The version comparison here can use plain string comparisons due to the nature of the naming scheme. If
 	// TFE every changes its scheme, the comparison will be problematic.
-	return r.capabilities.IsCloud() || r.capabilities.RemoteTFEVersion() > "v202404"
+	if r.supportsStages == nil {
+		value := r.capabilities.IsCloud() || r.capabilities.RemoteTFEVersion() > "v202404"
+		r.supportsStages = &value
+	}
+	return *r.supportsStages
 }
 
 func (r *resourceWorkspaceRunTask) addStageSupportDiag(d *diag.Diagnostics, isError bool) {

--- a/internal/provider/resource_tfe_workspace_run_task.go
+++ b/internal/provider/resource_tfe_workspace_run_task.go
@@ -170,7 +170,7 @@ func (r *resourceWorkspaceRunTask) Create(ctx context.Context, req resource.Crea
 		options.Stage = stage //nolint:staticcheck
 	}
 	if stages != nil {
-		options.Stages = stages
+		options.Stages = &stages
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Create task %s in workspace: %s", taskID, workspaceID))
@@ -218,7 +218,7 @@ func (r *resourceWorkspaceRunTask) Update(ctx context.Context, req resource.Upda
 		options.Stage = stage //nolint:staticcheck
 	}
 	if stages != nil {
-		options.Stages = stages
+		options.Stages = &stages
 	}
 
 	wstaskID := plan.ID.ValueString()
@@ -344,7 +344,7 @@ func (r *resourceWorkspaceRunTask) addStageSupportDiag(d *diag.Diagnostics, isEr
 	}
 }
 
-func (r *resourceWorkspaceRunTask) extractStageAndStages(plan modelTFEWorkspaceRunTaskV1, d *diag.Diagnostics) (*tfe.Stage, *[]tfe.Stage) {
+func (r *resourceWorkspaceRunTask) extractStageAndStages(plan modelTFEWorkspaceRunTaskV1, d *diag.Diagnostics) (*tfe.Stage, []tfe.Stage) {
 	// There are some complex interactions here between deprecated values in the TF model, and whether the backend server even supports the newer
 	// API call style. This function attempts to extract the Stage and Stages properties and emit useful diagnostics
 
@@ -358,7 +358,7 @@ func (r *resourceWorkspaceRunTask) extractStageAndStages(plan modelTFEWorkspaceR
 			// The user has supplied Stage but not Stages. They would already have received the deprecation warning so just munge
 			// the stage into a slice and we're fine
 			stages := []tfe.Stage{tfe.Stage(plan.Stage.ValueString())}
-			return nil, &stages
+			return nil, stages
 		}
 
 		// Convert the plan values into the slice we need
@@ -371,7 +371,7 @@ func (r *resourceWorkspaceRunTask) extractStageAndStages(plan modelTFEWorkspaceR
 		for idx, s := range stageStrings {
 			stages[idx] = tfe.Stage(s.ValueString())
 		}
-		return nil, &stages
+		return nil, stages
 	}
 
 	// The backend server doesn't support Stages

--- a/internal/provider/resource_tfe_workspace_run_task_schemas.go
+++ b/internal/provider/resource_tfe_workspace_run_task_schemas.go
@@ -134,7 +134,6 @@ var resourceWorkspaceRunTaskSchemaV1 = schema.Schema{
 			)),
 			Optional: true,
 			Computed: true,
-			Default:  stringdefault.StaticString(string(tfe.PostPlan)),
 			Validators: []validator.String{
 				stringvalidator.OneOf(workspaceRunTaskStages()...),
 			},

--- a/internal/provider/resource_tfe_workspace_run_task_test.go
+++ b/internal/provider/resource_tfe_workspace_run_task_test.go
@@ -14,13 +14,6 @@ import (
 )
 
 func TestTFEWorkspaceRunTask_stagesSupport(t *testing.T) {
-	resolver := &staticCapabilityResolver{}
-
-	subject := resourceWorkspaceRunTask{
-		config:       ConfiguredClient{Organization: "Mock", Client: &tfe.Client{}},
-		capabilities: resolver,
-	}
-
 	testCases := map[string]struct {
 		isCloud      bool
 		tfeVer       string
@@ -36,8 +29,14 @@ func TestTFEWorkspaceRunTask_stagesSupport(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
+			resolver := &staticCapabilityResolver{}
 			resolver.SetIsCloud(testCase.isCloud)
 			resolver.SetRemoteTFEVersion(testCase.tfeVer)
+
+			subject := resourceWorkspaceRunTask{
+				config:       ConfiguredClient{Organization: "Mock", Client: &tfe.Client{}},
+				capabilities: resolver,
+			}
 
 			actual := subject.supportsStagesProperty()
 			if actual != testCase.expectResult {


### PR DESCRIPTION
Fixes #1456

## Description

Previously the schema for workspace run tasks was updated for the new stages
property however it wasn't actually used. This commit updates the Workspace
Run Task resource to aware of the stages attributes. In particular;

* Attempts to detect if the remote service supports the stages property. Stages
is available in HCP Terraform and TFE v202404-1 onwards.

* Munges the Stages and Stage attribtue depending on the remote capability.

* Emits a warning about the remove server capability.

* Adds some automated tests. Unfortunately we can't test older TFE versions,
to ensure the munging is correct, however manual testing was performed in
a local development enivronment to confirm the behaviour.

* Removes the default value for the Stage property in the Schema. This will
not cause issues with existing state and allows the provider to determine
if the attribute was passed in via configuration as opposed to defaulting.

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Apart from CI

1. Use a version of TFE
1. Apply configuration which uses the `stages` property with multiple values

## External links

- [API documentation](https://github.com/hashicorp/terraform-provider-tfe/pull/1330)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/1330)

## Output from acceptance tests

Tests can be run in CI
