### PR TITLE
chore: use run tasks url for notification configuration acc tests

### DIFF
--- a/internal/provider/resource_tfe_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_notification_configuration_test.go
@@ -21,7 +21,7 @@ func TestAccTFENotificationConfiguration_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -40,7 +40,7 @@ func TestAccTFENotificationConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_notification_configuration.foobar", "triggers.#", "0"),
 					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
+						"tfe_notification_configuration.foobar", "url", runTasksURL()),
 				),
 			},
 		},
@@ -52,7 +52,7 @@ func TestAccTFENotificationConfiguration_emailUserIDs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -83,7 +83,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -102,7 +102,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_notification_configuration.foobar", "triggers.#", "0"),
 					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
+						"tfe_notification_configuration.foobar", "url", runTasksURL()),
 				),
 			},
 			{
@@ -124,7 +124,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_notification_configuration.foobar", "triggers.#", "2"),
 					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com/?update=true"),
+						"tfe_notification_configuration.foobar", "url", fmt.Sprintf("%s/?update=true", runTasksURL())),
 				),
 			},
 		},
@@ -136,7 +136,7 @@ func TestAccTFENotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -186,7 +186,7 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesEmail(t *testin
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { preCheckTFENotificationConfiguration(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -205,7 +205,7 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesGeneric(t *test
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { preCheckTFENotificationConfiguration(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -228,7 +228,7 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesSlack(t *testin
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { preCheckTFENotificationConfiguration(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -255,7 +255,7 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesMicrosoftTeams(
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { preCheckTFENotificationConfiguration(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -283,7 +283,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail(t *
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -322,7 +322,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -341,7 +341,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t
 					resource.TestCheckResourceAttr(
 						"tfe_notification_configuration.foobar", "triggers.#", "0"),
 					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
+						"tfe_notification_configuration.foobar", "url", runTasksURL()),
 				),
 			},
 			{
@@ -365,7 +365,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -384,7 +384,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *
 					resource.TestCheckResourceAttr(
 						"tfe_notification_configuration.foobar", "triggers.#", "0"),
 					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
+						"tfe_notification_configuration.foobar", "url", runTasksURL()),
 				),
 			},
 			{
@@ -412,7 +412,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesMicrosoft
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -427,7 +427,7 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesMicrosoft
 					resource.TestCheckResourceAttr(
 						"tfe_notification_configuration.foobar", "name", "notification_msteams"),
 					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
+						"tfe_notification_configuration.foobar", "url", runTasksURL()),
 				),
 			},
 			{
@@ -455,7 +455,7 @@ func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -474,7 +474,7 @@ func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_notification_configuration.foobar", "triggers.#", "1"),
 					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", "http://example.com"),
+						"tfe_notification_configuration.foobar", "url", runTasksURL()),
 				),
 			},
 		},
@@ -485,7 +485,7 @@ func TestAccTFENotificationConfigurationImport_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -507,7 +507,7 @@ func TestAccTFENotificationConfigurationImport_emailUserIDs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -529,7 +529,7 @@ func TestAccTFENotificationConfigurationImport_emptyEmailUserIDs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -591,7 +591,7 @@ func testAccCheckTFENotificationConfigurationAttributes(notificationConfiguratio
 			return fmt.Errorf("Bad triggers: %v", notificationConfiguration.Triggers)
 		}
 
-		if notificationConfiguration.URL != "http://example.com" {
+		if notificationConfiguration.URL != runTasksURL() {
 			return fmt.Errorf("Bad URL: %s", notificationConfiguration.URL)
 		}
 
@@ -619,7 +619,7 @@ func testAccCheckTFENotificationConfigurationAttributesUpdate(notificationConfig
 			return fmt.Errorf("Bad triggers: %v", notificationConfiguration.Triggers)
 		}
 
-		if notificationConfiguration.URL != "http://example.com/?update=true" {
+		if notificationConfiguration.URL != fmt.Sprintf("%s/?update=true", runTasksURL()) {
 			return fmt.Errorf("Bad URL: %s", notificationConfiguration.URL)
 		}
 
@@ -725,7 +725,7 @@ func testAccCheckTFENotificationConfigurationAttributesMicrosoftTeams(notificati
 			return fmt.Errorf("Bad triggers: %v", notificationConfiguration.Triggers)
 		}
 
-		if notificationConfiguration.URL != "http://example.com" {
+		if notificationConfiguration.URL != runTasksURL() {
 			return fmt.Errorf("Bad URL: %s", notificationConfiguration.URL)
 		}
 
@@ -753,7 +753,7 @@ func testAccCheckTFENotificationConfigurationAttributesDuplicateTriggers(notific
 			return fmt.Errorf("Bad triggers: %v", notificationConfiguration.Triggers)
 		}
 
-		if notificationConfiguration.URL != "http://example.com" {
+		if notificationConfiguration.URL != runTasksURL() {
 			return fmt.Errorf("Bad URL: %s", notificationConfiguration.URL)
 		}
 
@@ -797,9 +797,9 @@ resource "tfe_workspace" "foobar" {
 resource "tfe_notification_configuration" "foobar" {
   name             = "notification_basic"
   destination_type = "generic"
-  url              = "http://example.com"
+  url              = "%s"
   workspace_id     = tfe_workspace.foobar.id
-}`, rInt)
+}`, rInt, runTasksURL())
 }
 
 func testAccTFENotificationConfiguration_emailUserIDs(rInt int) string {
@@ -841,9 +841,9 @@ resource "tfe_workspace" "foobar" {
 resource "tfe_notification_configuration" "foobar" {
   name             = "notification_slack"
   destination_type = "slack"
-  url              = "http://example.com"
+  url              = "%s"
   workspace_id     = tfe_workspace.foobar.id
-}`, rInt)
+}`, rInt, runTasksURL())
 }
 
 func testAccTFENotificationConfiguration_microsoftTeams(rInt int) string {
@@ -861,9 +861,9 @@ resource "tfe_workspace" "foobar" {
 resource "tfe_notification_configuration" "foobar" {
   name             = "notification_msteams"
   destination_type = "microsoft-teams"
-  url              = "http://example.com"
+  url              = "%s"
   workspace_id     = tfe_workspace.foobar.id
-}`, rInt)
+}`, rInt, runTasksURL())
 }
 
 func testAccTFENotificationConfiguration_update(rInt int) string {
@@ -884,9 +884,9 @@ resource "tfe_notification_configuration" "foobar" {
   enabled          = true
   token            = "1234567890_update"
   triggers         = ["run:created", "run:needs_attention"]
-  url              = "http://example.com/?update=true"
+  url              = "%s/?update=true"
   workspace_id     = tfe_workspace.foobar.id
-}`, rInt)
+}`, rInt, runTasksURL())
 }
 
 func testAccTFENotificationConfiguration_updateEmailUserIDs(rInt int) string {
@@ -930,9 +930,9 @@ resource "tfe_workspace" "foobar" {
 resource "tfe_notification_configuration" "foobar" {
   name             = "notification_email_with_url"
   destination_type = "email"
-  url              = "http://example.com"
+  url              = "%s"
   workspace_id     = tfe_workspace.foobar.id
-}`, rInt)
+}`, rInt, runTasksURL())
 }
 
 func testAccTFENotificationConfiguration_emailWithToken(rInt int) string {
@@ -1080,9 +1080,9 @@ resource "tfe_notification_configuration" "foobar" {
   name             = "notification_slack_with_token"
   destination_type = "slack"
   token            = "1234567890"
-  url              = "http://example.com"
+  url              = "%s"
   workspace_id     = tfe_workspace.foobar.id
-}`, rInt)
+}`, rInt, runTasksURL())
 }
 
 func testAccTFENotificationConfiguration_slackWithoutURL(rInt int) string {
@@ -1165,9 +1165,9 @@ resource "tfe_notification_configuration" "foobar" {
   name             = "notification_msteams_with_token"
   destination_type = "microsoft-teams"
   token            = "1234567890"
-  url              = "http://example.com"
+  url              = "%s"
   workspace_id     = tfe_workspace.foobar.id
-}`, rInt)
+}`, rInt, runTasksURL())
 }
 
 func testAccTFENotificationConfiguration_microsoftTeamsWithoutURL(rInt int) string {
@@ -1205,7 +1205,15 @@ resource "tfe_notification_configuration" "foobar" {
   name             = "notification_duplicate_triggers"
   destination_type = "generic"
   triggers         = ["run:created", "run:created", "run:created"]
-  url              = "http://example.com"
+  url              = "%s"
   workspace_id     = tfe_workspace.foobar.id
-}`, rInt)
+}`, rInt, runTasksURL())
+}
+
+func preCheckTFENotificationConfiguration(t *testing.T) {
+	testAccPreCheck(t)
+
+	if runTasksURL() == "" {
+		t.Skip("RUN_TASKS_URL must be set for notification configuration acceptance tests")
+	}
 }


### PR DESCRIPTION

## Description

This PR fixes acceptance tests for notification configurations by using a valid run tasks URL in place of `example.com` while testing.

## External links
- [JIRA](https://hashicorp.atlassian.net/browse/TF-20376)
