### PR TITLE
Standardize use of testing-mocks.tfe for `run_tasks_url` between CI and Nightly tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
           matrix_index: ${{ matrix.index }}
           matrix_total: ${{ matrix.total }}
           hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
-          run_tasks_url: 'https://httpstat.us/200'
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
           admin_configuration_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.configuration }}

--- a/internal/provider/resource_tfe_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_notification_configuration_test.go
@@ -124,7 +124,7 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_notification_configuration.foobar", "triggers.#", "2"),
 					resource.TestCheckResourceAttr(
-						"tfe_notification_configuration.foobar", "url", fmt.Sprintf("%s/?update=true", runTasksURL())),
+						"tfe_notification_configuration.foobar", "url", fmt.Sprintf("%s?update=true", runTasksURL())),
 				),
 			},
 		},
@@ -484,6 +484,8 @@ func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 func TestAccTFENotificationConfigurationImport_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
+	fmt.Printf("Config for testAccTFENotificationConfigurationImport_basic:\n %s\n", testAccTFENotificationConfiguration_basic(rInt))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
 		Providers:    testAccProviders,
@@ -619,7 +621,7 @@ func testAccCheckTFENotificationConfigurationAttributesUpdate(notificationConfig
 			return fmt.Errorf("Bad triggers: %v", notificationConfiguration.Triggers)
 		}
 
-		if notificationConfiguration.URL != fmt.Sprintf("%s/?update=true", runTasksURL()) {
+		if notificationConfiguration.URL != fmt.Sprintf("%s?update=true", runTasksURL()) {
 			return fmt.Errorf("Bad URL: %s", notificationConfiguration.URL)
 		}
 
@@ -884,7 +886,7 @@ resource "tfe_notification_configuration" "foobar" {
   enabled          = true
   token            = "1234567890_update"
   triggers         = ["run:created", "run:needs_attention"]
-  url              = "%s/?update=true"
+  url              = "%s?update=true"
   workspace_id     = tfe_workspace.foobar.id
 }`, rInt, runTasksURL())
 }


### PR DESCRIPTION
## Description

Follow-up work to [this PR](https://github.com/hashicorp/terraform-provider-tfe/pull/1467) that migrated away from using `example.com` for the testing run task url.

Standardized use of `http://testing-mocks.tfe:22180/runtasks/pass` between CI and Nightly tests, as well as fixes for the failing tests that popped up from using this new URL. Turns out we were just incorrectly formatting certain query params.

## Testing plan

Fixed failing tests
