### PR TITLE
Do not error when reading workspace tasks when that no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+BUG FIXES:
+* `r/tfe_workspace_run_task`: Do not error when reading workspace tasks that no longer exist by @glennsarti [#1500](https://github.com/hashicorp/terraform-provider-tfe/pull/1459)
+* `r/tfe_organization_run_task`: Do not error when reading organization tasks that no longer exist by @glennsarti [#1500](https://github.com/hashicorp/terraform-provider-tfe/pull/1459)
+* `r/tfe_organization_run_task_global_settings`: Do not error when reading organization task global settings that no longer exist by @glennsarti [#1500](https://github.com/hashicorp/terraform-provider-tfe/pull/1459)
+
+## v0.59.0
+
 ## BREAKING CHANGES
 
 * `r/tfe_team`: Default "secret" visibility has been removed from tfe_team because it now requires explicit or owner access. The default, "organization", is now computed by the platform. by @brandonc [#1439](https://github.com/hashicorp/terraform-provider-tfe/pull/1439)

--- a/internal/provider/resource_tfe_organization_run_task.go
+++ b/internal/provider/resource_tfe_organization_run_task.go
@@ -160,7 +160,11 @@ func (r *resourceOrgRunTask) Read(ctx context.Context, req resource.ReadRequest,
 	tflog.Debug(ctx, "Reading organization run task")
 	task, err := r.config.Client.RunTasks.Read(ctx, taskID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading Organization Run Task", "Could not read Organization Run Task, unexpected error: "+err.Error())
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError("Error reading Organization Run Task", "Could not read Organization Run Task, unexpected error: "+err.Error())
+		}
 		return
 	}
 

--- a/internal/provider/resource_tfe_workspace_run_task.go
+++ b/internal/provider/resource_tfe_workspace_run_task.go
@@ -122,7 +122,11 @@ func (r *resourceWorkspaceRunTask) Read(ctx context.Context, req resource.ReadRe
 	tflog.Debug(ctx, "Reading workspace run task")
 	wstask, err := r.config.Client.WorkspaceRunTasks.Read(ctx, workspaceID, wstaskID)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading Workspace Run Task", "Could not read Workspace Run Task, unexpected error: "+err.Error())
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError("Error reading Workspace Run Task", "Could not read Workspace Run Task, unexpected error: "+err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
## Description

Previously if Workspace Run Tasks, Organiaztion Run Tasks or global settings
were managed by TF and deleted server-side, the TF apply/plan  would error.

However this stopped resources being removed or ignored.
This commit modifies the Read methods to remove the previous resource state
when the object no longer exists (a 404 response). The Read methods still
raise if another error type is received (e.g. 500 or Network error).

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_


## Testing plan

Handled by acceptance tests

## External links

Fixes issue #1497

