### PR TITLE
Add data dictionary

### DIFF
--- a/META.d/data.yaml
+++ b/META.d/data.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data_summary:
+  gdpr:
+    exempt: true
+    last_reviewed: 2024-11-04


### PR DESCRIPTION
## Description

Adds a data dictionary noting that this repo/service is exempt from GDPR reporting (as it doesn't persist personally identifiable info). While the repo does provide the ability to update user emails (which is personal info) it doesn't persist this info itself, therefore it is GDPR exempt.

For reference, here are similar files from across the Hashicorp org: https://github.com/search?q=org%3Ahashicorp+meta.d%2Fdata.yaml&type=code&p=1

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-21754?atlOrigin=eyJpIjoiOTA1NDcxYzg2NmI3NGI0YTkyNWM1NDY4OWQ1ZjUyODciLCJwIjoiaiJ9)

