### PR TITLE
Update enforcement mode for OPA policy resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+BUG FIXES:
+* `r/tfe_policy`: enforcement level can be updated on OPA policies by @glennsarti [#1521](https://github.com/hashicorp/terraform-provider-tfe/pull/1521)
+
 ## v0.60.0
 
 BUG FIXES:

--- a/internal/provider/resource_tfe_policy_test.go
+++ b/internal/provider/resource_tfe_policy_test.go
@@ -319,6 +319,27 @@ func TestAccTFEPolicyOPA_update(t *testing.T) {
 						"tfe_policy.foobar", "enforce_mode", "advisory"),
 				),
 			},
+			// And check that we can back to what we had before
+			{
+				Config: testAccTFEPolicyOPA_updateQuery(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicyExists(
+						"tfe_policy.foobar", policy),
+					testAccCheckTFEOPAPolicyAttributesUpdatedQuery(policy),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "kind", "opa"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "policy", "package example rule[\"not allowed\"] { false }"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "query", "data.example.ruler"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy.foobar", "enforce_mode", "mandatory"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Description

Fixes #1407

Previously the tfe_policy resource could only set policies to advisory. This commit updates the update function to properly switch path for the policy enforcement name based on the kind. This was due to the previous comparison not comparing the same types so it always failed.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_

## Testing plan

Handled by additional acceptance test

## Output from acceptance tests

