### PR TITLE
Add support for project-owned variable sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 FEATURES:
-* `r/tfe_variable_set`: Add `parent_project_id` attribute, which is a beta feature and is not available to all users, by @mkam [#1522](https://github.com/hashicorp/terraform-provider-tfe/pull/1522)
+* `r/tfe_variable_set`: Add `parent_project_id` attribute, by @mkam [#1522](https://github.com/hashicorp/terraform-provider-tfe/pull/1522)
 
 ## v0.61.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+FEATURES:
+* `r/tfe_variable_set`: Add `parent_project_id` attribute, which is a beta feature and is not available to all users, by @mkam [#1522](https://github.com/hashicorp/terraform-provider-tfe/pull/1522)
+
 ## v0.61.0
 
 DEPRECATIONS:

--- a/internal/provider/data_source_variable_set.go
+++ b/internal/provider/data_source_variable_set.go
@@ -65,6 +65,12 @@ func dataSourceTFEVariableSet() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"parent_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -99,6 +105,10 @@ func dataSourceTFEVariableSetRead(d *schema.ResourceData, meta interface{}) erro
 				d.Set("description", vs.Description)
 				d.Set("global", vs.Global)
 				d.Set("priority", vs.Priority)
+
+				if vs.Parent != nil && vs.Parent.Project != nil {
+					d.Set("parent_project_id", vs.Parent.Project.ID)
+				}
 
 				// Only now include vars and workspaces to cut down on request load.
 				readOptions := tfe.VariableSetReadOptions{

--- a/website/docs/d/variable_set.html.markdown
+++ b/website/docs/d/variable_set.html.markdown
@@ -38,4 +38,4 @@ The following arguments are supported:
 * `workspace_ids` - IDs of the workspaces that use the variable set.
 * `variable_ids` - IDs of the variables attached to the variable set.
 * `project_ids` - IDs of the projects that use the variable set.
-* `parent_project_id` - ID of the project that owns the variable set. This feature is currently in beta and is not available to all users.
+* `parent_project_id` - ID of the project that owns the variable set.

--- a/website/docs/d/variable_set.html.markdown
+++ b/website/docs/d/variable_set.html.markdown
@@ -38,3 +38,4 @@ The following arguments are supported:
 * `workspace_ids` - IDs of the workspaces that use the variable set.
 * `variable_ids` - IDs of the variables attached to the variable set.
 * `project_ids` - IDs of the projects that use the variable set.
+* `parent_project_id` - ID of the project that owns the variable set. This feature is currently in beta and is not available to all users.

--- a/website/docs/r/project_variable_set.html.markdown
+++ b/website/docs/r/project_variable_set.html.markdown
@@ -7,7 +7,11 @@ description: |-
 
 # tfe_project_variable_set
 
-Adds and removes variable sets from a project
+Adds and removes a project from a variable set's scope.
+
+-> **Note:** This resource controls whether a project has access to a variable set, not whether
+a project owns the variable set. Ownership is specified by setting the `parent_project_id` on the
+`tfe_variable_set` resource.
 
 ## Example Usage
 

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -139,6 +139,7 @@ The following arguments are supported:
   Must not be set if `global` is set. This argument is mutually exclusive with using the resource
   [tfe_workspace_variable_set](workspace_variable_set.html) which is the preferred method of associating a workspace
   with a variable set.
+* `parent_project_id` - (Optional) ID of the project that should own the variable set. If set, than the value of `global` must be `false`. This feature is currently in beta and is not available to all users.
 
 ## Attributes Reference
 

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -139,7 +139,7 @@ The following arguments are supported:
   Must not be set if `global` is set. This argument is mutually exclusive with using the resource
   [tfe_workspace_variable_set](workspace_variable_set.html) which is the preferred method of associating a workspace
   with a variable set.
-* `parent_project_id` - (Optional) ID of the project that should own the variable set. If set, than the value of `global` must be `false`. This feature is currently in beta and is not available to all users.
+* `parent_project_id` - (Optional) ID of the project that should own the variable set. If set, than the value of `global` must be `false`.
 
 ## Attributes Reference
 

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -126,6 +126,64 @@ resource "tfe_variable" "test-b" {
 }
 ```
 
+Creating a project-owned variable set that is applied to all workspaces in the project:
+
+```hcl
+resource "tfe_organization" "test" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_project" "test" {
+  organization = tfe_organization.test.name
+  name = "projectname"
+}
+
+resource "tfe_variable_set" "test" {
+  name              = "Project-owned Varset"
+  description       = "Varset that is owned and managed by a project."
+  organization      = tfe_organization.test.name
+  parent_project_id = tfe_project.test.id
+}
+
+resource "tfe_project_variable_set" "test" {
+  project_id      = tfe_project.test.id
+  variable_set_id = tfe_variable_set.test.id
+}
+```
+
+Creating a project-owned variable set that is applied to specific workspaces:
+
+```hcl
+resource "tfe_organization" "test" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_project" "test" {
+  organization = tfe_organization.test.name
+  name = "projectname"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "my-workspace-name"
+  organization = tfe_organization.test.name
+  project_id   = tfe_project.test.id 
+}
+
+resource "tfe_variable_set" "test" {
+  name              = "Project-owned Varset"
+  description       = "Varset that is owned and managed by a project."
+  organization      = tfe_organization.test.name
+  parent_project_id = tfe_project.test.id
+}
+
+resource "tfe_workspace_variable_set" "test" {
+  workspace_id    = tfe_workspace.test.id
+  variable_set_id = tfe_variable_set.test.id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -140,6 +198,7 @@ The following arguments are supported:
   [tfe_workspace_variable_set](workspace_variable_set.html) which is the preferred method of associating a workspace
   with a variable set.
 * `parent_project_id` - (Optional) ID of the project that should own the variable set. If set, than the value of `global` must be `false`.
+  To assign whether a variable set should be applied to a project, use the [`tfe_project_variable_set`](project_variable_set.html) resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/workspace_variable_set.html.markdown
+++ b/website/docs/r/workspace_variable_set.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # tfe_workspace_variable_set
 
-Adds and removes variable sets from a workspace
+Adds and removes a workspace from a variable set's scope.
 
 -> **Note:** `tfe_variable_set` has a deprecated argument `workspace_ids` that should not be used alongside this resource. They attempt to manage the same attachments and are mutually exclusive.
 


### PR DESCRIPTION
## Description
This PR adds `parent_project_id` to the variable sets resource and data source, which specifies the ID of the project that should own the varset. Project-owned varsets cannot also be global varsets, and if the varset is updated to have a different parent project, then the varset under the old project should be deleted and then recreated under the new project.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Create a project-owned varset and an org-owned varset.
1. Validate that the project-owned varset has the expected project ID set and the org-owned does not.
1. Get the project-owned varset as a data source and output it.
1. Validate that the outputted data source has the expected project ID set.

```
resource "tfe_project" "test_project" {
  name         = "ProjectOwnedVarSetProviderProject"
  organization = data.tfe_organization.test.name
}

resource "tfe_variable_set" "org_owned" {
  name         = "org-owned-owned-varset"
  organization = data.tfe_organization.test.name
}

resource "tfe_variable_set" "project_owned" {
  name              = "project-owned-owned-varset"
  organization      = data.tfe_organization.test.name
  parent_project_id = tfe_project.test_project.id
}

data "tfe_variable_set" "project_owned_data_source" {
  organization = data.tfe_organization.test.name
  name         = tfe_variable_set.project_owned.name
}

output "project_owned_data_source" {
  value = data.tfe_variable_set.project_owned_data_source
}
```
</details>

<details><summary> Creating a project-owned varset</summary>

```
-> % terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/tfe in /Users/mkam/hashicorp/terraform-provider-tfe
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.tfe_organization.test: Reading...
data.tfe_organization.unified: Reading...
data.tfe_organization.test: Read complete after 1s [id=org-uXyx3dqZekFuhw4B]
data.tfe_project.default_project: Reading...
data.tfe_organization.unified: Read complete after 1s [id=55d75d5b-277a-44e0-b937-754c0520dc83]
data.tfe_project.default_project: Read complete after 0s [id=prj-gKmEBeazgefwjaBE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.tfe_variable_set.project_owned_data_source will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "tfe_variable_set" "project_owned_data_source" {
      + description       = (known after apply)
      + global            = (known after apply)
      + id                = (known after apply)
      + name              = "project-owned-owned-varset"
      + organization      = "hashicorp"
      + parent_project_id = (known after apply)
      + priority          = (known after apply)
      + project_ids       = (known after apply)
      + variable_ids      = (known after apply)
      + workspace_ids     = (known after apply)
    }

  # tfe_project.test_project will be created
  + resource "tfe_project" "test_project" {
      + id           = (known after apply)
      + name         = "ProjectOwnedVarSetProviderProject"
      + organization = "hashicorp"
    }

  # tfe_variable_set.org_owned will be created
  + resource "tfe_variable_set" "org_owned" {
      + global            = false
      + id                = (known after apply)
      + name              = "org-owned-owned-varset"
      + organization      = "hashicorp"
      + parent_project_id = (known after apply)
      + priority          = false
      + workspace_ids     = (known after apply)
    }

  # tfe_variable_set.project_owned will be created
  + resource "tfe_variable_set" "project_owned" {
      + global            = false
      + id                = (known after apply)
      + name              = "project-owned-owned-varset"
      + organization      = "hashicorp"
      + parent_project_id = (known after apply)
      + priority          = false
      + workspace_ids     = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + project_owned_data_source = {
      + description       = (known after apply)
      + global            = (known after apply)
      + id                = (known after apply)
      + name              = "project-owned-owned-varset"
      + organization      = "hashicorp"
      + parent_project_id = (known after apply)
      + priority          = (known after apply)
      + project_ids       = (known after apply)
      + variable_ids      = (known after apply)
      + workspace_ids     = (known after apply)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tfe_variable_set.org_owned: Creating...
tfe_project.test_project: Creating...
tfe_variable_set.org_owned: Creation complete after 0s [id=varset-tQZf2cuVwDUc14CL]
tfe_project.test_project: Creation complete after 1s [id=prj-bkCFT1cRaJYXg5RT]
tfe_variable_set.project_owned: Creating...
tfe_variable_set.project_owned: Creation complete after 0s [id=varset-zHK2e1p1F6sHonrv]
data.tfe_variable_set.project_owned_data_source: Reading...
data.tfe_variable_set.project_owned_data_source: Read complete after 1s [id=varset-zHK2e1p1F6sHonrv]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

project_owned_data_source = {
  "description" = ""
  "global" = false
  "id" = "varset-zHK2e1p1F6sHonrv"
  "name" = "project-owned-owned-varset"
  "organization" = "hashicorp"
  "parent_project_id" = "prj-bkCFT1cRaJYXg5RT"
  "priority" = false
  "project_ids" = toset([])
  "variable_ids" = toset([])
  "workspace_ids" = toset([])
}
```

</details>



<details><summary>Updating a project-owned varset’s project_id</summary>

Note that the resource is destroyed and created with the new project_id.

```
-> % terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/tfe in /Users/mkam/hashicorp/terraform-provider-tfe
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.tfe_organization.test: Reading...
data.tfe_organization.unified: Reading...
data.tfe_organization.unified: Read complete after 0s [id=55d75d5b-277a-44e0-b937-754c0520dc83]
data.tfe_organization.test: Read complete after 0s [id=org-uXyx3dqZekFuhw4B]
data.tfe_project.default_project: Reading...
tfe_project.test_project: Refreshing state... [id=prj-bkCFT1cRaJYXg5RT]
tfe_variable_set.org_owned: Refreshing state... [id=varset-tQZf2cuVwDUc14CL]
data.tfe_project.default_project: Read complete after 1s [id=prj-gKmEBeazgefwjaBE]
tfe_variable_set.project_owned: Refreshing state... [id=varset-zHK2e1p1F6sHonrv]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement
 <= read (data resources)

Terraform will perform the following actions:

  # data.tfe_variable_set.project_owned_data_source will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "tfe_variable_set" "project_owned_data_source" {
      + description       = (known after apply)
      + global            = (known after apply)
      + id                = (known after apply)
      + name              = "project-owned-owned-varset"
      + organization      = "hashicorp"
      + parent_project_id = (known after apply)
      + priority          = (known after apply)
      + project_ids       = (known after apply)
      + variable_ids      = (known after apply)
      + workspace_ids     = (known after apply)
    }

  # tfe_variable_set.project_owned must be replaced
-/+ resource "tfe_variable_set" "project_owned" {
      ~ id                = "varset-zHK2e1p1F6sHonrv" -> (known after apply)
        name              = "project-owned-owned-varset"
      ~ parent_project_id = "prj-bkCFT1cRaJYXg5RT" -> "prj-gKmEBeazgefwjaBE" # forces replacement
      ~ workspace_ids     = [] -> (known after apply)
        # (4 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  ~ project_owned_data_source = {
      ~ description       = "" -> (known after apply)
      ~ global            = false -> (known after apply)
      ~ id                = "varset-zHK2e1p1F6sHonrv" -> (known after apply)
        name              = "project-owned-owned-varset"
      ~ parent_project_id = "prj-bkCFT1cRaJYXg5RT" -> (known after apply)
      ~ priority          = false -> (known after apply)
      ~ project_ids       = [] -> (known after apply)
      ~ variable_ids      = [] -> (known after apply)
      ~ workspace_ids     = [] -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tfe_variable_set.project_owned: Destroying... [id=varset-zHK2e1p1F6sHonrv]
tfe_variable_set.project_owned: Destruction complete after 1s
tfe_variable_set.project_owned: Creating...
tfe_variable_set.project_owned: Creation complete after 0s [id=varset-EQciAsw8NFYAdNUE]
data.tfe_variable_set.project_owned_data_source: Reading...
data.tfe_variable_set.project_owned_data_source: Read complete after 1s [id=varset-EQciAsw8NFYAdNUE]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.

Outputs:

project_owned_data_source = {
  "description" = ""
  "global" = false
  "id" = "varset-EQciAsw8NFYAdNUE"
  "name" = "project-owned-owned-varset"
  "organization" = "hashicorp"
  "parent_project_id" = "prj-gKmEBeazgefwjaBE"
  "priority" = false
  "project_ids" = toset([])
  "variable_ids" = toset([])
  "workspace_ids" = toset([])
}
```

</details>



<details><summary>Creating an invalid project-owned varset where global is set to true</summary>

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: global must be 'false' when setting parent_project_id
│
│   with tfe_variable_set.project_owned,
│   on main.tf line 29, in resource "tfe_variable_set" "project_owned":
│   29: resource "tfe_variable_set" "project_owned" {
│
╵
```
</details>

## Output from acceptance tests
Tested against environment where beta feature is enabled:
```
-> % ENABLE_BETA=1 TESTARGS="-run TestAccTFEVariableSet" make testacc

TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEVariableSet -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	0.887s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	0.882s [no tests to run]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFEVariableSetsDataSource_basic
--- PASS: TestAccTFEVariableSetsDataSource_basic (6.23s)
=== RUN   TestAccTFEVariableSetsDataSource_full
--- PASS: TestAccTFEVariableSetsDataSource_full (8.75s)
=== RUN   TestAccTFEVariableSetsDataSource_ProjectOwned
--- PASS: TestAccTFEVariableSetsDataSource_ProjectOwned (6.64s)
=== RUN   TestAccTFEVariableSet_basic
--- PASS: TestAccTFEVariableSet_basic (3.64s)
=== RUN   TestAccTFEVariableSet_full
--- PASS: TestAccTFEVariableSet_full (6.30s)
=== RUN   TestAccTFEVariableSet_update
--- PASS: TestAccTFEVariableSet_update (7.67s)
=== RUN   TestAccTFEVariableSet_import
--- PASS: TestAccTFEVariableSet_import (3.95s)
=== RUN   TestAccTFEVariableSet_project_owned
--- PASS: TestAccTFEVariableSet_project_owned (8.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	52.936s
```

<details> <summary> Also tested against environment where beta feature is disabled </summary>

```
-> % ENABLE_BETA=0 TESTARGS="-run TestAccTFEVariableSet" make testacc

TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEVariableSet -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
=== RUN   TestAccTFEVariableSetsDataSource_basic
--- PASS: TestAccTFEVariableSetsDataSource_basic (6.99s)
=== RUN   TestAccTFEVariableSetsDataSource_full
--- PASS: TestAccTFEVariableSetsDataSource_full (8.62s)
=== RUN   TestAccTFEVariableSetsDataSource_ProjectOwned
    helper_test.go:226: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEVariableSetsDataSource_ProjectOwned (0.00s)
=== RUN   TestAccTFEVariableSet_basic
--- PASS: TestAccTFEVariableSet_basic (3.69s)
=== RUN   TestAccTFEVariableSet_full
--- PASS: TestAccTFEVariableSet_full (6.15s)
=== RUN   TestAccTFEVariableSet_update
--- PASS: TestAccTFEVariableSet_update (7.91s)
=== RUN   TestAccTFEVariableSet_import
--- PASS: TestAccTFEVariableSet_import (3.69s)
=== RUN   TestAccTFEVariableSet_project_owned
    helper_test.go:226: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEVariableSet_project_owned (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	37.474s
```

</details>

## Output from Documentation Preview
<details><summary>Resource</summary>

![Screenshot 2024-11-19 at 3 48 59 PM](https://github.com/user-attachments/assets/3f8385f6-d7e2-4ab0-93d8-7493331b939a)
![Screenshot 2024-11-19 at 3 49 06 PM](https://github.com/user-attachments/assets/43a62348-e680-4671-aeb9-c49d4c3239e8)
![Screenshot 2024-11-19 at 3 49 35 PM](https://github.com/user-attachments/assets/eb640f09-52a9-49d9-917f-73112f9da8bd)

</details>

<details><summary>Data source</summary>

![Screenshot 2024-11-19 at 3 42 19 PM](https://github.com/user-attachments/assets/1d142f28-660a-4a8d-8365-22ea1a3b8faf)
</details>

<details><summary> tfe_workspace_variable_set </summary>

![Screenshot 2024-11-19 at 3 42 44 PM](https://github.com/user-attachments/assets/f27f8eb6-ac43-4a81-b169-977b52b8a9ae)
</details>

<details><summary> tfe_project_variable_set </summary>

![Screenshot 2024-11-19 at 3 43 05 PM](https://github.com/user-attachments/assets/4e7b1f8e-cfef-4a1a-899d-df9d6eb1b64d)
</details>


