### PR TITLE
Adds remote state consumers to tfe_workspace_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+DEPRECATIONS:
+* `r/tfe_workspace`: `global_remote_state` and `remote_state_consumer_ids` have been **deprecated** and moved to `tfe_workspace_settings` (see ENHANCEMENTS below for more details)
+
 FEATURES:
 * `r/tfe_audit_trail_token` is a new resource for managing audit trail tokens in organization, by @glensarti and @c4po [1533](https://github.com/hashicorp/terraform-provider-tfe/pull/1533)
 
@@ -7,6 +10,9 @@ FEATURES:
 
 BUG FIXES:
 * `r/tfe_policy`: enforcement level can be updated on OPA policies by @glennsarti [#1521](https://github.com/hashicorp/terraform-provider-tfe/pull/1521)
+
+ENHANCEMENTS:
+* `r/tfe_workspace_settings`: `global_remote_state` and `remote_state_consumer_ids` can now be managed using `tfe_workspace_settings`. This enhancement avoids the possibility of a mutual dependency between two or more workspaces that may access each others' state by @brandonc [#1524](https://github.com/hashicorp/terraform-provider-tfe/pull/1524)
 
 ## v0.60.0
 

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -51,10 +51,6 @@ func resourceTFEWorkspace() *schema.Resource {
 				return err
 			}
 
-			if err := validateRemoteState(c, d); err != nil {
-				return err
-			}
-
 			if err := validateTagNames(c, d); err != nil {
 				return err
 			}
@@ -156,16 +152,18 @@ func resourceTFEWorkspace() *schema.Resource {
 			},
 
 			"global_remote_state": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Use resource `tfe_workspace_settings` to modify the workspace `global_remote_state`. `global_remote_state` on `tfe_workspace` is no longer validated properly and will be removed in a future release of the provider.",
 			},
 
 			"remote_state_consumer_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				Elem:       &schema.Schema{Type: schema.TypeString},
+				Deprecated: "Use resource `tfe_workspace_settings` to modify the workspace `remote_state_consumer_ids`. `remote_state_consumer_ids` on `tfe_workspace` is no longer validated properly on this resource and This attribute will be removed in a future release of the provider.",
 			},
 
 			"assessments_enabled": {
@@ -1029,23 +1027,6 @@ func validateTagNames(_ context.Context, d *schema.ResourceDiff) error {
 			return fmt.Errorf("%q is not a valid tag name. Tag must be one or more characters; can include lowercase letters, numbers, colons, hyphens, and underscores; and must begin and end with a letter or number", tagName)
 		}
 	}
-	return nil
-}
-
-func validateRemoteState(_ context.Context, d *schema.ResourceDiff) error {
-	// If remote state consumers aren't set, the global setting can be either value and it
-	// doesn't matter.
-	_, ok := d.GetOk("remote_state_consumer_ids")
-	if !ok {
-		return nil
-	}
-
-	if globalRemoteState, ok := d.GetOk("global_remote_state"); ok {
-		if globalRemoteState.(bool) {
-			return fmt.Errorf("global_remote_state must be 'false' when setting remote_state_consumer_ids")
-		}
-	}
-
 	return nil
 }
 

--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
@@ -89,6 +90,58 @@ func TestAccTFEWorkspaceSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_workspace_settings.foobar", "overwrites.#", "1"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspaceSettingsRemoteState(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	ws := createTempWorkspace(t, tfeClient, org.Name)
+	ws2 := createTempWorkspace(t, tfeClient, org.Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceSettingsDestroy,
+		Steps: []resource.TestStep{
+			// Have remote state consumer ids
+			{
+				Config: testAccTFEWorkspaceSettingsRemoteState(ws.ID, ws2.ID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"tfe_workspace_settings.foobar", "id"),
+					resource.TestCheckResourceAttrSet(
+						"tfe_workspace_settings.foobar", "workspace_id"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.foobar", "global_remote_state", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.foobar", "remote_state_consumer_ids.0", ws2.ID),
+				),
+			},
+			// Unset remote state consumer ids and set global remote state
+			{
+				Config: testAccTFEWorkspaceSettingsRemoteState_Global(ws.ID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"tfe_workspace_settings.foobar", "id"),
+					resource.TestCheckResourceAttrSet(
+						"tfe_workspace_settings.foobar", "workspace_id"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.foobar", "global_remote_state", "true"),
+				),
+			},
+			// Unset execution mode
+			{
+				Config:      testAccTFEWorkspaceSettingsRemoteState_GlobalConflict(ws.ID, ws2.ID),
+				ExpectError: regexp.MustCompile("If global_remote_state is true, remote_state_consumer_ids must not be set"),
 			},
 		},
 	})
@@ -201,6 +254,35 @@ func testAccCheckTFEWorkspaceSettingsDestroyProvider(p *schema.Provider) func(s 
 
 		return nil
 	}
+}
+
+func testAccTFEWorkspaceSettingsRemoteState(workspaceID, workspaceID2 string) string {
+	return fmt.Sprintf(`
+resource "tfe_workspace_settings" "foobar" {
+	workspace_id              = "%s"
+	global_remote_state       = false
+	remote_state_consumer_ids = ["%s"]
+}
+`, workspaceID, workspaceID2)
+}
+
+func testAccTFEWorkspaceSettingsRemoteState_Global(workspaceID string) string {
+	return fmt.Sprintf(`
+resource "tfe_workspace_settings" "foobar" {
+	workspace_id              = "%s"
+	global_remote_state       = true
+}
+`, workspaceID)
+}
+
+func testAccTFEWorkspaceSettingsRemoteState_GlobalConflict(workspaceID, workspaceID2 string) string {
+	return fmt.Sprintf(`
+resource "tfe_workspace_settings" "foobar" {
+	workspace_id              = "%s"
+	global_remote_state       = true
+	remote_state_consumer_ids = ["%s"]
+}
+`, workspaceID, workspaceID2)
 }
 
 func testAccTFEWorkspaceSettings_basic(workspaceID string) string {

--- a/internal/provider/workspace_helpers.go
+++ b/internal/provider/workspace_helpers.go
@@ -69,9 +69,9 @@ func unpackWorkspaceID(id string) (organization, name string, err error) {
 	return s[0], s[1], nil
 }
 
-func readWorkspaceStateConsumers(id string, client *tfe.Client) (bool, []interface{}, error) {
+func readWorkspaceStateConsumers(id string, client *tfe.Client) (bool, []string, error) {
 	options := &tfe.RemoteStateConsumersListOptions{ListOptions: tfe.ListOptions{PageSize: 100}}
-	var remoteStateConsumerIDs []interface{}
+	remoteStateConsumerIDs := make([]string, 0)
 
 	for {
 		wl, err := client.Workspaces.ListRemoteStateConsumers(ctx, id, options)

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -11,8 +11,6 @@ Provides a workspace resource.
 
 ~> **NOTE:** Setting the execution mode and agent pool affinity directly on the workspace is deprecated in favor of using both [tfe_workspace_settings](workspace_settings) and [tfe_organization_default_settings](organization_default_settings), since they allow more precise control and fully support [agent_pool_allowed_workspaces](agent_pool_allowed_workspaces). Use caution when unsetting `execution_mode`, as it now leaves any prior value unmanaged instead of reverting to the old default value of `"remote"`.
 
-~> **NOTE:** Using `global_remote_state` or `remote_state_consumer_ids` requires using the provider with HCP Terraform or an instance of Terraform Enterprise at least as recent as v202104-1.
-
 ## Example Usage
 
 Basic usage:
@@ -80,7 +78,7 @@ The following arguments are supported:
   trigger prefixes describe a set of paths which must contain changes for a
   VCS push to trigger a run. If disabled, any push will trigger a run.
 * `force_delete` - (Optional) If this attribute is present on a workspace that is being deleted through the provider, it will use the existing force delete API. If this attribute is not present or false it will safe delete the workspace.
-* `global_remote_state` - (Optional) Whether the workspace allows all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (`remote_state_consumer_ids`).
+* `global_remote_state` - (Optional) **Deprecated** Whether the workspace allows all workspaces in the organization to access its state data during runs. Use [tfe_workspace_settings](workspace_settings) instead.
 * `operations` - **Deprecated** Whether to use remote execution mode.
   Defaults to `true`. When set to `false`, the workspace will be used for
   state storage only. This value _must not_ be provided if `execution_mode` is
@@ -95,7 +93,7 @@ The following arguments are supported:
   is `false`. The provider uses `true` as any workspace provisioned with
   `false` would need to then have a run manually queued out-of-band before
   accepting webhooks.
-* `remote_state_consumer_ids` - (Optional) The set of workspace IDs set as explicit remote state consumers for the given workspace.
+* `remote_state_consumer_ids` - (Optional) **Deprecated** The set of workspace IDs set as explicit remote state consumers for the given workspace. Use [tfe_workspace_settings](workspace_settings) instead.
 * `source_name` - (Optional) A friendly name for the application or client
    creating this workspace. If set, this will be displayed on the workspace as
    "Created via <SOURCE NAME>".


### PR DESCRIPTION
## Description

Moving this attribute to the auxiliary workspace resource removes possible mutual dependence when adding workspace IDs to tfe_workspace resources.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [X] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

This is the most 👍  open issue on the repo.

## Testing plan

Try this config:

```terraform
provider "tfe" {}

resource "tfe_organization" "example" {
  name  = "example-remote-state"
  email = "you@example.com"
}

resource "tfe_workspace" "test" {
  for_each     = toset(["qa","production"])
  name         = "${each.value}-test"
  organization = tfe_organization.example.name
}

resource "tfe_workspace_settings" "test-settings" {
  for_each                  = toset(["qa","production"])
  workspace_id              = tfe_workspace.test[each.value].id
  global_remote_state       = false
  remote_state_consumer_ids = toset(compact([each.value == "production" ? tfe_workspace.test["qa"].id : ""]))
}

```

If remote_state_consumer_ids were defined on tfe_workspace, this kind of config would be invalid.

Closes #331 

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspaceSettings" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceSettings -timeout 15m
=== RUN   TestAccTFEWorkspaceSettings
2024/11/14 10:38:04 [DEBUG] Configuring client for host "tfcdev-xxx.ngrok.app"
2024/11/14 10:38:04 [DEBUG] Service discovery for tfcdev-xxx.ngrok.app at https://tfcdev-xxx.ngrok.app/.well-known/terraform.json
--- PASS: TestAccTFEWorkspaceSettings (10.96s)
=== RUN   TestAccTFEWorkspaceSettingsRemoteState
--- PASS: TestAccTFEWorkspaceSettingsRemoteState (8.72s)
=== RUN   TestAccTFEWorkspaceSettingsImport
--- PASS: TestAccTFEWorkspaceSettingsImport (6.13s)
=== RUN   TestAccTFEWorkspaceSettingsImport_ByName
--- PASS: TestAccTFEWorkspaceSettingsImport_ByName (6.22s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   32.669s
```
