### PR TITLE
Add support for the custom project variable set permission 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 
 * `r/tfe_project`: Add `auto_destroy_activity_duration` field to the project resource, which automatically propagates auto-destroy settings to workspaces [1550](https://github.com/hashicorp/terraform-provider-tfe/pull/1550)
 * `d/tfe_project`: Add `auto_destroy_activity_duration` field to the project datasource [1550](https://github.com/hashicorp/terraform-provider-tfe/pull/1550)
+* `r/tfe_team_project_access`: Add `variable_sets` attribute to `project_access`, by @mkam [#1565](https://github.com/hashicorp/terraform-provider-tfe/pull/1565)
 
 BUG FIXES:
 * `r/tfe_stack`: Fix serialization issue when using github app installation within vcs_repo block, by @mjyocca [#1572](https://github.com/hashicorp/terraform-provider-tfe/pull/1572)

--- a/internal/provider/data_source_team_project_access.go
+++ b/internal/provider/data_source_team_project_access.go
@@ -51,6 +51,11 @@ func dataSourceTFETeamProjectAccess() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+
+						"variable_sets": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/provider/data_source_team_project_access_test.go
+++ b/internal/provider/data_source_team_project_access_test.go
@@ -86,6 +86,31 @@ func TestAccTFETeamProjectCustomAccessDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamProjectCustomAccessDataSource_basic_with_project_variable_sets(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createBusinessOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccessDataSourceConfig_with_project_variable_sets(org.Name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_project_access.foobar_custom", "project_access.0.variable_sets", "read"),
+				),
+			},
+		},
+	})
+}
+
 func testAccTFETeamProjectAccessDataSourceConfig(organization string) string {
 	return fmt.Sprintf(`
 resource "tfe_team" "foobar" {
@@ -135,6 +160,47 @@ resource "tfe_team_project_access" "foobar_custom" {
     state_versions = "write"
     sentinel_mocks = "read"
 		runs					 = "apply"
+    variables      = "write"
+    create         = true
+    locking        = true
+    move           = true
+    delete         = false
+    run_tasks      = false
+  }
+}
+
+data "tfe_team_project_access" "foobar_custom" {
+  team_id      = tfe_team.foobar_custom.id
+  project_id   = tfe_project.foobar_custom.id
+  depends_on   = [tfe_team_project_access.foobar_custom]
+}`, organization, organization)
+}
+
+func testAccTFETeamProjectCustomAccessDataSourceConfig_with_project_variable_sets(organization string) string {
+	return fmt.Sprintf(`
+resource "tfe_team" "foobar_custom" {
+  name         = "team-test2"
+  organization = "%s"
+}
+
+resource "tfe_project" "foobar_custom" {
+  name         = "projecttest2"
+  organization = "%s"
+}
+
+resource "tfe_team_project_access" "foobar_custom" {
+  access       = "custom"
+  team_id      = tfe_team.foobar_custom.id
+  project_id   = tfe_project.foobar_custom.id
+  project_access {
+    settings      = "delete"
+    teams         = "manage"
+    variable_sets = "read"
+  }
+  workspace_access {
+    state_versions = "write"
+    sentinel_mocks = "read"
+    runs           = "apply"
     variables      = "write"
     create         = true
     locking        = true

--- a/internal/provider/resource_tfe_team_project_access_test.go
+++ b/internal/provider/resource_tfe_team_project_access_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestAccTFETeamProjectAccess(t *testing.T) {
 	tmAccess := &tfe.TeamProjectAccess{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	for _, access := range []tfe.TeamProjectAccessType{tfe.TeamProjectAccessAdmin, tfe.TeamProjectAccessMaintain, tfe.TeamProjectAccessWrite, tfe.TeamProjectAccessRead} {
 		resource.Test(t, resource.TestCase{
@@ -26,7 +25,7 @@ func TestAccTFETeamProjectAccess(t *testing.T) {
 			CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccTFETeamProjectAccess(rInt, access),
+					Config: testAccTFETeamProjectAccess(rand.New(rand.NewSource(time.Now().UnixNano())).Int(), access),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckTFETeamProjectAccessExists(
 							"tfe_team_project_access.foobar", tmAccess),

--- a/internal/provider/resource_tfe_team_project_access_test.go
+++ b/internal/provider/resource_tfe_team_project_access_test.go
@@ -72,6 +72,32 @@ func TestAccTFETeamProjectCustomAccess(t *testing.T) {
 		},
 	})
 }
+
+func TestAccTFETeamProjectCustomAccess_with_project_variable_sets(t *testing.T) {
+	skipUnlessBeta(t)
+	tmAccess := &tfe.TeamProjectAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	access := tfe.TeamProjectAccessCustom
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.variable_sets", "read"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFETeamProjectAccess_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -120,6 +146,36 @@ func TestAccTFETeamProjectCustomAccess_import(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
 					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "false"),
 					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+			{
+				ResourceName:      "tfe_team_project_access.custom_foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFETeamProjectCustomAccess_import_with_project_variable_set(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	tmAccess := &tfe.TeamProjectAccess{}
+	access := tfe.TeamProjectAccessCustom
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.variable_sets", "read"),
 				),
 			},
 			{
@@ -183,6 +239,61 @@ func TestAccTFETeamProjectCustomAccess_full_update(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamProjectCustomAccess_full_update_with_project_variable_sets(t *testing.T) {
+	skipUnlessBeta(t)
+	tmAccess := &tfe.TeamProjectAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	access := tfe.TeamProjectAccessCustom
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "delete"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.variable_sets", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.runs", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+			{
+				Config: testAccTFETeamProjectCustomAccess_full_update_with_project_variable_sets(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "none"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.variable_sets", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "none"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.runs", "apply"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFETeamProjectCustomAccess_partial_update(t *testing.T) {
 	tmAccess := &tfe.TeamProjectAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
@@ -223,6 +334,63 @@ func TestAccTFETeamProjectCustomAccess_partial_update(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "true"),
 					// unchanged access levels
 					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFETeamProjectCustomAccess_partial_update_with_project_variable_sets(t *testing.T) {
+	skipUnlessBeta(t)
+	tmAccess := &tfe.TeamProjectAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	access := tfe.TeamProjectAccessCustom
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "delete"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.variable_sets", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.create", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.move", "true"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "false"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.run_tasks", "false"),
+				),
+			},
+			{
+				Config: testAccTFETeamProjectCustomAccess_partial_update(rInt, access),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamProjectAccessExists(
+						"tfe_team_project_access.custom_foobar", tmAccess),
+					testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess, access),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "access", string(access)),
+					// changed access levels
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.settings", "read"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.delete", "true"),
+					// unchanged access levels
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.teams", "manage"),
+					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "project_access.0.variable_sets", "read"),
 					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.state_versions", "write"),
 					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.sentinel_mocks", "read"),
 					resource.TestCheckResourceAttr("tfe_team_project_access.custom_foobar", "workspace_access.0.variables", "write"),
@@ -376,6 +544,47 @@ resource "tfe_team_project_access" "custom_foobar" {
 }`, rInt, access)
 }
 
+func testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt int, access tfe.TeamProjectAccessType) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar_2" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar_2" {
+  name         = "team-test"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_project" "foobar_2" {
+  name         = "projecttest"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_team_project_access" "custom_foobar" {
+  access       = "%s"
+  team_id      = tfe_team.foobar_2.id
+  project_id   = tfe_project.foobar_2.id
+  project_access {
+    settings      = "delete"
+    teams         = "manage"
+    variable_sets = "read"
+  }
+  workspace_access {
+    state_versions = "write"
+    sentinel_mocks = "read"
+    runs           = "read"
+    variables      = "write"
+    create         = true
+    locking        = true
+    move           = true
+    delete         = false
+    run_tasks      = false
+  }
+
+}`, rInt, access)
+}
+
 func testAccTFETeamProjectCustomAccess_full_update(rInt int, access tfe.TeamProjectAccessType) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar_2" {
@@ -400,6 +609,46 @@ resource "tfe_team_project_access" "custom_foobar" {
   project_access {
     settings = "read"
     teams    = "none"
+  }
+  workspace_access {
+    state_versions = "read"
+    sentinel_mocks = "none"
+    runs           = "apply"
+    variables      = "read"
+    create         = false
+    locking        = false
+    move           = false
+    delete         = true
+    run_tasks      = true
+  }
+}`, rInt, access)
+}
+
+func testAccTFETeamProjectCustomAccess_full_update_with_project_variable_sets(rInt int, access tfe.TeamProjectAccessType) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar_2" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar_2" {
+  name         = "team-test"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_project" "foobar_2" {
+  name         = "projecttest"
+  organization = tfe_organization.foobar_2.id
+}
+
+resource "tfe_team_project_access" "custom_foobar" {
+  access       = "%s"
+  team_id      = tfe_team.foobar_2.id
+  project_id   = tfe_project.foobar_2.id
+  project_access {
+    settings      = "read"
+    teams         = "none"
+    variable_sets = "write"
   }
   workspace_access {
     state_versions = "read"

--- a/website/docs/r/team_project_access.html.markdown
+++ b/website/docs/r/team_project_access.html.markdown
@@ -50,6 +50,7 @@ The following permissions apply to the project itself.
 |---------------------|---------------------------------------------|
 | `settings`          | The permission to grant for the project's settings. Default: `read`. Valid strings: `read`, `update`, or `delete` |
 | `teams`             | The permission to grant for the project's teams. Default: `none`, Valid strings: `none`, `read`, or `manage` |
+| `variable_sets`     | The permission to grant for the project's variable sets. Default: `none`, Valid strings: `none`, `read`, or `write` |
 
 </n>
 </n>
@@ -89,8 +90,9 @@ resource "tfe_team_project_access" "custom" {
   project_id   = tfe_project.test.id
 
   project_access {
-    settings = "read"
-    teams    = "none"
+    settings      = "read"
+    teams         = "none"
+    variable_sets = "write"
   }
   workspace_access {
     state_versions = "write"


### PR DESCRIPTION
## Description

This PR adds `variable_sets` to the `project_access` of `tfe_team_project_access`, allowing users to set the project variable set permission of a team when access is set to `custom`.

This feature has not been released to GA yet, so I've labeled it as do not merge for now.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Create a team and a project.
1. Assign the team custom access and set `variable_sets`.
1. Get the team project access as a data source and output it.
1. Validate for the expected outputted value for `variable_sets`
1. Validate in the UI or API that `variable_sets` is set to the expected value.

```
resource "tfe_project" "test" {
  name         = "TeamProjectVarSetProvider"
  organization = data.tfe_organization.test.name
}


resource "tfe_team" "custom" {
  name         = "custom-project-varset-permission-provider-team"
  organization = data.tfe_organization.test.name
}

resource "tfe_team_project_access" "custom" {
  access     = "custom"
  team_id    = tfe_team.custom.id
  project_id = tfe_project.test.id

  project_access {
    variable_sets = "write"
  }
}

data "tfe_team_project_access" "custom" {
  team_id    = tfe_team.custom.id
  project_id = tfe_project.test.id
  depends_on = [ tfe_team_project_access.custom ]
}

output "custom_team_project_access" {
  value = data.tfe_team_project_access.custom
  depends_on = [ data.tfe_team_project_access.custom ]
}
```

<details>
<summary>Setting the new permission</summary>

```
-> % terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/tfe in /Users/mkam/hashicorp/terraform-provider-tfe
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.tfe_organization.test: Reading...
data.tfe_organization.test: Read complete after 0s [id=org-uXyx3dqZekFuhw4B]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.tfe_team_project_access.custom will be read during apply
  # (config refers to values not yet known)
 <= data "tfe_team_project_access" "custom" {
      + access           = (known after apply)
      + id               = (known after apply)
      + project_access   = (known after apply)
      + project_id       = (known after apply)
      + team_id          = (known after apply)
      + workspace_access = (known after apply)
    }

  # tfe_project.test will be created
  + resource "tfe_project" "test" {
      + id           = (known after apply)
      + name         = "TeamProjectVarSetProvider"
      + organization = "hashicorp"
    }

  # tfe_team.custom will be created
  + resource "tfe_team" "custom" {
      + allow_member_token_management = true
      + id                            = (known after apply)
      + name                          = "custom-project-varset-permission-provider-team"
      + organization                  = "hashicorp"
      + visibility                    = (known after apply)

      + organization_access {
          + access_secret_teams        = (known after apply)
          + manage_agent_pools         = (known after apply)
          + manage_membership          = (known after apply)
          + manage_modules             = (known after apply)
          + manage_organization_access = (known after apply)
          + manage_policies            = (known after apply)
          + manage_policy_overrides    = (known after apply)
          + manage_projects            = (known after apply)
          + manage_providers           = (known after apply)
          + manage_run_tasks           = (known after apply)
          + manage_teams               = (known after apply)
          + manage_vcs_settings        = (known after apply)
          + manage_workspaces          = (known after apply)
          + read_projects              = (known after apply)
          + read_workspaces            = (known after apply)
        }
    }

  # tfe_team_project_access.custom will be created
  + resource "tfe_team_project_access" "custom" {
      + access     = "custom"
      + id         = (known after apply)
      + project_id = (known after apply)
      + team_id    = (known after apply)

      + project_access {
          + settings      = (known after apply)
          + teams         = (known after apply)
          + variable_sets = "write"
        }

      + workspace_access {
          + create         = (known after apply)
          + delete         = (known after apply)
          + locking        = (known after apply)
          + move           = (known after apply)
          + run_tasks      = (known after apply)
          + runs           = (known after apply)
          + sentinel_mocks = (known after apply)
          + state_versions = (known after apply)
          + variables      = (known after apply)
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + custom_team_project_access = {
      + access           = (known after apply)
      + id               = (known after apply)
      + project_access   = (known after apply)
      + project_id       = (known after apply)
      + team_id          = (known after apply)
      + workspace_access = (known after apply)
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

tfe_project.test: Creating...
tfe_team.custom: Creating...
tfe_team.custom: Creation complete after 1s [id=team-UuMJNXYL9nyYzHgL]
tfe_project.test: Creation complete after 1s [id=prj-QBh7ydm2j6JVRkGD]
tfe_team_project_access.custom: Creating...
tfe_team_project_access.custom: Creation complete after 1s [id=tprj-U9kKxuebyxkuNtwA]
data.tfe_team_project_access.custom: Reading...
data.tfe_team_project_access.custom: Read complete after 0s [id=tprj-U9kKxuebyxkuNtwA]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

custom_team_project_access = {
  "access" = "custom"
  "id" = "tprj-U9kKxuebyxkuNtwA"
  "project_access" = tolist([
    {
      "settings" = "read"
      "teams" = "none"
      "variable_sets" = "write"
    },
  ])
  "project_id" = "prj-QBh7ydm2j6JVRkGD"
  "team_id" = "team-UuMJNXYL9nyYzHgL"
  "workspace_access" = tolist([
    {
      "create" = false
      "delete" = false
      "locking" = false
      "move" = false
      "run_tasks" = false
      "runs" = "read"
      "sentinel_mocks" = "none"
      "state_versions" = "none"
      "variables" = "none"
    },
  ])
}
```
![Screenshot 2025-01-21 at 11 57 37 AM](https://github.com/user-attachments/assets/7f75bf61-c9b6-4a91-9ff3-0098e45546e0)



</details>



## Output from acceptance tests

```
-> % ENABLE_BETA=1 TESTARGS="-run TestAccTFETeamProject" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFETeamProject -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFETeamProjectAccessDataSource_basic
2025/01/14 14:03:09 [DEBUG] Configuring client for host "tfcdev-ac1517e2.ngrok.app"
2025/01/14 14:03:09 [DEBUG] Service discovery for tfcdev-ac1517e2.ngrok.app at https://tfcdev-ac1517e2.ngrok.app/.well-known/terraform.json
--- PASS: TestAccTFETeamProjectAccessDataSource_basic (9.38s)
=== RUN   TestAccTFETeamProjectCustomAccessDataSource_basic
--- PASS: TestAccTFETeamProjectCustomAccessDataSource_basic (8.35s)
=== RUN   TestAccTFETeamProjectCustomAccessDataSource_basic_with_project_variable_sets
--- PASS: TestAccTFETeamProjectCustomAccessDataSource_basic_with_project_variable_sets (8.27s)
=== RUN   TestAccTFETeamProjectAccess
--- PASS: TestAccTFETeamProjectAccess (24.48s)
=== RUN   TestAccTFETeamProjectCustomAccess
--- PASS: TestAccTFETeamProjectCustomAccess (6.38s)
=== RUN   TestAccTFETeamProjectCustomAccess_with_project_variable_sets
--- PASS: TestAccTFETeamProjectCustomAccess_with_project_variable_sets (6.32s)
=== RUN   TestAccTFETeamProjectAccess_import
--- PASS: TestAccTFETeamProjectAccess_import (6.46s)
=== RUN   TestAccTFETeamProjectCustomAccess_import
--- PASS: TestAccTFETeamProjectCustomAccess_import (6.55s)
=== RUN   TestAccTFETeamProjectCustomAccess_import_with_project_variable_set
--- PASS: TestAccTFETeamProjectCustomAccess_import_with_project_variable_set (6.58s)
=== RUN   TestAccTFETeamProjectCustomAccess_full_update
--- PASS: TestAccTFETeamProjectCustomAccess_full_update (9.26s)
=== RUN   TestAccTFETeamProjectCustomAccess_full_update_with_project_variable_sets
--- PASS: TestAccTFETeamProjectCustomAccess_full_update_with_project_variable_sets (9.28s)
=== RUN   TestAccTFETeamProjectCustomAccess_partial_update
--- PASS: TestAccTFETeamProjectCustomAccess_partial_update (8.85s)
=== RUN   TestAccTFETeamProjectCustomAccess_partial_update_with_project_variable_sets
--- PASS: TestAccTFETeamProjectCustomAccess_partial_update_with_project_variable_sets (9.65s)
=== RUN   TestAccTFETeamProjectCustomAccess_invalid_custom_access
--- PASS: TestAccTFETeamProjectCustomAccess_invalid_custom_access (0.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	120.786s
```

## Output from Documentation Preview
The [doc-preview tool](https://registry.terraform.io/tools/doc-preview) doesn't seem to support markdown tables, which is why the formatting looks off here.
![Screenshot 2025-01-13 at 10 44 46 AM](https://github.com/user-attachments/assets/26ead118-3100-4d3c-9f6e-cc632cd66ed2)
![Screenshot 2025-01-13 at 10 45 06 AM](https://github.com/user-attachments/assets/28a649ec-5916-4470-80ce-9688a735835d)
