### PR TITLE
Don't ensure workspace ID is in collection when it is unknown

### DIFF
--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -179,7 +179,7 @@ func (m validateSelfReference) PlanModifySet(_ context.Context, req planmodifier
 	}
 
 	// Check if the workspace ID is in the set
-	if slices.Contains(remoteStateConsumerIDs, workspaceID.ValueString()) {
+	if !workspaceID.IsUnknown() && slices.Contains(remoteStateConsumerIDs, workspaceID.ValueString()) {
 		resp.Diagnostics.AddError("Invalid remote_state_consumer_ids", "workspace_id cannot be in the set of remote_state_consumer_ids")
 	}
 }


### PR DESCRIPTION
## Description

When workspace ID is unknown, we validate during planning that it's not listed twice in remote state consumers. This is problematic when creating more than one workspace in a plan.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

See #1568 for sample config

```
$ TESTARGS="-run TestAccTFEWorkspaceWithSettings" make testacc

=== RUN   TestAccTFEWorkspaceWithSettings
2025/01/21 13:46:16 [DEBUG] Configuring client for host "tfcdev-4483a00f.ngrok.app"
2025/01/21 13:46:16 [DEBUG] Service discovery for tfcdev-4483a00f.ngrok.app at https://tfcdev-4483a00f.ngrok.app/.well-known/terraform.json
--- PASS: TestAccTFEWorkspaceWithSettings (7.86s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   8.524s
```
