### PR TITLE
fix(stacks/vcs): update stack create/update options to use new json annotated VCSRepoOptions struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUG FIXES:
+* `r/tfe_stack`: Fix serialization issue when using github app installation within vcs_repo block, by @mjyocca [#1572](https://github.com/hashicorp/terraform-provider-tfe/pull/1572)
+
 ## v.0.63.0
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-slug v0.16.3
-	github.com/hashicorp/go-tfe v1.73.0
+	github.com/hashicorp/go-tfe v1.74.1
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.19.1 // indirect
@@ -61,7 +61,7 @@ require (
 require (
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISH
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-slug v0.16.3 h1:pe0PMwz2UWN1168QksdW/d7u057itB2gY568iF0E2Ns=
 github.com/hashicorp/go-slug v0.16.3/go.mod h1:THWVTAXwJEinbsp4/bBRcmbaO5EYNLTqxbG4tZ3gCYQ=
-github.com/hashicorp/go-tfe v1.73.0 h1:6WuAFjNMd60Ko288K3NzCguBc+UjQQfgQoGQkiaJGQs=
-github.com/hashicorp/go-tfe v1.73.0/go.mod h1:4/yd7fl8960i71v5q8cmpIiA5wB9rBRfvTpFfD/dbvE=
+github.com/hashicorp/go-tfe v1.74.1 h1:I/8fOwSYox17IZV7SULIQH0ZRPNL2g/biW6hHWnOTVY=
+github.com/hashicorp/go-tfe v1.74.1/go.mod h1:kGHWMZ3HHjitgqON8nBZ4kPVJ3cLbzM4JMgmNVMs9aQ=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -153,8 +153,8 @@ github.com/skeema/knownhosts v1.2.1 h1:SHWdIUa82uGZz+F+47k8SY4QhhI291cXCpopT1lK2
 github.com/skeema/knownhosts v1.2.1/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resource_tfe_stack.go
+++ b/internal/provider/resource_tfe_stack.go
@@ -157,7 +157,7 @@ func (r *resourceTFEStack) Create(ctx context.Context, req resource.CreateReques
 
 	options := tfe.StackCreateOptions{
 		Name: plan.Name.ValueString(),
-		VCSRepo: &tfe.StackVCSRepo{
+		VCSRepo: &tfe.StackVCSRepoOptions{
 			Identifier:        plan.VCSRepo.Identifier.ValueString(),
 			Branch:            plan.VCSRepo.Branch.ValueString(),
 			GHAInstallationID: plan.VCSRepo.GHAInstallationID.ValueString(),
@@ -225,7 +225,7 @@ func (r *resourceTFEStack) Update(ctx context.Context, req resource.UpdateReques
 	options := tfe.StackUpdateOptions{
 		Name:        tfe.String(plan.Name.ValueString()),
 		Description: tfe.String(plan.Description.ValueString()),
-		VCSRepo: &tfe.StackVCSRepo{
+		VCSRepo: &tfe.StackVCSRepoOptions{
 			Identifier:        plan.VCSRepo.Identifier.ValueString(),
 			Branch:            plan.VCSRepo.Branch.ValueString(),
 			GHAInstallationID: plan.VCSRepo.GHAInstallationID.ValueString(),


### PR DESCRIPTION
## Description

Fixes an issue with the experimental stack resource's vcs_repo block when using GitHub App installation. Updates the go-tfe dependency to resolve a serialization issue with JSONAPI annotated struct fields.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Obtain github_app_installation_id static value or obtain with data block (requires user authorization of github app).
1. Provision a stack with vcs_repo block using github_app_installation_id attribute.
2. Apply changes, verify a stack was provisioned correctly with github app integration.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Related go-tfe PR#1029](https://github.com/hashicorp/go-tfe/pull/1029)
- [Related go-tfe PR#1039](https://github.com/hashicorp/go-tfe/pull/1039)
- [Ticket](https://hashicorp.atlassian.net/browse/TF-23253)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
