### PR TITLE
Add default project to organization default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * `r/tfe_project`: Add `auto_destroy_activity_duration` field to the project resource, which automatically propagates auto-destroy settings to workspaces [1550](https://github.com/hashicorp/terraform-provider-tfe/pull/1550)
 * `d/tfe_project`: Add `auto_destroy_activity_duration` field to the project datasource [1550](https://github.com/hashicorp/terraform-provider-tfe/pull/1550)
 * `r/tfe_team_project_access`: Add `variable_sets` attribute to `project_access`, by @mkam [#1565](https://github.com/hashicorp/terraform-provider-tfe/pull/1565)
+* `r/tfe_organization_default_settings`: Add `default_project_id` to `organization_default_settings`, by @netramali [#1603](https://github.com/hashicorp/terraform-provider-tfe/pull/1603)
 
 BUG FIXES:
 * `r/tfe_stack`: Fix serialization issue when using github app installation within vcs_repo block, by @mjyocca [#1572](https://github.com/hashicorp/terraform-provider-tfe/pull/1572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
 * `r/tfe_project`: Add `auto_destroy_activity_duration` field to the project resource, which automatically propagates auto-destroy settings to workspaces [1550](https://github.com/hashicorp/terraform-provider-tfe/pull/1550)
 * `d/tfe_project`: Add `auto_destroy_activity_duration` field to the project datasource [1550](https://github.com/hashicorp/terraform-provider-tfe/pull/1550)
 * `r/tfe_team_project_access`: Add `variable_sets` attribute to `project_access`, by @mkam [#1565](https://github.com/hashicorp/terraform-provider-tfe/pull/1565)
-* `r/tfe_organization_default_settings`: Add `default_project_id` to `organization_default_settings`, by @netramali [#1603](https://github.com/hashicorp/terraform-provider-tfe/pull/1603)
+* `r/tfe_organization_default_settings`: Add `default_project_id` to allow setting a default project for an organization, by @netramali [#1603](https://github.com/hashicorp/terraform-provider-tfe/pull/1603)
 
 BUG FIXES:
 * `r/tfe_stack`: Fix serialization issue when using github app installation within vcs_repo block, by @mjyocca [#1572](https://github.com/hashicorp/terraform-provider-tfe/pull/1572)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-slug v0.16.4
-	github.com/hashicorp/go-tfe v1.75.0
+	github.com/hashicorp/go-tfe v1.75.1-0.20250210225844-d114b5d76004
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hashicorp/jsonapi v1.3.2
+	github.com/hashicorp/jsonapi v1.4.1
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.22.0 // indirect
 	github.com/hashicorp/terraform-json v0.24.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-slug v0.16.4
-	github.com/hashicorp/go-tfe v1.75.1-0.20250210225844-d114b5d76004
+	github.com/hashicorp/go-tfe v1.75.1-0.20250221201235-2bf0f5fde70c
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-plugin v1.6.3 // indirect
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hashicorp/jsonapi v1.4.1
+	github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.22.0 // indirect
 	github.com/hashicorp/terraform-json v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/hashicorp/go-slug v0.16.4 h1:kI0mOUVjbBsyocwO29pZIQzzkBnfQNdU4eqlUpNd
 github.com/hashicorp/go-slug v0.16.4/go.mod h1:THWVTAXwJEinbsp4/bBRcmbaO5EYNLTqxbG4tZ3gCYQ=
 github.com/hashicorp/go-tfe v1.75.0 h1:7dixINN0rOmNo4Vpe/6aVCbF0j4bQpSVzw64CSLBTe8=
 github.com/hashicorp/go-tfe v1.75.0/go.mod h1:IyJtCSk6TxidVAWcZeEgFzc/6fDDjinf21wyaBBc2mg=
+github.com/hashicorp/go-tfe v1.75.1-0.20250210225844-d114b5d76004 h1:3BwbVozz6xQQEcdizD7inM35fCvFtNV/QNov69M2LqY=
+github.com/hashicorp/go-tfe v1.75.1-0.20250210225844-d114b5d76004/go.mod h1:0y+AMmGlixZulyaEWAFu/pwLC0PQmY6XYnKDGODytps=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -87,6 +89,8 @@ github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3q
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/jsonapi v1.3.2 h1:gP3fX2ZT7qXi+PbwieptzkspIohO2kCSiBUvUTBAbMs=
 github.com/hashicorp/jsonapi v1.3.2/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
+github.com/hashicorp/jsonapi v1.4.1 h1:U6CZvnS70Sg7im0kpfhWAoF3NasLumaMndQhEWniHZA=
+github.com/hashicorp/jsonapi v1.4.1/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.22.0 h1:G5+4Sz6jYZfRYUCg6eQgDsqTzkNXV+fP8l+uRmZHj64=

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/hashicorp/go-tfe v1.75.0 h1:7dixINN0rOmNo4Vpe/6aVCbF0j4bQpSVzw64CSLBT
 github.com/hashicorp/go-tfe v1.75.0/go.mod h1:IyJtCSk6TxidVAWcZeEgFzc/6fDDjinf21wyaBBc2mg=
 github.com/hashicorp/go-tfe v1.75.1-0.20250210225844-d114b5d76004 h1:3BwbVozz6xQQEcdizD7inM35fCvFtNV/QNov69M2LqY=
 github.com/hashicorp/go-tfe v1.75.1-0.20250210225844-d114b5d76004/go.mod h1:0y+AMmGlixZulyaEWAFu/pwLC0PQmY6XYnKDGODytps=
+github.com/hashicorp/go-tfe v1.75.1-0.20250221201235-2bf0f5fde70c h1:WlfLV1Mb5Mms0wsbcsjHlsuhlYkCrGk8Br5Sot5q8lY=
+github.com/hashicorp/go-tfe v1.75.1-0.20250221201235-2bf0f5fde70c/go.mod h1:+EccOb8gn34nC7HMd2ErF0TrUbltwyPWSFyRJclSFk4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -91,6 +93,8 @@ github.com/hashicorp/jsonapi v1.3.2 h1:gP3fX2ZT7qXi+PbwieptzkspIohO2kCSiBUvUTBAb
 github.com/hashicorp/jsonapi v1.3.2/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
 github.com/hashicorp/jsonapi v1.4.1 h1:U6CZvnS70Sg7im0kpfhWAoF3NasLumaMndQhEWniHZA=
 github.com/hashicorp/jsonapi v1.4.1/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
+github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e h1:xwy/1T0cxHWaLx2MM0g4BlaQc1BXn/9835mPrBqwSPU=
+github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.22.0 h1:G5+4Sz6jYZfRYUCg6eQgDsqTzkNXV+fP8l+uRmZHj64=

--- a/internal/provider/resource_tfe_organization_default_settings.go
+++ b/internal/provider/resource_tfe_organization_default_settings.go
@@ -15,6 +15,7 @@ import (
 	"log"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/jsonapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -85,11 +86,9 @@ func resourceTFEOrganizationDefaultSettingsCreate(d *schema.ResourceData, meta i
 	}
 
 	// If the default project id was provided, get the default project
-	var project *tfe.Project
+	var project jsonapi.NullableRelationship[*tfe.Project]
 	if v, ok := d.GetOk("default_project_id"); ok && v.(string) != "" {
-		project = &tfe.Project{
-			ID: v.(string),
-		}
+		project = jsonapi.NewNullableRelationshipWithValue[*tfe.Project](&tfe.Project{ID: v.(string)})
 	}
 
 	defaultExecutionMode := ""
@@ -156,7 +155,7 @@ func resourceTFEOrganizationDefaultSettingsDelete(d *schema.ResourceData, meta i
 	_, err = config.Client.Organizations.Update(context.Background(), organization, tfe.OrganizationUpdateOptions{
 		DefaultExecutionMode: tfe.String("remote"),
 		DefaultAgentPool:     nil,
-		DefaultProject:       nil,
+		DefaultProject:       jsonapi.NewNullNullableRelationship[*tfe.Project](),
 	})
 	if err != nil {
 		return fmt.Errorf("error updating organization default execution mode: %w", err)

--- a/internal/provider/resource_tfe_organization_default_settings_test.go
+++ b/internal/provider/resource_tfe_organization_default_settings_test.go
@@ -97,9 +97,6 @@ func TestAccTFEOrganizationDefaultSettings_project(t *testing.T) {
 					testAccCheckTFEOrganizationDefaultProjectIDExists(org),
 				),
 			},
-			{
-				Config: testAccTFEOrganizationDefaultSettings_project_update(rInt),
-			},
 		},
 	})
 }
@@ -139,9 +136,6 @@ func TestAccTFEOrganizationDefaultSettings_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEOrganizationDefaultSettings_project_update(rInt),
-			},
-			{
 				Config: testAccTFEOrganizationDefaultSettings_local(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
@@ -171,9 +165,6 @@ func TestAccTFEOrganizationDefaultSettings_import(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationDefaultSettings_remote(rInt),
-			},
-			{
-				Config: testAccTFEOrganizationDefaultSettings_project_update(rInt),
 			},
 			{
 				ResourceName:      "tfe_organization_default_settings.foobar",
@@ -287,33 +278,5 @@ resource "tfe_organization_default_settings" "foobar" {
   default_execution_mode = "agent"
   default_agent_pool_id = tfe_agent_pool.foobar.id
   default_project_id = tfe_project.foobar.id
-}`, rInt)
-}
-
-// Since we are setting the previously created project to be the default project, and a default project
-// cannot be deleted, we need to reset it to the original project so the project and organization can be deleted.
-func testAccTFEOrganizationDefaultSettings_project_update(rInt int) string {
-	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-  name  = "tst-terraform-%d"
-  email = "admin@company.com"
-}
-resource "tfe_agent_pool" "foobar" {
-  name         = "agent-pool-test"
-  organization = tfe_organization.foobar.name
-}
-resource "tfe_project" "foobar" {
-  name         = "project-test"
-  organization = tfe_organization.foobar.name
-}
-data "tfe_project" "original" {
-  name         = "Default Project"
-  organization = tfe_organization.foobar.name
-}
-resource "tfe_organization_default_settings" "foobar" {
-  organization       = tfe_organization.foobar.name
-  default_execution_mode = "agent"
-  default_agent_pool_id = tfe_agent_pool.foobar.id
-  default_project_id = data.tfe_project.original.id
 }`, rInt)
 }

--- a/internal/provider/resource_tfe_organization_default_settings_test.go
+++ b/internal/provider/resource_tfe_organization_default_settings_test.go
@@ -258,6 +258,11 @@ resource "tfe_organization" "foobar" {
   email = "admin@company.com"
 }
 
+resource "tfe_agent_pool" "foobar" {
+  name = "agent-pool-test"
+  organization = tfe_organization.foobar.name
+}
+
 resource "tfe_project" "foobar" {
   name = "project-test"
   organization = tfe_organization.foobar.name
@@ -265,6 +270,8 @@ resource "tfe_project" "foobar" {
 
 resource "tfe_organization_default_settings" "foobar" {
   organization       = tfe_organization.foobar.name
+  default_execution_mode = "agent"
+  default_agent_pool_id = tfe_agent_pool.foobar.id
   default_project_id = tfe_project.foobar.id
 }`, rInt)
 }

--- a/internal/provider/resource_tfe_organization_default_settings_test.go
+++ b/internal/provider/resource_tfe_organization_default_settings_test.go
@@ -98,7 +98,6 @@ func TestAccTFEOrganizationDefaultSettings_project(t *testing.T) {
 				),
 			},
 			{
-				// Reset to the original default project to destroy the previously created one.
 				Config: testAccTFEOrganizationDefaultSettings_project_update(rInt),
 			},
 		},
@@ -140,7 +139,6 @@ func TestAccTFEOrganizationDefaultSettings_update(t *testing.T) {
 				),
 			},
 			{
-				// Reset to the original default project to destroy the previously created one.
 				Config: testAccTFEOrganizationDefaultSettings_project_update(rInt),
 			},
 			{
@@ -175,7 +173,6 @@ func TestAccTFEOrganizationDefaultSettings_import(t *testing.T) {
 				Config: testAccTFEOrganizationDefaultSettings_remote(rInt),
 			},
 			{
-				// Reset to the original default project to destroy the previously created one.
 				Config: testAccTFEOrganizationDefaultSettings_project_update(rInt),
 			},
 			{
@@ -293,6 +290,8 @@ resource "tfe_organization_default_settings" "foobar" {
 }`, rInt)
 }
 
+// Since we are setting the previously created project to be the default project, and a default project
+// cannot be deleted, we need to reset it to the original project so the project and organization can be deleted.
 func testAccTFEOrganizationDefaultSettings_project_update(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {

--- a/website/docs/r/organization_default_settings.html.markdown
+++ b/website/docs/r/organization_default_settings.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "tfe"
-page_title: "Terraform Enterprise: tfe_organization_default_settings
+page_title: "Terraform Enterprise: tfe_organization_default_settings"
 description: |-
   Sets the workspace defaults for an organization
 ---
@@ -24,10 +24,16 @@ resource "tfe_agent_pool" "my_agents" {
   organization = tfe_organization.test.name
 }
 
+resource "tfe_project" "my_project" {
+  name         = "my-project"
+  organization = tfe_organization.test.name
+}
+
 resource "tfe_organization_default_settings" "org_default" {
   organization           = tfe_organization.test.name
   default_execution_mode = "agent"
   default_agent_pool_id  = tfe_agent_pool.my_agents.id
+  default_project_id     = tfe_project.my_project.id
 }
 
 resource "tfe_workspace" "my_workspace" {
@@ -46,6 +52,7 @@ The following arguments are supported:
 * `default_execution_mode` - (Optional) Which [execution mode](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#execution-mode)
   to use as the default for all workspaces in the organization. Valid values are `remote`, `local` or`agent`.
 * `default_agent_pool_id` - (Optional) The ID of an agent pool to assign to the workspace. Requires `default_execution_mode` to be set to `agent`. This value _must not_ be provided if `default_execution_mode` is set to any other value.
+* `default_project_id` - (Optional) The ID of a project to assign as the default project for the organization.
 * `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 
 

--- a/website/docs/r/organization_default_settings.html.markdown
+++ b/website/docs/r/organization_default_settings.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 ## Import
 
-Organization default execution mode can be imported; use `<ORGANIZATION NAME>` as the import ID. For example:
+Organization default execution mode and default project can be imported; use `<ORGANIZATION NAME>` as the import ID. For example:
 
 ```shell
 terraform import tfe_organization_default_settings.test my-org-name


### PR DESCRIPTION
## Description

In atlas, we can now update the default project hence we need to add default project id to the organization default settings.

Note:
- I have added default project to the importer as well, is this a needed change?
- Cleaning up resources for a default project is a little tricky because default project cannot be deleted so, while testing I needed to set the default project to be the original default project to be able to delete the resource.


_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://github.com/hashicorp/go-tfe/pull/1056)
- [API documentation](https://github.com/hashicorp/terraform-docs-common/pull/683)
- [Jira](https://hashicorp.atlassian.net/browse/TF-14884)

## Output from Documentation Preview
<img width="795" alt="Screenshot 2025-02-11 at 12 21 20 PM" src="https://github.com/user-attachments/assets/b2b7d938-c0c8-4d46-9cbe-2806a5acc2f8" />
<img width="808" alt="Screenshot 2025-02-24 at 1 09 25 PM" src="https://github.com/user-attachments/assets/c607f681-ec97-4cbd-b0d2-30ef8654309b" />



## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

![Screenshot 2025-02-13 at 9 54 36 AM](https://github.com/user-attachments/assets/ec416674-ab38-4628-b4cb-3843c5cc3d63)
![Screenshot 2025-02-13 at 9 57 56 AM](https://github.com/user-attachments/assets/d265565a-77e8-445f-a532-e676ad8e7a94)
![Screenshot 2025-02-13 at 11 27 31 AM](https://github.com/user-attachments/assets/f08c8f67-a62d-451f-9edf-ebce5f2e9a7b)

