### PR TITLE
Only fetch remote state consumers when global remote state is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ FEATURES:
 BUG FIXES:
 * `r/tfe_stack`: Fix serialization issue when using github app installation within vcs_repo block, by @mjyocca [#1572](https://github.com/hashicorp/terraform-provider-tfe/pull/1572)
 
+* `r/tfe_workspace_settings`: Prevent fetching of all workspaces as the `remote_state_consumer_ids` when `global_remote_state` is set to true, by @uk1288 [#1606](https://github.com/hashicorp/terraform-provider-tfe/pull/1606)
+
 ## v.0.63.0
 
 BUG FIXES:

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -357,13 +357,13 @@ func (r *workspaceSettings) workspaceSettingsModelFromTFEWorkspace(ws *tfe.Works
 
 	result.RemoteStateConsumerIDs = types.SetNull(types.StringType)
 
-	_, remoteStateConsumerIDs, err := readWorkspaceStateConsumers(ws.ID, r.config.Client)
-	if err != nil {
-		log.Printf("[ERROR] Error reading remote state consumers for workspace %s: %s", ws.ID, err)
-		return nil
-	}
-
 	if !ws.GlobalRemoteState {
+		_, remoteStateConsumerIDs, err := readWorkspaceStateConsumers(ws.ID, r.config.Client)
+		if err != nil {
+			log.Printf("[ERROR] Error reading remote state consumers for workspace %s: %s", ws.ID, err)
+			return nil
+		}
+
 		remoteStateConsumerIDValues, diags := types.SetValueFrom(ctx, types.StringType, remoteStateConsumerIDs)
 		if diags.HasError() {
 			log.Printf("[ERROR] Error reading remote state consumers for workspace %s: %v", ws.ID, diags)


### PR DESCRIPTION
## Description

Previously,  remote state consumers was always fetched regardless of the global remote state setting. This means that, when `global_remote_state` was true, the provider fetches all the workspaces within that org as its remote state consumers. For users with large number of workspaces, this resulted in significant fetch time.

With this PR, remote state consumers are only fetched when state is shared with a subset of existing workspaces, i.e when the `global_remote_state` is false.

Caveat: Note that if the list of remote state consumers is large, say >100s, then the fetch time will also increase.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Create multiple `tfe_workspace` and `tfe_workspace_settings` resources
1.  Set the `global_remote_state` to false, add some workspaces to the `remote_state_consumer_ids`, only the listed IDs should be fetched.
1.  Set the `global_remote_state` to true, now no remote state consumers should be fetched

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspaceSettings" make testacc

=== RUN   TestAccTFEWorkspaceSettings
--- PASS: TestAccTFEWorkspaceSettings (11.71s)
=== RUN   TestAccTFEWorkspaceSettingsRemoteState
--- PASS: TestAccTFEWorkspaceSettingsRemoteState (8.40s)
=== RUN   TestAccTFEWorkspaceSettingsImport
--- PASS: TestAccTFEWorkspaceSettingsImport (6.59s)
=== RUN   TestAccTFEWorkspaceSettingsImport_ByName
--- PASS: TestAccTFEWorkspaceSettingsImport_ByName (6.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	33.389s
```
