### PR TITLE
Remove beta flag for custom project variable set permission

### DIFF
--- a/internal/provider/data_source_team_project_access_test.go
+++ b/internal/provider/data_source_team_project_access_test.go
@@ -87,7 +87,6 @@ func TestAccTFETeamProjectCustomAccessDataSource_basic(t *testing.T) {
 }
 
 func TestAccTFETeamProjectCustomAccessDataSource_basic_with_project_variable_sets(t *testing.T) {
-	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/provider/resource_tfe_team_project_access_test.go
+++ b/internal/provider/resource_tfe_team_project_access_test.go
@@ -73,7 +73,6 @@ func TestAccTFETeamProjectCustomAccess(t *testing.T) {
 }
 
 func TestAccTFETeamProjectCustomAccess_with_project_variable_sets(t *testing.T) {
-	skipUnlessBeta(t)
 	tmAccess := &tfe.TeamProjectAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	access := tfe.TeamProjectAccessCustom
@@ -157,7 +156,6 @@ func TestAccTFETeamProjectCustomAccess_import(t *testing.T) {
 }
 
 func TestAccTFETeamProjectCustomAccess_import_with_project_variable_set(t *testing.T) {
-	skipUnlessBeta(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	tmAccess := &tfe.TeamProjectAccess{}
 	access := tfe.TeamProjectAccessCustom
@@ -239,7 +237,6 @@ func TestAccTFETeamProjectCustomAccess_full_update(t *testing.T) {
 }
 
 func TestAccTFETeamProjectCustomAccess_full_update_with_project_variable_sets(t *testing.T) {
-	skipUnlessBeta(t)
 	tmAccess := &tfe.TeamProjectAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	access := tfe.TeamProjectAccessCustom
@@ -348,7 +345,6 @@ func TestAccTFETeamProjectCustomAccess_partial_update(t *testing.T) {
 }
 
 func TestAccTFETeamProjectCustomAccess_partial_update_with_project_variable_sets(t *testing.T) {
-	skipUnlessBeta(t)
 	tmAccess := &tfe.TeamProjectAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	access := tfe.TeamProjectAccessCustom


### PR DESCRIPTION
## Description

Now that the feature is GA and the feature flag is removed from atlas, we can remove the beta flags from test.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Tests all pass.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [Jira](https://hashicorp.atlassian.net/browse/TF-23829)

