### PR TITLE
[IPL-7245] Fix OAuth Token ID updates not registering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ FEATURES:
 * `r/tfe_team_project_access`: Add `variable_sets` attribute to `project_access`, by @mkam [#1565](https://github.com/hashicorp/terraform-provider-tfe/pull/1565)
 
 BUG FIXES:
+* `r/tfe_oauth_client`: Ensure `oauth_token_id` updates register when performing a `terraform apply`, by @hashimoon[#1631](https://github.com/hashicorp/terraform-provider-tfe/pull/1631)
+
 * `r/tfe_stack`: Fix serialization issue when using github app installation within vcs_repo block, by @mjyocca [#1572](https://github.com/hashicorp/terraform-provider-tfe/pull/1572)
 
 * `r/tfe_workspace_settings`: Prevent fetching of all workspaces as the `remote_state_consumer_ids` when `global_remote_state` is set to true, by @uk1288 [#1606](https://github.com/hashicorp/terraform-provider-tfe/pull/1606)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ FEATURES:
 * **New Ephemeral Resource:** `agent_token` is a new ephemeral
   resource for creating and managing agent tokens, by @uturunku1 ([#1627](https://github.com/hashicorp/terraform-provider-tfe/pull/1627))
 
+BUG FIXES:
+* `r/tfe_oauth_client`: Ensure `oauth_token_id` updates register when performing a `terraform apply`, by @hashimoon[#1631](https://github.com/hashicorp/terraform-provider-tfe/pull/1631)
+
 ENHANCEMENTS:
 
 * resource/tfe_variable: Add `value_wo` write-only attribute, by @uturunku ([#1639](https://github.com/hashicorp/terraform-provider-tfe/pull/1639))
@@ -26,6 +29,7 @@ ENHANCEMENTS:
 * resource/tfe_saml_settings: Add `private_key_wo` write-only attribute, by @uturunku1 ([#1660](https://github.com/hashicorp/terraform-provider-tfe/pull/1660))
 
 * resource/tfe_ssh_key: Add `key_wo` write-only attribute, by @ctrombley ([#1659](https://github.com/hashicorp/terraform-provider-tfe/pull/1659))
+
 ## v.0.64.0
 
 FEATURES:
@@ -35,8 +39,6 @@ FEATURES:
 * `r/tfe_team_project_access`: Add `variable_sets` attribute to `project_access`, by @mkam [#1565](https://github.com/hashicorp/terraform-provider-tfe/pull/1565)
 
 BUG FIXES:
-* `r/tfe_oauth_client`: Ensure `oauth_token_id` updates register when performing a `terraform apply`, by @hashimoon[#1631](https://github.com/hashicorp/terraform-provider-tfe/pull/1631)
-
 * `r/tfe_stack`: Fix serialization issue when using github app installation within vcs_repo block, by @mjyocca [#1572](https://github.com/hashicorp/terraform-provider-tfe/pull/1572)
 
 * `r/tfe_workspace_settings`: Prevent fetching of all workspaces as the `remote_state_consumer_ids` when `global_remote_state` is set to true, by @uk1288 [#1606](https://github.com/hashicorp/terraform-provider-tfe/pull/1606)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,18 +36,19 @@ these values with the environment variables specified below:
 
 ##### Optional:
 1. `TFE_USER1` and `TFE_USER2`: The usernames of two pre-existing users on the HCP Terraform or Terraform Enterprise instance being used for testing. Required for running team membership tests.
-2. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Used to establish a VCS provider connection.
-3. `GITHUB_POLICY_SET_IDENTIFIER` - GitHub policy set repository identifier in the format `username/repository`. Required for running policy set tests.
-4. `GITHUB_POLICY_SET_BRANCH`: A GitHub branch for the repository specified by `GITHUB_POLICY_SET_IDENTIFIER`. Required for running policy set tests.
-5. `GITHUB_POLICY_SET_PATH`: A GitHub subdirectory for the repository specified by `GITHUB_POLICY_SET_IDENTIFIER`. Required for running policy set tests.
-6. `GITHUB_REGISTRY_MODULE_IDENTIFIER` - GitHub registry module repository identifier in the format `username/repository`. Required for running registry module tests.
-7. `GITHUB_WORKSPACE_IDENTIFIER` - GitHub workspace repository identifier in the format `username/repository`. Required for running workspace tests.
-8. `GITHUB_WORKSPACE_BRANCH`: A GitHub branch for the repository specified by `GITHUB_WORKSPACE_IDENTIFIER`. Required for running workspace tests.
-9. `ENABLE_TFE` - Some tests cover features available only in HCP Terraform. To skip these tests when running against a Terraform Enterprise instance, set `ENABLE_TFE=1`.
-10. `RUN_TASKS_URL` - External URL to use for testing Run Tasks operations, for example `RUN_TASKS_URL=http://somewhere.local:8080/pass`. Required for running run tasks tests.
-11. `RUN_TASKS_HMAC` - The optional HMAC Key that should be used for Run Task operations. The default is no key.
-12. `GITHUB_APP_INSTALLATION_ID` - GitHub App installation internal id in the format `ghain-xxxxxxx`. Required for running any tests that use GitHub App VCS (workspace, policy sets, registry module).
-13. `GITHUB_APP_INSTALLATION_NAME` - GitHub App installation name. Required for running tfe_github_app_installation data source test.
+1. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Used to establish a VCS provider connection.
+1. `GITHUB_TOKEN2` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Used to establish a secondary VCS provider connection.
+1. `GITHUB_POLICY_SET_IDENTIFIER` - GitHub policy set repository identifier in the format `username/repository`. Required for running policy set tests.
+1. `GITHUB_POLICY_SET_BRANCH`: A GitHub branch for the repository specified by `GITHUB_POLICY_SET_IDENTIFIER`. Required for running policy set tests.
+1. `GITHUB_POLICY_SET_PATH`: A GitHub subdirectory for the repository specified by `GITHUB_POLICY_SET_IDENTIFIER`. Required for running policy set tests.
+1. `GITHUB_REGISTRY_MODULE_IDENTIFIER` - GitHub registry module repository identifier in the format `username/repository`. Required for running registry module tests.
+1. `GITHUB_WORKSPACE_IDENTIFIER` - GitHub workspace repository identifier in the format `username/repository`. Required for running workspace tests.
+1. `GITHUB_WORKSPACE_BRANCH`: A GitHub branch for the repository specified by `GITHUB_WORKSPACE_IDENTIFIER`. Required for running workspace tests.
+1. `ENABLE_TFE` - Some tests cover features available only in HCP Terraform. To skip these tests when running against a Terraform Enterprise instance, set `ENABLE_TFE=1`.
+1. `RUN_TASKS_URL` - External URL to use for testing Run Tasks operations, for example `RUN_TASKS_URL=http://somewhere.local:8080/pass`. Required for running run tasks tests.
+1. `RUN_TASKS_HMAC` - The optional HMAC Key that should be used for Run Task operations. The default is no key.
+1. `GITHUB_APP_INSTALLATION_ID` - GitHub App installation internal id in the format `ghain-xxxxxxx`. Required for running any tests that use GitHub App VCS (workspace, policy sets, registry module).
+1. `GITHUB_APP_INSTALLATION_NAME` - GitHub App installation name. Required for running tfe_github_app_installation data source test.
 
 **Note:** In order to run integration tests for **Paid** features you will need a token `TFE_TOKEN` with HCP Terraform or Terraform Enterprise administrator privileges, otherwise the attempt to upgrade an organization's feature set will fail.
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -264,6 +264,7 @@ func init() {
 	envGithubPolicySetPath = os.Getenv("GITHUB_POLICY_SET_PATH")
 	envGithubRegistryModuleIdentifer = os.Getenv("GITHUB_REGISTRY_MODULE_IDENTIFIER")
 	envGithubToken = os.Getenv("GITHUB_TOKEN")
+	envGithubToken2 = os.Getenv("GITHUB_TOKEN2")
 	envGithubAppInstallationID = os.Getenv("GITHUB_APP_INSTALLATION_ID")
 	envGithubAppInstallationName = os.Getenv("GITHUB_APP_INSTALLATION_NAME")
 	envGithubWorkspaceIdentifier = os.Getenv("GITHUB_WORKSPACE_IDENTIFIER")
@@ -277,6 +278,7 @@ var envGithubPolicySetBranch string
 var envGithubPolicySetPath string
 var envGithubRegistryModuleIdentifer string
 var envGithubToken string
+var envGithubToken2 string
 var envGithubAppInstallationID string
 var envGithubAppInstallationName string
 var envGithubWorkspaceIdentifier string

--- a/internal/provider/resource_tfe_oauth_client.go
+++ b/internal/provider/resource_tfe_oauth_client.go
@@ -181,6 +181,12 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(oc.ID)
 
+	if len(oc.OAuthTokens) > 0 {
+		d.Set("oauth_token_id", oc.OAuthTokens[0].ID)
+	} else {
+		d.Set("oauth_token_id", "")
+	}
+
 	return resourceTFEOAuthClientRead(d, meta)
 }
 
@@ -238,6 +244,7 @@ func resourceTFEOAuthClientUpdate(d *schema.ResourceData, meta interface{}) erro
 	// Create a new options struct.
 	options := tfe.OAuthClientUpdateOptions{
 		OrganizationScoped: tfe.Bool(d.Get("organization_scoped").(bool)),
+		OAuthToken:         tfe.String(d.Get("oauth_token").(string)),
 	}
 
 	log.Printf("[DEBUG] Update OAuth client %s", d.Id())

--- a/internal/provider/resource_tfe_oauth_client_test.go
+++ b/internal/provider/resource_tfe_oauth_client_test.go
@@ -150,8 +150,8 @@ func TestAccTFEOAuthClient_updateOAuthTokenID(t *testing.T) {
 				t.Skip("Please set GITHUB_TOKEN2 to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			// Step 1: Create with the initial oauth_token_id.
 			{


### PR DESCRIPTION
## Description

Previously, `terraform apply` was required to run twice before the `oauth_token_id` would be persisted in the state file when the OAuth token changes even though the `oauth_token_id` was updated as expected on the server after the first run of `terraform apply`. With this change, only a single run of `terraform apply` is necessary to persist the changes for the `oauth_token_id` to the state file when the OAuth token changes..

In order for the test to run, **two** OAuth tokens need to be present in the environment. I added `GITHUB_TOKEN2` to the test environment. The same will need to be done for CI.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Create a resource with an `oauth_token`.
1.  Perform `terraform plan` and verify no changes are required.
1.  Update the value of `oauth_token`.
1.  Perform `terraform plan` and verify that changes to the `vcs_repo.oauth_token_id` are necessary
1.  Perform `terraform apply`.
1.  Perform `terraform plan` and verify no changes are required.

## External links

- [Bug Example Repo](https://github.com/dlavric/tfe-vcs-gitlab)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
GOROOT=/opt/homebrew/opt/go/libexec #gosetup
GOPATH=/Users/joseph/go #gosetup
/opt/homebrew/opt/go/libexec/bin/go test -c -o /Users/joseph/Library/Caches/JetBrains/IntelliJIdea2024.3/tmp/GoLand/___2TestAccTFEOAuthClient_updateOAuthTokenID_in_github_com_hashicorp_terraform_provider_tfe_internal_provider.test github.com/hashicorp/terraform-provider-tfe/internal/provider #gosetup
/opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/joseph/Library/Caches/JetBrains/IntelliJIdea2024.3/tmp/GoLand/___2TestAccTFEOAuthClient_updateOAuthTokenID_in_github_com_hashicorp_terraform_provider_tfe_internal_provider.test -test.v=test2json -test.paniconexit0 -test.run ^\QTestAccTFEOAuthClient_updateOAuthTokenID\E$ #gosetup
=== RUN   TestAccTFEOAuthClient_updateOAuthTokenID
--- PASS: TestAccTFEOAuthClient_updateOAuthTokenID (6.09s)
PASS

Process finished with the exit code 0

...
```
