### PR TITLE
Add agent_pool_id to OAuth client resource

### DIFF
--- a/internal/provider/resource_tfe_oauth_client.go
+++ b/internal/provider/resource_tfe_oauth_client.go
@@ -204,6 +204,7 @@ func resourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("http_url", oc.HTTPURL)
 	d.Set("service_provider", string(oc.ServiceProvider))
 	d.Set("organization_scoped", oc.OrganizationScoped)
+	d.Set("agent_pool_id", oc.AgentPool.ID)
 
 	switch len(oc.OAuthTokens) {
 	case 0:
@@ -238,6 +239,9 @@ func resourceTFEOAuthClientUpdate(d *schema.ResourceData, meta interface{}) erro
 	// Create a new options struct.
 	options := tfe.OAuthClientUpdateOptions{
 		OrganizationScoped: tfe.Bool(d.Get("organization_scoped").(bool)),
+	}
+	if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
+		options.AgentPool = &tfe.AgentPool{ID: *tfe.String(v.(string))}
 	}
 
 	log.Printf("[DEBUG] Update OAuth client %s", d.Id())


### PR DESCRIPTION
This change adds the agent_pool_id field to the read and update functions, which is used to associate a VCS Provider with an AgentPool for PrivateVCS support.
