### PR TITLE
create a write only mode attribute to set a tfe_variable and tfe_test_variable value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ FEATURES:
   resource for creating and managing team tokens in an organization, by
   @shwetamurali and @ctrombley [#1628](https://github.com/hashicorp/terraform-provider-tfe/pull/1628)
 
+* **New Ephemeral Resource:** `agent_token` is a new ephemeral
+  resource for creating and managing agent tokens, by @uturunku1 ([#1627](https://github.com/hashicorp/terraform-provider-tfe/pull/1627))
+
+ENHANCEMENTS:
+
+* resource/tfe_variable: Add `value_wo` write-only attribute ([#1639](https://github.com/hashicorp/terraform-provider-tfe/pull/1639))
+
 ## v.0.64.0
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ ENHANCEMENTS:
 
 * resource/tfe_variable: Add `value_wo` write-only attribute ([#1639](https://github.com/hashicorp/terraform-provider-tfe/pull/1639))
 
+* resource/tfe_test_variable: Add `value_wo` write-only attribute ([#1639](https://github.com/hashicorp/terraform-provider-tfe/pull/1639))
+
 ## v.0.64.0
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
-	github.com/hashicorp/terraform-plugin-framework v1.13.0
-	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
+	github.com/hashicorp/terraform-plugin-framework v1.14.1
+	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.26.0
 	github.com/hashicorp/terraform-plugin-mux v0.18.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.0
@@ -71,7 +71,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.5.0 // indirect
 	github.com/hashicorp/hc-install v0.9.1 // indirect
-	github.com/hashicorp/terraform-plugin-testing v1.11.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.4 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,10 +95,14 @@ github.com/hashicorp/terraform-json v0.24.0 h1:rUiyF+x1kYawXeRth6fKFm/MdfBS6+lW4
 github.com/hashicorp/terraform-json v0.24.0/go.mod h1:Nfj5ubo9xbu9uiAoZVBsNOjvNKB66Oyrvtit74kC7ow=
 github.com/hashicorp/terraform-plugin-framework v1.13.0 h1:8OTG4+oZUfKgnfTdPTJwZ532Bh2BobF4H+yBiYJ/scw=
 github.com/hashicorp/terraform-plugin-framework v1.13.0/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
+github.com/hashicorp/terraform-plugin-framework v1.14.1 h1:jaT1yvU/kEKEsxnbrn4ZHlgcxyIfjvZ41BLdlLk52fY=
+github.com/hashicorp/terraform-plugin-framework v1.14.1/go.mod h1:xNUKmvTs6ldbwTuId5euAtg37dTxuyj3LHS3uj7BHQ4=
 github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0 h1:v3DapR8gsp3EM8fKMh6up9cJUFQ2iRaFsYLP8UJnCco=
 github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0/go.mod h1:c3PnGE9pHBDfdEVG9t1S1C9ia5LW+gkFR0CygXlM8ak=
 github.com/hashicorp/terraform-plugin-framework-validators v0.16.0 h1:O9QqGoYDzQT7lwTXUsZEtgabeWW96zUBh47Smn2lkFA=
 github.com/hashicorp/terraform-plugin-framework-validators v0.16.0/go.mod h1:Bh89/hNmqsEWug4/XWKYBwtnw3tbz5BAy1L1OgvbIaY=
+github.com/hashicorp/terraform-plugin-framework-validators v0.17.0 h1:0uYQcqqgW3BMyyve07WJgpKorXST3zkpzvrOnf3mpbg=
+github.com/hashicorp/terraform-plugin-framework-validators v0.17.0/go.mod h1:VwdfgE/5Zxm43flraNa0VjcvKQOGVrcO4X8peIri0T0=
 github.com/hashicorp/terraform-plugin-go v0.26.0 h1:cuIzCv4qwigug3OS7iKhpGAbZTiypAfFQmw8aE65O2M=
 github.com/hashicorp/terraform-plugin-go v0.26.0/go.mod h1:+CXjuLDiFgqR+GcrM5a2E2Kal5t5q2jb0E3D57tTdNY=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/provider/attribute_helpers.go
+++ b/internal/provider/attribute_helpers.go
@@ -5,6 +5,8 @@ package provider
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -38,4 +40,10 @@ func (c *ConfiguredClient) dataOrDefaultOrganization(ctx context.Context, data A
 	}
 
 	return diags
+}
+
+func generateSHA256Hash(data string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(data))
+	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/internal/provider/attribute_helpers.go
+++ b/internal/provider/attribute_helpers.go
@@ -13,6 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+const (
+	ValueWOHashedPrivateKey = "value_wo_hashed"
+)
+
 // AttrGettable is a small enabler for helper functions that need to read one
 // attribute of a Configuration, Plan, or State.
 type AttrGettable interface {

--- a/internal/provider/resource_tfe_test_variable.go
+++ b/internal/provider/resource_tfe_test_variable.go
@@ -273,11 +273,11 @@ func (r *resourceTFETestVariable) Create(ctx context.Context, req resource.Creat
 	if !config.ValueWO.IsNull() {
 		// Use the resource's private state to store secure hashes of write-only argument values, the provider during planmodify will use the hash to determine if a write-only argument value has changed in later Terraform runs.
 		hashedValue := generateSHA256Hash(config.ValueWO.ValueString())
-		diags := resp.Private.SetKey(ctx, "value_wo", fmt.Appendf(nil, `"%s"`, hashedValue))
+		diags := resp.Private.SetKey(ctx, ValueWOHashedPrivateKey, fmt.Appendf(nil, `"%s"`, hashedValue))
 		resp.Diagnostics.Append(diags...)
 	} else {
 		// if the value is not configured as write-only, then remove valueWO key from private state. Setting a key with an empty byte slice is interpreted by the framework as a request to remove the key from the ProviderData map.
-		diags := resp.Private.SetKey(ctx, "value_wo", []byte(""))
+		diags := resp.Private.SetKey(ctx, ValueWOHashedPrivateKey, []byte(""))
 		resp.Diagnostics.Append(diags...)
 	}
 
@@ -418,11 +418,11 @@ func (r *resourceTFETestVariable) updatePrivateState(ctx context.Context, resp *
 	if !configValueWO.IsNull() {
 		// Use the resource's private state to store secure hashes of write-only argument values, planModify will use the hash to determine if a write-only argument value has changed in later Terraform runs.
 		hashedValue := generateSHA256Hash(configValueWO.ValueString())
-		diags := resp.Private.SetKey(ctx, "value_wo", fmt.Appendf(nil, `"%s"`, hashedValue))
+		diags := resp.Private.SetKey(ctx, ValueWOHashedPrivateKey, fmt.Appendf(nil, `"%s"`, hashedValue))
 		resp.Diagnostics.Append(diags...)
 	} else {
 		// if value is not configured as write-only, remove valueWO key from private state
-		diags := resp.Private.SetKey(ctx, "value_wo", []byte(""))
+		diags := resp.Private.SetKey(ctx, ValueWOHashedPrivateKey, []byte(""))
 		resp.Diagnostics.Append(diags...)
 	}
 }

--- a/internal/provider/resource_tfe_test_variable.go
+++ b/internal/provider/resource_tfe_test_variable.go
@@ -214,7 +214,7 @@ func (r *resourceTFETestVariable) Schema(ctx context.Context, req resource.Schem
 		Description:         "",
 		MarkdownDescription: "",
 		DeprecationMessage:  "",
-		Version:             0,
+		Version:             1,
 	}
 }
 

--- a/internal/provider/resource_tfe_test_variable.go
+++ b/internal/provider/resource_tfe_test_variable.go
@@ -281,6 +281,10 @@ func (r *resourceTFETestVariable) Create(ctx context.Context, req resource.Creat
 		resp.Diagnostics.Append(diags...)
 	}
 
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
@@ -382,6 +386,9 @@ func (r *resourceTFETestVariable) Update(ctx context.Context, req resource.Updat
 	// Update state
 	result := modelFromTFETestVariable(*variable, plan.Value, moduleID, !config.ValueWO.IsNull())
 	r.updatePrivateState(ctx, resp, config.ValueWO)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/resource_tfe_test_variable.go
+++ b/internal/provider/resource_tfe_test_variable.go
@@ -214,7 +214,7 @@ func (r *resourceTFETestVariable) Schema(ctx context.Context, req resource.Schem
 		Description:         "",
 		MarkdownDescription: "",
 		DeprecationMessage:  "",
-		Version:             1,
+		Version:             0,
 	}
 }
 

--- a/internal/provider/resource_tfe_variable.go
+++ b/internal/provider/resource_tfe_variable.go
@@ -81,12 +81,6 @@ func modelFromTFEVariable(v tfe.Variable, lastValue types.String, isWriteOnlyVal
 	return m
 }
 
-func isWriteOnlyValueInPrivateState(req resource.ReadRequest, resp *resource.ReadResponse) bool {
-	storedValueWO, diags := req.Private.GetKey(ctx, "value_wo")
-	resp.Diagnostics.Append(diags...)
-	return len(storedValueWO) != 0
-}
-
 // modelFromTFEVariableSetVariable builds a modelTFEVariable struct from a
 // tfe.VariableSetVariable value (plus the last known value of the variable's
 // `value` attribute).
@@ -846,6 +840,12 @@ func handleConfigValueWO(valueWO types.String, storedValueWO []byte, response *p
 		log.Printf("[DEBUG] Replacing resource because `value_wo` attribute has been added to a pre-existing variable resource")
 		response.RequiresReplace = true
 	}
+}
+
+func isWriteOnlyValueInPrivateState(req resource.ReadRequest, resp *resource.ReadResponse) bool {
+	storedValueWO, diags := req.Private.GetKey(ctx, "value_wo")
+	resp.Diagnostics.Append(diags...)
+	return len(storedValueWO) != 0
 }
 
 type updateReadableValuePlanModifier struct{}

--- a/internal/provider/resource_tfe_variable.go
+++ b/internal/provider/resource_tfe_variable.go
@@ -25,10 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const (
-	ValueWOHashedPrivateKey = "value_wo_hashed"
-)
-
 // resourceTFEVariable implements the tfe_variable resource type. Note: Much of
 // the complexity of this type's Resource implementation is because the
 // tfe_variable resource is an abstraction over two parallel APIs, so each

--- a/internal/provider/resource_tfe_variable.go
+++ b/internal/provider/resource_tfe_variable.go
@@ -264,7 +264,7 @@ func (r *resourceTFEVariable) Schema(ctx context.Context, req resource.SchemaReq
 		Description:         "",
 		MarkdownDescription: "",
 		DeprecationMessage:  "",
-		Version:             0,
+		Version:             1,
 	}
 }
 

--- a/internal/provider/resource_tfe_variable.go
+++ b/internal/provider/resource_tfe_variable.go
@@ -264,7 +264,7 @@ func (r *resourceTFEVariable) Schema(ctx context.Context, req resource.SchemaReq
 		Description:         "",
 		MarkdownDescription: "",
 		DeprecationMessage:  "",
-		Version:             1,
+		Version:             0,
 	}
 }
 

--- a/internal/provider/resource_tfe_variable.go
+++ b/internal/provider/resource_tfe_variable.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -39,6 +40,7 @@ type modelTFEVariable struct {
 	ID            types.String `tfsdk:"id"`
 	Key           types.String `tfsdk:"key"`
 	Value         types.String `tfsdk:"value"`
+	ValueWO       types.String `tfsdk:"value_wo"`
 	ReadableValue types.String `tfsdk:"readable_value"`
 	Category      types.String `tfsdk:"category"`
 	Description   types.String `tfsdk:"description"`
@@ -50,7 +52,7 @@ type modelTFEVariable struct {
 
 // modelFromTFEVariable builds a modelTFEVariable struct from a tfe.Variable
 // value (plus the last known value of the variable's `value` attribute).
-func modelFromTFEVariable(v tfe.Variable, lastValue types.String) modelTFEVariable {
+func modelFromTFEVariable(v tfe.Variable, lastValue types.String, isWriteOnlyValue bool) modelTFEVariable {
 	// Initialize all fields from the provided API struct
 	m := modelTFEVariable{
 		ID:            types.StringValue(v.ID),
@@ -71,7 +73,18 @@ func modelFromTFEVariable(v tfe.Variable, lastValue types.String) modelTFEVariab
 	} else {
 		m.ReadableValue = m.Value
 	}
+	// Don't retrieve values if write-only is being used. Unset the value and readable_value fields before updating the state.
+	if isWriteOnlyValue {
+		m.Value = types.StringValue("")
+		m.ReadableValue = types.StringValue("")
+	}
 	return m
+}
+
+func isWriteOnlyValueInPrivateState(req resource.ReadRequest, resp *resource.ReadResponse) bool {
+	storedValueWO, diags := req.Private.GetKey(ctx, "valueWO")
+	resp.Diagnostics.Append(diags...)
+	return len(storedValueWO) != 0
 }
 
 // modelFromTFEVariableSetVariable builds a modelTFEVariable struct from a
@@ -160,6 +173,21 @@ func (r *resourceTFEVariable) Schema(ctx context.Context, req resource.SchemaReq
 				Default:     stringdefault.StaticString(""),
 				Sensitive:   true,
 				Description: "Value of the variable",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("value_wo")),
+				},
+			},
+			"value_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Description: "Value of the variable in write-only mode",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("value")),
+				},
+				PlanModifiers: []planmodifier.String{
+					&replaceValueWOPlanModifier{},
+				},
 			},
 			"category": schema.StringAttribute{
 				Required:    true,
@@ -275,17 +303,29 @@ func (r *resourceTFEVariable) createWithWorkspace(ctx context.Context, req resou
 		return
 	}
 
+	var config modelTFEVariable
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	key := data.Key.ValueString()
 	category := data.Category.ValueString()
 	workspaceID := data.WorkspaceID.ValueString()
 
 	options := tfe.VariableCreateOptions{
 		Key:         data.Key.ValueStringPointer(),
-		Value:       data.Value.ValueStringPointer(),
 		Category:    tfe.Category(tfe.CategoryType(category)),
 		HCL:         data.HCL.ValueBoolPointer(),
 		Sensitive:   data.Sensitive.ValueBoolPointer(),
 		Description: data.Description.ValueStringPointer(),
+	}
+
+	if !config.ValueWO.IsNull() {
+		options.Value = config.ValueWO.ValueStringPointer()
+	} else {
+		options.Value = data.Value.ValueStringPointer()
 	}
 
 	log.Printf("[DEBUG] Create %s variable: %s", category, key)
@@ -297,9 +337,19 @@ func (r *resourceTFEVariable) createWithWorkspace(ctx context.Context, req resou
 		)
 		return
 	}
-
 	// Got a variable back, so set state to new values
-	result := modelFromTFEVariable(*variable, data.Value)
+	result := modelFromTFEVariable(*variable, data.Value, !config.ValueWO.IsNull())
+
+	if !config.ValueWO.IsNull() {
+		// Use the resource's private state to store secure hashes of write-only argument values, the provider during planmodify will use the hash to determine if a write-only argument value has changed in later Terraform runs.
+		diags := resp.Private.SetKey(ctx, "valueWO", fmt.Appendf(nil, `"%s"`, config.ValueWO.ValueString()))
+		resp.Diagnostics.Append(diags...)
+	} else {
+		// if the value is not configured as write-only, then remove valueWO key from private state. Setting a key with an empty byte slice is interpreted by the framework as a request to remove the key from the ProviderData map.
+		diags := resp.Private.SetKey(ctx, "valueWO", []byte(""))
+		resp.Diagnostics.Append(diags...)
+	}
+
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
@@ -377,8 +427,12 @@ func (r *resourceTFEVariable) readWithWorkspace(ctx context.Context, req resourc
 		return
 	}
 
-	// We got a variable, so update state:
-	result := modelFromTFEVariable(*variable, data.Value)
+	isWriteOnlyValue := isWriteOnlyValueInPrivateState(req, resp) // to avoid reading from written-only values
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// update state
+	result := modelFromTFEVariable(*variable, data.Value, isWriteOnlyValue)
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
@@ -428,13 +482,19 @@ func (r *resourceTFEVariable) Update(ctx context.Context, req resource.UpdateReq
 func (r *resourceTFEVariable) updateWithWorkspace(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Get both plan and state; must compare them to handle sensitive values safely.
 	var plan modelTFEVariable
-	var state modelTFEVariable
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	var state modelTFEVariable
 	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var config modelTFEVariable
+	diags = req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -464,7 +524,6 @@ func (r *resourceTFEVariable) updateWithWorkspace(ctx context.Context, req resou
 	if state.Value.ValueString() != plan.Value.ValueString() {
 		options.Value = plan.Value.ValueStringPointer()
 	}
-
 	log.Printf("[DEBUG] Update variable: %s", variableID)
 	variable, err := r.config.Client.Variables.Update(ctx, workspaceID, variableID, options)
 	if err != nil {
@@ -475,9 +534,26 @@ func (r *resourceTFEVariable) updateWithWorkspace(ctx context.Context, req resou
 		return
 	}
 	// Update state
-	result := modelFromTFEVariable(*variable, plan.Value)
+	result := modelFromTFEVariable(*variable, plan.Value, !config.ValueWO.IsNull())
+	updatePrivateState(ctx, resp, config.ValueWO)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
+}
+
+func updatePrivateState(ctx context.Context, resp *resource.UpdateResponse, configValueWO types.String) {
+	if !configValueWO.IsNull() {
+		// Use the resource's private state to store secure hashes of write-only argument values, planModify will use the hash to determine if a write-only argument value has changed in later Terraform runs.
+		diags := resp.Private.SetKey(ctx, "valueWO", fmt.Appendf(nil, `"%s"`, configValueWO.ValueString()))
+		resp.Diagnostics.Append(diags...)
+	} else {
+		// if value is not configured as write-only, remove valueWO key from private state
+		diags := resp.Private.SetKey(ctx, "valueWO", []byte(""))
+		resp.Diagnostics.Append(diags...)
+	}
 }
 
 // updateWithVariableSet is the variable set version of Update.
@@ -717,6 +793,58 @@ func (r *resourceTFEVariable) ImportState(ctx context.Context, req resource.Impo
 	resp.Diagnostics.Append(diags...)
 }
 
+type replaceValueWOPlanModifier struct{}
+
+func (v *replaceValueWOPlanModifier) Description(ctx context.Context) string {
+	return "The resource will be replaced when the value of value_wo has changed"
+}
+
+func (v *replaceValueWOPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v *replaceValueWOPlanModifier) PlanModifyString(ctx context.Context, request planmodifier.StringRequest, response *planmodifier.StringResponse) {
+	// Write-only argument values cannot produce a Terraform plan difference. The prior state value for a write-only argument will always be null and the planned state value will also be null, therefore, it cannot produce a diff on its own. The one exception to this case is if the write-only argument is added to requires_replace during Plan Modification, in that case, the write-only argument will always cause a diff/trigger a resource recreation.
+	var configValueWO types.String
+	diag := request.Config.GetAttribute(ctx, path.Root("value_wo"), &configValueWO)
+	response.Diagnostics.Append(diag...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	storedValueWO, diags := request.Private.GetKey(ctx, "valueWO")
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if !configValueWO.IsNull() {
+		handleConfigValueWO(configValueWO, storedValueWO, response)
+	} else if len(storedValueWO) != 0 {
+		// when `value_wo` was previously set in the config, but the config switched to either `value` or no value whatsoever
+		response.RequiresReplace = true
+	}
+}
+
+func handleConfigValueWO(valueWO types.String, storedValueWO []byte, response *planmodifier.StringResponse) {
+	if len(storedValueWO) != 0 {
+		var storedValueWOString string
+		err := json.Unmarshal(storedValueWO, &storedValueWOString)
+		if err != nil {
+			response.Diagnostics.AddError("Error unmarshalling stored value_wo", err.Error())
+			return
+		}
+		// when an ephemeral value is being used, they will generate a new token on every run. So the previous value_wo will not match the current one.
+		if storedValueWOString != valueWO.ValueString() {
+			log.Printf("[DEBUG] Replacing resource because the value of `value_wo` attribute has changed")
+			response.RequiresReplace = true
+		}
+	} else {
+		log.Printf("[DEBUG] Replacing resource because `value_wo` attribute has been added to a pre-existing variable resource")
+		response.RequiresReplace = true
+	}
+}
+
 type updateReadableValuePlanModifier struct{}
 
 func (u *updateReadableValuePlanModifier) Description(ctx context.Context) string {
@@ -728,27 +856,34 @@ func (u *updateReadableValuePlanModifier) MarkdownDescription(ctx context.Contex
 }
 
 func (u *updateReadableValuePlanModifier) PlanModifyString(ctx context.Context, request planmodifier.StringRequest, response *planmodifier.StringResponse) {
-	var sensitive types.Bool
-	diags := request.Plan.GetAttribute(ctx, path.Root("sensitive"), &sensitive)
+	var valueWO types.String
+	diags := request.Config.GetAttribute(ctx, path.Root("value_wo"), &valueWO)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
 	}
+	if valueWO.IsNull() {
+		var sensitive types.Bool
+		diags := request.Plan.GetAttribute(ctx, path.Root("sensitive"), &sensitive)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
 
-	// If the variable is sensitive, unset the readable_value
-	if sensitive.ValueBool() {
-		response.PlanValue = types.StringNull()
-		return
-	}
+		// If the variable is sensitive, unset the readable_value
+		if sensitive.ValueBool() {
+			response.PlanValue = types.StringNull()
+			return
+		}
 
-	// Otherwise, it should equal the actual value
-	var actualValue types.String
-	diags = request.Plan.GetAttribute(ctx, path.Root("value"), &actualValue)
-	response.Diagnostics.Append(diags...)
-	if response.Diagnostics.HasError() {
-		return
+		var actualValue types.String
+		diags = request.Plan.GetAttribute(ctx, path.Root("value"), &actualValue)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+		response.PlanValue = actualValue
 	}
-	response.PlanValue = actualValue
 }
 
 // Compile-time interface check
@@ -757,6 +892,7 @@ var _ resource.ResourceWithConfigure = &resourceTFEVariable{}
 var _ resource.ResourceWithUpgradeState = &resourceTFEVariable{}
 var _ resource.ResourceWithImportState = &resourceTFEVariable{}
 var _ planmodifier.String = &updateReadableValuePlanModifier{}
+var _ planmodifier.String = &replaceValueWOPlanModifier{}
 
 // NewResourceVariable is a resource function for the framework provider.
 func NewResourceVariable() resource.Resource {

--- a/internal/provider/resource_tfe_variable_test.go
+++ b/internal/provider/resource_tfe_variable_test.go
@@ -12,9 +12,11 @@ import (
 	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestAccTFEVariable_basic(t *testing.T) {
@@ -186,6 +188,38 @@ func TestAccTFEVariable_update_key_sensitive(t *testing.T) {
 						"tfe_variable.foobar", "hcl", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "sensitive", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEVariable_valueWriteOnly(t *testing.T) {
+	variable := &tfe.Variable{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	variableValue1 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	variableValue2 := variableValue1 + 42
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEVariable_valueWriteOnly(rInt, variableValue1, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTFEVariableExists(
+						"tfe_variable.foobar", variable),
+				),
+			},
+			{
+				Config: testAccTFEVariable_valueWriteOnly(rInt, variableValue2, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTFEVariableExists(
+						"tfe_variable.foobar", variable),
 				),
 			},
 		},
@@ -806,6 +840,30 @@ resource "tfe_variable" "vs_terraform" {
   variable_set_id = tfe_variable_set.foobar.id
 }`, rInt)
 }
+
+func testAccTFEVariable_valueWriteOnly(rIntOrg int, rIntVariableValue int, sensitive bool) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+	name  = "tst-terraform-%d"
+	email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+	name         = "workspace-test"
+	organization = tfe_organization.foobar.id
+}
+
+resource "tfe_variable" "foobar" {
+  key          = "key_test"
+  value_wo        = "%d"
+  description  = "my description"
+  category     = "env"
+  workspace_id = tfe_workspace.foobar.id
+  sensitive    = %s
+}
+`, rIntOrg, rIntVariableValue, strconv.FormatBool(sensitive))
+}
+
 func testAccTFEVariable_readablevalue(rIntOrg int, rIntVariableValue int, sensitive bool) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {

--- a/website/docs/r/tfe_test_variable.html.markdown
+++ b/website/docs/r/tfe_test_variable.html.markdown
@@ -18,7 +18,7 @@ resource "tfe_organization" "test_org" {
 }
   
 resource "tfe_oauth_client" "test_client" {
-  organization     = tfe_organization.test.name
+  organization     = tfe_organization.test_org.name
   api_url          = "https://api.github.com"
   http_url         = "https://github.com"
   oauth_token      = "my-token-123"
@@ -30,7 +30,7 @@ resource "tfe_registry_module" "test_module" {
   vcs_repo {
   display_identifier = "GH_NAME/REPO_NAME"
   identifier         = "GH_NAME/REPO_NAME"
-  oauth_token_id     = tfe_oauth_client.test.oauth_token_id
+  oauth_token_id     = tfe_oauth_client.test_client.oauth_token_id
   branch             = "main"
   tags				 = false
 }
@@ -44,8 +44,10 @@ resource "tfe_test_variable" "tf_test_test_variable" {
   value        = "value_test"
   description  = "some description"
   category     = "env"
-  organization = tfe_organization.test.name
-  module_name = tfe_registry_module.test.name
-  module_provider = tfe_registry_module.test.module_provider
+  organization = tfe_organization.test_org.name
+  module_name = tfe_registry_module.test_module.name
+  module_provider = tfe_registry_module.test_module.module_provider
 }
 ```
+
+-> **Note:** Write-Only argument `value_wo` is available to use in place of `value`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -65,13 +65,30 @@ resource "tfe_variable" "test-b" {
 }
 ```
 
+Basic usage for the write-only value of tfe_variable:
+
+```hcl
+variable "session_token" {
+  type      = string
+  ephemeral = true
+}
+
+resource "tfe_variable" "test" {
+  key          = "my_key_name"
+  value_wo        = var.session_token
+  category     = "terraform"
+  workspace_id = tfe_workspace.test.id
+  description  = "a useful description"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `key` - (Required) Name of the variable.
 * `value` - (Required) Value of the variable.
-* `value_wo` - (Optional) Write-Only value of the variable.
+* `value_wo` - (Optional) Write-Only value of the variable. `write-only` values are never stored to state and do not display in the Terraform plan output. Set the `sensitive` argument to `true` to not display its value in the `Variables` UI for HCP. If the value passed to `value_wo` changes, it will force to recreate the resource. 
 * `category` - (Required) Whether this is a Terraform or environment variable.
   Valid values are `terraform` or `env`.
 * `description` - (Optional) Description of the variable.

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -71,6 +71,7 @@ The following arguments are supported:
 
 * `key` - (Required) Name of the variable.
 * `value` - (Required) Value of the variable.
+* `value_wo` - (Optional) Write-Only value of the variable.
 * `category` - (Required) Whether this is a Terraform or environment variable.
   Valid values are `terraform` or `env`.
 * `description` - (Optional) Description of the variable.
@@ -87,6 +88,8 @@ drift if `value` is later changed out-of-band via the HCP Terraform UI.
 Terraform will only change the value for a sensitive variable if you change
 `value` in the configuration, so that it no longer matches the last known value
 in the state.
+
+-> **Note:** Write-Only argument `value_wo` is available to use in place of `value`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Add a write-only attributes to `tfe_variable`, so that a user can pass sensitive data to the resource securely and temporarily without storing it in the Terraform state file or having it show up in the plan.

Write only arguments can consume ephemeral values and non ephemeral values.

More info about write-only :

https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments
https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Apply a configuration that uses a tfe_variable and the new value_wo attribute:

```
variable "session_token" {
  type      = string
  ephemeral = true
}

resource "tfe_variable" "agent_token" {
  key          = "my_agent_token_name"
  value_wo = var.session_token
  sensitive    = false
  category     = "terraform"
  workspace_id = data.tfe_workspace.testing.id
  description  = "a useful description"
}
```

The state should not include the value information:

```
    "value": "",
    "value_wo": null,
```

The value that was written into TFC's Workspace variables will show up in the UI because the value of sensitive was set to `false` in this case.


2. Apply the same configuration and pass the same value to the session_token variable. There should be no changes to infrastructure.

3. Now pass a different value to session_token and when you apply, the tfe_variable resource will be recreated.

## External links


_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
