### PR TITLE
[TF-23089] implement write only values for tfe_policy_set_parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* resource/tfe_variable: Add `value_wo` write-only attribute ([#1639](https://github.com/hashicorp/terraform-provider-tfe/pull/1639))
+* resource/tfe_variable: Add `value_wo` write-only attribute, by @uturunku ([#1639](https://github.com/hashicorp/terraform-provider-tfe/pull/1639))
 
-* resource/tfe_test_variable: Add `value_wo` write-only attribute ([#1639](https://github.com/hashicorp/terraform-provider-tfe/pull/1639))
+* resource/tfe_test_variable: Add `value_wo` write-only attribute, by @uturunku ([#1639](https://github.com/hashicorp/terraform-provider-tfe/pull/1639))
+
+* resource/tfe_policy_set_parameter: Add `value_wo` write-only attribute, by @ctrombley ([#1641](https://github.com/hashicorp/terraform-provider-tfe/pull/1641))
 
 ## v.0.64.0
 

--- a/internal/provider/helpers/write_only.go
+++ b/internal/provider/helpers/write_only.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package helpers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func NewWriteOnlyValueStore(private PrivateState, attributeName string) *WriteOnlyValueStore {
+	return &WriteOnlyValueStore{
+		private:       private,
+		attributeName: attributeName,
+	}
+}
+
+type WriteOnlyValueStore struct {
+	private       PrivateState
+	attributeName string
+}
+
+type PrivateState interface {
+	SetKey(ctx context.Context, key string, value []byte) diag.Diagnostics
+	GetKey(ctx context.Context, key string) ([]byte, diag.Diagnostics)
+}
+
+// MatchesPriorValue determines if the given string value matches the prior
+// value in state by comparing the hased values of each.
+func (w *WriteOnlyValueStore) MatchesPriorValue(ctx context.Context, configValue types.String) (bool, diag.Diagnostics) {
+	serializedPriorValue, diags := w.private.GetKey(ctx, w.attributeName)
+	var hashedPriorValue string
+	err := json.Unmarshal(serializedPriorValue, &hashedPriorValue)
+	if err != nil {
+		diags.AddError(fmt.Sprintf("failed to unmarshal prior value for `%s`", w.attributeName), err.Error())
+	}
+
+	hashedValue := generateSHA256Hash(configValue.ValueString())
+	return hashedPriorValue == hashedValue, diags
+}
+
+// PriorValueExists determines if a hashed prior value exists in state.
+func (w *WriteOnlyValueStore) PriorValueExists(ctx context.Context) (bool, diag.Diagnostics) {
+	serializedPriorValue, diags := w.private.GetKey(ctx, w.attributeName)
+	return len(serializedPriorValue) != 0, diags
+}
+
+// SetPriorValue stores the hashed value of the given string value in state.
+func (w *WriteOnlyValueStore) SetPriorValue(ctx context.Context, configValue types.String) diag.Diagnostics {
+	// If not write-only, then remove the hashed value from private state.
+	// Setting a key with an empty byte slice is interpreted by the framework as a request to remove the key from the ProviderData map.
+	if configValue.IsNull() {
+		return w.private.SetKey(ctx, w.attributeName, []byte(""))
+	}
+
+	// Store the hashed value of the string in private state.
+	hashedValue := generateSHA256Hash(configValue.ValueString())
+	return w.private.SetKey(ctx, w.attributeName, fmt.Appendf(nil, `"%s"`, hashedValue))
+}
+
+func generateSHA256Hash(data string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(data))
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/internal/provider/planmodifiers/write_only.go
+++ b/internal/provider/planmodifiers/write_only.go
@@ -1,0 +1,92 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package planmodifiers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers"
+)
+
+var _ planmodifier.String = &replaceForWriteOnlyStringValue{}
+
+func NewReplaceForWriteOnlyStringValue(attributeWriteOnly string) planmodifier.String {
+	return &replaceForWriteOnlyStringValue{
+		attributeWriteOnly: attributeWriteOnly,
+	}
+}
+
+// replaceForWriteOnlyStringValue is a plan modifier that will cause a resource
+// to be replaced if the value of a write-only attribute has changed.
+//
+// For this to work, the write-only attribute must be added to private state
+// using WriteOnlyValueStore.SetPriorValue() after creating or updating the value.
+type replaceForWriteOnlyStringValue struct {
+	attributeWriteOnly string
+}
+
+func (p *replaceForWriteOnlyStringValue) Description(ctx context.Context) string {
+	return "The resource will be replaced when the value of `%s` has changed"
+}
+
+func (p *replaceForWriteOnlyStringValue) MarkdownDescription(ctx context.Context) string {
+	return p.Description(ctx)
+}
+
+func (p *replaceForWriteOnlyStringValue) PlanModifyString(ctx context.Context, request planmodifier.StringRequest, response *planmodifier.StringResponse) {
+	// This plan modifier can be used to trigger a resource replacement when the
+	// value of a write-only attribute has changed.
+	//
+	// Write-only argument values cannot produce a Terraform plan difference on
+	// their own. The prior state value for a write-only argument will always be
+	// null, and the planned state value will also be null.
+	//
+	// The one exception to this case is if the write-only argument is added to
+	// requires_replace during Plan Modification, in that case, the write-only
+	// argument will always cause a diff/trigger a resource recreation.
+	var writeOnlyValue types.String
+	diags := request.Config.GetAttribute(ctx, path.Root(p.attributeWriteOnly), &writeOnlyValue)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	writeOnlyValueExists := !writeOnlyValue.IsNull()
+	writeOnlyValueStore := helpers.NewWriteOnlyValueStore(request.Private, p.attributeWriteOnly)
+	priorWriteOnlyValueExists, diags := writeOnlyValueStore.PriorValueExists(ctx)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if !writeOnlyValueExists && priorWriteOnlyValueExists {
+		tflog.Debug(ctx, fmt.Sprintf("Replacing resource because the write-only `%s` attribute has been removed", p.attributeWriteOnly))
+		response.RequiresReplace = true
+		return
+	}
+
+	if !writeOnlyValueExists {
+		return
+	}
+
+	// Now are dealing with a write-only attribute that has a value set.
+	if !priorWriteOnlyValueExists {
+		tflog.Debug(ctx, fmt.Sprintf("Replacing resource because the write-only `%s` attribute has been newly added to a resource in state", p.attributeWriteOnly))
+		response.RequiresReplace = true
+		return
+	}
+
+	matches, diags := writeOnlyValueStore.MatchesPriorValue(ctx, writeOnlyValue)
+	response.Diagnostics.Append(diags...)
+
+	if !matches {
+		tflog.Debug(ctx, fmt.Sprintf("Replacing resource because the value of the write-only `%s` attribute has changed", p.attributeWriteOnly))
+		response.RequiresReplace = true
+	}
+}

--- a/website/docs/r/policy_set_parameter.html.markdown
+++ b/website/docs/r/policy_set_parameter.html.markdown
@@ -55,3 +55,4 @@ example:
 terraform import tfe_policy_set_parameter.test polset-wAs3zYmWAhYK7peR/var-5rTwnSaRPogw6apb
 ```
 
+-> **Note:** Write-Only argument `value_wo` is available to use in place of `value`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).


### PR DESCRIPTION
## Description

Add a write-only attributes to `tfe_policy_set_parameter`, so that a user can pass sensitive data to the resource securely and temporarily without storing it in the Terraform state file or having it show up in the plan.

Write only arguments can consume ephemeral values and non ephemeral values.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Apply a configuration that uses a `tfe_policy_set_parameter` and the new `value_wo` attribute:

```
variable "secret" {
  type      = string
  ephemeral = true
}

data "tfe_policy_set" "this" {
  name         = "my-policy-set-name"
  organization = "my-org-name"
}

resource "tfe_policy_set_parameter" "secret" {
  key          = "my_secret"
  value_wo = var.secret
  sensitive    = false
  policy_set_id = data.tfe_policy_set.this.id
}
```

The state should not include the value information:

```
    "value": "",
    "value_wo": null,
```

The value that was written into TFC's Workspace variables will show up in the UI because the value of sensitive was set to `false` in this case.


2. Apply the same configuration and pass the same value to the session_token variable. There should be no changes to infrastructure.

3. Now pass a different value to session_token and when you apply, the tfe_policy_set_parameter resource will be recreated.

## External links

- [write-only valuesin the provider framework](https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments)
- [write-only values for ephemeral resources](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)
- [Related PR: upgrade tfe_policy_set_parameter to provide framework](https://github.com/hashicorp/terraform-provider-tfe/pull/1637)

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEPolicySetParameter" make testacc

=== RUN   TestAccTFEPolicySetParameter_basic
2025/03/11 18:21:21 [DEBUG] Configuring client for host "tfcdev-781a2fe5.ngrok.io"
2025/03/11 18:21:21 [DEBUG] Service discovery for tfcdev-781a2fe5.ngrok.io at https://tfcdev-781a2fe5.ngrok.io/.well-known/terraform.json
--- PASS: TestAccTFEPolicySetParameter_basic (5.98s)
=== RUN   TestAccTFEPolicySetParameter_update
--- PASS: TestAccTFEPolicySetParameter_update (9.20s)
=== RUN   TestAccTFEPolicySetParameter_import
--- PASS: TestAccTFEPolicySetParameter_import (6.42s)
=== RUN   TestAccTFEPolicySetParameter_valueWO
--- PASS: TestAccTFEPolicySetParameter_valueWO (12.57s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider
```
