### PR TITLE
chore: migrate tfe_project to the provider framework

### DIFF
--- a/internal/provider/data_source_project.go
+++ b/internal/provider/data_source_project.go
@@ -1,104 +1,189 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// NOTE: This is a legacy resource and should be migrated to the Plugin
-// Framework if substantial modifications are planned. See
-// docs/new-resources.md if planning to use this code as boilerplate for
-// a new resource.
-
 package provider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	tfe "github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func dataSourceTFEProject() *schema.Resource {
-	return &schema.Resource{
-		ReadContext: dataSourceTFEProjectRead,
+var (
+	_ datasource.DataSource              = &dataSourceTFEProject{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFEProject{}
+)
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+func NewProjectDataSource() datasource.DataSource {
+	return &dataSourceTFEProject{}
+}
+
+type modelDataSourceTFEProject struct {
+	ID                          types.String `tfsdk:"id"`
+	Name                        types.String `tfsdk:"name"`
+	Description                 types.String `tfsdk:"description"`
+	Organization                types.String `tfsdk:"organization"`
+	AutoDestroyActivityDuration types.String `tfsdk:"auto_destroy_activity_duration"`
+	WorkspaceIDs                types.Set    `tfsdk:"workspace_ids"`
+	WorkspaceNames              types.Set    `tfsdk:"workspace_names"`
+}
+
+func modelDataSourceFromTFEProject(p *tfe.Project, workspaceIDs, workspaceNames []string) (modelDataSourceTFEProject, diag.Diagnostics) {
+	m := modelDataSourceTFEProject{
+		ID:           types.StringValue(p.ID),
+		Name:         types.StringValue(p.Name),
+		Description:  types.StringValue(p.Description),
+		Organization: types.StringValue(p.Organization.Name),
+	}
+
+	var wids, wnames []attr.Value
+	for w := range workspaceIDs {
+		wids = append(wids, types.StringValue(workspaceIDs[w]))
+		wnames = append(wnames, types.StringValue(workspaceNames[w]))
+	}
+	m.WorkspaceIDs = types.SetValueMust(types.StringType, wids)
+	m.WorkspaceNames = types.SetValueMust(types.StringType, wnames)
+
+	var diags diag.Diagnostics
+	if p.AutoDestroyActivityDuration.IsSpecified() {
+		autoDestroyDuration, err := p.AutoDestroyActivityDuration.Get()
+		if err != nil {
+			diags.AddAttributeError(path.Root("auto_destroy_activity_duration"), "Error reading auto destroy activity duration", err.Error())
+			return m, diags
+		}
+
+		m.AutoDestroyActivityDuration = types.StringValue(autoDestroyDuration)
+	}
+
+	return m, diags
+}
+
+type dataSourceTFEProject struct {
+	config ConfiguredClient
+}
+
+// Metadata returns the data source type name.
+func (d *dataSourceTFEProject) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project"
+}
+
+// Schema defines the schema for the data source.
+func (d *dataSourceTFEProject) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source can be used to retrieve a project in an organization.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The system-generated ID of the project.",
+				Computed:    true,
 			},
-
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
+			"name": schema.StringAttribute{
+				Description: "The name of the project.",
+				Required:    true,
 			},
-
-			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+			"description": schema.StringAttribute{
+				Description: "The description of the project.",
+				Computed:    true,
 			},
-
-			"auto_destroy_activity_duration": {
-				Type:     schema.TypeString,
-				Computed: true,
+			"organization": schema.StringAttribute{
+				Description: "The name of the organization that the project belongs to.",
+				Optional:    true,
+				Computed:    true,
 			},
-
-			"workspace_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+			"auto_destroy_activity_duration": schema.StringAttribute{
+				Description: "The duration after which the project will be auto-destroyed.",
+				Computed:    true,
 			},
-
-			"workspace_names": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+			"workspace_ids": schema.SetAttribute{
+				Description: "The IDs of the workspaces associated with the project.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"workspace_names": schema.SetAttribute{
+				Description: "The names of the workspaces associated with the project.",
+				Computed:    true,
+				ElementType: types.StringType,
 			},
 		},
 	}
 }
 
-func dataSourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(ConfiguredClient)
+// Configure adds the provider configured client to the data source.
+func (d *dataSourceTFEProject) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
 
-	// Get the project name and organization
-	projName := d.Get("name").(string)
-	orgName, err := config.schemaOrDefaultOrganizationKey(d, "organization")
-	if err != nil {
-		return diag.Errorf("Error retrieving organization name: %v", err)
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+	d.config = client
+}
+
+// Read implements datasource.DataSource.
+func (d *dataSourceTFEProject) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// Read Terraform configuration data into the model
+	var config modelDataSourceTFEProject
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var organization string
+	resp.Diagnostics.Append(d.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Create an options struct.
+	name := config.Name.ValueString()
 	options := &tfe.ProjectListOptions{
-		Name: projName,
+		Name: name,
 	}
 
-	l, err := config.Client.Projects.List(ctx, orgName, options)
+	tflog.Debug(ctx, fmt.Sprintf("Read project: %s", name))
+	l, err := d.config.Client.Projects.List(ctx, organization, options)
 	if err != nil {
-		return diag.Errorf("Error retrieving projects: %v", err)
+		resp.Diagnostics.AddError("Error retrieving projects", err.Error())
+		return
 	}
 
 	for _, proj := range l.Items {
 		// Case-insensitive uniqueness is enforced in TFC
-		if !strings.EqualFold(proj.Name, projName) {
+		if !strings.EqualFold(proj.Name, name) {
 			continue
 		}
+
 		// Only now include workspaces to cut down on request load.
 		readOptions := &tfe.WorkspaceListOptions{
 			ProjectID: proj.ID,
 		}
-		var workspaces []interface{}
-		var workspaceNames []interface{}
+
+		var workspaceIDs []string
+		var workspaceNames []string
 		for {
-			wl, err := config.Client.Workspaces.List(ctx, orgName, readOptions)
+			wl, err := d.config.Client.Workspaces.List(ctx, organization, readOptions)
 			if err != nil {
-				return diag.Errorf("Error retrieving workspaces: %v", err)
+				resp.Diagnostics.AddError("Error retrieving workspaces", err.Error())
+				return
 			}
 
 			for _, workspace := range wl.Items {
-				workspaces = append(workspaces, workspace.ID)
+				workspaceIDs = append(workspaceIDs, workspace.ID)
 				workspaceNames = append(workspaceNames, workspace.Name)
 			}
 
@@ -111,21 +196,16 @@ func dataSourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta 
 			readOptions.PageNumber = wl.NextPage
 		}
 
-		d.Set("workspace_ids", workspaces)
-		d.Set("workspace_names", workspaceNames)
-		d.Set("description", proj.Description)
-
-		var autoDestroyDuration string
-		if proj.AutoDestroyActivityDuration.IsSpecified() {
-			autoDestroyDuration, err = proj.AutoDestroyActivityDuration.Get()
-			if err != nil {
-				return diag.Errorf("Error reading auto destroy activity duration: %v", err)
-			}
+		m, diags := modelDataSourceFromTFEProject(proj, workspaceIDs, workspaceNames)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
 		}
-		d.Set("auto_destroy_activity_duration", autoDestroyDuration)
-		d.SetId(proj.ID)
 
-		return nil
+		// Update state
+		resp.Diagnostics.Append(resp.State.Set(ctx, m)...)
+		return
 	}
-	return diag.Errorf("could not find project %s/%s", orgName, projName)
+
+	resp.Diagnostics.AddError("Could not find project", fmt.Sprintf("Project %s/%s not found", organization, name))
 }

--- a/internal/provider/data_source_project_test.go
+++ b/internal/provider/data_source_project_test.go
@@ -52,7 +52,7 @@ func TestAccTFEProjectDataSource_caseInsensitive(t *testing.T) {
 				Config: testAccTFEProjectDataSourceConfigCaseInsensitive(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.tfe_project.foobar", "name", fmt.Sprintf("PROJECT-TEST-%d", rInt)),
+						"data.tfe_project.foobar", "name", fmt.Sprintf("project-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"data.tfe_project.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_project.foobar", "id"),

--- a/internal/provider/data_source_projects.go
+++ b/internal/provider/data_source_projects.go
@@ -28,7 +28,7 @@ func NewProjectsDataSource() datasource.DataSource {
 
 // modelTFEProject maps the resource or data source schema data to a
 // struct.
-type modelTFEProject struct {
+type modelTFEProjectsProject struct {
 	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
 	Description  types.String `tfsdk:"description"`
@@ -37,8 +37,8 @@ type modelTFEProject struct {
 
 // modelFromTFEProject builds a modelTFEProject struct from a
 // tfe.Project value.
-func modelFromTFEProject(v *tfe.Project) modelTFEProject {
-	return modelTFEProject{
+func modelFromTFEProjectsProject(v *tfe.Project) modelTFEProjectsProject {
+	return modelTFEProjectsProject{
 		ID:           types.StringValue(v.ID),
 		Name:         types.StringValue(v.Name),
 		Description:  types.StringValue(v.Description),
@@ -53,9 +53,9 @@ type dataSourceTFEProjects struct {
 
 // modelTFEProjects maps the data source schema data.
 type modelTFEProjects struct {
-	ID           types.String      `tfsdk:"id"`
-	Organization types.String      `tfsdk:"organization"`
-	Projects     []modelTFEProject `tfsdk:"projects"`
+	ID           types.String              `tfsdk:"id"`
+	Organization types.String              `tfsdk:"organization"`
+	Projects     []modelTFEProjectsProject `tfsdk:"projects"`
 }
 
 // Metadata returns the data source type name.
@@ -142,11 +142,11 @@ func (d *dataSourceTFEProjects) Read(ctx context.Context, req datasource.ReadReq
 
 	model.ID = types.StringValue(organization)
 	model.Organization = types.StringValue(organization)
-	model.Projects = []modelTFEProject{}
+	model.Projects = []modelTFEProjectsProject{}
 
 	for { // paginate
 		for _, project := range projectList.Items {
-			model.Projects = append(model.Projects, modelFromTFEProject(project))
+			model.Projects = append(model.Projects, modelFromTFEProjectsProject(project))
 		}
 
 		if projectList.CurrentPage >= projectList.TotalPages {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,7 +87,6 @@ func Provider() *schema.Provider {
 			"tfe_oauth_client":            dataSourceTFEOAuthClient(),
 			"tfe_organization_membership": dataSourceTFEOrganizationMembership(),
 			"tfe_organization_tags":       dataSourceTFEOrganizationTags(),
-			"tfe_project":                 dataSourceTFEProject(),
 			"tfe_slug":                    dataSourceTFESlug(),
 			"tfe_ssh_key":                 dataSourceTFESSHKey(),
 			"tfe_team":                    dataSourceTFETeam(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -120,7 +120,6 @@ func Provider() *schema.Provider {
 			"tfe_organization_token":             resourceTFEOrganizationToken(),
 			"tfe_policy":                         resourceTFEPolicy(),
 			"tfe_policy_set":                     resourceTFEPolicySet(),
-			"tfe_project":                        resourceTFEProject(),
 			"tfe_project_oauth_client":           resourceTFEProjectOAuthClient(),
 			"tfe_project_policy_set":             resourceTFEProjectPolicySet(),
 			"tfe_project_variable_set":           resourceTFEProjectVariableSet(),

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -152,6 +152,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewOrganizationRunTaskGlobalSettingsResource,
 		NewOrganizationRunTaskResource,
 		NewPolicySetParameterResource,
+		NewProjectResource,
 		NewRegistryGPGKeyResource,
 		NewRegistryProviderResource,
 		NewResourceVariable,

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -134,6 +134,7 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewOrganizationRunTaskDataSource,
 		NewOrganizationRunTaskGlobalSettingsDataSource,
 		NewOutputsDataSource,
+		NewProjectDataSource,
 		NewProjectsDataSource,
 		NewRegistryGPGKeyDataSource,
 		NewRegistryGPGKeysDataSource,

--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -10,160 +10,276 @@ package provider
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log"
-
 	"regexp"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/jsonapi"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func resourceTFEProject() *schema.Resource {
-	return &schema.Resource{
-		CreateContext: resourceTFEProjectCreate,
-		ReadContext:   resourceTFEProjectRead,
-		UpdateContext: resourceTFEProjectUpdate,
-		DeleteContext: resourceTFEProjectDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
+var (
+	_ resource.Resource                = &resourceTFEProject{}
+	_ resource.ResourceWithConfigure   = &resourceTFEProject{}
+	_ resource.ResourceWithImportState = &resourceTFEProject{}
+	_ resource.ResourceWithModifyPlan  = &resourceTFEProject{}
+)
 
-		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+func NewProjectResource() resource.Resource {
+	return &resourceTFEProject{}
+}
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(3, 40),
-					validation.StringMatch(regexp.MustCompile(`\A[\w\-][\w\- ]+[\w\-]\z`),
-						"can only include letters, numbers, spaces, -, and _."),
-				),
+type resourceTFEProject struct {
+	config ConfiguredClient
+}
+
+// modelTFEProject maps the resource schema data to a struct.
+type modelTFEProject struct {
+	ID                          types.String `tfsdk:"id"`
+	Name                        types.String `tfsdk:"name"`
+	Description                 types.String `tfsdk:"description"`
+	Organization                types.String `tfsdk:"organization"`
+	AutoDestroyActivityDuration types.String `tfsdk:"auto_destroy_activity_duration"`
+}
+
+// modelFromTFEProject builds a modelTFEProject struct from a tfe.Project value.
+func modelFromTFEProject(p *tfe.Project) (modelTFEProject, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	model := modelTFEProject{
+		ID:           types.StringValue(p.ID),
+		Name:         types.StringValue(p.Name),
+		Description:  types.StringValue(p.Description),
+		Organization: types.StringValue(p.Organization.Name),
+	}
+
+	if p.AutoDestroyActivityDuration.IsSpecified() {
+		duration, err := p.AutoDestroyActivityDuration.Get()
+		if err != nil {
+			diags.AddAttributeError(path.Root("auto_destroy_activity_duration"), "Invalid duration", fmt.Sprintf("Error reading auto destroy activity duration: %v", err))
+		}
+
+		model.AutoDestroyActivityDuration = types.StringValue(duration)
+	}
+
+	return model, diags
+}
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFEProject) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Early exit if provider is unconfigured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	r.config = client
+}
+
+// Metadata implements resource.Resource
+func (r *resourceTFEProject) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project"
+}
+
+// Schema implements resource.Resource
+func (r *resourceTFEProject) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service-generated identifier for the variable",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+			"name": schema.StringAttribute{
+				Description: "Name of the project.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 40),
+					stringvalidator.RegexMatches(regexp.MustCompile(`\A[\w\-][\w\- ]+[\w\-]\z`),
+						"can only include letters, numbers, spaces, -, and _.",
+					),
+				},
 			},
 
-			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+			"description": schema.StringAttribute{
+				Description: "Description of the project.",
+				Optional:    true,
+				Computed:    true,
 			},
 
-			"auto_destroy_activity_duration": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\d{1,4}[dh]$`), "must be 1-4 digits followed by d or h"),
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization to which the project belongs.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"auto_destroy_activity_duration": schema.StringAttribute{
+				Description: "Duration after which the project will be auto-destroyed.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d{1,4}[dh]$`),
+						"must be 1-4 digits followed by 'd' or 'h'.",
+					),
+				},
 			},
 		},
 	}
 }
 
-func resourceTFEProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(ConfiguredClient)
-
-	organization, err := config.schemaOrDefaultOrganization(d)
-	if err != nil {
-		return diag.FromErr(err)
+// Create implements resource.Resource
+func (r *resourceTFEProject) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTFEProject
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	name := d.Get("name").(string)
+
+	// Get the organization name from resource or provider config
+	var orgName string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Config, &orgName)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := plan.Name.ValueString()
 
 	options := tfe.ProjectCreateOptions{
 		Name:        name,
-		Description: tfe.String(d.Get("description").(string)),
+		Description: plan.Description.ValueStringPointer(),
 	}
 
-	if v, ok := d.GetOk("auto_destroy_activity_duration"); ok {
-		options.AutoDestroyActivityDuration = jsonapi.NewNullableAttrWithValue(v.(string))
+	if !plan.AutoDestroyActivityDuration.IsNull() {
+		options.AutoDestroyActivityDuration = jsonapi.NewNullableAttrWithValue(plan.AutoDestroyActivityDuration.ValueString())
 	}
 
-	log.Printf("[DEBUG] Create new project: %s", name)
-	project, err := config.Client.Projects.Create(ctx, organization, options)
+	log.Printf("[DEBUG] Create project %s", name)
+	project, err := r.config.Client.Projects.Create(ctx, orgName, options)
+
 	if err != nil {
-		return diag.Errorf("Error creating the new project %s: %v", name, err)
+		resp.Diagnostics.AddError("Error creating project", err.Error())
+		return
 	}
 
-	d.SetId(project.ID)
+	result, diags := modelFromTFEProject(project)
+	if diags.HasError() {
+		return
+	}
 
-	return resourceTFEProjectUpdate(ctx, d, meta)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
-func resourceTFEProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(ConfiguredClient)
+// Read implements resource.Resource
+func (r *resourceTFEProject) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFEProject
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	log.Printf("[DEBUG] Read configuration of project: %s", d.Id())
-	project, err := config.Client.Projects.Read(ctx, d.Id())
+	log.Printf("[DEBUG] Read project %s", state.ID.ValueString())
+	project, err := r.config.Client.Projects.Read(ctx, state.ID.ValueString())
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
-			log.Printf("[DEBUG] Project %s no longer exists", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError("Error reading project", err.Error())
+		return
 	}
 
-	d.Set("name", project.Name)
-	d.Set("description", project.Description)
-	d.Set("organization", project.Organization.Name)
-
-	if project.AutoDestroyActivityDuration.IsSpecified() {
-		v, err := project.AutoDestroyActivityDuration.Get()
-		if err != nil {
-			return diag.Errorf("Error reading auto destroy activity duration: %v", err)
-		}
-
-		d.Set("auto_destroy_activity_duration", v)
+	result, diags := modelFromTFEProject(project)
+	if diags.HasError() {
+		return
 	}
 
-	return nil
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
-func resourceTFEProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(ConfiguredClient)
+// Update implements resource.Resource
+func (r *resourceTFEProject) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan modelTFEProject
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state modelTFEProject
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := plan.Name.ValueString()
 
 	options := tfe.ProjectUpdateOptions{
-		Name:        tfe.String(d.Get("name").(string)),
-		Description: tfe.String(d.Get("description").(string)),
+		Name:        &name,
+		Description: plan.Description.ValueStringPointer(),
 	}
 
-	if d.HasChange("auto_destroy_activity_duration") {
-		duration, ok := d.GetOk("auto_destroy_activity_duration")
-		if !ok {
-			options.AutoDestroyActivityDuration = jsonapi.NewNullNullableAttr[string]()
-		} else {
-			options.AutoDestroyActivityDuration = jsonapi.NewNullableAttrWithValue(duration.(string))
-		}
+	// If auto_destroy_activity_duration was previously specified and is now being
+	// cleared out, set an explicit null in the update options struct.
+	if !state.AutoDestroyActivityDuration.IsNull() && plan.AutoDestroyActivityDuration.IsNull() {
+		options.AutoDestroyActivityDuration = jsonapi.NewNullNullableAttr[string]()
+	} else if !plan.AutoDestroyActivityDuration.IsNull() {
+		options.AutoDestroyActivityDuration = jsonapi.NewNullableAttrWithValue(plan.AutoDestroyActivityDuration.ValueString())
 	}
 
-	log.Printf("[DEBUG] Update configuration of project: %s", d.Id())
-	project, err := config.Client.Projects.Update(ctx, d.Id(), options)
+	log.Printf("[DEBUG] Update project %s", plan.ID.ValueString())
+	project, err := r.config.Client.Projects.Update(ctx, plan.ID.ValueString(), options)
 	if err != nil {
-		return diag.Errorf("Error updating project %s: %v", d.Id(), err)
+		resp.Diagnostics.AddError("Error updating project", err.Error())
+		return
 	}
 
-	d.SetId(project.ID)
+	result, diags := modelFromTFEProject(project)
+	if diags.HasError() {
+		return
+	}
 
-	return resourceTFEProjectRead(ctx, d, meta)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
-func resourceTFEProjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(ConfiguredClient)
-
-	log.Printf("[DEBUG] Delete project: %s", d.Id())
-	err := config.Client.Projects.Delete(ctx, d.Id())
-	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
-			return nil
-		}
-		return diag.Errorf("Error deleting project %s: %v", d.Id(), err)
+// Delete implements resource.Resource
+func (r *resourceTFEProject) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFEProject
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return nil
+	log.Printf("[DEBUG] Delete project %s", state.ID.ValueString())
+	err := r.config.Client.Projects.Delete(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error deleting project", err.Error())
+		return
+	}
+}
+
+func (r *resourceTFEProject) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	modifyPlanForDefaultOrganizationChange(ctx, r.config.Organization, req.State, req.Config, req.Plan, resp)
+}
+
+func (r *resourceTFEProject) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/resource_tfe_project_test.go
+++ b/internal/provider/resource_tfe_project_test.go
@@ -57,7 +57,7 @@ func TestAccTFEProject_invalidName(t *testing.T) {
 			},
 			{
 				Config:      testAccTFEProject_invalidNameLen(rInt),
-				ExpectError: regexp.MustCompile(`expected length of name to be in the range \(3 - 40\),`),
+				ExpectError: regexp.MustCompile(`string length must be between 3 and 40`),
 			},
 		},
 	})
@@ -150,7 +150,7 @@ func TestAccTFEProject_withAutoDestroy(t *testing.T) {
 			},
 			{
 				Config:      testAccTFEProject_basicWithAutoDestroy(rInt, "10m"),
-				ExpectError: regexp.MustCompile(`must be 1-4 digits followed by d or h`),
+				ExpectError: regexp.MustCompile("must be 1-4 digits followed by"),
 			},
 			{
 				Config: testAccTFEProject_basic(rInt),
@@ -158,8 +158,7 @@ func TestAccTFEProject_withAutoDestroy(t *testing.T) {
 					testAccCheckTFEProjectExists(
 						"tfe_project.foobar", project),
 					testAccCheckTFEProjectAttributes(project),
-					resource.TestCheckResourceAttr(
-						"tfe_project.foobar", "auto_destroy_activity_duration", ""),
+					resource.TestCheckNoResourceAttr("tfe_project.foobar", "auto_destroy_activity_duration"),
 				),
 			},
 		},

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -87,7 +87,7 @@ func TestAccTFEWorkspace_defaultOrg(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: providers,
-		CheckDestroy:             testAccCheckTFEWorkspaceDestroyProvider(providers["tfe"]),
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_defaultOrgExplicit(rInt),
@@ -129,8 +129,7 @@ func TestAccTFEWorkspaceProviderDefaultOrgChanged(t *testing.T) {
 	providersWithAnotherOrg := muxedProvidersWithDefaultOrganization(anotherOrg.Name)
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: providers,

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -87,7 +87,7 @@ func TestAccTFEWorkspace_defaultOrg(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: providers,
-		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroyProvider(providers["tfe"]),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_defaultOrgExplicit(rInt),
@@ -129,8 +129,8 @@ func TestAccTFEWorkspaceProviderDefaultOrgChanged(t *testing.T) {
 	providersWithAnotherOrg := muxedProvidersWithDefaultOrganization(anotherOrg.Name)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: providers,


### PR DESCRIPTION
## Description

This PR migrates the `tfe_project` resource and data source to the provider framework:

Acceptance tests that made use of any of the above also needed to be switched to the muxed provider factory.

## Testing plan

1.  acc tests
2. all data sources and resources should continue to function as usual

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEProjectDataSource_" make testacc

=== RUN   TestAccTFEProjectDataSource_basic
--- PASS: TestAccTFEProjectDataSource_basic (8.12s)
=== RUN   TestAccTFEProjectDataSource_caseInsensitive
--- PASS: TestAccTFEProjectDataSource_caseInsensitive (5.33s)
=== RUN   TestAccTFEProjectDataSource_basicWithAutoDestroy
--- PASS: TestAccTFEProjectDataSource_basicWithAutoDestroy (5.27s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   19.255s


$ TESTARGS="-run TestAccTFEProject_" make testacc
=== RUN   TestAccTFEProject_basic
--- PASS: TestAccTFEProject_basic (5.07s)
=== RUN   TestAccTFEProject_invalidName
--- PASS: TestAccTFEProject_invalidName (0.52s)
=== RUN   TestAccTFEProject_update
--- PASS: TestAccTFEProject_update (6.48s)
=== RUN   TestAccTFEProject_import
--- PASS: TestAccTFEProject_import (5.46s)
=== RUN   TestAccTFEProject_withAutoDestroy
--- PASS: TestAccTFEProject_withAutoDestroy (6.40s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   24.449s

```
