### PR TITLE
feat: add write-only `key_wo` attribute to `tfe_ssh_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ ENHANCEMENTS:
 
 * resource/tfe_saml_settings: Add `private_key_wo` write-only attribute, by @uturunku1 ([#1660](https://github.com/hashicorp/terraform-provider-tfe/pull/1660))
 
+* resource/tfe_ssh_key: Add `key_wo` write-only attribute, by @ctrombley ([#1659](https://github.com/hashicorp/terraform-provider-tfe/pull/1659))
 ## v.0.64.0
 
 FEATURES:

--- a/internal/provider/data_source_ssh_key_test.go
+++ b/internal/provider/data_source_ssh_key_test.go
@@ -17,8 +17,8 @@ func TestAccTFESSHKeyDataSource_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESSHKeyDataSourceConfig(rInt),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -129,7 +129,6 @@ func Provider() *schema.Provider {
 			"tfe_run_trigger":                    resourceTFERunTrigger(),
 			"tfe_sentinel_policy":                resourceTFESentinelPolicy(),
 			"tfe_sentinel_version":               resourceTFESentinelVersion(),
-			"tfe_ssh_key":                        resourceTFESSHKey(),
 			"tfe_team":                           resourceTFETeam(),
 			"tfe_team_access":                    resourceTFETeamAccess(),
 			"tfe_team_organization_member":       resourceTFETeamOrganizationMember(),

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -142,6 +142,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewResourceVariable,
 		NewResourceWorkspaceSettings,
 		NewSAMLSettingsResource,
+		NewSSHKey,
 		NewStackResource,
 		NewTeamNotificationConfigurationResource,
 		NewTestVariableResource,

--- a/internal/provider/resource_tfe_ssh_key.go
+++ b/internal/provider/resource_tfe_ssh_key.go
@@ -288,6 +288,12 @@ func (r *resourceTFESSHKey) Delete(ctx context.Context, req resource.DeleteReque
 	tflog.Debug(ctx, fmt.Sprintf("Delete SSH key %s for organization: %s", id, organization))
 	err := r.config.Client.SSHKeys.Delete(ctx, id)
 	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("SSH key %s no longer exists", id))
+			// The resource is implicitly deleted from state on return
+			return
+		}
+
 		resp.Diagnostics.AddError("Error deleting SSH key", err.Error())
 		return
 	}

--- a/internal/provider/resource_tfe_ssh_key.go
+++ b/internal/provider/resource_tfe_ssh_key.go
@@ -1,128 +1,239 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// NOTE: This is a legacy resource and should be migrated to the Plugin
-// Framework if substantial modifications are planned. See
-// docs/new-resources.md if planning to use this code as boilerplate for
-// a new resource.
-
 package provider
 
 import (
+	"context"
 	"fmt"
-	"log"
 
 	tfe "github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func resourceTFESSHKey() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceTFESSHKeyCreate,
-		Read:   resourceTFESSHKeyRead,
-		Update: resourceTFESSHKeyUpdate,
-		Delete: resourceTFESSHKeyDelete,
+var (
+	_ resource.Resource              = &resourceTFESSHKey{}
+	_ resource.ResourceWithConfigure = &resourceTFESSHKey{}
+)
 
-		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+func NewSSHKey() resource.Resource {
+	return &resourceTFESSHKey{}
+}
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+type resourceTFESSHKey struct {
+	config ConfiguredClient
+}
+
+type modelTFESSHKey struct {
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Organization types.String `tfsdk:"organization"`
+	Key          types.String `tfsdk:"key"`
+}
+
+func modelFromTFESSHKey(organization string, sshKey *tfe.SSHKey, lastValue types.String) *modelTFESSHKey {
+	m := &modelTFESSHKey{
+		ID:           types.StringValue(sshKey.ID),
+		Name:         types.StringValue(sshKey.Name),
+		Organization: types.StringValue(organization),
+		Key:          lastValue,
+	}
+
+	return m
+}
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFESSHKey) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Early exit if provider is unconfigured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	r.config = client
+}
+
+// Metadata implements resource.Resource
+func (r *resourceTFESSHKey) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ssh_key"
+}
+
+// Schema implements resource.Resource
+func (r *resourceTFESSHKey) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Service-generated ID for the SSH key.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 
-			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+			"name": schema.StringAttribute{
+				Description: "The name of the SSH key.",
+				Required:    true,
 			},
 
-			"key": {
-				Type:      schema.TypeString,
-				Required:  true,
-				Sensitive: true,
+			"organization": schema.StringAttribute{
+				Description: "The name of the organization.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"key": schema.StringAttribute{
+				Description: "The text of the SSH private key",
+				Optional:    true,
+				Sensitive:   false,
 			},
 		},
 	}
 }
 
-func resourceTFESSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
-
-	// Get the name and organization.
-	name := d.Get("name").(string)
-	organization, err := config.schemaOrDefaultOrganization(d)
-	if err != nil {
-		return err
+// Create implements resource.Resource
+func (r *resourceTFESSHKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Load the plan and config into the model
+	var plan, config modelTFESSHKey
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	// Create a new options struct.
+	// Determine the organization
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	options := tfe.SSHKeyCreateOptions{
-		Name:  tfe.String(name),
-		Value: tfe.String(d.Get("key").(string)),
+		Name:  plan.Name.ValueStringPointer(),
+		Value: plan.Key.ValueStringPointer(),
 	}
 
-	log.Printf("[DEBUG] Create new SSH key for organization: %s", organization)
-	sshKey, err := config.Client.SSHKeys.Create(ctx, organization, options)
+	tflog.Debug(ctx, fmt.Sprintf("Create new SSH key for organization: %s", organization))
+	sshKey, err := r.config.Client.SSHKeys.Create(ctx, organization, options)
 	if err != nil {
-		return fmt.Errorf(
-			"Error creating SSH key %s for organization %s: %w", name, organization, err)
+		resp.Diagnostics.AddError("Error creating SSH key", err.Error())
+		return
 	}
 
-	d.SetId(sshKey.ID)
+	// Load the response data into the model
+	result := modelFromTFESSHKey(organization, sshKey, plan.Key)
 
-	return resourceTFESSHKeyUpdate(d, meta)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Update state
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
-func resourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
-
-	log.Printf("[DEBUG] Read configuration of SSH key: %s", d.Id())
-	sshKey, err := config.Client.SSHKeys.Read(ctx, d.Id())
-	if err != nil {
-		if err == tfe.ErrResourceNotFound {
-			log.Printf("[DEBUG] SSH key %s no longer exists", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error reading configuration of SSH key %s: %w", d.Id(), err)
+// Read implements resource.Resource
+func (r *resourceTFESSHKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Load the plan into the model
+	var state modelTFESSHKey
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	// Update the config.
-	d.Set("name", sshKey.Name)
+	// Determine the organization
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.State, &organization)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	return nil
+	id := state.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Read SSH key %s for organization: %s", id, organization))
+	sshKey, err := r.config.Client.SSHKeys.Read(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading SSH key", err.Error())
+		return
+	}
+
+	// Load the response data into the model
+	result := modelFromTFESSHKey(organization, sshKey, state.Key)
+
+	// Update state
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
-func resourceTFESSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
+// Update implements resource.Resource
+func (r *resourceTFESSHKey) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Load the plan and config into the model
+	var plan, config modelTFESSHKey
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	// Create a new options struct.
+	// Determine the organization
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	options := tfe.SSHKeyUpdateOptions{
-		Name: tfe.String(d.Get("name").(string)),
+		Name: plan.Name.ValueStringPointer(),
 	}
 
-	log.Printf("[DEBUG] Update SSH key: %s", d.Id())
-	_, err := config.Client.SSHKeys.Update(ctx, d.Id(), options)
+	id := plan.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Update SSH key %s for organization: %s", id, organization))
+	sshKey, err := r.config.Client.SSHKeys.Update(ctx, id, options)
 	if err != nil {
-		return fmt.Errorf("Error updating SSH key %s: %w", d.Id(), err)
+		resp.Diagnostics.AddError("Error updating SSH key", err.Error())
+		return
 	}
 
-	return resourceTFESSHKeyRead(d, meta)
+	// Load the response data into the model
+	result := modelFromTFESSHKey(organization, sshKey, plan.Key)
+
+	// Update state
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
-func resourceTFESSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
-
-	log.Printf("[DEBUG] Delete SSH key: %s", d.Id())
-	err := config.Client.SSHKeys.Delete(ctx, d.Id())
-	if err != nil {
-		if err == tfe.ErrResourceNotFound {
-			return nil
-		}
-		return fmt.Errorf("Error deleting SSH key %s: %w", d.Id(), err)
+// Delete implements resource.Resource
+func (r *resourceTFESSHKey) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Load the plan into the model
+	var state modelTFESSHKey
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return nil
+	// Determine the organization
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.State, &organization)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Delete SSH key %s for organization: %s", id, organization))
+	err := r.config.Client.SSHKeys.Delete(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError("Error deleting SSH key", err.Error())
+		return
+	}
 }

--- a/internal/provider/resource_tfe_ssh_key_test.go
+++ b/internal/provider/resource_tfe_ssh_key_test.go
@@ -19,9 +19,9 @@ func TestAccTFESSHKey_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFESSHKeyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFESSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESSHKey_basic(rInt),
@@ -44,9 +44,9 @@ func TestAccTFESSHKey_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFESSHKeyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFESSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESSHKey_basic(rInt),
@@ -172,5 +172,34 @@ resource "tfe_ssh_key" "foobar" {
   name         = "ssh-key-updated"
   organization = tfe_organization.foobar.id
   key          = "SSH-KEY-CONTENT"
+}`, rInt)
+}
+
+func testAccTFESSHKey_keyWO(rInt int, key string) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_ssh_key" "foobar" {
+  name         = "ssh-key-test"
+  organization = tfe_organization.foobar.id
+  key_wo       = "%s"
+}`, rInt, key)
+}
+
+func testAccTFESSHKey_keyAndKeyWO(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_ssh_key" "foobar" {
+  name         = "ssh-key-test"
+  organization = tfe_organization.foobar.id
+  key          = "SSH-KEY-CONTENT"
+  key_wo       = "SSH-KEY-CONTENT"
 }`, rInt)
 }

--- a/internal/provider/resource_tfe_ssh_key_test.go
+++ b/internal/provider/resource_tfe_ssh_key_test.go
@@ -6,12 +6,16 @@ package provider
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 	"testing"
 	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccTFESSHKey_basic(t *testing.T) {
@@ -72,6 +76,75 @@ func TestAccTFESSHKey_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_ssh_key.foobar", "key", "SSH-KEY-CONTENT"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccTFESSHKey_keyWO(t *testing.T) {
+	sshKey := &tfe.SSHKey{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	// Create the value comparer so we can add state values to it during the test steps
+	compareValuesDiffer := statecheck.CompareValue(compare.ValuesDiffer())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationRunTaskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFESSHKey_keyAndKeyWO(rInt),
+				ExpectError: regexp.MustCompile(`Attribute "key_wo" cannot be specified when "key" is specified`),
+			},
+			{
+				Config: testAccTFESSHKey_keyWO(rInt, "SSH-KEY-CONTENT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFESSHKeyExists("tfe_ssh_key.foobar", sshKey),
+					testAccCheckTFESSHKeyAttributes(sshKey),
+					resource.TestCheckResourceAttr("tfe_ssh_key.foobar", "name", "ssh-key-test"),
+					resource.TestCheckNoResourceAttr("tfe_ssh_key.foobar", "key"),
+					resource.TestCheckNoResourceAttr("tfe_ssh_key.foobar", "key_wo"),
+				),
+				// Register the id with the value comparer so we can assert that the
+				// resource has been replaced in the next step.
+				ConfigStateChecks: []statecheck.StateCheck{
+					compareValuesDiffer.AddStateValue(
+						"tfe_ssh_key.foobar", tfjsonpath.New("id"),
+					),
+				},
+			},
+			{
+				Config: testAccTFESSHKey_keyWO(rInt, "SSH-KEY-CONTENT-UPDATED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFESSHKeyExists("tfe_ssh_key.foobar", sshKey),
+					testAccCheckTFESSHKeyAttributes(sshKey),
+					resource.TestCheckResourceAttr("tfe_ssh_key.foobar", "name", "ssh-key-test"),
+					resource.TestCheckNoResourceAttr("tfe_ssh_key.foobar", "key"),
+					resource.TestCheckNoResourceAttr("tfe_ssh_key.foobar", "key_wo"),
+				),
+				// Register the id with the value comparer so we can assert that the
+				// resource has been replaced in the next step.
+				ConfigStateChecks: []statecheck.StateCheck{
+					compareValuesDiffer.AddStateValue(
+						"tfe_ssh_key.foobar", tfjsonpath.New("id"),
+					),
+				},
+			},
+			{
+				Config: testAccTFESSHKey_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFESSHKeyExists("tfe_ssh_key.foobar", sshKey),
+					testAccCheckTFESSHKeyAttributes(sshKey),
+					resource.TestCheckResourceAttr("tfe_ssh_key.foobar", "name", "ssh-key-test"),
+					resource.TestCheckResourceAttr("tfe_ssh_key.foobar", "key", "SSH-KEY-CONTENT"),
+				),
+				// Ensure that the resource has been replaced
+				ConfigStateChecks: []statecheck.StateCheck{
+					compareValuesDiffer.AddStateValue(
+						"tfe_ssh_key.foobar", tfjsonpath.New("id"),
+					),
+				},
 			},
 		},
 	})

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -1790,9 +1790,9 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),

--- a/website/docs/d/ssh_key.html.markdown
+++ b/website/docs/d/ssh_key.html.markdown
@@ -23,7 +23,8 @@ data "tfe_ssh_key" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the SSH key.
-* `organization` - (Required) Name of the organization.
+* `organization` - (Optional) Name of the organization. If omitted, organization
+  must be defined in the provider config.
 
 ## Attributes Reference
 

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -28,7 +28,10 @@ The following arguments are supported:
 
 * `name` - (Required) Name to identify the SSH key.
 * `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
-* `key` - (Required) The text of the SSH private key.
+* `key` - (Optional) The text of the SSH private key. One of `key` or `key_wo`
+  must be provided.
+* `key_wo` - (Optional) The text of the SSH private key, guaranteed not to be
+  written to plan or state artifacts. One of `key` or `key_wo` must be provided.
 
 ## Attributes Reference
 
@@ -38,3 +41,5 @@ The following arguments are supported:
 
 Because the Terraform Enterprise API does not return the private SSH key
 content, this resource cannot be imported.
+
+-> **Note:** Write-Only argument `key_wo` is available to use in place of `key`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).


### PR DESCRIPTION
## Description


This PR migrates `tfe_ssh_key` to the provider framework and adds the write-only attribute `key_wo`, so that a user can pass sensitive private key data to the resource securely and temporarily without storing it in the Terraform state file or having it show up in the plan.

Write only arguments can consume ephemeral values and non ephemeral values.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Apply a configuration that uses a `tfe_policy_set_parameter` and the new `value_wo` attribute:

```
variable "private_key" {
  type      = string
  ephemeral = true
}

resource "tfe_ssh_key" "this" {
  name            = "my_key"
  organization    = "my_org"
  key_wo          = var.secret
}
```

The state should not include the value information:

```
    "key": null,
    "key_wo": null,
```

The value that was written into HCPT will not show up in the UI due to the way the API works.


2. Apply the same configuration and pass the same value to the `private_key` variable. There should be no changes to infrastructure.

3. Now pass a different value to `private_key` and when you apply, the `tfe_ssh_key` resource will be recreated.

## External links

- [write-only values in the provider framework](https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments)
- [write-only values for ephemeral resources](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFESSHKey_" make testacc

=== RUN   TestAccTFESSHKey_basic
--- PASS: TestAccTFESSHKey_basic (5.04s)
=== RUN   TestAccTFESSHKey_update
--- PASS: TestAccTFESSHKey_update (6.13s)
=== RUN   TestAccTFESSHKey_keyWO
--- PASS: TestAccTFESSHKey_keyWO (13.32s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   25.257s

```
