### PR TITLE
chore: migrate tfe_oauth_client to framework

### DIFF
--- a/internal/provider/data_source_oauth_client_test.go
+++ b/internal/provider/data_source_oauth_client_test.go
@@ -24,8 +24,8 @@ func TestAccTFEOAuthClientDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClientDataSourceConfig_basic(rInt),
@@ -45,8 +45,8 @@ func TestAccTFEOAuthClientDataSource_basic(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_findByID(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClientDataSourceConfig_findByID(rInt),
@@ -75,8 +75,8 @@ func TestAccTFEOAuthClientDataSource_findByID(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_findByName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClientDataSourceConfig_findByName(rInt),
@@ -105,8 +105,8 @@ func TestAccTFEOAuthClientDataSource_findByName(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_findByServiceProvider(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClientDataSourceConfig_findByServiceProvider(rInt),
@@ -132,8 +132,8 @@ func TestAccTFEOAuthClientDataSource_findByServiceProvider(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_missingParameters(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_missingParameters(rInt),
@@ -146,8 +146,8 @@ func TestAccTFEOAuthClientDataSource_missingParameters(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_missingOrgWithName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_missingOrgWithName(rInt),
@@ -160,8 +160,8 @@ func TestAccTFEOAuthClientDataSource_missingOrgWithName(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_missingOrgWithServiceProvider(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_missingOrgWithServiceProvider(rInt),
@@ -174,8 +174,8 @@ func TestAccTFEOAuthClientDataSource_missingOrgWithServiceProvider(t *testing.T)
 func TestAccTFEOAuthClientDataSource_sameName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_sameName(rInt),
@@ -188,8 +188,8 @@ func TestAccTFEOAuthClientDataSource_sameName(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_noName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_noName(rInt),
@@ -202,8 +202,8 @@ func TestAccTFEOAuthClientDataSource_noName(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_sameServiceProvider(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_sameServiceProvider(rInt),

--- a/internal/provider/data_source_policy_set_test.go
+++ b/internal/provider/data_source_policy_set_test.go
@@ -191,7 +191,7 @@ func TestAccTFEPolicySetDataSource_vcs(t *testing.T) {
 				t.Skip("Please set GITHUB_POLIY_SET_PATH to run this test")
 			}
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySetDataSourceConfig_vcs(org.Name, rInt),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -112,7 +112,6 @@ func Provider() *schema.Provider {
 			"tfe_agent_pool_allowed_workspaces":  resourceTFEAgentPoolAllowedWorkspaces(),
 			"tfe_agent_token":                    resourceTFEAgentToken(),
 			"tfe_notification_configuration":     resourceTFENotificationConfiguration(),
-			"tfe_oauth_client":                   resourceTFEOAuthClient(),
 			"tfe_opa_version":                    resourceTFEOPAVersion(),
 			"tfe_organization":                   resourceTFEOrganization(),
 			"tfe_organization_membership":        resourceTFEOrganizationMembership(),

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -133,6 +133,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 	return []func() resource.Resource{
 		NewAuditTrailTokenResource,
 		NewDataRetentionPolicyResource,
+		NewOAuthClient,
 		NewOrganizationDefaultSettings,
 		NewOrganizationRunTaskGlobalSettingsResource,
 		NewOrganizationRunTaskResource,

--- a/internal/provider/resource_tfe_oauth_client.go
+++ b/internal/provider/resource_tfe_oauth_client.go
@@ -1,250 +1,479 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// NOTE: This is a legacy resource and should be migrated to the Plugin
-// Framework if substantial modifications are planned. See
-// docs/new-resources.md if planning to use this code as boilerplate for
-// a new resource.
-
 package provider
 
 import (
+	"context"
+	"errors"
 	"fmt"
-	"log"
 
-	tfe "github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func resourceTFEOAuthClient() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceTFEOAuthClientCreate,
-		Read:   resourceTFEOAuthClientRead,
-		Delete: resourceTFEOAuthClientDelete,
-		Update: resourceTFEOAuthClientUpdate,
+var (
+	// Compile-time proof of interface implementation.
+	_ resource.Resource                   = &resourceTFEOAuthClient{}
+	_ resource.ResourceWithConfigure      = &resourceTFEOAuthClient{}
+	_ resource.ResourceWithValidateConfig = &resourceTFEOAuthClient{}
+)
 
-		CustomizeDiff: customizeDiffIfProviderDefaultOrganizationChanged,
+func NewOAuthClient() resource.Resource {
+	return &resourceTFEOAuthClient{}
+}
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+type resourceTFEOAuthClient struct {
+	config ConfiguredClient
+}
+
+type modelTFEOAuthClient struct {
+	ID                 types.String `tfsdk:"id"`
+	Name               types.String `tfsdk:"name"`
+	Organization       types.String `tfsdk:"organization"`
+	APIURL             types.String `tfsdk:"api_url"`
+	HTTPURL            types.String `tfsdk:"http_url"`
+	Key                types.String `tfsdk:"key"`
+	OAuthToken         types.String `tfsdk:"oauth_token"`
+	PrivateKey         types.String `tfsdk:"private_key"`
+	Secret             types.String `tfsdk:"secret"`
+	RSAPublicKey       types.String `tfsdk:"rsa_public_key"`
+	ServiceProvider    types.String `tfsdk:"service_provider"`
+	OAuthTokenID       types.String `tfsdk:"oauth_token_id"`
+	AgentPoolID        types.String `tfsdk:"agent_pool_id"`
+	OrganizationScoped types.Bool   `tfsdk:"organization_scoped"`
+}
+
+func modelFromTFEOAuthClient(c *tfe.OAuthClient, lastValues map[string]types.String) (*modelTFEOAuthClient, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	m := modelTFEOAuthClient{
+		ID:                 types.StringValue(c.ID),
+		Name:               types.StringPointerValue(c.Name),
+		Organization:       types.StringValue(c.Organization.Name),
+		APIURL:             types.StringValue(c.APIURL),
+		HTTPURL:            types.StringValue(c.HTTPURL),
+		ServiceProvider:    types.StringValue(string(c.ServiceProvider)),
+		OrganizationScoped: types.BoolPointerValue(c.OrganizationScoped),
+	}
+
+	if oauthToken, ok := lastValues["oauth_token"]; ok {
+		m.OAuthToken = oauthToken
+	}
+
+	if privateKey, ok := lastValues["private_key"]; ok {
+		m.PrivateKey = privateKey
+	}
+
+	if key, ok := lastValues["key"]; ok {
+		m.Key = key
+	}
+
+	if secret, ok := lastValues["secret"]; ok {
+		m.Secret = secret
+	}
+
+	if c.AgentPool != nil {
+		m.AgentPoolID = types.StringValue(c.AgentPool.ID)
+	}
+
+	if len(c.RSAPublicKey) > 0 {
+		m.RSAPublicKey = types.StringValue(c.RSAPublicKey)
+	}
+
+	if len(c.RSAPublicKey) > 0 {
+		m.RSAPublicKey = types.StringValue(c.RSAPublicKey)
+	}
+
+	switch len(c.OAuthTokens) {
+	case 0:
+		m.OAuthTokenID = types.StringValue("")
+	case 1:
+		m.OAuthTokenID = types.StringValue(c.OAuthTokens[0].ID)
+	default:
+		diags.AddError("Error parsing API result", fmt.Sprintf("unexpected number of OAuth tokens: %d", len(c.OAuthTokens)))
+	}
+
+	return &m, diags
+}
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFEOAuthClient) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Early exit if provider is unconfigured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	r.config = client
+}
+
+// Metadata implements resource.Resource
+func (r *resourceTFEOAuthClient) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_oauth_client"
+}
+
+// Schema implements resource.Resource
+func (r *resourceTFEOAuthClient) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Service-generated identifier for the variable",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 
-			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+			"name": schema.StringAttribute{
+				Description: "Display name for the OAuth Client",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
-			"api_url": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization",
+				Computed:    true,
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
-			"http_url": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"api_url": schema.StringAttribute{
+				Description: "The base URL of the VCS provider's API",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
-			"key": {
-				Type:      schema.TypeString,
-				ForceNew:  true,
-				Sensitive: true,
-				Optional:  true,
+			"http_url": schema.StringAttribute{
+				Description: "The homepage of the VCS provider",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
-			"oauth_token": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Sensitive: true,
-				ForceNew:  true,
+			"key": schema.StringAttribute{
+				Description: "The OAuth Client key can refer to a Consumer Key, Application Key, or another type of client key for the VCS provider",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
-			"private_key": {
-				Type:      schema.TypeString,
-				ForceNew:  true,
-				Sensitive: true,
-				Optional:  true,
+			"oauth_token": schema.StringAttribute{
+				Description: "The OAuth token string for the VCS provider",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
-			"secret": {
-				Type:      schema.TypeString,
-				ForceNew:  true,
-				Sensitive: true,
-				Optional:  true,
+			"private_key": schema.StringAttribute{
+				Description: "The text of the private key associated with a Azure DevOps Server account",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
-			"rsa_public_key": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
-				// this field is only for BitBucket Data Center, and requires these other
-				RequiredWith: []string{"secret", "key"},
+			"secret": schema.StringAttribute{
+				Description: "The text of the SSH private key associated with a Bitbucket Data Center Application Link",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
-			"service_provider": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice(
-					[]string{
-						string(tfe.ServiceProviderAzureDevOpsServer),
-						string(tfe.ServiceProviderAzureDevOpsServices),
-						string(tfe.ServiceProviderBitbucket),
-						string(tfe.ServiceProviderBitbucketServer),
-						string(tfe.ServiceProviderBitbucketDataCenter),
+			"rsa_public_key": schema.StringAttribute{
+				Description: "The text of the SSH public key associated with a Bitbucket Data Center Application Link",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"service_provider": schema.StringAttribute{
+				Description: "The VCS provider being connected with",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf(
 						string(tfe.ServiceProviderGithub),
 						string(tfe.ServiceProviderGithubEE),
 						string(tfe.ServiceProviderGitlab),
 						string(tfe.ServiceProviderGitlabCE),
 						string(tfe.ServiceProviderGitlabEE),
-					},
-					false,
-				),
+						string(tfe.ServiceProviderBitbucket),
+						string(tfe.ServiceProviderBitbucketServer),
+						string(tfe.ServiceProviderBitbucketServerLegacy),
+						string(tfe.ServiceProviderBitbucketDataCenter),
+						string(tfe.ServiceProviderAzureDevOpsServer),
+						string(tfe.ServiceProviderAzureDevOpsServices),
+					),
+				},
 			},
-			"oauth_token_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+
+			"oauth_token_id": schema.StringAttribute{
+				Description: "OAuth Token ID for the OAuth Client",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
-			"agent_pool_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+
+			"agent_pool_id": schema.StringAttribute{
+				Description: "An existing agent pool ID within the organization that has Private VCS support enabled",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
-			"organization_scoped": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+
+			"organization_scoped": schema.BoolAttribute{
+				Description: "Whether or not the oauth client is scoped to all projects and workspaces in the organization",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 	}
 }
 
-func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
-
-	// Get the organization and provider.
-	organization, err := config.schemaOrDefaultOrganization(d)
-	if err != nil {
-		return err
+// Create implements resource.Resource
+func (r *resourceTFEOAuthClient) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Load the plan into the model
+	var plan modelTFEOAuthClient
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	name := d.Get("name").(string)
-	privateKey := d.Get("private_key").(string)
-	rsaPublicKey := d.Get("rsa_public_key").(string)
-	key := d.Get("key").(string)
-	secret := d.Get("secret").(string)
-	serviceProvider := tfe.ServiceProviderType(d.Get("service_provider").(string))
 
-	if serviceProvider == tfe.ServiceProviderAzureDevOpsServer && privateKey == "" {
-		return fmt.Errorf("private_key is required for service_provider %s", serviceProvider)
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Create a new options struct.
 	// The tfe.OAuthClientCreateOptions has omitempty for these values, so if it
 	// is empty, then it will be ignored in the create request
 	options := tfe.OAuthClientCreateOptions{
-		Name:               tfe.String(name),
-		APIURL:             tfe.String(d.Get("api_url").(string)),
-		HTTPURL:            tfe.String(d.Get("http_url").(string)),
-		OAuthToken:         tfe.String(d.Get("oauth_token").(string)),
-		Key:                tfe.String(key),
-		ServiceProvider:    tfe.ServiceProvider(serviceProvider),
-		OrganizationScoped: tfe.Bool(d.Get("organization_scoped").(bool)),
+		Name:               plan.Name.ValueStringPointer(),
+		APIURL:             plan.APIURL.ValueStringPointer(),
+		HTTPURL:            plan.HTTPURL.ValueStringPointer(),
+		OAuthToken:         plan.OAuthToken.ValueStringPointer(),
+		Key:                plan.Key.ValueStringPointer(),
+		ServiceProvider:    tfe.ServiceProvider(tfe.ServiceProviderType(plan.ServiceProvider.ValueString())),
+		OrganizationScoped: plan.OrganizationScoped.ValueBoolPointer(),
 	}
 
-	if serviceProvider == tfe.ServiceProviderAzureDevOpsServer {
-		options.PrivateKey = tfe.String(privateKey)
-	}
-	if serviceProvider == tfe.ServiceProviderBitbucketServer || serviceProvider == tfe.ServiceProviderBitbucketDataCenter {
-		options.RSAPublicKey = tfe.String(rsaPublicKey)
-		options.Secret = tfe.String(secret)
-	}
-	if serviceProvider == tfe.ServiceProviderBitbucket {
-		options.Secret = tfe.String(secret)
-	}
-	if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
-		options.AgentPool = &tfe.AgentPool{ID: *tfe.String(v.(string))}
+	serviceProviderType := tfe.ServiceProviderType(plan.ServiceProvider.ValueString())
+
+	if serviceProviderType == tfe.ServiceProviderAzureDevOpsServer {
+		options.PrivateKey = plan.PrivateKey.ValueStringPointer()
 	}
 
-	log.Printf("[DEBUG] Create an OAuth client for organization: %s", organization)
-	oc, err := config.Client.OAuthClients.Create(ctx, organization, options)
+	if serviceProviderType == tfe.ServiceProviderBitbucketServer || serviceProviderType == tfe.ServiceProviderBitbucketDataCenter {
+		options.RSAPublicKey = plan.RSAPublicKey.ValueStringPointer()
+		options.Secret = plan.Secret.ValueStringPointer()
+	}
+
+	if serviceProviderType == tfe.ServiceProviderBitbucket {
+		options.Secret = plan.Secret.ValueStringPointer()
+	}
+
+	if !plan.AgentPoolID.IsNull() {
+		options.AgentPool = &tfe.AgentPool{ID: plan.AgentPoolID.ValueString()}
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Create an OAuth client for organization: %s", organization))
+	oc, err := r.config.Client.OAuthClients.Create(ctx, organization, options)
 	if err != nil {
-		return fmt.Errorf(
-			"Error creating OAuth client for organization %s: %w", organization, err)
+		resp.Diagnostics.AddError("Error creating OAuth client", err.Error())
+		return
 	}
 
-	d.SetId(oc.ID)
+	lastValues := map[string]types.String{
+		"oauth_token":    plan.OAuthToken,
+		"rsa_public_key": plan.RSAPublicKey,
+		"key":            plan.Key,
+		"secret":         plan.Secret,
+	}
 
-	return resourceTFEOAuthClientRead(d, meta)
+	// Load the result into the model
+	result, diags := modelFromTFEOAuthClient(oc, lastValues)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
-func resourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
+// Read implements resource.Resource
+func (r *resourceTFEOAuthClient) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Load the state into the model
+	var state modelTFEOAuthClient
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	log.Printf("[DEBUG] Read configuration of OAuth client: %s", d.Id())
-	oc, err := config.Client.OAuthClients.Read(ctx, d.Id())
+	id := state.ID.ValueString()
+
+	// Read the OAuth client
+	tflog.Debug(ctx, fmt.Sprintf("Read OAuth client: %s", id))
+	oc, err := r.config.Client.OAuthClients.Read(ctx, id)
 	if err != nil {
-		if err == tfe.ErrResourceNotFound {
-			log.Printf("[DEBUG] OAuth client %s no longer exists", d.Id())
-			d.SetId("")
-			return nil
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("OAuth client %s no longer exists", id))
+			resp.State.RemoveResource(ctx)
+			return
 		}
-		return err
+		resp.Diagnostics.AddError("Error reading OAuth client", err.Error())
+		return
 	}
 
-	// Update the config.
-	d.Set("organization", oc.Organization.Name)
-	d.Set("api_url", oc.APIURL)
-	d.Set("http_url", oc.HTTPURL)
-	d.Set("service_provider", string(oc.ServiceProvider))
-	d.Set("organization_scoped", oc.OrganizationScoped)
-
-	switch len(oc.OAuthTokens) {
-	case 0:
-		d.Set("oauth_token_id", "")
-	case 1:
-		d.Set("oauth_token_id", oc.OAuthTokens[0].ID)
-	default:
-		return fmt.Errorf("unexpected number of OAuth tokens: %d", len(oc.OAuthTokens))
+	lastValues := map[string]types.String{
+		"oauth_token":    state.OAuthToken,
+		"rsa_public_key": state.RSAPublicKey,
+		"key":            state.Key,
+		"secret":         state.Secret,
 	}
 
-	return nil
+	// Load the result into the model
+	result, diags := modelFromTFEOAuthClient(oc, lastValues)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
-func resourceTFEOAuthClientDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
-
-	log.Printf("[DEBUG] Delete OAuth client: %s", d.Id())
-	err := config.Client.OAuthClients.Delete(ctx, d.Id())
-	if err != nil {
-		if err == tfe.ErrResourceNotFound {
-			return nil
-		}
-		return fmt.Errorf("Error deleting OAuth client %s: %w", d.Id(), err)
+// Update implements resource.Resource
+func (r *resourceTFEOAuthClient) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Load the plan and state into the models
+	var plan, state modelTFEOAuthClient
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return nil
-}
-
-func resourceTFEOAuthClientUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
+	var organization string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Create a new options struct.
 	options := tfe.OAuthClientUpdateOptions{
-		OrganizationScoped: tfe.Bool(d.Get("organization_scoped").(bool)),
+		OrganizationScoped: plan.OrganizationScoped.ValueBoolPointer(),
 	}
 
-	log.Printf("[DEBUG] Update OAuth client %s", d.Id())
-	_, err := config.Client.OAuthClients.Update(ctx, d.Id(), options)
+	id := state.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Update OAuth client: %s", id))
+	oc, err := r.config.Client.OAuthClients.Update(ctx, id, options)
 	if err != nil {
-		return fmt.Errorf("Error updating OAuth client %s: %w", d.Id(), err)
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("OAuth client %s no longer exists", id))
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("Error updating OAuth client", err.Error())
+		return
 	}
 
-	return resourceTFEOAuthClientRead(d, meta)
+	lastValues := map[string]types.String{
+		"oauth_token":    plan.OAuthToken,
+		"rsa_public_key": plan.RSAPublicKey,
+		"key":            plan.Key,
+		"secret":         plan.Secret,
+	}
+
+	// Load the result into the model
+	result, diags := modelFromTFEOAuthClient(oc, lastValues)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Update state
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
+}
+
+// Delete implements resource.Resource
+func (r *resourceTFEOAuthClient) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Load the state into the model
+	var state modelTFEOAuthClient
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Delete OAuth client: %s", id))
+	err := r.config.Client.OAuthClients.Delete(ctx, id)
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("OAuth client %s no longer exists", id))
+			// The resource will implicitly be removed from state on return
+			return
+		}
+
+		resp.Diagnostics.AddError("Error deleting OAuth client", err.Error())
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *resourceTFEOAuthClient) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	// Load the config into the model
+	var config modelTFEOAuthClient
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceProviderType := tfe.ServiceProviderType(config.ServiceProvider.ValueString())
+	if serviceProviderType == tfe.ServiceProviderAzureDevOpsServer &&
+		config.PrivateKey.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("private_key"),
+			"Invalid configuration",
+			fmt.Sprintf("private_key is required for service_provider %s", serviceProviderType))
+		return
+	}
 }

--- a/internal/provider/resource_tfe_oauth_client_test.go
+++ b/internal/provider/resource_tfe_oauth_client_test.go
@@ -25,8 +25,8 @@ func TestAccTFEOAuthClient_basic(t *testing.T) {
 				t.Skip("Please set GITHUB_TOKEN to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClient_basic(rInt),
@@ -56,8 +56,8 @@ func TestAccTFEOAuthClientWithOrganizationScoped_basic(t *testing.T) {
 				t.Skip("Please set GITHUB_TOKEN to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClient_basic(rInt),
@@ -83,9 +83,9 @@ func TestAccTFEOAuthClient_rsaKeys(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClient_rsaKeys(rInt),
@@ -118,8 +118,8 @@ func TestAccTFEOAuthClient_agentPool(t *testing.T) {
 				t.Skip("Please set GITHUB_TOKEN to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClient_agentPool(),

--- a/internal/provider/resource_tfe_policy_set_test.go
+++ b/internal/provider/resource_tfe_policy_set_test.go
@@ -498,8 +498,8 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 				t.Skip("Please set GITHUB_POLICY_SET_PATH to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_vcs(org.Name),
@@ -608,8 +608,8 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 				t.Skip("Please set GITHUB_POLICY_SET_PATH to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_vcs(org.Name),

--- a/internal/provider/resource_tfe_project_oauth_client_test.go
+++ b/internal/provider/resource_tfe_project_oauth_client_test.go
@@ -35,9 +35,9 @@ func TestAccTFEProjectOAuthClient_basic(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectOAuthClientDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectOAuthClient_basic(org.Name, project.ID),
@@ -155,8 +155,8 @@ func testAccCheckTFEProjectOAuthClientDestroy(s *terraform.State) error {
 
 func testAccTFEProjectOAuthClient_base(orgName string) string {
 	return fmt.Sprintf(`
-		resource "tfe_oauth_client" "test" {			
-			name = "oauth_client_test"			
+		resource "tfe_oauth_client" "test" {
+			name = "oauth_client_test"
 			organization     = "%s"
 			api_url          = "https://api.github.com"
 			http_url         = "https://github.com"

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -34,8 +34,8 @@ func TestAccTFERegistryModule_vcsBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsBasic(rInt),
@@ -95,8 +95,8 @@ func TestAccTFERegistryModule_GitHubApp(t *testing.T) {
 			testAccPreCheckTFERegistryModule(t)
 			testAccGHAInstallationPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_GitHubApp(rInt),
@@ -142,8 +142,8 @@ func TestAccTFERegistryModule_emptyVCSRepo(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_emptyVCSRepo(rInt, envGithubToken),
@@ -170,8 +170,8 @@ func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName(t *
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_privateRMWithoutRegistryName(rInt),
@@ -219,8 +219,8 @@ func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName(t *tes
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
@@ -268,8 +268,8 @@ func TestAccTFERegistryModule_publicRegistryModule(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_publicRM(rInt),
@@ -309,7 +309,7 @@ func TestAccTFERegistryModule_branchOnly(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_branchOnly(rInt),
@@ -333,7 +333,7 @@ func TestAccTFERegistryModule_vcsRepoWithTags(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsRepoWithFalseTags(rInt),
@@ -368,8 +368,8 @@ func TestAccTFERegistryModule_noCodeModule(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_NoCode(rInt),
@@ -410,8 +410,8 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsWithTagsTrue(rInt),
@@ -434,8 +434,8 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat(t *testing.T) 
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsWithTagsTrue(rInt),
@@ -458,7 +458,7 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch(t
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsBranch(rInt),
@@ -518,7 +518,7 @@ func TestAccTFERegistryModule_branchOnlyEmpty(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_branchOnlyEmpty(rInt),
@@ -541,7 +541,7 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWi
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsBranchWithTests(rInt),
@@ -582,7 +582,7 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags(t *
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsTags(rInt),
@@ -632,7 +632,7 @@ func TestAccTFERegistryModule_invalidTestConfigOnCreate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsInvalidBranch(rInt),
@@ -650,7 +650,7 @@ func TestAccTFERegistryModule_invalidTestConfigOnUpdate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsTags(rInt),
@@ -678,7 +678,7 @@ func TestAccTFERegistryModule_vcsTagsOnlyFalse(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsTagsOnlyFalse(rInt),
@@ -696,7 +696,7 @@ func TestAccTFERegistryModule_branchAndInvalidTagsOnCreate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsBranchWithInvalidTests(rInt),
@@ -714,7 +714,7 @@ func TestAccTFERegistryModule_branchAndTagsEnabledOnCreate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsBranchWithTestsAndTagsEnabled(rInt),
@@ -733,7 +733,7 @@ func TestAccTFERegistryModule_branchAndTagsDisabledOnCreate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsWithBranchAndTagsDisabled(rInt),
@@ -751,7 +751,7 @@ func TestAccTFERegistryModule_branchAndTagsEnabledOnUpdate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsTags(rInt),
@@ -779,7 +779,7 @@ func TestAccTFERegistryModule_branchAndTagsDisabledOnUpdate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsTags(rInt),
@@ -805,8 +805,8 @@ func TestAccTFERegistryModuleImport_nonVCSPrivateRM(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
@@ -828,8 +828,8 @@ func TestAccTFERegistryModuleImport_publicRM(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_publicRM(rInt),
@@ -849,7 +849,7 @@ func TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider(t *testing
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider(),
@@ -864,7 +864,7 @@ func TestAccTFERegistryModule_invalidRegistryName(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidRegistryName(),
@@ -879,7 +879,7 @@ func TestAccTFERegistryModule_invalidWithModuleProviderAndNoName(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithModuleProviderAndNoName(),
@@ -894,7 +894,7 @@ func TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization(t *test
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization(),
@@ -909,7 +909,7 @@ func TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName(t *testing.T
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName(),
@@ -924,7 +924,7 @@ func TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(t *test
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(),

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -31,9 +31,9 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 	workspaceName := "workspace-test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -167,9 +167,9 @@ func TestAccTFEWorkspace_basicReadProjectId(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -188,9 +188,9 @@ func TestAccTFEWorkspace_customProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_orgProjectWorkspace(rInt),
@@ -209,9 +209,9 @@ func TestAccTFEWorkspace_HTMLURL(t *testing.T) {
 
 	// When name is changed, the html_url should be updated as well
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_HTMLURL(rInt),
@@ -264,9 +264,9 @@ func TestAccTFEWorkspace_panic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:             testAccTFEWorkspace_basic(rInt),
@@ -286,9 +286,9 @@ func TestAccTFEWorkspace_monorepo(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_monorepo(rInt),
@@ -322,9 +322,9 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -384,9 +384,9 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -449,9 +449,9 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -504,9 +504,9 @@ func TestAccTFEWorkspace_updateProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_orgProjectWorkspace(rInt),
@@ -529,9 +529,9 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -561,9 +561,9 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_triggerPrefixes(rInt),
@@ -598,9 +598,9 @@ func TestAccTFEWorkspace_overwriteTriggerPatternsWithPrefixes(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_triggerPatterns(rInt),
@@ -653,9 +653,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -694,9 +694,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -737,9 +737,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -778,9 +778,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -817,9 +817,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -858,9 +858,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -901,9 +901,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -946,9 +946,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -992,9 +992,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 		t.Run("and both trigger prefixes and patterns are populated", func(t *testing.T) {
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -1011,9 +1011,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 		t.Run("and both trigger prefixes and patterns are empty", func(t *testing.T) {
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -1032,9 +1032,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -1180,9 +1180,9 @@ func TestAccTFEWorkspace_updateTriggerPatterns(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			// Create trigger prefixes first so we can verify they are being removed if we introduce trigger patterns
 			{
@@ -1243,9 +1243,9 @@ func TestAccTFEWorkspace_patternsAndPrefixesConflicting(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEWorkspace_prefixesAndPatternsConflicting(rInt),
@@ -1264,9 +1264,9 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				// create with 2 tags
@@ -1422,9 +1422,9 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -1454,9 +1454,9 @@ func TestAccTFEWorkspace_structuredRunOutputDisabled(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -1490,8 +1490,8 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
@@ -1567,8 +1567,8 @@ func TestAccTFEWorkspace_updateGitHubAppRepo(t *testing.T) {
 			testAccGithubPreCheck(t)
 			testAccGHAInstallationPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
@@ -1644,8 +1644,8 @@ func TestAccTFEWorkspace_updateVCSRepoTagsRegex(t *testing.T) {
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
@@ -1696,8 +1696,8 @@ func TestAccTFEWorkspace_updateVCSRepoChangeTagRegexToTriggerPattern(t *testing.
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
@@ -1748,8 +1748,8 @@ func TestAccTFEWorkspace_updateRemoveVCSRepoWithTagsRegex(t *testing.T) {
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
@@ -1790,9 +1790,9 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -1830,9 +1830,9 @@ func TestAccTFEWorkspace_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -1864,8 +1864,8 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoBranch(rInt),
@@ -1897,9 +1897,9 @@ func TestAccTFEWorkspace_importProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_orgProjectWorkspace(rInt),
@@ -1928,9 +1928,9 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 	workspace := &tfe.Workspace{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_operationsTrue(org.Name),
@@ -2006,9 +2006,9 @@ func TestAccTFEWorkspace_globalRemoteState(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_globalRemoteStateFalse(rInt),
@@ -2043,9 +2043,9 @@ func TestAccTFEWorkspace_alterRemoteStateConsumers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -2100,9 +2100,9 @@ func TestAccTFEWorkspace_createWithRemoteStateConsumers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_TwoRemoteStateConsumers(rInt),
@@ -2124,9 +2124,9 @@ func TestAccTFEWorkspace_paginatedRemoteStateConsumers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_OverAPageOfRemoteStateConsumers(rInt),
@@ -2144,9 +2144,9 @@ func TestAccTFEWorkspace_delete_forceDeleteSettingDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -2194,9 +2194,9 @@ func TestAccTFEWorkspace_delete_forceDeleteSettingEnabled(t *testing.T) {
 		t.Fatal(err)
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
@@ -2665,9 +2665,9 @@ func TestAccTFEWorkspace_basicAssessmentsEnabled(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -2700,9 +2700,9 @@ func TestAccTFEWorkspace_createWithAutoDestroyAt(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAt(rInt),
@@ -2719,9 +2719,9 @@ func TestAccTFEWorkspace_updateWithAutoDestroyAt(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -2746,9 +2746,9 @@ func TestAccTFEWorkspace_createWithAutoDestroyDuration(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDuration(rInt, "1d"),
@@ -2765,9 +2765,9 @@ func TestAccTFEWorkspace_updateWithAutoDestroyDuration(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDuration(rInt, "1d"),
@@ -2811,10 +2811,10 @@ func TestAccTFEWorkspace_validationAutoDestroyDuration(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
-		Steps:        steps,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
+		Steps:                    steps,
 	})
 }
 
@@ -2822,9 +2822,9 @@ func TestAccTFEWorkspace_createWithAutoDestroyDurationInProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDurationInProject(rInt, "1d", "3d"),
@@ -2842,9 +2842,9 @@ func TestAccTFEWorkspace_updateWithAutoDestroyDurationInProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDurationInProject(rInt, "1d", "3d"),
@@ -2878,9 +2878,9 @@ func TestAccTFEWorkspace_createWithAutoDestroyAtInProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAtInProject(rInt, "1d"),
@@ -2898,9 +2898,9 @@ func TestAccTFEWorkspace_updateWithAutoDestroyAtInProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAtInProject(rInt, "1d"),
@@ -2926,9 +2926,9 @@ func TestAccTFEWorkspace_createWithSourceURL(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEWorkspace_basicWithSourceURL(rInt),
@@ -2942,9 +2942,9 @@ func TestAccTFEWorkspace_createWithSourceName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEWorkspace_basicWithSourceName(rInt),
@@ -2959,9 +2959,9 @@ func TestAccTFEWorkspace_createWithSourceURLAndName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithSourceURLAndName(rInt),


### PR DESCRIPTION
## Description

This PR migrates the `tfe_oauth_client` resource and data source to the provider framework.

Acceptance tests that made use of any of the above also needed to be switched to the muxed provider factory.

## Testing plan

1.  acc tests
2. all data sources and resources should continue to function as usual

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEOAuthClient_" make testacc

=== RUN   TestAccTFEOAuthClient_basic
--- PASS: TestAccTFEOAuthClient_basic (3.99s)
=== RUN   TestAccTFEOAuthClient_rsaKeys
--- PASS: TestAccTFEOAuthClient_rsaKeys (3.51s)
=== RUN   TestAccTFEOAuthClient_agentPool
    helper_test.go:237: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEOAuthClient_agentPool (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   7.995s


```
