### PR TITLE
data source for registry module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* **New Data Source:** `tfe_registry_module` is a new data source for finding
+  registry modules by @drewmullen and @danquack [#1667]https://github.com/hashicorp/terraform-provider-tfe/pull/1667
+
 FEATURES:
 
 * **New Ephemeral Resource:** `tfe_organization_token` is a new ephemeral

--- a/internal/provider/data_source_registry_module.go
+++ b/internal/provider/data_source_registry_module.go
@@ -1,0 +1,423 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &dataSourceTFERegistryModule{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFERegistryModule{}
+)
+
+// NewModuleDataSource is a helper function to simplify the implementation.
+func NewRegistryModuleDataSource() datasource.DataSource {
+	return &dataSourceTFERegistryModule{}
+}
+
+// dataSourceTFEModule is the data source implementation.
+type dataSourceTFERegistryModule struct {
+	config ConfiguredClient
+}
+
+// modelModule maps the data source schema data.
+type modelRegistryModule struct {
+	ID                  types.String                         `tfsdk:"id"`
+	Organization        types.String                         `tfsdk:"organization"`
+	Namespace           types.String                         `tfsdk:"namespace"`
+	Name                types.String                         `tfsdk:"name"`
+	RegistryName        types.String                         `tfsdk:"registry_name"`
+	ModuleProvider      types.String                         `tfsdk:"module_provider"`
+	NoCodeModuleId      types.String                         `tfsdk:"no_code_module_id"`
+	NoCodeModuleSource  types.String                         `tfsdk:"no_code_module_source"`
+	NoCode              types.Bool                           `tfsdk:"no_code"`
+	Permissions         []modelRegistryModulePermissions     `tfsdk:"permissions"`
+	PublishingMechanism types.String                         `tfsdk:"publishing_mechanism"`
+	Status              types.String                         `tfsdk:"status"`
+	TestConfig          []modelTestConfig                    `tfsdk:"test_config"`
+	VCSRepo             []modelTFEVCSRepo                    `tfsdk:"vcs_repo"`
+	VersionStatuses     []modelRegistryModuleVersionStatuses `tfsdk:"version_statuses"`
+	CreatedAt           types.String                         `tfsdk:"created_at"`
+	UpdatedAt           types.String                         `tfsdk:"updated_at"`
+}
+
+type modelRegistryModuleVersionStatuses struct {
+	Version types.String `tfsdk:"version"`
+	Status  types.String `tfsdk:"status"`
+	Error   types.String `tfsdk:"error"`
+}
+
+func (m modelRegistryModuleVersionStatuses) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"version": types.StringType,
+		"status":  types.StringType,
+		"error":   types.StringType,
+	}
+}
+
+func modelFromTFERegistryModuleVersionStatuses(v *tfe.RegistryModuleVersionStatuses) modelRegistryModuleVersionStatuses {
+	return modelRegistryModuleVersionStatuses{
+		Version: types.StringValue(v.Version),
+		Status:  types.StringValue(string(v.Status)),
+		Error:   types.StringValue(v.Error),
+	}
+}
+
+type modelTestConfig struct {
+	TestsEnabled types.Bool `tfsdk:"tests_enabled"`
+}
+
+func (m modelTestConfig) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"tests_enabled": types.BoolType,
+	}
+}
+
+type modelTFEVCSRepo struct {
+	Branch            types.String `tfsdk:"branch"`
+	DisplayIdentifier types.String `tfsdk:"display_identifier"`
+	Identifier        types.String `tfsdk:"identifier"`
+	IngressSubmodules types.Bool   `tfsdk:"ingress_submodules"`
+	OAuthTokenID      types.String `tfsdk:"oauth_token_id"`
+	GHAInstallationID types.String `tfsdk:"github_app_installation_id"`
+	RepositoryHTTPURL types.String `tfsdk:"repository_http_url"`
+	ServiceProvider   types.String `tfsdk:"service_provider"`
+	Tags              types.Bool   `tfsdk:"tags"`
+	TagsRegex         types.String `tfsdk:"tags_regex"`
+	WebhookURL        types.String `tfsdk:"webhook_url"`
+}
+
+func (m modelTFEVCSRepo) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"branch":                     types.StringType,
+		"display_identifier":         types.StringType,
+		"identifier":                 types.StringType,
+		"ingress_submodules":         types.BoolType,
+		"oauth_token_id":             types.StringType,
+		"github_app_installation_id": types.StringType,
+		"repository_http_url":        types.StringType,
+		"service_provider":           types.StringType,
+		"tags":                       types.BoolType,
+		"tags_regex":                 types.StringType,
+		"webhook_url":                types.StringType,
+	}
+}
+
+func modelFromTFEVCSRepo(v *tfe.VCSRepo) modelTFEVCSRepo {
+	return modelTFEVCSRepo{
+		Branch:            types.StringValue(v.Branch),
+		DisplayIdentifier: types.StringValue(v.DisplayIdentifier),
+		Identifier:        types.StringValue(v.Identifier),
+		IngressSubmodules: types.BoolValue(v.IngressSubmodules),
+		OAuthTokenID:      types.StringValue(v.OAuthTokenID),
+		GHAInstallationID: types.StringValue(v.GHAInstallationID),
+		RepositoryHTTPURL: types.StringValue(v.RepositoryHTTPURL),
+		ServiceProvider:   types.StringValue(v.ServiceProvider),
+		Tags:              types.BoolValue(v.Tags),
+		TagsRegex:         types.StringValue(v.TagsRegex),
+		WebhookURL:        types.StringValue(v.WebhookURL),
+	}
+}
+
+func modelFromTFETestConfig(v *tfe.TestConfig) modelTestConfig {
+	return modelTestConfig{
+		TestsEnabled: types.BoolValue(v.TestsEnabled),
+	}
+}
+
+type modelRegistryModulePermissions struct {
+	CanDelete types.Bool `tfsdk:"can_delete"`
+	CanResync types.Bool `tfsdk:"can_resync"`
+	CanRetry  types.Bool `tfsdk:"can_retry"`
+}
+
+func (m modelRegistryModulePermissions) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"can_delete": types.BoolType,
+		"can_resync": types.BoolType,
+		"can_retry":  types.BoolType,
+	}
+}
+
+func modelFromTFERegistryModulePermission(v *tfe.RegistryModulePermissions) modelRegistryModulePermissions {
+	return modelRegistryModulePermissions{
+		CanDelete: types.BoolValue(v.CanDelete),
+		CanResync: types.BoolValue(v.CanResync),
+		CanRetry:  types.BoolValue(v.CanRetry),
+	}
+}
+
+// Metadata returns the data source type name.
+func (d *dataSourceTFERegistryModule) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_registry_module"
+}
+
+// Schema defines the schema for the data source.
+func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source can be used to retrieve a public or private no-code module.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "ID of the no-code module.",
+				Computed:    true,
+			},
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization.",
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the module.",
+				Required:    true,
+			},
+			"registry_name": schema.StringAttribute{
+				Description: "Name of the registry. Valid options: \"public\", \"private\". Defaults to \"private\".",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						string(tfe.PrivateRegistry),
+						string(tfe.PublicRegistry),
+					),
+				},
+			},
+			"module_provider": schema.StringAttribute{
+				Description: "Name of the module provider.",
+				Required:    true,
+			},
+			"namespace": schema.StringAttribute{
+				Description: "The namespace of the no-code module. Uses organization name if not provided.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"no_code_module_id": schema.StringAttribute{
+				Description: "ID of the no-code module.",
+				Computed:    true,
+			},
+			"no_code_module_source": schema.StringAttribute{
+				Description: "Source value of the no-code module.",
+				Computed:    true,
+			},
+			"no_code": schema.BoolAttribute{
+				Description: "Whether or not this is a no-code module.",
+				Computed:    true,
+			},
+			"publishing_mechanism": schema.StringAttribute{
+				Description: "The publishing mechanism of the module.",
+				Computed:    true,
+			},
+			"status": schema.StringAttribute{
+				Description: "The status of the module.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "The time when the modules was created.",
+				Computed:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "The time when the modules was last updated.",
+				Computed:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"permissions": schema.ListNestedBlock{
+				Description: "The permissions for this module.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"can_delete": schema.BoolAttribute{
+							Description: "Whether or not this is a delete permission.",
+							Computed:    true,
+						},
+						"can_resync": schema.BoolAttribute{
+							Description: "Whether or not this is a resync permission.",
+							Computed:    true,
+						},
+						"can_retry": schema.BoolAttribute{
+							Description: "Whether or not this is a retry permission.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"test_config": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"tests_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"version_statuses": schema.ListNestedBlock{
+				Description: "The status of each version of this module.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"version": schema.StringAttribute{
+							Description: "The version of this module.",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Computed: true,
+						},
+						"error": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"vcs_repo": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"branch": schema.StringAttribute{
+							Computed: true,
+						},
+						"display_identifier": schema.StringAttribute{
+							Computed: true,
+						},
+						"identifier": schema.StringAttribute{
+							Computed: true,
+						},
+						"ingress_submodules": schema.BoolAttribute{
+							Computed: true,
+						},
+						"oauth_token_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"github_app_installation_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"repository_http_url": schema.StringAttribute{
+							Computed: true,
+						},
+						"service_provider": schema.StringAttribute{
+							Computed: true,
+						},
+						"tags": schema.BoolAttribute{
+							Computed: true,
+						},
+						"tags_regex": schema.StringAttribute{
+							Computed: true,
+						},
+						"webhook_url": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *dataSourceTFERegistryModule) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe modules, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+	d.config = client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *dataSourceTFERegistryModule) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data modelRegistryModule
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If the namespace is not provided, use the organization name
+	var namespace types.String
+	if data.Namespace.IsNull() {
+		namespace = data.Organization
+	} else {
+		namespace = data.Namespace
+	}
+
+	// defaults to private registry
+	var registryName types.String
+	if data.RegistryName.IsNull() {
+		registryName = types.StringValue(string(tfe.PrivateRegistry))
+	} else {
+		registryName = data.RegistryName
+	}
+
+	rmID := tfe.RegistryModuleID{
+		Organization: data.Organization.ValueString(),
+		Name:         data.Name.ValueString(),
+		Provider:     data.ModuleProvider.ValueString(),
+		Namespace:    namespace.ValueString(),
+		RegistryName: tfe.RegistryName(registryName.ValueString()),
+		//tfe.RegistryName(data.RegistryName.ValueString()),
+	}
+
+	tflog.Debug(ctx, "Reading module")
+	module, err := d.config.Client.RegistryModules.Read(ctx, rmID)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read module", err.Error())
+		return
+	}
+
+	data = modelFromTFERegistryModule(module)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func modelFromTFERegistryModule(v *tfe.RegistryModule) modelRegistryModule {
+	m := modelRegistryModule{
+		ID:                  types.StringValue(v.ID),
+		Organization:        types.StringValue(v.Organization.Name),
+		Name:                types.StringValue(v.Name),
+		Namespace:           types.StringValue(v.Namespace),
+		RegistryName:        types.StringValue(string(v.RegistryName)),
+		ModuleProvider:      types.StringValue(v.Provider),
+		NoCode:              types.BoolValue(v.NoCode),
+		PublishingMechanism: types.StringValue(string(v.PublishingMechanism)),
+		Status:              types.StringValue(string(v.Status)),
+		CreatedAt:           types.StringValue(v.CreatedAt),
+		UpdatedAt:           types.StringValue(v.UpdatedAt),
+	}
+	for _, s := range v.VersionStatuses {
+		m.VersionStatuses = append(m.VersionStatuses, modelFromTFERegistryModuleVersionStatuses(&s))
+	}
+	if v.TestConfig != nil {
+		m.TestConfig = append(m.TestConfig, modelFromTFETestConfig(v.TestConfig))
+	}
+	if v.Permissions != nil {
+		m.Permissions = append(m.Permissions, modelFromTFERegistryModulePermission(v.Permissions))
+	}
+	if v.VCSRepo != nil {
+		m.VCSRepo = append(m.VCSRepo, modelFromTFEVCSRepo(v.VCSRepo))
+	}
+	// Only valid options are no RegistryNoCodeModule or a single entry
+	if v.RegistryNoCodeModule != nil {
+		m.NoCodeModuleId = types.StringValue(v.RegistryNoCodeModule[0].ID)
+		m.NoCodeModuleSource = types.StringValue(fmt.Sprintf("%s/%s/%s/%s", v.RegistryName, v.Namespace, v.Name, v.Provider))
+	}
+	return m
+}

--- a/internal/provider/data_source_registry_module.go
+++ b/internal/provider/data_source_registry_module.go
@@ -42,7 +42,7 @@ type modelRegistryModule struct {
 	Name                types.String                         `tfsdk:"name"`
 	RegistryName        types.String                         `tfsdk:"registry_name"`
 	ModuleProvider      types.String                         `tfsdk:"module_provider"`
-	NoCodeModuleId      types.String                         `tfsdk:"no_code_module_id"`
+	NoCodeModuleID      types.String                         `tfsdk:"no_code_module_id"`
 	NoCodeModuleSource  types.String                         `tfsdk:"no_code_module_source"`
 	NoCode              types.Bool                           `tfsdk:"no_code"`
 	Permissions         []modelRegistryModulePermissions     `tfsdk:"permissions"`
@@ -372,7 +372,6 @@ func (d *dataSourceTFERegistryModule) Read(ctx context.Context, req datasource.R
 		Provider:     data.ModuleProvider.ValueString(),
 		Namespace:    namespace.ValueString(),
 		RegistryName: tfe.RegistryName(registryName.ValueString()),
-		//tfe.RegistryName(data.RegistryName.ValueString()),
 	}
 
 	tflog.Debug(ctx, "Reading module")
@@ -416,7 +415,7 @@ func modelFromTFERegistryModule(v *tfe.RegistryModule) modelRegistryModule {
 	}
 	// Only valid options are no RegistryNoCodeModule or a single entry
 	if v.RegistryNoCodeModule != nil {
-		m.NoCodeModuleId = types.StringValue(v.RegistryNoCodeModule[0].ID)
+		m.NoCodeModuleID = types.StringValue(v.RegistryNoCodeModule[0].ID)
 		m.NoCodeModuleSource = types.StringValue(fmt.Sprintf("%s/%s/%s/%s", v.RegistryName, v.Namespace, v.Name, v.Provider))
 	}
 	return m

--- a/internal/provider/data_source_registry_module_test.go
+++ b/internal/provider/data_source_registry_module_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccTFERegistryModuleDataSource_basicPrivate(t *testing.T) {
+	// registryModule := &tfe.RegistryModule{}
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	expectedRegistryModuleAttributes := &tfe.RegistryModule{
+		Name:         getRegistryModuleName(),
+		Provider:     getRegistryModuleProvider(),
+		RegistryName: tfe.PrivateRegistry,
+		Namespace:    orgName,
+		Organization: &tfe.Organization{Name: orgName},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModuleDataSourceBasic(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "organization", orgName),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "namespace", orgName),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "name", expectedRegistryModuleAttributes.Name),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "registry_name", string(expectedRegistryModuleAttributes.RegistryName)),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "module_provider", string(expectedRegistryModuleAttributes.Provider)),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "no_code", "false"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "permissions.0.can_delete", "true"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "permissions.0.can_retry", "true"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "permissions.0.can_resync", "true"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "publishing_mechanism", "git_tag"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "status", "pending"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "vcs_repo.0.display_identifier", envGithubRegistryModuleIdentifer),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "vcs_repo.0.identifier", envGithubRegistryModuleIdentifer),
+					resource.TestCheckResourceAttrSet("data.tfe_registry_module.test", "vcs_repo.0.oauth_token_id"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "vcs_repo.0.branch", ""),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "vcs_repo.0.tags", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModuleDataSource_basicNoCodePublic(t *testing.T) {
+	skipIfEnterprise(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+	dsName := "data.tfe_registry_module.test"
+	rsName := "tfe_no_code_module.foobar"
+
+	expectedRegistryModuleAttributes := &tfe.RegistryModule{
+		Name:         "vpc",
+		Provider:     "aws",
+		RegistryName: tfe.PublicRegistry,
+		Namespace:    "terraform-aws-modules",
+		Organization: &tfe.Organization{Name: orgName},
+	}
+
+	ncms := fmt.Sprintf("%s/%s/%s/%s", expectedRegistryModuleAttributes.RegistryName, expectedRegistryModuleAttributes.Namespace, expectedRegistryModuleAttributes.Name, expectedRegistryModuleAttributes.Provider)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModuleDataSourceBasic_noCodePublic(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dsName, "no_code_module_id", rsName, "id"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "organization", orgName),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "namespace", expectedRegistryModuleAttributes.Namespace),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "name", expectedRegistryModuleAttributes.Name),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "registry_name", string(expectedRegistryModuleAttributes.RegistryName)),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "module_provider", string(expectedRegistryModuleAttributes.Provider)),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "no_code_module_source", ncms),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERegistryModuleDataSource_basicNoCodePrivate(t *testing.T) {
+	skipIfEnterprise(t)
+
+	dsName := "data.tfe_registry_module.test"
+	rsName := "tfe_no_code_module.foobar"
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	expectedRegistryModuleAttributes := &tfe.RegistryModule{
+		Name:         getRegistryModuleName(),
+		Provider:     getRegistryModuleProvider(),
+		RegistryName: tfe.PrivateRegistry,
+		Namespace:    orgName,
+		Organization: &tfe.Organization{Name: orgName},
+	}
+	ncms := fmt.Sprintf("%s/%s/%s/%s", expectedRegistryModuleAttributes.RegistryName, expectedRegistryModuleAttributes.Namespace, expectedRegistryModuleAttributes.Name, expectedRegistryModuleAttributes.Provider)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERegistryModuleDataSourceBasic_noCodePrivate(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dsName, "no_code_module_id", rsName, "id"),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "no_code_module_source", ncms),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFERegistryModuleDataSourceBasic(rInt int) string {
+	return fmt.Sprintf(`
+%s
+data "tfe_registry_module" "test" {
+  organization    = tfe_registry_module.foobar.organization
+  name            = tfe_registry_module.foobar.name
+  module_provider = tfe_registry_module.foobar.module_provider
+}`, testAccTFERegistryModule_vcsBasic(rInt))
+}
+
+func testAccTFERegistryModuleDataSourceBasic_noCodePublic(rInt int) string {
+	return fmt.Sprintf(`
+%s
+data "tfe_registry_module" "test" {
+  organization    = tfe_no_code_module.foobar.organization
+  name            = tfe_registry_module.foobar.name
+  module_provider = tfe_registry_module.foobar.module_provider
+  registry_name   = tfe_registry_module.foobar.registry_name
+  namespace       = tfe_registry_module.foobar.namespace
+}`, testAccTFERegistryModule_NoCode(rInt))
+}
+
+func testAccTFERegistryModuleDataSourceBasic_noCodePrivate(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+ name  = "tst-terraform-%d"
+ email = "admin@company.com"
+}
+
+resource "tfe_oauth_client" "foobar" {
+ organization     = tfe_organization.foobar.name
+ api_url          = "https://api.github.com"
+ http_url         = "https://github.com"
+ oauth_token      = "%s"
+ service_provider = "github"
+}
+
+resource "tfe_registry_module" "foobar" {
+ organization     = tfe_organization.foobar.name
+ vcs_repo {
+   display_identifier = "%s"
+   identifier         = "%s"
+   oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
+ }
+}
+
+resource "tfe_no_code_module" "foobar" {
+  organization    = tfe_organization.foobar.id
+  registry_module = tfe_registry_module.foobar.id
+} 
+
+data "tfe_registry_module" "test" {
+  organization    = tfe_no_code_module.foobar.organization
+  name            = tfe_registry_module.foobar.name
+  module_provider = tfe_registry_module.foobar.module_provider
+  registry_name   = tfe_registry_module.foobar.registry_name
+  namespace       = tfe_registry_module.foobar.namespace
+}
+`,
+		rInt,
+		envGithubToken,
+		envGithubRegistryModuleIdentifer,
+		envGithubRegistryModuleIdentifer)
+}

--- a/internal/provider/data_source_registry_module_test.go
+++ b/internal/provider/data_source_registry_module_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestAccTFERegistryModuleDataSource_basicPrivate(t *testing.T) {
-	// registryModule := &tfe.RegistryModule{}
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
@@ -38,7 +36,7 @@ func TestAccTFERegistryModuleDataSource_basicPrivate(t *testing.T) {
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "namespace", orgName),
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "name", expectedRegistryModuleAttributes.Name),
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "registry_name", string(expectedRegistryModuleAttributes.RegistryName)),
-					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "module_provider", string(expectedRegistryModuleAttributes.Provider)),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "module_provider", expectedRegistryModuleAttributes.Provider),
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "no_code", "false"),
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "permissions.0.can_delete", "true"),
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "permissions.0.can_retry", "true"),
@@ -86,7 +84,7 @@ func TestAccTFERegistryModuleDataSource_basicNoCodePublic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "namespace", expectedRegistryModuleAttributes.Namespace),
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "name", expectedRegistryModuleAttributes.Name),
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "registry_name", string(expectedRegistryModuleAttributes.RegistryName)),
-					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "module_provider", string(expectedRegistryModuleAttributes.Provider)),
+					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "module_provider", expectedRegistryModuleAttributes.Provider),
 					resource.TestCheckResourceAttr("data.tfe_registry_module.test", "no_code_module_source", ncms),
 				),
 			},

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -137,6 +137,7 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewProjectsDataSource,
 		NewRegistryGPGKeyDataSource,
 		NewRegistryGPGKeysDataSource,
+		NewRegistryModuleDataSource,
 		NewRegistryProviderDataSource,
 		NewRegistryProvidersDataSource,
 		NewSAMLSettingsDataSource,

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -361,7 +361,7 @@ func TestAccTFERegistryModule_noCodeModule(t *testing.T) {
 		RegistryName: tfe.PublicRegistry,
 		Namespace:    "terraform-aws-modules",
 		Organization: &tfe.Organization{Name: orgName},
-		NoCode:       true,
+		NoCode:       false, // changes to false on refresh
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -1620,8 +1620,13 @@ resource "tfe_registry_module" "foobar" {
   module_provider = "aws"
   name            = "vpc"
   registry_name   = "public"
-  no_code         = true
- }`,
+ }
+ 
+ resource "tfe_no_code_module" "foobar" {
+  organization    = tfe_organization.foobar.id
+  registry_module = tfe_registry_module.foobar.id
+} 
+ `,
 		rInt)
 }
 

--- a/website/docs/d/registry_module.html.markdown
+++ b/website/docs/d/registry_module.html.markdown
@@ -1,0 +1,81 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_registry_module"
+description: |-
+  Get information on a registry module
+---
+
+# Data Source: tfe_registry_module
+
+Use this data source to get information about a registry module.
+
+## Example Usage
+
+Basic usage:
+
+Since modules have a [required naming convention](https://developer.hashicorp.com/terraform/registry/modules/publish#requirements), you can get these values from your module repository (`terraform-<module_provider>-<name>`). 
+
+```hcl
+data "tfe_registry_module" "example" {
+  organization    = var.organization_name
+  name            = "no-code-ssm"
+  module_provider = "aws"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `organization` - (Required) The name of the organization associated with the registry module.
+* `name` - (Required) The name of the module. Can be found from repository name convention `terraform-<provider>-<name>.`
+* `module_provider` - (Required) The provider associated with the module. Can be found from repository name convention `terraform-<provider>-<name>.`
+
+The following arguments are supported:
+
+* `namespace` - (Optional) The namespace of a registry module. Typically this is the same as the organization name. Defaults to `organization` value.
+* `registry_name` - (Optional) The registry name of a registry module. Valid options: "public", "private". Defaults to "private".
+
+## Attributes Reference
+
+* `id` - The ID of the registry module.
+* `no_code_module_id` - The ID of the no-code module, if enabled.
+* `no_code_module_source` - The source value of the no-code module (`<ORGANIZATION>/<REGISTRY_NAME>/<NAMESPACE>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>`).
+* `no_code` - Boolean value if no-code module is enabled.
+* `publishing_mechanism` - The publishing mechanism used when releasing new versions of the module.
+* `vcs_repo` - Settings for the registry module's VCS repository. 
+* `permissions` - The permissions on a module.
+* `status` - Current status of registry module.
+* `test_config` - Test configuration indicating module testing setup.
+* `version_statuses` - Version information for a given module.
+* `created_at` - Date module was created.
+* `updated_at` - Date module was last updated.
+
+The `vcs_repo` block supports:
+
+* `display_identifier` - The display identifier for your VCS repository.
+  For most VCS providers outside of BitBucket Cloud and Azure DevOps, this will match the `identifier`
+  string.
+* `identifier` - A reference to your VCS repository in the format
+  `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Data Center)
+  and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.
+* `oauth_token_id` - Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.
+* `github_app_installation_id` - The installation id of the Github App. This conflicts with `oauth_token_id` and can only be used if `oauth_token_id` is not used.
+* `branch` - The git branch used for publishing when using branch-based publishing for the registry module. When a `branch` is set, `tags` will be returned as `false`.
+* `tags` - Specifies whether tag based publishing is enabled for the registry module. When `tags` is set to `true`, the `branch` must be set to an empty value.
+
+The `permissions` block supports:
+
+- `can_delete` - Can delete.
+- `can_resync` - Can resync.
+- `can_retry` -  Can retry.
+
+The `test_config` block supports:
+
+- `tests_enabled` - Indicates whether tests are enabled for a module
+
+The `version_statuses` block supports:
+
+- `version` - Version of the module.
+- `status` - Status of the module at specific version.
+- `error` - Error message reported by module at specific version.


### PR DESCRIPTION
## Description

Closes: #1666, #1141
_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

```shell
TESTARGS="-run TestAccTFERegistryModuleDataSource" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFERegistryModuleDataSource -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
=== RUN   TestAccTFERegistryModuleDataSource_basicPrivate
--- PASS: TestAccTFERegistryModuleDataSource_basicPrivate (4.36s)
=== RUN   TestAccTFERegistryModuleDataSource_basicNoCodePublic
--- PASS: TestAccTFERegistryModuleDataSource_basicNoCodePublic (3.08s)
=== RUN   TestAccTFERegistryModuleDataSource_basicNoCodePrivate
--- PASS: TestAccTFERegistryModuleDataSource_basicNoCodePrivate (4.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider
```