### PR TITLE
tests: replace all remaining sdk provider factories with framework muxed provider factories

### DIFF
--- a/internal/provider/data_source_agent_pool_test.go
+++ b/internal/provider/data_source_agent_pool_test.go
@@ -28,8 +28,8 @@ func TestAccTFEAgentPoolDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentPoolDataSourceConfig(org.Name, rInt),
@@ -68,8 +68,8 @@ func TestAccTFEAgentPoolDataSource_allowed_workspaces(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentPoolDataSourceAllowedWorkspacesConfig(org.Name, rInt, ws.ID),

--- a/internal/provider/data_source_github_app_installation_test.go
+++ b/internal/provider/data_source_github_app_installation_test.go
@@ -19,8 +19,8 @@ func testAccTFEGHAInstallationDataSourcePreCheck(t *testing.T) {
 
 func TestAccTFEGHAInstallationDataSource_findByName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEGHAInstallationDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEGHAInstallationDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEGHAInstallationDataSourceConfig_findByName(envGithubAppInstallationName),

--- a/internal/provider/data_source_ip_ranges_test.go
+++ b/internal/provider/data_source_ip_ranges_test.go
@@ -15,8 +15,8 @@ func TestAccTFEIPRangesDataSource_basic(t *testing.T) {
 	ipRegex := regexp.MustCompile(`^([\d]{1,3}\.){3}[\d]{1,3}/[\d]{1,3}$`)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEIPRangesDataSourceConfig(),

--- a/internal/provider/data_source_oauth_client_test.go
+++ b/internal/provider/data_source_oauth_client_test.go
@@ -24,8 +24,8 @@ func TestAccTFEOAuthClientDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClientDataSourceConfig_basic(rInt),
@@ -45,8 +45,8 @@ func TestAccTFEOAuthClientDataSource_basic(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_findByID(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClientDataSourceConfig_findByID(rInt),
@@ -75,8 +75,8 @@ func TestAccTFEOAuthClientDataSource_findByID(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_findByName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClientDataSourceConfig_findByName(rInt),
@@ -105,8 +105,8 @@ func TestAccTFEOAuthClientDataSource_findByName(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_findByServiceProvider(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClientDataSourceConfig_findByServiceProvider(rInt),
@@ -132,8 +132,8 @@ func TestAccTFEOAuthClientDataSource_findByServiceProvider(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_missingParameters(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_missingParameters(rInt),
@@ -146,8 +146,8 @@ func TestAccTFEOAuthClientDataSource_missingParameters(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_missingOrgWithName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_missingOrgWithName(rInt),
@@ -160,8 +160,8 @@ func TestAccTFEOAuthClientDataSource_missingOrgWithName(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_missingOrgWithServiceProvider(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_missingOrgWithServiceProvider(rInt),
@@ -174,8 +174,8 @@ func TestAccTFEOAuthClientDataSource_missingOrgWithServiceProvider(t *testing.T)
 func TestAccTFEOAuthClientDataSource_sameName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_sameName(rInt),
@@ -188,8 +188,8 @@ func TestAccTFEOAuthClientDataSource_sameName(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_noName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_noName(rInt),
@@ -202,8 +202,8 @@ func TestAccTFEOAuthClientDataSource_noName(t *testing.T) {
 func TestAccTFEOAuthClientDataSource_sameServiceProvider(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccTFEOAuthClientDataSourcePreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOAuthClientDataSourceConfig_sameServiceProvider(rInt),

--- a/internal/provider/data_source_organization_members_test.go
+++ b/internal/provider/data_source_organization_members_test.go
@@ -26,8 +26,8 @@ func TestAccTFEOrganizationMembersDataSource_basic(t *testing.T) {
 	membership := createOrganizationMembership(t, tfeClient, org.Name, options)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationMembersDataSourceConfig(org.Name),

--- a/internal/provider/data_source_organization_membership_test.go
+++ b/internal/provider/data_source_organization_membership_test.go
@@ -19,8 +19,8 @@ func TestAccTFEOrganizationMembershipDataSource_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationMembershipDataSourceConfig(rInt),
@@ -67,7 +67,7 @@ func TestAccTFEOrganizationMembershipDataSource_findByName(t *testing.T) {
 				t.Skip("Please set TFE_USER1 to run this test")
 			}
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationMembershipDataSourceSearchUsername(envTFEUser1),
@@ -89,8 +89,8 @@ func TestAccTFEOrganizationMembershipDataSource_missingParams(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOrganizationMembershipDataSourceMissingParams(rInt),

--- a/internal/provider/data_source_organization_tags_test.go
+++ b/internal/provider/data_source_organization_tags_test.go
@@ -17,8 +17,8 @@ func TestAccTFEOrganizationTagsDataSource_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationTagsDataSourceConfig(rInt),

--- a/internal/provider/data_source_organization_test.go
+++ b/internal/provider/data_source_organization_test.go
@@ -20,8 +20,8 @@ func TestAccTFEOrganizationDataSource_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-foo-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationDataSourceConfig_basic(rInt),
@@ -45,8 +45,8 @@ func TestAccTFEOrganizationDataSource_defaultProject(t *testing.T) {
 	org := &tfe.Organization{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationDataSourceConfig_basic(rInt),

--- a/internal/provider/data_source_organization_test.go
+++ b/internal/provider/data_source_organization_test.go
@@ -67,11 +67,11 @@ func TestAccTFEOrganizationDataSource_defaultProject(t *testing.T) {
 // The data source will use the default org name from provider config if omitted.
 func TestAccTFEOrganizationDataSource_defaultOrganization(t *testing.T) {
 	defaultOrgName, _ := setupDefaultOrganization(t)
-	providers := providerWithDefaultOrganization(defaultOrgName)
+	providers := muxedProvidersWithDefaultOrganization(defaultOrgName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: providers,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: providers,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationDataSourceConfig_noName(),

--- a/internal/provider/data_source_organizations_test.go
+++ b/internal/provider/data_source_organizations_test.go
@@ -18,8 +18,8 @@ func TestAccTFEOrganizationsDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationsDataSourceConfig_basic_resource(rInt),

--- a/internal/provider/data_source_policy_set_test.go
+++ b/internal/provider/data_source_policy_set_test.go
@@ -31,8 +31,8 @@ func TestAccTFEPolicySetDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySetDataSourceConfig_basic(org.Name, rInt),
@@ -77,9 +77,9 @@ func TestAccTFEPolicySetDataSource_pinnedPolicyRuntimeVersion(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckTFESentinelVersionDestroy,
-		Providers:    testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckTFESentinelVersionDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySetDataSourceConfig_pinnedPolicyRuntimeVersion(org.Name, rInt, KnownSentinelToolVersion),
@@ -126,9 +126,9 @@ func TestAccTFEPolicySetDataSourceOPA_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckTFEOPAVersionDestroy,
-		Providers:    testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckTFEOPAVersionDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySetDataSourceConfigOPA_basic(org.Name, rInt, KnownOPAToolVersion),
@@ -191,7 +191,7 @@ func TestAccTFEPolicySetDataSource_vcs(t *testing.T) {
 				t.Skip("Please set GITHUB_POLIY_SET_PATH to run this test")
 			}
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySetDataSourceConfig_vcs(org.Name, rInt),
@@ -230,8 +230,8 @@ func TestAccTFEPolicySetDataSource_notFound(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEPolicySetDataSourceConfig_notFound(rInt),

--- a/internal/provider/data_source_project_test.go
+++ b/internal/provider/data_source_project_test.go
@@ -17,8 +17,8 @@ func TestAccTFEProjectDataSource_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectDataSourceConfig(rInt),
@@ -45,8 +45,8 @@ func TestAccTFEProjectDataSource_caseInsensitive(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectDataSourceConfigCaseInsensitive(rInt),
@@ -74,8 +74,8 @@ func TestAccTFEProjectDataSource_basicWithAutoDestroy(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectDataSourceConfigWithAutoDestroy(rInt, org.Name, "3d"),

--- a/internal/provider/data_source_slug_test.go
+++ b/internal/provider/data_source_slug_test.go
@@ -21,8 +21,8 @@ func TestAccTFEVersionFiles_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEVersionFilesConfig_basic(testFixtureVersionFiles),

--- a/internal/provider/data_source_team_access_test.go
+++ b/internal/provider/data_source_team_access_test.go
@@ -20,8 +20,8 @@ func TestAccTFETeamAccessDataSource_basic(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamAccessDataSourceConfig(org.Name),

--- a/internal/provider/data_source_team_project_access_test.go
+++ b/internal/provider/data_source_team_project_access_test.go
@@ -20,8 +20,8 @@ func TestAccTFETeamProjectAccessDataSource_basic(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectAccessDataSourceConfig(org.Name),
@@ -47,8 +47,8 @@ func TestAccTFETeamProjectCustomAccessDataSource_basic(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccessDataSourceConfig(org.Name),
@@ -96,8 +96,8 @@ func TestAccTFETeamProjectCustomAccessDataSource_basic_with_project_variable_set
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccessDataSourceConfig_with_project_variable_sets(org.Name),

--- a/internal/provider/data_source_team_test.go
+++ b/internal/provider/data_source_team_test.go
@@ -24,8 +24,8 @@ func TestAccTFETeamDataSource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamDataSourceConfig_basic(rInt, org.Name),
@@ -54,8 +54,8 @@ func TestAccTFETeamDataSource_ssoTeamId(t *testing.T) {
 	testSsoTeamID := fmt.Sprintf("sso-team-id-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamDataSourceConfig_ssoTeamId(rInt, org.Name, testSsoTeamID),

--- a/internal/provider/data_source_teams_test.go
+++ b/internal/provider/data_source_teams_test.go
@@ -30,8 +30,8 @@ func TestAccTFETeamsDataSource_basic(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamsDataSourceConfig_basic_resource(rInt, org.Name),

--- a/internal/provider/data_source_workspace_ids_test.go
+++ b/internal/provider/data_source_workspace_ids_test.go
@@ -18,8 +18,8 @@ func TestAccTFEWorkspaceIDsDataSource_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_basic(rInt),
@@ -71,9 +71,9 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, "*"),
@@ -131,9 +131,9 @@ func TestAccTFEWorkspaceIDsDataSource_prefixWildcard(t *testing.T) {
 	fooWorkspaceName := fmt.Sprintf("*-foo-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, fooWorkspaceName),
@@ -177,9 +177,9 @@ func TestAccTFEWorkspaceIDsDataSource_suffixWildcard(t *testing.T) {
 	fooWorkspaceName := "workspace-foo-*"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, fooWorkspaceName),
@@ -223,9 +223,9 @@ func TestAccTFEWorkspaceIDsDataSource_noMatch(t *testing.T) {
 	fooWorkspaceName := "workspace-foo"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, fooWorkspaceName),
@@ -260,9 +260,9 @@ func TestAccTFEWorkspaceIDsDataSource_substringWildcard(t *testing.T) {
 	fooWorkspaceName := "*-foo-*"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt, fooWorkspaceName),
@@ -305,8 +305,8 @@ func TestAccTFEWorkspaceIDsDataSource_tags(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_tags(rInt),
@@ -350,9 +350,9 @@ func TestAccTFEWorkspaceIDsDataSource_searchByTagAndName(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_searchByTagAndName(rInt),
@@ -388,9 +388,9 @@ func TestAccTFEWorkspaceIDsDataSource_empty(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEWorkspaceIDsDataSourceConfig_empty(rInt),
@@ -405,9 +405,9 @@ func TestAccTFEWorkspaceIDsDataSource_namesEmpty(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_namesEmpty(rInt),
@@ -446,9 +446,9 @@ func TestAccTFEWorkspaceIDsDataSource_excludeTags(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_excludeTags(rInt),
@@ -484,9 +484,9 @@ func TestAccTFEWorkspaceIDsDataSource_sameTagInTagNamesAndExcludeTags(t *testing
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceIDsDataSourceConfig_sameTagInTagNamesAndExcludeTags(rInt),

--- a/internal/provider/data_source_workspace_test.go
+++ b/internal/provider/data_source_workspace_test.go
@@ -23,8 +23,8 @@ func TestAccTFEWorkspaceDataSource_remoteStateConsumers(t *testing.T) {
 	rInt2 := r.Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceDataSourceConfig_remoteStateConsumers(rInt1, rInt2),
@@ -64,8 +64,8 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 	workspaceName := fmt.Sprintf("workspace-test-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceDataSourceConfig(rInt),
@@ -146,8 +146,8 @@ func TestAccTFEWorkspaceDataSourceWithTriggerPatterns(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceDataSourceConfigWithTriggerPatterns(workspaceName, organization.Name),
@@ -175,8 +175,8 @@ func TestAccTFEWorkspaceDataSource_readAutoDestroyAt(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceDataSourceConfig_basic(rInt),
@@ -197,8 +197,8 @@ func TestAccTFEWorkspaceDataSource_readAutoDestroyDuration(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceDataSourceConfig_basic(rInt),
@@ -219,8 +219,8 @@ func TestAccTFEWorkspaceDataSource_readProjectIDDefault(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceDataSourceConfig(rInt),
@@ -234,8 +234,8 @@ func TestAccTFEWorkspaceDataSource_readProjectIDNonDefault(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceDataSourceConfig_project(rInt),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -36,6 +36,18 @@ func init() {
 			nextProvider := providerserver.NewProtocol5(NewFrameworkProvider())
 
 			sdkProvider := Provider()
+			sdkProvider.ConfigureContextFunc = func(ctx context.Context, rd *schema.ResourceData) (interface{}, diag.Diagnostics) {
+				client, err := getClientUsingEnv()
+				cc := ConfiguredClient{
+					Client: client,
+				}
+
+				// Save a reference to the configured client instance for use in tests.
+				testAccConfiguredClient = &cc
+
+				return cc, diag.FromErr(err)
+			}
+
 			mux, err := tf5muxserver.NewMuxServer(
 				ctx, nextProvider, sdkProvider.GRPCProvider,
 			)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -61,8 +61,8 @@ func init() {
 }
 
 func muxedProvidersWithDefaultOrganization(defaultOrgName string) map[string]func() (tfprotov5.ProviderServer, error) {
-	testAccProviderDefaultOrganization := Provider()
-	testAccProviderDefaultOrganization.ConfigureContextFunc = func(ctx context.Context, rd *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	sdkProvider := Provider()
+	sdkProvider.ConfigureContextFunc = func(ctx context.Context, rd *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		client, err := getClientUsingEnv()
 		cc := ConfiguredClient{
 			Client:       client,
@@ -82,7 +82,6 @@ func muxedProvidersWithDefaultOrganization(defaultOrgName string) map[string]fun
 				NewFrameworkProviderWithDefaultOrg(defaultOrgName),
 			)
 
-			sdkProvider := Provider()
 			mux, err := tf5muxserver.NewMuxServer(
 				ctx, nextProvider, sdkProvider.GRPCProvider,
 			)

--- a/internal/provider/resource_tfe_admin_organization_settings_test.go
+++ b/internal/provider/resource_tfe_admin_organization_settings_test.go
@@ -121,7 +121,6 @@ resource "tfe_admin_organization_settings" "settings" {
 
 func deleteOrganization(name string) func() {
 	return func() {
-		client := testAccProvider.Meta().(ConfiguredClient).Client
-		client.Organizations.Delete(context.Background(), name)
+		testAccConfiguredClient.Client.Organizations.Delete(context.Background(), name)
 	}
 }

--- a/internal/provider/resource_tfe_admin_organization_settings_test.go
+++ b/internal/provider/resource_tfe_admin_organization_settings_test.go
@@ -22,8 +22,8 @@ func TestAccTFEAdminOrganizationSettings_basic(t *testing.T) {
 	rInt3 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testConfigTFEAdminOrganizationSettings_basic(rInt1, rInt2, rInt3),

--- a/internal/provider/resource_tfe_agent_pool_allowed_workspaces_test.go
+++ b/internal/provider/resource_tfe_agent_pool_allowed_workspaces_test.go
@@ -54,7 +54,6 @@ func TestAccTFEAgentPoolAllowedWorkspaces_create_update(t *testing.T) {
 
 func testAccCheckTFEAgentPoolAllowedWorkspacesExists(resourceName string, allowedWorkspaces *[]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
 		*allowedWorkspaces = []string{}
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -67,7 +66,7 @@ func testAccCheckTFEAgentPoolAllowedWorkspacesExists(resourceName string, allowe
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		agentPool, err := config.Client.AgentPools.Read(ctx, rs.Primary.ID)
+		agentPool, err := testAccConfiguredClient.Client.AgentPools.Read(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return fmt.Errorf("error while fetching agent pool: %w", err)
 		}
@@ -86,8 +85,6 @@ func testAccCheckTFEAgentPoolAllowedWorkspacesExists(resourceName string, allowe
 
 func testAccCheckTFEAgentPoolAllowedWorkspacesNotExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
@@ -98,7 +95,7 @@ func testAccCheckTFEAgentPoolAllowedWorkspacesNotExists(resourceName string) res
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		agentPool, err := config.Client.AgentPools.Read(ctx, rs.Primary.ID)
+		agentPool, err := testAccConfiguredClient.Client.AgentPools.Read(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return fmt.Errorf("error while fetching agent pool: %w", err)
 		}

--- a/internal/provider/resource_tfe_agent_pool_allowed_workspaces_test.go
+++ b/internal/provider/resource_tfe_agent_pool_allowed_workspaces_test.go
@@ -25,8 +25,8 @@ func TestAccTFEAgentPoolAllowedWorkspaces_create_update(t *testing.T) {
 	allowedWorkspaceIDs := &[]string{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentPoolAllowedWorkspaces_basic(org.Name),
@@ -132,8 +132,8 @@ func TestAccTFEAgentPoolAllowedWorkspaces_import(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentPoolAllowedWorkspaces_basic(org.Name),

--- a/internal/provider/resource_tfe_agent_pool_test.go
+++ b/internal/provider/resource_tfe_agent_pool_test.go
@@ -164,8 +164,6 @@ func TestAccTFEAgentPool_import(t *testing.T) {
 func testAccCheckTFEAgentPoolExists(
 	n string, agentPool *tfe.AgentPool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -175,7 +173,7 @@ func testAccCheckTFEAgentPoolExists(
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		sk, err := config.Client.AgentPools.Read(ctx, rs.Primary.ID)
+		sk, err := testAccConfiguredClient.Client.AgentPools.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -211,8 +209,6 @@ func testAccCheckTFEAgentPoolAttributesUpdated(
 }
 
 func testAccCheckTFEAgentPoolDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_agent_pool" {
 			continue
@@ -222,7 +218,7 @@ func testAccCheckTFEAgentPoolDestroy(s *terraform.State) error {
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		_, err := config.Client.AgentPools.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.AgentPools.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("agent pool %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_agent_pool_test.go
+++ b/internal/provider/resource_tfe_agent_pool_test.go
@@ -26,9 +26,9 @@ func TestAccTFEAgentPool_basic(t *testing.T) {
 	agentPool := &tfe.AgentPool{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentPool_basic(org.Name),
@@ -60,9 +60,9 @@ func TestAccTFEAgentPool_custom_scope(t *testing.T) {
 	agentPool := &tfe.AgentPool{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentPool_custom_scope(org.Name),
@@ -94,9 +94,9 @@ func TestAccTFEAgentPool_update(t *testing.T) {
 	agentPool := &tfe.AgentPool{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentPool_basic(org.Name),
@@ -139,9 +139,9 @@ func TestAccTFEAgentPool_import(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEAgentPoolDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEAgentPoolDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentPool_basic(org.Name),

--- a/internal/provider/resource_tfe_agent_token_test.go
+++ b/internal/provider/resource_tfe_agent_token_test.go
@@ -26,9 +26,9 @@ func TestAccTFEAgentToken_basic(t *testing.T) {
 	agentToken := &tfe.AgentToken{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEAgentTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEAgentTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEAgentToken_basic(org.Name),

--- a/internal/provider/resource_tfe_agent_token_test.go
+++ b/internal/provider/resource_tfe_agent_token_test.go
@@ -47,8 +47,6 @@ func TestAccTFEAgentToken_basic(t *testing.T) {
 func testAccCheckTFEAgentTokenExists(
 	n string, agentToken *tfe.AgentToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -58,7 +56,7 @@ func testAccCheckTFEAgentTokenExists(
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		sk, err := config.Client.AgentTokens.Read(ctx, rs.Primary.ID)
+		sk, err := testAccConfiguredClient.Client.AgentTokens.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -84,8 +82,6 @@ func testAccCheckTFEAgentTokenAttributes(
 }
 
 func testAccCheckTFEAgentTokenDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_agent_token" {
 			continue
@@ -95,7 +91,7 @@ func testAccCheckTFEAgentTokenDestroy(s *terraform.State) error {
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		_, err := config.Client.AgentTokens.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.AgentTokens.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("agent token %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_audit_trail_token_test.go
+++ b/internal/provider/resource_tfe_audit_trail_token_test.go
@@ -193,8 +193,6 @@ func TestAccTFEAuditTrailToken_import(t *testing.T) {
 func testAccCheckTFEAuditTrailTokenExists(
 	n string, token *tfe.OrganizationToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -207,7 +205,7 @@ func testAccCheckTFEAuditTrailTokenExists(
 		readOptions := tfe.OrganizationTokenReadOptions{
 			TokenType: &auditTrailTokenType,
 		}
-		ot, err := config.Client.OrganizationTokens.ReadWithOptions(ctx, rs.Primary.ID, readOptions)
+		ot, err := testAccConfiguredClient.Client.OrganizationTokens.ReadWithOptions(ctx, rs.Primary.ID, readOptions)
 		if err != nil {
 			return err
 		}
@@ -223,8 +221,6 @@ func testAccCheckTFEAuditTrailTokenExists(
 }
 
 func testAccCheckTFEAuditTrailTokenDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_audit_trail_token" {
 			continue
@@ -237,7 +233,7 @@ func testAccCheckTFEAuditTrailTokenDestroy(s *terraform.State) error {
 		readOptions := tfe.OrganizationTokenReadOptions{
 			TokenType: &auditTrailTokenType,
 		}
-		_, err := config.Client.OrganizationTokens.ReadWithOptions(ctx, rs.Primary.ID, readOptions)
+		_, err := testAccConfiguredClient.Client.OrganizationTokens.ReadWithOptions(ctx, rs.Primary.ID, readOptions)
 		if err == nil {
 			return fmt.Errorf("Audit trail token %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_data_retention_policy_test.go
+++ b/internal/provider/resource_tfe_data_retention_policy_test.go
@@ -316,8 +316,6 @@ resource "tfe_data_retention_policy" "foobar" {
 func testAccCheckTFEDataRetentionPolicyExists(
 	n string, policy *tfe.DataRetentionPolicyChoice) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -330,13 +328,13 @@ func testAccCheckTFEDataRetentionPolicyExists(
 		wsID := rs.Primary.Attributes["workspace_id"]
 
 		if wsID != "" {
-			ws, err := config.Client.Workspaces.ReadByID(ctx, wsID)
+			ws, err := testAccConfiguredClient.Client.Workspaces.ReadByID(ctx, wsID)
 			if err != nil {
 				return fmt.Errorf(
 					"Error retrieving workspace %s: %w", wsID, err)
 			}
 
-			drp, err := config.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, ws.ID)
+			drp, err := testAccConfiguredClient.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, ws.ID)
 			if err != nil {
 				return fmt.Errorf(
 					"Error retrieving data retention policy for workspace %s: %w", ws.ID, err)
@@ -346,7 +344,7 @@ func testAccCheckTFEDataRetentionPolicyExists(
 		} else {
 			orgName := rs.Primary.Attributes["organization"]
 
-			drp, err := config.Client.Organizations.ReadDataRetentionPolicyChoice(ctx, orgName)
+			drp, err := testAccConfiguredClient.Client.Organizations.ReadDataRetentionPolicyChoice(ctx, orgName)
 			if err != nil {
 				return fmt.Errorf(
 					"Error retrieving data retention policy for organization %s: %w", orgName, err)
@@ -360,8 +358,6 @@ func testAccCheckTFEDataRetentionPolicyExists(
 }
 
 func testAccCheckTFEDataRetentionPolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_data_retention_policy" {
 			continue
@@ -371,7 +367,7 @@ func testAccCheckTFEDataRetentionPolicyDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		dataRetentionPolicy, err := config.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, rs.Primary.Attributes["workspace_id"])
+		dataRetentionPolicy, err := testAccConfiguredClient.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, rs.Primary.Attributes["workspace_id"])
 		if err == nil {
 			if dataRetentionPolicy.DataRetentionPolicyDeleteOlder != nil {
 				return fmt.Errorf("data retention policy %s still exists", dataRetentionPolicy.DataRetentionPolicyDeleteOlder.ID)

--- a/internal/provider/resource_tfe_no_code_module_test.go
+++ b/internal/provider/resource_tfe_no_code_module_test.go
@@ -50,14 +50,14 @@ func TestAccTFENoCodeModule_with_variable_options(t *testing.T) {
 	}
 	org, cleanup := createBusinessOrganization(t, tfeClient)
 	defer cleanup()
-	providers := providerWithDefaultOrganization(org.Name)
+	providers := muxedProvidersWithDefaultOrganization(org.Name)
 	cfg := testAccTFENoCodeModule_with_variable_options(org.Name)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: providers,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: providers,
 		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(providers["tfe"].Meta().(ConfiguredClient), s)
+			return testAccCheckTFENoCodeModuleDestroy(*testAccConfiguredClient, s)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -110,14 +110,14 @@ func TestAccTFENoCodeModule_with_version_pin(t *testing.T) {
 	}
 	org, cleanup := createBusinessOrganization(t, tfeClient)
 	defer cleanup()
-	providers := providerWithDefaultOrganization(org.Name)
+	providers := muxedProvidersWithDefaultOrganization(org.Name)
 	cfg := testAccTFENoCodeModule_with_version_pin(org.Name)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: providers,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: providers,
 		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(providers["tfe"].Meta().(ConfiguredClient), s)
+			return testAccCheckTFENoCodeModuleDestroy(*testAccConfiguredClient, s)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -130,11 +130,10 @@ func TestAccTFENoCodeModule_with_version_pin(t *testing.T) {
 							return fmt.Errorf("Not found: %s", n)
 						}
 
-						config := providers["tfe"].Meta().(ConfiguredClient)
 						opts := &tfe.RegistryNoCodeModuleReadOptions{
 							Include: []tfe.RegistryNoCodeModuleIncludeOpt{tfe.RegistryNoCodeIncludeVariableOptions},
 						}
-						nocodeModule, err := config.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, opts)
+						nocodeModule, err := testAccConfiguredClient.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, opts)
 						if err != nil {
 							return fmt.Errorf("unable to read nocodeModule with ID %s", rs.Primary.ID)
 						}

--- a/internal/provider/resource_tfe_no_code_module_test.go
+++ b/internal/provider/resource_tfe_no_code_module_test.go
@@ -22,8 +22,8 @@ func TestAccTFENoCodeModule_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
 		},
@@ -161,8 +161,8 @@ func TestAccTFENoCodeModule_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
 		},
@@ -197,8 +197,8 @@ func TestAccTFENoCodeModule_update_variable_options(t *testing.T) {
 	updatedRegionOptions := `"eu-east-1", "eu-west-1", "us-west-2"`
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
 		},
@@ -255,8 +255,8 @@ func TestAccTFENoCodeModule_delete(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
 		},
@@ -288,8 +288,8 @@ func TestAccTFENoCodeModule_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	nocodeModule := &tfe.RegistryNoCodeModule{}
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
 		},

--- a/internal/provider/resource_tfe_no_code_module_test.go
+++ b/internal/provider/resource_tfe_no_code_module_test.go
@@ -24,9 +24,7 @@ func TestAccTFENoCodeModule_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
-		},
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENoCodeModule_basic(rInt),
@@ -56,9 +54,7 @@ func TestAccTFENoCodeModule_with_variable_options(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: providers,
-		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(*testAccConfiguredClient, s)
-		},
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: cfg,
@@ -70,11 +66,10 @@ func TestAccTFENoCodeModule_with_variable_options(t *testing.T) {
 							return fmt.Errorf("Not found: %s", n)
 						}
 
-						config := providers["tfe"].Meta().(ConfiguredClient)
 						opts := &tfe.RegistryNoCodeModuleReadOptions{
 							Include: []tfe.RegistryNoCodeModuleIncludeOpt{tfe.RegistryNoCodeIncludeVariableOptions},
 						}
-						nocodeModule, err := config.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, opts)
+						nocodeModule, err := testAccConfiguredClient.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, opts)
 						if err != nil {
 							return fmt.Errorf("unable to read nocodeModule with ID %s", rs.Primary.ID)
 						}
@@ -116,9 +111,7 @@ func TestAccTFENoCodeModule_with_version_pin(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: providers,
-		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(*testAccConfiguredClient, s)
-		},
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: cfg,
@@ -162,9 +155,7 @@ func TestAccTFENoCodeModule_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
-		},
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENoCodeModule_basic(rInt),
@@ -198,9 +189,7 @@ func TestAccTFENoCodeModule_update_variable_options(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
-		},
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENoCodeModule_with_options(rInt, regionOptions),
@@ -256,9 +245,7 @@ func TestAccTFENoCodeModule_delete(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
-		},
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENoCodeModule_basic(rInt),
@@ -289,9 +276,7 @@ func TestAccTFENoCodeModule_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV5ProviderFactories: testAccMuxedProviders,
-		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckTFENoCodeModuleDestroy(testAccProvider.Meta().(ConfiguredClient), s)
-		},
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENoCodeModule_basic(rInt),
@@ -385,7 +370,7 @@ resource "tfe_no_code_module" "foobar" {
 `, rInt, regionOpts)
 }
 
-func testAccCheckTFENoCodeModuleDestroy(config ConfiguredClient, s *terraform.State) error {
+func testAccCheckTFENoCodeModuleDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_no_code_module" {
 			continue
@@ -395,7 +380,7 @@ func testAccCheckTFENoCodeModuleDestroy(config ConfiguredClient, s *terraform.St
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, nil)
+		_, err := testAccConfiguredClient.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, nil)
 		if err == nil {
 			return fmt.Errorf("Project %s still exists", rs.Primary.ID)
 		}
@@ -406,8 +391,6 @@ func testAccCheckTFENoCodeModuleDestroy(config ConfiguredClient, s *terraform.St
 
 func testAccCheckTFENoCodeModuleExists(n string, nocodeModule *tfe.RegistryNoCodeModule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -420,7 +403,7 @@ func testAccCheckTFENoCodeModuleExists(n string, nocodeModule *tfe.RegistryNoCod
 		opts := &tfe.RegistryNoCodeModuleReadOptions{
 			Include: []tfe.RegistryNoCodeModuleIncludeOpt{tfe.RegistryNoCodeIncludeVariableOptions},
 		}
-		p, err := config.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, opts)
+		p, err := testAccConfiguredClient.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, opts)
 		if err != nil {
 			return fmt.Errorf("unable to read nocodeModule with ID %s", nocodeModule.ID)
 		}

--- a/internal/provider/resource_tfe_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_notification_configuration_test.go
@@ -551,8 +551,6 @@ func TestAccTFENotificationConfigurationImport_emptyEmailUserIDs(t *testing.T) {
 
 func testAccCheckTFENotificationConfigurationExists(n string, notificationConfiguration *tfe.NotificationConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -562,7 +560,7 @@ func testAccCheckTFENotificationConfigurationExists(n string, notificationConfig
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		nc, err := config.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
+		nc, err := testAccConfiguredClient.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -764,8 +762,6 @@ func testAccCheckTFENotificationConfigurationAttributesDuplicateTriggers(notific
 }
 
 func testAccCheckTFENotificationConfigurationDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_notification_configuration" {
 			continue
@@ -775,7 +771,7 @@ func testAccCheckTFENotificationConfigurationDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Notification configuration %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_notification_configuration_test.go
@@ -21,9 +21,9 @@ func TestAccTFENotificationConfiguration_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_basic(rInt),
@@ -52,9 +52,9 @@ func TestAccTFENotificationConfiguration_emailUserIDs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_emailUserIDs(rInt),
@@ -83,9 +83,9 @@ func TestAccTFENotificationConfiguration_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_basic(rInt),
@@ -136,9 +136,9 @@ func TestAccTFENotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_emailUserIDs(rInt),
@@ -186,8 +186,8 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesEmail(t *testin
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { preCheckTFENotificationConfiguration(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFENotificationConfiguration_emailWithURL(rInt),
@@ -205,8 +205,8 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesGeneric(t *test
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { preCheckTFENotificationConfiguration(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFENotificationConfiguration_genericWithEmailAddresses(rInt),
@@ -228,8 +228,8 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesSlack(t *testin
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { preCheckTFENotificationConfiguration(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFENotificationConfiguration_slackWithEmailAddresses(rInt),
@@ -255,8 +255,8 @@ func TestAccTFENotificationConfiguration_validateSchemaAttributesMicrosoftTeams(
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { preCheckTFENotificationConfiguration(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFENotificationConfiguration_microsoftTeamsWithEmailAddresses(rInt),
@@ -283,9 +283,9 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesEmail(t *
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_emailUserIDs(rInt),
@@ -322,9 +322,9 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesGeneric(t
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_basic(rInt),
@@ -365,9 +365,9 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesSlack(t *
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_slack(rInt),
@@ -412,9 +412,9 @@ func TestAccTFENotificationConfiguration_updateValidateSchemaAttributesMicrosoft
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_microsoftTeams(rInt),
@@ -455,9 +455,9 @@ func TestAccTFENotificationConfiguration_duplicateTriggers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_duplicateTriggers(rInt),
@@ -487,9 +487,9 @@ func TestAccTFENotificationConfigurationImport_basic(t *testing.T) {
 	fmt.Printf("Config for testAccTFENotificationConfigurationImport_basic:\n %s\n", testAccTFENotificationConfiguration_basic(rInt))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_update(rInt),
@@ -509,9 +509,9 @@ func TestAccTFENotificationConfigurationImport_emailUserIDs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_updateEmailUserIDs(rInt),
@@ -531,9 +531,9 @@ func TestAccTFENotificationConfigurationImport_emptyEmailUserIDs(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { preCheckTFENotificationConfiguration(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFENotificationConfigurationDestroy,
+		PreCheck:                 func() { preCheckTFENotificationConfiguration(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFENotificationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFENotificationConfiguration_emailUserIDs(rInt),

--- a/internal/provider/resource_tfe_oauth_client_test.go
+++ b/internal/provider/resource_tfe_oauth_client_test.go
@@ -25,8 +25,8 @@ func TestAccTFEOAuthClient_basic(t *testing.T) {
 				t.Skip("Please set GITHUB_TOKEN to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClient_basic(rInt),
@@ -56,8 +56,8 @@ func TestAccTFEOAuthClientWithOrganizationScoped_basic(t *testing.T) {
 				t.Skip("Please set GITHUB_TOKEN to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClient_basic(rInt),
@@ -83,9 +83,9 @@ func TestAccTFEOAuthClient_rsaKeys(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClient_rsaKeys(rInt),
@@ -118,8 +118,8 @@ func TestAccTFEOAuthClient_agentPool(t *testing.T) {
 				t.Skip("Please set GITHUB_TOKEN to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOAuthClient_agentPool(),

--- a/internal/provider/resource_tfe_oauth_client_test.go
+++ b/internal/provider/resource_tfe_oauth_client_test.go
@@ -137,8 +137,6 @@ func TestAccTFEOAuthClient_agentPool(t *testing.T) {
 func testAccCheckTFEOAuthClientExists(
 	n string, oc *tfe.OAuthClient) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -148,7 +146,7 @@ func testAccCheckTFEOAuthClientExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		client, err := config.Client.OAuthClients.Read(ctx, rs.Primary.ID)
+		client, err := testAccConfiguredClient.Client.OAuthClients.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -179,8 +177,6 @@ func testAccCheckTFEOAuthClientAttributes(
 }
 
 func testAccCheckTFEOAuthClientDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_oauth_client" {
 			continue
@@ -190,7 +186,7 @@ func testAccCheckTFEOAuthClientDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.OAuthClients.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.OAuthClients.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("OAuth client %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_opa_version_test.go
+++ b/internal/provider/resource_tfe_opa_version_test.go
@@ -25,9 +25,9 @@ func TestAccTFEOPAVersion_basic(t *testing.T) {
 	version := genSafeRandomOPAVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOPAVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOPAVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOPAVersion_basic(version, sha),
@@ -53,9 +53,9 @@ func TestAccTFEOPAVersion_import(t *testing.T) {
 	version := genSafeRandomOPAVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOPAVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOPAVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOPAVersion_basic(version, sha),
@@ -83,9 +83,9 @@ func TestAccTFEOPAVersion_full(t *testing.T) {
 	version := genSafeRandomOPAVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOPAVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOPAVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOPAVersion_full(version, sha),

--- a/internal/provider/resource_tfe_opa_version_test.go
+++ b/internal/provider/resource_tfe_opa_version_test.go
@@ -115,8 +115,6 @@ func TestAccTFEOPAVersion_full(t *testing.T) {
 }
 
 func testAccCheckTFEOPAVersionDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_opa_version" {
 			continue
@@ -126,7 +124,7 @@ func testAccCheckTFEOPAVersionDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Admin.OPAVersions.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Admin.OPAVersions.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("OPA version %s still exists", rs.Primary.ID)
 		}
@@ -137,8 +135,6 @@ func testAccCheckTFEOPAVersionDestroy(s *terraform.State) error {
 
 func testAccCheckTFEOPAVersionExists(n string, opaVersion *tfe.AdminOPAVersion) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -148,7 +144,7 @@ func testAccCheckTFEOPAVersionExists(n string, opaVersion *tfe.AdminOPAVersion) 
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		v, err := config.Client.Admin.OPAVersions.Read(ctx, rs.Primary.ID)
+		v, err := testAccConfiguredClient.Client.Admin.OPAVersions.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_tfe_organization_membership_test.go
+++ b/internal/provider/resource_tfe_organization_membership_test.go
@@ -21,9 +21,9 @@ func TestAccTFEOrganizationMembership_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationMembershipDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationMembership_basic(rInt),
@@ -48,9 +48,9 @@ func TestAccTFEOrganizationMembershipImport_ByID(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationMembershipDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationMembership_basic(rInt),
@@ -71,9 +71,9 @@ func TestAccTFEOrganizationMembershipImport_ByEmail(t *testing.T) {
 	email := "testuser@hashicorp.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationMembershipDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationMembership_nameAndEmail(orgName, email),
@@ -95,9 +95,9 @@ func TestAccTFEOrganizationMembershipImport_invalidImportId(t *testing.T) {
 	email := "testuser@hashicorp.com"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationMembershipDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationMembershipDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationMembership_nameAndEmail(orgName, email),

--- a/internal/provider/resource_tfe_organization_membership_test.go
+++ b/internal/provider/resource_tfe_organization_membership_test.go
@@ -127,8 +127,6 @@ func TestAccTFEOrganizationMembershipImport_invalidImportId(t *testing.T) {
 func testAccCheckTFEOrganizationMembershipExists(
 	n string, membership *tfe.OrganizationMembership) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -142,7 +140,7 @@ func testAccCheckTFEOrganizationMembershipExists(
 			Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser},
 		}
 
-		m, err := config.Client.OrganizationMemberships.ReadWithOptions(ctx, rs.Primary.ID, options)
+		m, err := testAccConfiguredClient.Client.OrganizationMemberships.ReadWithOptions(ctx, rs.Primary.ID, options)
 		if err != nil {
 			return err
 		}
@@ -175,8 +173,6 @@ func testAccCheckTFEOrganizationMembershipAttributes(
 }
 
 func testAccCheckTFEOrganizationMembershipDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_organization_membership" {
 			continue
@@ -186,7 +182,7 @@ func testAccCheckTFEOrganizationMembershipDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.OrganizationMemberships.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.OrganizationMemberships.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Membership %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_organization_module_sharing_test.go
+++ b/internal/provider/resource_tfe_organization_module_sharing_test.go
@@ -25,8 +25,8 @@ func TestAccTFEOrganizationModuleSharing_basic(t *testing.T) {
 	// has been deleted requires the organizations to exist (and they are destroyed
 	// prior to CheckDestroy being executed)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationModuleSharing_basic(rInt1, rInt2, rInt3),
@@ -55,8 +55,8 @@ func TestAccTFEOrganizationModuleSharing_emptyOrg(t *testing.T) {
 	rInt2 := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationModuleSharing_emptyOrg(rInt1, rInt2),
@@ -89,8 +89,8 @@ func TestAccTFEOrganizationModuleSharing_stopSharing(t *testing.T) {
 	// setting a module_consumers to an empty array of
 	// "destroys" the resource
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationModuleSharing_stopSharing(rInt1),

--- a/internal/provider/resource_tfe_organization_run_task_global_settings_test.go
+++ b/internal/provider/resource_tfe_organization_run_task_global_settings_test.go
@@ -219,8 +219,6 @@ func TestAccTFEOrganizationRunTaskGlobalSettings_Read(t *testing.T) {
 
 func testAccCheckTFEOrganizationRunTaskGlobalEnabled(resourceName string, expectedEnabled bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
@@ -229,7 +227,7 @@ func testAccCheckTFEOrganizationRunTaskGlobalEnabled(resourceName string, expect
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No instance ID is set")
 		}
-		rt, err := config.Client.RunTasks.Read(ctx, rs.Primary.ID)
+		rt, err := testAccConfiguredClient.Client.RunTasks.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error reading Run Task: %w", err)
 		}

--- a/internal/provider/resource_tfe_organization_run_task_test.go
+++ b/internal/provider/resource_tfe_organization_run_task_test.go
@@ -253,8 +253,6 @@ func TestAccTFEOrganizationRunTask_HMACWriteOnly(t *testing.T) {
 
 func testAccCheckTFEOrganizationRunTaskExists(n string, runTask *tfe.RunTask) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -263,7 +261,7 @@ func testAccCheckTFEOrganizationRunTaskExists(n string, runTask *tfe.RunTask) re
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No instance ID is set")
 		}
-		rt, err := config.Client.RunTasks.Read(ctx, rs.Primary.ID)
+		rt, err := testAccConfiguredClient.Client.RunTasks.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error reading Run Task: %w", err)
 		}
@@ -279,8 +277,6 @@ func testAccCheckTFEOrganizationRunTaskExists(n string, runTask *tfe.RunTask) re
 }
 
 func testAccCheckTFEOrganizationRunTaskDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_organization_run_task" {
 			continue
@@ -290,7 +286,7 @@ func testAccCheckTFEOrganizationRunTaskDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.RunTasks.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.RunTasks.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Organization Run Task %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_organization_test.go
+++ b/internal/provider/resource_tfe_organization_test.go
@@ -265,8 +265,6 @@ func TestAccTFEOrganization_import(t *testing.T) {
 func testAccCheckTFEOrganizationExists(
 	n string, org *tfe.Organization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -276,7 +274,7 @@ func testAccCheckTFEOrganizationExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		o, err := config.Client.Organizations.Read(ctx, rs.Primary.ID)
+		o, err := testAccConfiguredClient.Client.Organizations.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -381,8 +379,6 @@ func testAccCheckTFEOrganizationAttributesUpdated(
 }
 
 func testAccCheckTFEOrganizationDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_organization" {
 			continue
@@ -392,7 +388,7 @@ func testAccCheckTFEOrganizationDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Organizations.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Organizations.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Organization %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_organization_test.go
+++ b/internal/provider/resource_tfe_organization_test.go
@@ -23,9 +23,9 @@ func TestAccTFEOrganization_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganization_basic(rInt),
@@ -51,9 +51,9 @@ func TestAccTFEOrganization_full(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganization_full(rInt),
@@ -96,9 +96,9 @@ func TestAccTFEOrganization_defaultProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganization_full(rInt),
@@ -140,9 +140,9 @@ func TestAccTFEOrganization_update_costEstimation(t *testing.T) {
 	updatedName := org.Name + "_foobar"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganization_update(org.Name, org.Email, costEstimationEnabled1, assessmentsEnforced1, allowForceDeleteWorkspaces1),
@@ -211,9 +211,9 @@ func TestAccTFEOrganization_case(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganization_basic(rInt),
@@ -245,9 +245,9 @@ func TestAccTFEOrganization_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganization_basic(rInt),

--- a/internal/provider/resource_tfe_organization_token_test.go
+++ b/internal/provider/resource_tfe_organization_token_test.go
@@ -186,8 +186,6 @@ func TestAccTFEOrganizationToken_import(t *testing.T) {
 func testAccCheckTFEOrganizationTokenExists(
 	n string, token *tfe.OrganizationToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -197,7 +195,7 @@ func testAccCheckTFEOrganizationTokenExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		ot, err := config.Client.OrganizationTokens.Read(ctx, rs.Primary.ID)
+		ot, err := testAccConfiguredClient.Client.OrganizationTokens.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -213,8 +211,6 @@ func testAccCheckTFEOrganizationTokenExists(
 }
 
 func testAccCheckTFEOrganizationTokenDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_organization_token" {
 			continue
@@ -224,7 +220,7 @@ func testAccCheckTFEOrganizationTokenDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.OrganizationTokens.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.OrganizationTokens.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("OrganizationToken %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_organization_token_test.go
+++ b/internal/provider/resource_tfe_organization_token_test.go
@@ -21,9 +21,9 @@ func TestAccTFEOrganizationToken_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationToken_basic(rInt),
@@ -44,9 +44,9 @@ func TestAccTFEOrganizationToken_existsWithoutForce(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationToken_basic(rInt),
@@ -72,9 +72,9 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationToken_basic(rInt),
@@ -105,9 +105,9 @@ func TestAccTFEOrganizationToken_withBlankExpiry(t *testing.T) {
 	expiredAt := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationToken_withBlankExpiry(rInt),
@@ -128,9 +128,9 @@ func TestAccTFEOrganizationToken_withValidExpiry(t *testing.T) {
 	expiredAt := "2051-04-11T23:15:59Z"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationToken_withValidExpiry(rInt),
@@ -149,9 +149,9 @@ func TestAccTFEOrganizationToken_withInvalidExpiry(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEOrganizationToken_withInvalidExpiry(rInt),
@@ -165,9 +165,9 @@ func TestAccTFEOrganizationToken_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEOrganizationTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEOrganizationToken_basic(rInt),

--- a/internal/provider/resource_tfe_policy_set_parameter_test.go
+++ b/internal/provider/resource_tfe_policy_set_parameter_test.go
@@ -202,8 +202,6 @@ func TestAccTFEPolicySetParameter_valueWriteOnly(t *testing.T) {
 func testAccCheckTFEPolicySetParameterExists(
 	n string, parameter *tfe.PolicySetParameter) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -213,7 +211,7 @@ func testAccCheckTFEPolicySetParameterExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		v, err := config.Client.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
+		v, err := testAccConfiguredClient.Client.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -263,8 +261,6 @@ func testAccCheckTFEPolicySetParameterAttributesUpdate(
 }
 
 func testAccCheckTFEPolicySetParameterDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy_set_parameter" {
 			continue
@@ -274,7 +270,7 @@ func testAccCheckTFEPolicySetParameterDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("PolicySetParameter %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_policy_set_test.go
+++ b/internal/provider/resource_tfe_policy_set_test.go
@@ -27,9 +27,9 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_basic(org.Name),
@@ -83,9 +83,9 @@ func TestAccTFEPolicySet_pinnedPolicyRuntimeVersion(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_pinnedPolicyRuntimeVersion(org.Name, tool.Version),
@@ -125,9 +125,9 @@ func TestAccTFEPolicySetOPA_basic(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySetOPA_basic(org.Name, version, sha),
@@ -168,9 +168,9 @@ func TestAccTFEPolicySet_updateOverridable(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySetOPA_basic(org.Name, version, sha),
@@ -226,9 +226,9 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_basic(org.Name),
@@ -279,9 +279,9 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_basic(org.Name),
@@ -330,9 +330,9 @@ func TestAccTFEPolicySet_updatePopulated(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_populated(org.Name),
@@ -383,9 +383,9 @@ func TestAccTFEPolicySet_updateToGlobal(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_populated(org.Name),
@@ -434,9 +434,9 @@ func TestAccTFEPolicySet_updateToWorkspace(t *testing.T) {
 	policySet := &tfe.PolicySet{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_global(org.Name),
@@ -498,8 +498,8 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 				t.Skip("Please set GITHUB_POLICY_SET_PATH to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_vcs(org.Name),
@@ -553,8 +553,8 @@ func TestAccTFEPolicySet_GithubApp(t *testing.T) {
 				t.Skip("Please set GITHUB_POLICY_SET_PATH to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_GithubApp(org.Name),
@@ -608,8 +608,8 @@ func TestAccTFEPolicySet_updateVCSBranch(t *testing.T) {
 				t.Skip("Please set GITHUB_POLICY_SET_PATH to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_vcs(org.Name),
@@ -676,9 +676,9 @@ func TestAccTFEPolicySet_versionedSlug(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_versionSlug(org.Name, testFixtureVersionFiles),
@@ -726,9 +726,9 @@ func TestAccTFEPolicySet_versionedSlugUpdate(t *testing.T) {
 	newFile := fmt.Sprintf("%s/newfile.test.sentinel", testFixtureVersionFiles)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_versionSlug(org.Name, testFixtureVersionFiles),
@@ -777,9 +777,9 @@ func TestAccTFEPolicySet_versionedNoConflicts(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEPolicySet_versionsConflict(org.Name, testFixtureVersionFiles),
@@ -823,9 +823,9 @@ func TestAccTFEPolicySet_invalidName(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEPolicySet_invalidName(org.Name),
@@ -845,9 +845,9 @@ func TestAccTFEPolicySetImport(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicySet_populated(org.Name),

--- a/internal/provider/resource_tfe_policy_set_test.go
+++ b/internal/provider/resource_tfe_policy_set_test.go
@@ -867,8 +867,6 @@ func TestAccTFEPolicySetImport(t *testing.T) {
 
 func testAccCheckTFEPolicySetExists(n string, policySet *tfe.PolicySet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -878,7 +876,7 @@ func testAccCheckTFEPolicySetExists(n string, policySet *tfe.PolicySet) resource
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		ps, err := config.Client.PolicySets.Read(ctx, rs.Primary.ID)
+		ps, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -913,8 +911,6 @@ func testAccCheckTFEPolicySetAttributes(policySet *tfe.PolicySet) resource.TestC
 
 func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		if policySet.Name != "terraform-populated" {
 			return fmt.Errorf("Bad name: %s", policySet.Name)
 		}
@@ -928,7 +924,7 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string)
 		}
 
 		policyID := policySet.Policies[0].ID
-		policy, _ := config.Client.Policies.Read(ctx, policyID)
+		policy, _ := testAccConfiguredClient.Client.Policies.Read(ctx, policyID)
 		if policy.Name != "policy-foo" {
 			return fmt.Errorf("Wrong member policy: %v", policy.Name)
 		}
@@ -938,7 +934,7 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string)
 		}
 
 		workspaceID := policySet.Workspaces[0].ID
-		workspace, _ := config.Client.Workspaces.Read(ctx, orgName, "workspace-foo")
+		workspace, _ := testAccConfiguredClient.Client.Workspaces.Read(ctx, orgName, "workspace-foo")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
 		}
@@ -949,8 +945,6 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet, orgName string)
 
 func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		if policySet.Name != "terraform-populated-updated" {
 			return fmt.Errorf("Bad name: %s", policySet.Name)
 		}
@@ -964,7 +958,7 @@ func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName 
 		}
 
 		policyID := policySet.Policies[0].ID
-		policy, _ := config.Client.Policies.Read(ctx, policyID)
+		policy, _ := testAccConfiguredClient.Client.Policies.Read(ctx, policyID)
 		if policy.Name != "policy-bar" {
 			return fmt.Errorf("Wrong member policy: %v", policy.Name)
 		}
@@ -974,7 +968,7 @@ func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName 
 		}
 
 		workspaceID := policySet.Workspaces[0].ID
-		workspace, _ := config.Client.Workspaces.Read(ctx, orgName, "workspace-bar")
+		workspace, _ := testAccConfiguredClient.Client.Workspaces.Read(ctx, orgName, "workspace-bar")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
 		}
@@ -985,8 +979,6 @@ func testAccCheckTFEPolicySetPopulatedUpdated(policySet *tfe.PolicySet, orgName 
 
 func testAccCheckTFEPolicySetGlobal(policySet *tfe.PolicySet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		if policySet.Name != "terraform-global" {
 			return fmt.Errorf("Bad name: %s", policySet.Name)
 		}
@@ -1000,7 +992,7 @@ func testAccCheckTFEPolicySetGlobal(policySet *tfe.PolicySet) resource.TestCheck
 		}
 
 		policyID := policySet.Policies[0].ID
-		policy, _ := config.Client.Policies.Read(ctx, policyID)
+		policy, _ := testAccConfiguredClient.Client.Policies.Read(ctx, policyID)
 		if policy.Name != "policy-foo" {
 			return fmt.Errorf("Wrong member policy: %v", policy.Name)
 		}
@@ -1015,8 +1007,6 @@ func testAccCheckTFEPolicySetGlobal(policySet *tfe.PolicySet) resource.TestCheck
 }
 
 func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy_set" {
 			continue
@@ -1026,7 +1016,7 @@ func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.PolicySets.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Sentinel policy %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_policy_test.go
+++ b/internal/provider/resource_tfe_policy_test.go
@@ -24,9 +24,9 @@ func TestAccTFEPolicy_basic(t *testing.T) {
 	policy := &tfe.Policy{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicy_basic(org.Name),
@@ -62,9 +62,9 @@ func TestAccTFEPolicy_basicWithDefaults(t *testing.T) {
 	policy := &tfe.Policy{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicy_basicWithDefaults(org.Name),
@@ -100,9 +100,9 @@ func TestAccTFEPolicyOPA_basic(t *testing.T) {
 	policy := &tfe.Policy{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicyOPA_basic(org.Name),
@@ -140,9 +140,9 @@ func TestAccTFEPolicy_update(t *testing.T) {
 	policy := &tfe.Policy{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicy_basic(org.Name),
@@ -198,9 +198,9 @@ func TestAccTFEPolicy_unsetEnforce(t *testing.T) {
 	policy := &tfe.Policy{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicy_basic(org.Name),
@@ -253,9 +253,9 @@ func TestAccTFEPolicyOPA_update(t *testing.T) {
 	policy := &tfe.Policy{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicyOPA_basic(org.Name),
@@ -354,9 +354,9 @@ func TestAccTFEPolicy_import(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEPolicy_basic(org.Name),

--- a/internal/provider/resource_tfe_policy_test.go
+++ b/internal/provider/resource_tfe_policy_test.go
@@ -375,8 +375,6 @@ func TestAccTFEPolicy_import(t *testing.T) {
 func testAccCheckTFEPolicyExists(
 	n string, policy *tfe.Policy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -386,7 +384,7 @@ func testAccCheckTFEPolicyExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		p, err := config.Client.Policies.Read(ctx, rs.Primary.ID)
+		p, err := testAccConfiguredClient.Client.Policies.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			// nolint: wrapcheck
 			return err
@@ -404,9 +402,7 @@ func testAccCheckTFEPolicyExists(
 
 func testAccCheckTFEPolicyContent(policy *tfe.Policy, content string) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
-		b, err := config.Client.Policies.Download(ctx, policy.ID)
+		b, err := testAccConfiguredClient.Client.Policies.Download(ctx, policy.ID)
 		if err != nil {
 			return fmt.Errorf("Problem downloading policy content: %w", err)
 		}
@@ -533,8 +529,6 @@ func testAccCheckTFEOPAPolicyAttributesUpdatedAll(
 }
 
 func testAccCheckTFEPolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy" {
 			continue
@@ -544,7 +538,7 @@ func testAccCheckTFEPolicyDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Policies.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Policies.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf(" policy %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_project_oauth_client_test.go
+++ b/internal/provider/resource_tfe_project_oauth_client_test.go
@@ -35,9 +35,9 @@ func TestAccTFEProjectOAuthClient_basic(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectOAuthClientDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectOAuthClientDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectOAuthClient_basic(org.Name, project.ID),
@@ -76,8 +76,8 @@ func TestAccTFEProjectOAuthClient_incorrectImportSyntax(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectOAuthClient_basic(org.Name, project.ID),

--- a/internal/provider/resource_tfe_project_oauth_client_test.go
+++ b/internal/provider/resource_tfe_project_oauth_client_test.go
@@ -94,8 +94,6 @@ func TestAccTFEProjectOAuthClient_incorrectImportSyntax(t *testing.T) {
 
 func testAccCheckTFEProjectOAuthClientExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -116,7 +114,7 @@ func testAccCheckTFEProjectOAuthClientExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("no project id set")
 		}
 
-		oauthClient, err := config.Client.OAuthClients.ReadWithOptions(ctx, oauthClientID, &tfe.OAuthClientReadOptions{
+		oauthClient, err := testAccConfiguredClient.Client.OAuthClients.ReadWithOptions(ctx, oauthClientID, &tfe.OAuthClientReadOptions{
 			Include: []tfe.OAuthClientIncludeOpt{tfe.OauthClientProjects},
 		})
 		if err != nil {
@@ -133,8 +131,6 @@ func testAccCheckTFEProjectOAuthClientExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckTFEProjectOAuthClientDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_oauth_client" {
 			continue
@@ -144,7 +140,7 @@ func testAccCheckTFEProjectOAuthClientDestroy(s *terraform.State) error {
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		_, err := config.Client.OAuthClients.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.OAuthClients.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("oauth client %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_project_policy_set_test.go
+++ b/internal/provider/resource_tfe_project_policy_set_test.go
@@ -94,8 +94,6 @@ func TestAccTFEProjectPolicySet_incorrectImportSyntax(t *testing.T) {
 
 func testAccCheckTFEProjectPolicySetExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -116,7 +114,7 @@ func testAccCheckTFEProjectPolicySetExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("no project id set")
 		}
 
-		policySet, err := config.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
+		policySet, err := testAccConfiguredClient.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
 			Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetProjects},
 		})
 		if err != nil {
@@ -133,8 +131,6 @@ func testAccCheckTFEProjectPolicySetExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckTFEProjectPolicySetDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy_set" {
 			continue
@@ -144,7 +140,7 @@ func testAccCheckTFEProjectPolicySetDestroy(s *terraform.State) error {
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		_, err := config.Client.PolicySets.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("policy set %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_project_policy_set_test.go
+++ b/internal/provider/resource_tfe_project_policy_set_test.go
@@ -35,9 +35,9 @@ func TestAccTFEProjectPolicySet_basic(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectPolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectPolicySet_basic(org.Name, project.ID),
@@ -76,8 +76,8 @@ func TestAccTFEProjectPolicySet_incorrectImportSyntax(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectPolicySet_basic(org.Name, project.ID),

--- a/internal/provider/resource_tfe_project_test.go
+++ b/internal/provider/resource_tfe_project_test.go
@@ -21,9 +21,9 @@ func TestAccTFEProject_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProject_basic(rInt),
@@ -47,9 +47,9 @@ func TestAccTFEProject_invalidName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEProject_invalidNameChar(rInt),
@@ -68,9 +68,9 @@ func TestAccTFEProject_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProject_basic(rInt),
@@ -104,9 +104,9 @@ func TestAccTFEProject_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	project := &tfe.Project{}
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProject_basic(rInt),
@@ -134,9 +134,9 @@ func TestAccTFEProject_withAutoDestroy(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProject_basicWithAutoDestroy(rInt, "3d"),

--- a/internal/provider/resource_tfe_project_test.go
+++ b/internal/provider/resource_tfe_project_test.go
@@ -234,8 +234,6 @@ resource "tfe_project" "foobar" {
 }
 
 func testAccCheckTFEProjectDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_project" {
 			continue
@@ -245,7 +243,7 @@ func testAccCheckTFEProjectDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Projects.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Projects.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Project %s still exists", rs.Primary.ID)
 		}
@@ -256,8 +254,6 @@ func testAccCheckTFEProjectDestroy(s *terraform.State) error {
 
 func testAccCheckTFEProjectExists(n string, project *tfe.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -267,7 +263,7 @@ func testAccCheckTFEProjectExists(n string, project *tfe.Project) resource.TestC
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		p, err := config.Client.Projects.Read(ctx, rs.Primary.ID)
+		p, err := testAccConfiguredClient.Client.Projects.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("unable to read project with ID %s", project.ID)
 		}

--- a/internal/provider/resource_tfe_project_variable_set_test.go
+++ b/internal/provider/resource_tfe_project_variable_set_test.go
@@ -59,8 +59,6 @@ func TestAccTFEProjectVariableSet_basic(t *testing.T) {
 
 func testAccCheckTFEProjectVariableSetExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -76,7 +74,7 @@ func testAccCheckTFEProjectVariableSetExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("error decoding ID (%s): %w", id, err)
 		}
 
-		vS, err := config.Client.VariableSets.Read(ctx, vSID, &tfe.VariableSetReadOptions{
+		vS, err := testAccConfiguredClient.Client.VariableSets.Read(ctx, vSID, &tfe.VariableSetReadOptions{
 			Include: &[]tfe.VariableSetIncludeOpt{tfe.VariableSetProjects},
 		})
 		if err != nil {
@@ -93,8 +91,6 @@ func testAccCheckTFEProjectVariableSetExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckTFEProjectVariableSetDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_variable_set" {
 			continue
@@ -104,7 +100,7 @@ func testAccCheckTFEProjectVariableSetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.VariableSets.Read(ctx, rs.Primary.ID, nil)
+		_, err := testAccConfiguredClient.Client.VariableSets.Read(ctx, rs.Primary.ID, nil)
 		if err == nil {
 			return fmt.Errorf("Variable Set %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_project_variable_set_test.go
+++ b/internal/provider/resource_tfe_project_variable_set_test.go
@@ -36,9 +36,9 @@ func TestAccTFEProjectVariableSet_basic(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEProjectVariableSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectVariableSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEProjectVariableSet_basic(org.Name, prj.ID),

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -936,8 +936,6 @@ func TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(t *test
 
 func testAccCheckTFERegistryModuleExists(n string, rmID tfe.RegistryModuleID, registryModule *tfe.RegistryModule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -947,7 +945,7 @@ func testAccCheckTFERegistryModuleExists(n string, rmID tfe.RegistryModuleID, re
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		rm, err := config.Client.RegistryModules.Read(ctx, rmID)
+		rm, err := testAccConfiguredClient.Client.RegistryModules.Read(ctx, rmID)
 		if err != nil {
 			return err
 		}
@@ -1018,8 +1016,6 @@ func testAccCheckTFERegistryModuleVCSAttributes(registryModule *tfe.RegistryModu
 }
 
 func testAccCheckTFERegistryModuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_registry_module" {
 			continue
@@ -1062,7 +1058,7 @@ func testAccCheckTFERegistryModuleDestroy(s *terraform.State) error {
 			Namespace:    rs.Primary.Attributes["namespace"],
 			RegistryName: tfe.RegistryName(rs.Primary.Attributes["registry_name"]),
 		}
-		_, err := config.Client.RegistryModules.Read(ctx, rmID)
+		_, err := testAccConfiguredClient.Client.RegistryModules.Read(ctx, rmID)
 		if err == nil {
 			return fmt.Errorf("Registry module %s still exists", id)
 		}

--- a/internal/provider/resource_tfe_registry_module_test.go
+++ b/internal/provider/resource_tfe_registry_module_test.go
@@ -34,8 +34,8 @@ func TestAccTFERegistryModule_vcsBasic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsBasic(rInt),
@@ -95,8 +95,8 @@ func TestAccTFERegistryModule_GitHubApp(t *testing.T) {
 			testAccPreCheckTFERegistryModule(t)
 			testAccGHAInstallationPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_GitHubApp(rInt),
@@ -142,8 +142,8 @@ func TestAccTFERegistryModule_emptyVCSRepo(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_emptyVCSRepo(rInt, envGithubToken),
@@ -170,8 +170,8 @@ func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithoutRegistryName(t *
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_privateRMWithoutRegistryName(rInt),
@@ -219,8 +219,8 @@ func TestAccTFERegistryModule_nonVCSPrivateRegistryModuleWithRegistryName(t *tes
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
@@ -268,8 +268,8 @@ func TestAccTFERegistryModule_publicRegistryModule(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_publicRM(rInt),
@@ -309,7 +309,7 @@ func TestAccTFERegistryModule_branchOnly(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_branchOnly(rInt),
@@ -333,7 +333,7 @@ func TestAccTFERegistryModule_vcsRepoWithTags(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsRepoWithFalseTags(rInt),
@@ -368,8 +368,8 @@ func TestAccTFERegistryModule_noCodeModule(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_NoCode(rInt),
@@ -410,8 +410,8 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMDeprecatedFormat(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsWithTagsTrue(rInt),
@@ -434,8 +434,8 @@ func TestAccTFERegistryModuleImport_vcsPrivateRMRecommendedFormat(t *testing.T) 
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsWithTagsTrue(rInt),
@@ -458,7 +458,7 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranch(t
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsBranch(rInt),
@@ -518,7 +518,7 @@ func TestAccTFERegistryModule_branchOnlyEmpty(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_branchOnlyEmpty(rInt),
@@ -541,7 +541,7 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismBranchToTagsToBranchWi
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsBranchWithTests(rInt),
@@ -582,7 +582,7 @@ func TestAccTFERegistryModuleImport_vcsPublishingMechanismTagsToBranchToTags(t *
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsTags(rInt),
@@ -632,7 +632,7 @@ func TestAccTFERegistryModule_invalidTestConfigOnCreate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsInvalidBranch(rInt),
@@ -650,7 +650,7 @@ func TestAccTFERegistryModule_invalidTestConfigOnUpdate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsTags(rInt),
@@ -678,7 +678,7 @@ func TestAccTFERegistryModule_vcsTagsOnlyFalse(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsTagsOnlyFalse(rInt),
@@ -696,7 +696,7 @@ func TestAccTFERegistryModule_branchAndInvalidTagsOnCreate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsBranchWithInvalidTests(rInt),
@@ -714,7 +714,7 @@ func TestAccTFERegistryModule_branchAndTagsEnabledOnCreate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsBranchWithTestsAndTagsEnabled(rInt),
@@ -733,7 +733,7 @@ func TestAccTFERegistryModule_branchAndTagsDisabledOnCreate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_vcsWithBranchAndTagsDisabled(rInt),
@@ -751,7 +751,7 @@ func TestAccTFERegistryModule_branchAndTagsEnabledOnUpdate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsTags(rInt),
@@ -779,7 +779,7 @@ func TestAccTFERegistryModule_branchAndTagsDisabledOnUpdate(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckTFERegistryModule(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_vcsTags(rInt),
@@ -805,8 +805,8 @@ func TestAccTFERegistryModuleImport_nonVCSPrivateRM(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_privateRMWithRegistryName(rInt),
@@ -828,8 +828,8 @@ func TestAccTFERegistryModuleImport_publicRM(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERegistryModuleDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERegistryModuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERegistryModule_publicRM(rInt),
@@ -849,7 +849,7 @@ func TestAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider(t *testing
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithBothVCSRepoAndModuleProvider(),
@@ -864,7 +864,7 @@ func TestAccTFERegistryModule_invalidRegistryName(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidRegistryName(),
@@ -879,7 +879,7 @@ func TestAccTFERegistryModule_invalidWithModuleProviderAndNoName(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithModuleProviderAndNoName(),
@@ -894,7 +894,7 @@ func TestAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization(t *test
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithModuleProviderAndNoOrganization(),
@@ -909,7 +909,7 @@ func TestAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName(t *testing.T
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithNamespaceAndNoRegistryName(),
@@ -924,7 +924,7 @@ func TestAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(t *test
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFERegistryModule_invalidWithRegistryNameAndNoModuleProvider(),

--- a/internal/provider/resource_tfe_run_trigger_test.go
+++ b/internal/provider/resource_tfe_run_trigger_test.go
@@ -20,9 +20,9 @@ func TestAccTFERunTrigger_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERunTriggerDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERunTrigger_basic(rInt),
@@ -44,9 +44,9 @@ func TestAccTFERunTrigger_many(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERunTriggerDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERunTrigger_many(rInt),
@@ -60,9 +60,9 @@ func TestAccTFERunTriggerImport(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFERunTriggerDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFERunTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFERunTrigger_basic(rInt),

--- a/internal/provider/resource_tfe_run_trigger_test.go
+++ b/internal/provider/resource_tfe_run_trigger_test.go
@@ -78,8 +78,6 @@ func TestAccTFERunTriggerImport(t *testing.T) {
 
 func testAccCheckTFERunTriggerExists(n string, runTrigger *tfe.RunTrigger) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -89,7 +87,7 @@ func testAccCheckTFERunTriggerExists(n string, runTrigger *tfe.RunTrigger) resou
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		rt, err := config.Client.RunTriggers.Read(ctx, rs.Primary.ID)
+		rt, err := testAccConfiguredClient.Client.RunTriggers.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -102,16 +100,14 @@ func testAccCheckTFERunTriggerExists(n string, runTrigger *tfe.RunTrigger) resou
 
 func testAccCheckTFERunTriggerAttributes(runTrigger *tfe.RunTrigger, orgName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		workspaceID := runTrigger.Workspace.ID
-		workspace, _ := config.Client.Workspaces.Read(ctx, orgName, "workspace-test")
+		workspace, _ := testAccConfiguredClient.Client.Workspaces.Read(ctx, orgName, "workspace-test")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong workspace: %v", workspace.ID)
 		}
 
 		sourceableID := runTrigger.Sourceable.ID
-		sourceable, _ := config.Client.Workspaces.Read(ctx, orgName, "sourceable-test")
+		sourceable, _ := testAccConfiguredClient.Client.Workspaces.Read(ctx, orgName, "sourceable-test")
 		if sourceable.ID != sourceableID {
 			return fmt.Errorf("Wrong sourceable: %v", sourceable.ID)
 		}
@@ -121,8 +117,6 @@ func testAccCheckTFERunTriggerAttributes(runTrigger *tfe.RunTrigger, orgName str
 }
 
 func testAccCheckTFERunTriggerDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_run_trigger" {
 			continue
@@ -132,7 +126,7 @@ func testAccCheckTFERunTriggerDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.RunTriggers.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.RunTriggers.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Run trigger %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_saml_settings_test.go
+++ b/internal/provider/resource_tfe_saml_settings_test.go
@@ -284,7 +284,7 @@ func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 }
 
 func testAccTFESAMLSettingsDestroy(_ *terraform.State) error {
-	s, err := testAccProvider.Meta().(ConfiguredClient).Client.Admin.Settings.SAML.Read(ctx)
+	s, err := testAccConfiguredClient.Client.Admin.Settings.SAML.Read(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to read SAML Settings: %w", err)
 	}

--- a/internal/provider/resource_tfe_sentinel_policy_test.go
+++ b/internal/provider/resource_tfe_sentinel_policy_test.go
@@ -19,9 +19,9 @@ func TestAccTFESentinelPolicy_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESentinelPolicy_basic(rInt),
@@ -48,9 +48,9 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESentinelPolicy_basic(rInt),
@@ -93,9 +93,9 @@ func TestAccTFESentinelPolicy_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFESentinelPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESentinelPolicy_basic(rInt),

--- a/internal/provider/resource_tfe_sentinel_policy_test.go
+++ b/internal/provider/resource_tfe_sentinel_policy_test.go
@@ -114,8 +114,6 @@ func TestAccTFESentinelPolicy_import(t *testing.T) {
 func testAccCheckTFESentinelPolicyExists(
 	n string, policy *tfe.Policy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -125,7 +123,7 @@ func testAccCheckTFESentinelPolicyExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		p, err := config.Client.Policies.Read(ctx, rs.Primary.ID)
+		p, err := testAccConfiguredClient.Client.Policies.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -173,8 +171,6 @@ func testAccCheckTFESentinelPolicyAttributesUpdated(
 }
 
 func testAccCheckTFESentinelPolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_sentinel_policy" {
 			continue
@@ -184,7 +180,7 @@ func testAccCheckTFESentinelPolicyDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Policies.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Policies.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Sentinel policy %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_sentinel_version_test.go
+++ b/internal/provider/resource_tfe_sentinel_version_test.go
@@ -115,8 +115,6 @@ func TestAccTFESentinelVersion_full(t *testing.T) {
 }
 
 func testAccCheckTFESentinelVersionDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_sentinel_version" {
 			continue
@@ -126,7 +124,7 @@ func testAccCheckTFESentinelVersionDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Admin.SentinelVersions.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Admin.SentinelVersions.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Sentinel version %s still exists", rs.Primary.ID)
 		}
@@ -137,8 +135,6 @@ func testAccCheckTFESentinelVersionDestroy(s *terraform.State) error {
 
 func testAccCheckTFESentinelVersionExists(n string, sentinelVersion *tfe.AdminSentinelVersion) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -148,7 +144,7 @@ func testAccCheckTFESentinelVersionExists(n string, sentinelVersion *tfe.AdminSe
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		v, err := config.Client.Admin.SentinelVersions.Read(ctx, rs.Primary.ID)
+		v, err := testAccConfiguredClient.Client.Admin.SentinelVersions.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_tfe_sentinel_version_test.go
+++ b/internal/provider/resource_tfe_sentinel_version_test.go
@@ -25,9 +25,9 @@ func TestAccTFESentinelVersion_basic(t *testing.T) {
 	version := genSafeRandomSentinelVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFESentinelVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFESentinelVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESentinelVersion_basic(version, sha),
@@ -53,9 +53,9 @@ func TestAccTFESentinelVersion_import(t *testing.T) {
 	version := genSafeRandomSentinelVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFESentinelVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFESentinelVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESentinelVersion_basic(version, sha),
@@ -83,9 +83,9 @@ func TestAccTFESentinelVersion_full(t *testing.T) {
 	version := genSafeRandomSentinelVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFESentinelVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFESentinelVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFESentinelVersion_full(version, sha),

--- a/internal/provider/resource_tfe_ssh_key_test.go
+++ b/internal/provider/resource_tfe_ssh_key_test.go
@@ -153,8 +153,6 @@ func TestAccTFESSHKey_keyWO(t *testing.T) {
 func testAccCheckTFESSHKeyExists(
 	n string, sshKey *tfe.SSHKey) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -164,7 +162,7 @@ func testAccCheckTFESSHKeyExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		sk, err := config.Client.SSHKeys.Read(ctx, rs.Primary.ID)
+		sk, err := testAccConfiguredClient.Client.SSHKeys.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -200,8 +198,6 @@ func testAccCheckTFESSHKeyAttributesUpdated(
 }
 
 func testAccCheckTFESSHKeyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_ssh_key" {
 			continue
@@ -211,7 +207,7 @@ func testAccCheckTFESSHKeyDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.SSHKeys.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.SSHKeys.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("SSH key %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_team_access_test.go
+++ b/internal/provider/resource_tfe_team_access_test.go
@@ -28,9 +28,9 @@ func TestAccTFETeamAccess_admin(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamAccess_admin(rInt),
@@ -66,9 +66,9 @@ func TestAccTFETeamAccess_write(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamAccess_write(rInt),
@@ -95,9 +95,9 @@ func TestAccTFETeamAccess_custom(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamAccess_custom(rInt),
@@ -134,9 +134,9 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamAccess_write(rInt),
@@ -199,9 +199,9 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamAccess_custom(rInt),
@@ -263,9 +263,9 @@ func TestAccTFETeamAccess_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamAccess_write(rInt),

--- a/internal/provider/resource_tfe_team_access_test.go
+++ b/internal/provider/resource_tfe_team_access_test.go
@@ -284,8 +284,6 @@ func TestAccTFETeamAccess_import(t *testing.T) {
 func testAccCheckTFETeamAccessExists(
 	n string, tmAccess *tfe.TeamAccess) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -295,7 +293,7 @@ func testAccCheckTFETeamAccessExists(
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		ta, err := config.Client.TeamAccess.Read(ctx, rs.Primary.ID)
+		ta, err := testAccConfiguredClient.Client.TeamAccess.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -344,8 +342,6 @@ func testAccCheckTFETeamAccessAttributesPermissionsAre(tmAccess *tfe.TeamAccess,
 }
 
 func testAccCheckTFETeamAccessDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_access" {
 			continue
@@ -355,7 +351,7 @@ func testAccCheckTFETeamAccessDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.TeamAccess.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.TeamAccess.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Team access %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_team_member_test.go
+++ b/internal/provider/resource_tfe_team_member_test.go
@@ -88,9 +88,9 @@ func TestAccTFETeamMember_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamMember_basic(rInt),
@@ -113,9 +113,9 @@ func TestAccTFETeamMember_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamMember_basic(rInt),

--- a/internal/provider/resource_tfe_team_member_test.go
+++ b/internal/provider/resource_tfe_team_member_test.go
@@ -133,8 +133,6 @@ func TestAccTFETeamMember_import(t *testing.T) {
 func testAccCheckTFETeamMemberExists(
 	n string, user *tfe.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -150,7 +148,7 @@ func testAccCheckTFETeamMemberExists(
 			return fmt.Errorf("error unpacking team member ID: %w", err)
 		}
 
-		users, err := config.Client.TeamMembers.List(ctx, teamID)
+		users, err := testAccConfiguredClient.Client.TeamMembers.List(ctx, teamID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}
@@ -183,8 +181,6 @@ func testAccCheckTFETeamMemberAttributes(
 }
 
 func testAccCheckTFETeamMemberDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_member" {
 			continue
@@ -200,7 +196,7 @@ func testAccCheckTFETeamMemberDestroy(s *terraform.State) error {
 			return fmt.Errorf("error unpacking team member ID: %w", err)
 		}
 
-		users, err := config.Client.TeamMembers.List(ctx, teamID)
+		users, err := testAccConfiguredClient.Client.TeamMembers.List(ctx, teamID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}

--- a/internal/provider/resource_tfe_team_members_test.go
+++ b/internal/provider/resource_tfe_team_members_test.go
@@ -137,8 +137,6 @@ func hashSchemaString(username string) int {
 func testAccCheckTFETeamMembersExists(
 	n string, users *[]*tfe.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -148,7 +146,7 @@ func testAccCheckTFETeamMembersExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		us, err := config.Client.TeamMembers.List(ctx, rs.Primary.ID)
+		us, err := testAccConfiguredClient.Client.TeamMembers.List(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}
@@ -185,8 +183,6 @@ func usernamesFromTFEUsers(users []*tfe.User) []string {
 }
 
 func testAccCheckTFETeamMembersDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_members" {
 			continue
@@ -196,7 +192,7 @@ func testAccCheckTFETeamMembersDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		users, err := config.Client.TeamMembers.List(ctx, rs.Primary.ID)
+		users, err := testAccConfiguredClient.Client.TeamMembers.List(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}

--- a/internal/provider/resource_tfe_team_members_test.go
+++ b/internal/provider/resource_tfe_team_members_test.go
@@ -30,8 +30,8 @@ func TestAccTFETeamMembers_basic(t *testing.T) {
 				t.Skip("Please set TFE_USER1 to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamMembersDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamMembers_basic(rInt),
@@ -68,8 +68,8 @@ func TestAccTFETeamMembers_update(t *testing.T) {
 				t.Skip("Please set TFE_USER2 to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamMembersDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamMembers_basic(rInt),
@@ -114,8 +114,8 @@ func TestAccTFETeamMembers_import(t *testing.T) {
 				t.Skip("Please set TFE_USER1 to run this test")
 			}
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamMembersDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamMembersDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamMembers_basic(rInt),

--- a/internal/provider/resource_tfe_team_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_team_notification_configuration_test.go
@@ -697,8 +697,6 @@ func TestAccTFETeamNotificationConfigurationImport_emptyEmailUserIDs(t *testing.
 
 func testAccCheckTFETeamNotificationConfigurationExists(n string, notificationConfiguration *tfe.NotificationConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -708,7 +706,7 @@ func testAccCheckTFETeamNotificationConfigurationExists(n string, notificationCo
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		nc, err := config.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
+		nc, err := testAccConfiguredClient.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -910,8 +908,6 @@ func testAccCheckTFETeamNotificationConfigurationAttributesDuplicateTriggers(not
 }
 
 func testAccCheckTFETeamNotificationConfigurationDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_notification_configuration" {
 			continue
@@ -921,7 +917,7 @@ func testAccCheckTFETeamNotificationConfigurationDestroy(s *terraform.State) err
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Notification configuration %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_team_organization_member_test.go
+++ b/internal/provider/resource_tfe_team_organization_member_test.go
@@ -80,9 +80,9 @@ func TestAccTFETeamOrganizationMember_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMember_basic(rInt),
@@ -100,9 +100,9 @@ func TestAccTFETeamOrganizationMember_import_byId(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMember_basic(rInt),
@@ -124,9 +124,9 @@ func TestAccTFETeamOrganizationMember_import_byTeamName(t *testing.T) {
 	userEmail := fmt.Sprintf("user-%d@company.com", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMember_byName(orgName, teamName, userEmail),
@@ -148,9 +148,9 @@ func TestAccTFETeamOrganizationMember_import_orgDoesNotExist(t *testing.T) {
 	userEmail := fmt.Sprintf("user-%d@company.com", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMember_byName(orgName, teamName, userEmail),
@@ -173,9 +173,9 @@ func TestAccTFETeamOrganizationMember_import_teamNameDoesNotExist(t *testing.T) 
 	userEmail := fmt.Sprintf("user-%d@company.com", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMember_byName(orgName, teamName, userEmail),
@@ -198,9 +198,9 @@ func TestAccTFETeamOrganizationMember_import_userEmailDoesNotExist(t *testing.T)
 	userEmail := fmt.Sprintf("user-%d@company.com", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMember_byName(orgName, teamName, userEmail),
@@ -223,9 +223,9 @@ func TestAccTFETeamOrganizationMember_import_incorrectFormat(t *testing.T) {
 	userEmail := fmt.Sprintf("user-%d@company.com", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMember_byName(orgName, teamName, userEmail),
@@ -247,9 +247,9 @@ func TestAccTFETeamOrganizationMember_import_slashesInTeamName(t *testing.T) {
 	userEmail := fmt.Sprintf("user-%d@company.com", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMemberDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMemberDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMember_byName(orgName, teamName, userEmail),

--- a/internal/provider/resource_tfe_team_organization_member_test.go
+++ b/internal/provider/resource_tfe_team_organization_member_test.go
@@ -267,8 +267,6 @@ func TestAccTFETeamOrganizationMember_import_slashesInTeamName(t *testing.T) {
 func testAccCheckTFETeamOrganizationMemberExists(
 	n string, organizationMembership *tfe.OrganizationMembership) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -284,7 +282,7 @@ func testAccCheckTFETeamOrganizationMemberExists(
 			return fmt.Errorf("Error unpacking team organization member ID: %w", err)
 		}
 
-		organizationMemberships, err := config.Client.TeamMembers.ListOrganizationMemberships(ctx, teamID)
+		organizationMemberships, err := testAccConfiguredClient.Client.TeamMembers.ListOrganizationMemberships(ctx, teamID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}
@@ -317,8 +315,6 @@ func testAccCheckTFETeamOrganizationMemberAttributes(
 }
 
 func testAccCheckTFETeamOrganizationMemberDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_organization_member" {
 			continue
@@ -334,7 +330,7 @@ func testAccCheckTFETeamOrganizationMemberDestroy(s *terraform.State) error {
 			return fmt.Errorf("Error unpacking team organization member ID: %w", err)
 		}
 
-		organizationMemberships, err := config.Client.TeamMembers.ListOrganizationMemberships(ctx, teamID)
+		organizationMemberships, err := testAccConfiguredClient.Client.TeamMembers.ListOrganizationMemberships(ctx, teamID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return err
 		}

--- a/internal/provider/resource_tfe_team_organization_members_test.go
+++ b/internal/provider/resource_tfe_team_organization_members_test.go
@@ -21,9 +21,9 @@ func TestAccTFETeamOrganizationMembers_create_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMembersDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMembersDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMembers_basic(rInt),
@@ -48,9 +48,9 @@ func TestAccTFETeamOrganizationMembers_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamOrganizationMembersDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamOrganizationMembersDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamOrganizationMembers_basic(rInt),

--- a/internal/provider/resource_tfe_team_organization_members_test.go
+++ b/internal/provider/resource_tfe_team_organization_members_test.go
@@ -67,7 +67,6 @@ func TestAccTFETeamOrganizationMembers_import(t *testing.T) {
 
 func testAccCheckTFETeamOrganizationMembersExists(resourceName string, organizationMemberships *[]tfe.OrganizationMembership) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
 		*organizationMemberships = []tfe.OrganizationMembership{}
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -80,7 +79,7 @@ func testAccCheckTFETeamOrganizationMembersExists(resourceName string, organizat
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		orgMemberships, err := config.Client.TeamMembers.ListOrganizationMemberships(ctx, rs.Primary.ID)
+		orgMemberships, err := testAccConfiguredClient.Client.TeamMembers.ListOrganizationMemberships(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return fmt.Errorf("error while listing organization memberships: %w", err)
 		}
@@ -129,8 +128,6 @@ func testAccCheckTFETeamOrganizationMembersCount(expected int, organizationMembe
 }
 
 func testAccCheckTFETeamOrganizationMembersDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		// Continue if current resource is not a "tfe_team_organization_members" resource
 		if rs.Type != "tfe_team_organization_members" {
@@ -142,7 +139,7 @@ func testAccCheckTFETeamOrganizationMembersDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		organizationMemberships, err := config.Client.TeamMembers.ListOrganizationMemberships(ctx, rs.Primary.ID)
+		organizationMemberships, err := testAccConfiguredClient.Client.TeamMembers.ListOrganizationMemberships(ctx, rs.Primary.ID)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return fmt.Errorf("error while listing organization memberships: %w", err)
 		}

--- a/internal/provider/resource_tfe_team_project_access_test.go
+++ b/internal/provider/resource_tfe_team_project_access_test.go
@@ -20,9 +20,9 @@ func TestAccTFETeamProjectAccess(t *testing.T) {
 
 	for _, access := range []tfe.TeamProjectAccessType{tfe.TeamProjectAccessAdmin, tfe.TeamProjectAccessMaintain, tfe.TeamProjectAccessWrite, tfe.TeamProjectAccessRead} {
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
-			Providers:    testAccProviders,
-			CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccCheckTFETeamProjectAccessDestroy,
 			Steps: []resource.TestStep{
 				{
 					Config: testAccTFETeamProjectAccess(rand.New(rand.NewSource(time.Now().UnixNano())).Int(), access),
@@ -44,9 +44,9 @@ func TestAccTFETeamProjectCustomAccess(t *testing.T) {
 	access := tfe.TeamProjectAccessCustom
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamProjectAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccess(rInt, access),
@@ -78,9 +78,9 @@ func TestAccTFETeamProjectCustomAccess_with_project_variable_sets(t *testing.T) 
 	access := tfe.TeamProjectAccessCustom
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamProjectAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt, access),
@@ -100,9 +100,9 @@ func TestAccTFETeamProjectAccess_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamProjectAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectAccess(rInt, tfe.TeamProjectAccessAdmin),
@@ -122,9 +122,9 @@ func TestAccTFETeamProjectCustomAccess_import(t *testing.T) {
 	access := tfe.TeamProjectAccessCustom
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamProjectAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccess(rInt, access),
@@ -161,9 +161,9 @@ func TestAccTFETeamProjectCustomAccess_import_with_project_variable_set(t *testi
 	access := tfe.TeamProjectAccessCustom
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamProjectAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt, access),
@@ -190,8 +190,8 @@ func TestAccTFETeamProjectCustomAccess_full_update(t *testing.T) {
 	access := tfe.TeamProjectAccessCustom
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccess(rInt, access),
@@ -242,8 +242,8 @@ func TestAccTFETeamProjectCustomAccess_full_update_with_project_variable_sets(t 
 	access := tfe.TeamProjectAccessCustom
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt, access),
@@ -296,8 +296,8 @@ func TestAccTFETeamProjectCustomAccess_partial_update(t *testing.T) {
 	access := tfe.TeamProjectAccessCustom
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccess(rInt, access),
@@ -350,8 +350,8 @@ func TestAccTFETeamProjectCustomAccess_partial_update_with_project_variable_sets
 	access := tfe.TeamProjectAccessCustom
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamProjectCustomAccess_with_project_variable_sets(rInt, access),
@@ -433,9 +433,9 @@ func TestAccTFETeamProjectCustomAccess_invalid_custom_access(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamProjectAccessDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamProjectAccessDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFETeamProjectCustomAccess_invalid_custom_config(rInt),

--- a/internal/provider/resource_tfe_team_project_access_test.go
+++ b/internal/provider/resource_tfe_team_project_access_test.go
@@ -403,8 +403,6 @@ func TestAccTFETeamProjectCustomAccess_partial_update_with_project_variable_sets
 func testAccCheckTFETeamProjectAccessExists(
 	n string, tmAccess *tfe.TeamProjectAccess) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -414,7 +412,7 @@ func testAccCheckTFETeamProjectAccessExists(
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		ta, err := config.Client.TeamProjectAccess.Read(ctx, rs.Primary.ID)
+		ta, err := testAccConfiguredClient.Client.TeamProjectAccess.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error reading team project access %s: %w", rs.Primary.ID, err)
 		}
@@ -455,8 +453,6 @@ func testAccCheckTFETeamProjectAccessAttributesAccessIs(tmAccess *tfe.TeamProjec
 }
 
 func testAccCheckTFETeamProjectAccessDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_project_access" {
 			continue
@@ -466,7 +462,7 @@ func testAccCheckTFETeamProjectAccessDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.TeamProjectAccess.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.TeamProjectAccess.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Team project access %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_team_test.go
+++ b/internal/provider/resource_tfe_team_test.go
@@ -422,8 +422,6 @@ func TestAccTFETeam_import_teamNameWhichLooksLikeID(t *testing.T) {
 func testAccCheckTFETeamExists(
 	n string, team *tfe.Team) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -433,7 +431,7 @@ func testAccCheckTFETeamExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		t, err := config.Client.Teams.Read(ctx, rs.Primary.ID)
+		t, err := testAccConfiguredClient.Client.Teams.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -567,8 +565,6 @@ func testAccCheckTFETeamAttributes_full_update(
 }
 
 func testAccCheckTFETeamDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team" {
 			continue
@@ -578,7 +574,7 @@ func testAccCheckTFETeamDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Teams.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Teams.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Team %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_team_test.go
+++ b/internal/provider/resource_tfe_team_test.go
@@ -20,9 +20,9 @@ func TestAccTFETeam_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_basic(rInt),
@@ -43,9 +43,9 @@ func TestAccTFETeam_full(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_full(rInt),
@@ -100,9 +100,9 @@ func TestAccTFETeam_full_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_full(rInt),
@@ -245,9 +245,9 @@ func TestAccTFETeam_import_byId(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_basic(rInt),
@@ -267,9 +267,9 @@ func TestAccTFETeam_import_byId_doesNotExist(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_basic(rInt),
@@ -289,9 +289,9 @@ func TestAccTFETeam_import_byName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_basic(rInt),
@@ -311,9 +311,9 @@ func TestAccTFETeam_import_missingOrg(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_basic(rInt),
@@ -333,9 +333,9 @@ func TestAccTFETeam_import_missingTeam(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_basic(rInt),
@@ -355,9 +355,9 @@ func TestAccTFETeam_import_teamNameWithSpaces(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_withSpaces(rInt),
@@ -377,9 +377,9 @@ func TestAccTFETeam_import_teamNameWithSlashes(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_withSlashes(rInt),
@@ -401,9 +401,9 @@ func TestAccTFETeam_import_teamNameWhichLooksLikeID(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeam_withIDLikeName(rInt),

--- a/internal/provider/resource_tfe_team_token_test.go
+++ b/internal/provider/resource_tfe_team_token_test.go
@@ -175,8 +175,6 @@ func TestAccTFETeamToken_import(t *testing.T) {
 func testAccCheckTFETeamTokenExists(
 	n string, token *tfe.TeamToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -186,7 +184,7 @@ func testAccCheckTFETeamTokenExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		tt, err := config.Client.TeamTokens.Read(ctx, rs.Primary.ID)
+		tt, err := testAccConfiguredClient.Client.TeamTokens.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -202,8 +200,6 @@ func testAccCheckTFETeamTokenExists(
 }
 
 func testAccCheckTFETeamTokenDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_team_token" {
 			continue
@@ -213,7 +209,7 @@ func testAccCheckTFETeamTokenDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.TeamTokens.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.TeamTokens.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Team token %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_team_token_test.go
+++ b/internal/provider/resource_tfe_team_token_test.go
@@ -20,9 +20,9 @@ func TestAccTFETeamToken_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamToken_basic(rInt),
@@ -40,9 +40,9 @@ func TestAccTFETeamToken_existsWithoutForce(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamToken_basic(rInt),
@@ -65,9 +65,9 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamToken_basic(rInt),
@@ -94,9 +94,9 @@ func TestAccTFETeamToken_withBlankExpiry(t *testing.T) {
 	expiredAt := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamToken_withBlankExpiry(rInt),
@@ -117,9 +117,9 @@ func TestAccTFETeamToken_withValidExpiry(t *testing.T) {
 	expiredAt := "2051-04-11T23:15:59Z"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamToken_withValidExpiry(rInt),
@@ -138,9 +138,9 @@ func TestAccTFETeamToken_withInvalidExpiry(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFETeamToken_withInvalidExpiry(rInt),
@@ -154,9 +154,9 @@ func TestAccTFETeamToken_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETeamToken_basic(rInt),

--- a/internal/provider/resource_tfe_terraform_version_test.go
+++ b/internal/provider/resource_tfe_terraform_version_test.go
@@ -25,9 +25,9 @@ func TestAccTFETerraformVersion_basic(t *testing.T) {
 	version := genSafeRandomTerraformVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETerraformVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETerraformVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETerraformVersion_basic(version, sha),
@@ -53,9 +53,9 @@ func TestAccTFETerraformVersion_import(t *testing.T) {
 	version := genSafeRandomTerraformVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETerraformVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETerraformVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETerraformVersion_basic(version, sha),
@@ -83,9 +83,9 @@ func TestAccTFETerraformVersion_full(t *testing.T) {
 	version := genSafeRandomTerraformVersion()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFETerraformVersionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETerraformVersionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFETerraformVersion_full(version, sha),

--- a/internal/provider/resource_tfe_terraform_version_test.go
+++ b/internal/provider/resource_tfe_terraform_version_test.go
@@ -115,8 +115,6 @@ func TestAccTFETerraformVersion_full(t *testing.T) {
 }
 
 func testAccCheckTFETerraformVersionDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_terraform_version" {
 			continue
@@ -126,7 +124,7 @@ func testAccCheckTFETerraformVersionDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Admin.TerraformVersions.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Admin.TerraformVersions.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Terraform version %s still exists", rs.Primary.ID)
 		}
@@ -137,8 +135,6 @@ func testAccCheckTFETerraformVersionDestroy(s *terraform.State) error {
 
 func testAccCheckTFETerraformVersionExists(n string, tfVersion *tfe.AdminTerraformVersion) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -148,7 +144,7 @@ func testAccCheckTFETerraformVersionExists(n string, tfVersion *tfe.AdminTerrafo
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		v, err := config.Client.Admin.TerraformVersions.Read(ctx, rs.Primary.ID)
+		v, err := testAccConfiguredClient.Client.Admin.TerraformVersions.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/resource_tfe_test_variable_test.go
+++ b/internal/provider/resource_tfe_test_variable_test.go
@@ -147,8 +147,6 @@ func TestAccTFETestVariable_update(t *testing.T) {
 func testAccCheckTFETestVariableExists(
 	n string, variable *tfe.Variable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -165,7 +163,7 @@ func testAccCheckTFETestVariableExists(
 			RegistryName: "private",
 		}
 
-		v, err := config.Client.TestVariables.Read(ctx, moduleID, rs.Primary.ID)
+		v, err := testAccConfiguredClient.Client.TestVariables.Read(ctx, moduleID, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -177,8 +175,6 @@ func testAccCheckTFETestVariableExists(
 }
 
 func testAccCheckTFETestVariableDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_test_variable" {
 			continue
@@ -196,7 +192,7 @@ func testAccCheckTFETestVariableDestroy(s *terraform.State) error {
 			RegistryName: "private",
 		}
 
-		_, err := config.Client.TestVariables.Read(ctx, moduleID, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.TestVariables.Read(ctx, moduleID, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Variable %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_variable_set_test.go
+++ b/internal/provider/resource_tfe_variable_set_test.go
@@ -19,9 +19,9 @@ func TestAccTFEVariableSet_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEVariableSet_basic(rInt),
@@ -48,9 +48,9 @@ func TestAccTFEVariableSet_full(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEVariableSet_full(rInt),
@@ -80,9 +80,9 @@ func TestAccTFEVariableSet_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEVariableSet_basic(rInt),
@@ -126,9 +126,9 @@ func TestAccTFEVariableSet_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEVariableSet_basic(rInt),
@@ -149,9 +149,9 @@ func TestAccTFEVariableSet_project_owned(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEVariableSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEVariableSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testACCTFEVariableSet_ProjectOwned(rInt),

--- a/internal/provider/resource_tfe_variable_set_test.go
+++ b/internal/provider/resource_tfe_variable_set_test.go
@@ -175,8 +175,6 @@ func TestAccTFEVariableSet_project_owned(t *testing.T) {
 func testAccCheckTFEVariableSetExists(
 	n string, variableSet *tfe.VariableSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -186,7 +184,7 @@ func testAccCheckTFEVariableSetExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		vs, err := config.Client.VariableSets.Read(
+		vs, err := testAccConfiguredClient.Client.VariableSets.Read(
 			ctx,
 			rs.Primary.ID,
 			&tfe.VariableSetReadOptions{Include: &[]tfe.VariableSetIncludeOpt{tfe.VariableSetWorkspaces}},
@@ -262,8 +260,6 @@ func testAccCheckTFEVariableSetApplicationUpdate(variableSet *tfe.VariableSet) r
 }
 
 func testAccCheckTFEVariableSetDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_variable_set" {
 			continue
@@ -273,7 +269,7 @@ func testAccCheckTFEVariableSetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.VariableSets.Read(ctx, rs.Primary.ID, nil)
+		_, err := testAccConfiguredClient.Client.VariableSets.Read(ctx, rs.Primary.ID, nil)
 		if err == nil {
 			return fmt.Errorf("Variable Set %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_variable_test.go
+++ b/internal/provider/resource_tfe_variable_test.go
@@ -460,8 +460,6 @@ func TestAccTFEVariable_rewrite(t *testing.T) {
 func testAccCheckTFEVariableExists(
 	n string, variable *tfe.Variable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -472,13 +470,13 @@ func testAccCheckTFEVariableExists(
 		}
 
 		wsID := rs.Primary.Attributes["workspace_id"]
-		ws, err := config.Client.Workspaces.ReadByID(ctx, wsID)
+		ws, err := testAccConfiguredClient.Client.Workspaces.ReadByID(ctx, wsID)
 		if err != nil {
 			return fmt.Errorf(
 				"Error retrieving workspace %s: %w", wsID, err)
 		}
 
-		v, err := config.Client.Variables.Read(ctx, ws.ID, rs.Primary.ID)
+		v, err := testAccConfiguredClient.Client.Variables.Read(ctx, ws.ID, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -492,8 +490,6 @@ func testAccCheckTFEVariableExists(
 func testAccCheckTFEVariableSetVariableExists(
 	n string, variable *tfe.VariableSetVariable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -504,13 +500,13 @@ func testAccCheckTFEVariableSetVariableExists(
 		}
 
 		vsID := rs.Primary.Attributes["variable_set_id"]
-		vs, err := config.Client.VariableSets.Read(ctx, vsID, nil)
+		vs, err := testAccConfiguredClient.Client.VariableSets.Read(ctx, vsID, nil)
 		if err != nil {
 			return fmt.Errorf(
 				"Error retrieving variable set %s: %w", vsID, err)
 		}
 
-		v, err := config.Client.VariableSetVariables.Read(ctx, vs.ID, rs.Primary.ID)
+		v, err := testAccConfiguredClient.Client.VariableSetVariables.Read(ctx, vs.ID, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -657,8 +653,6 @@ func testAccCheckTFEVariableIDsNotEqual(
 }
 
 func testAccCheckTFEVariableDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_variable" {
 			continue
@@ -668,7 +662,7 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.Variables.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.Variables.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Variable %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_workspace_policy_set_exclusion_test.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_exclusion_test.go
@@ -77,8 +77,6 @@ func TestAccTFEWorkspacePolicySetExclusion_incorrectImportSyntax(t *testing.T) {
 
 func testAccCheckTFEWorkspacePolicySetExclusionExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -99,7 +97,7 @@ func testAccCheckTFEWorkspacePolicySetExclusionExists(n string) resource.TestChe
 			return fmt.Errorf("no excluded workspace id set")
 		}
 
-		policySet, err := config.Client.PolicySets.Read(ctx, policySetID)
+		policySet, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, policySetID)
 		if err != nil {
 			return fmt.Errorf("error reading polciy set %s: %w", policySetID, err)
 		}
@@ -114,8 +112,6 @@ func testAccCheckTFEWorkspacePolicySetExclusionExists(n string) resource.TestChe
 }
 
 func testAccCheckTFEWorkspacePolicySetExclusionDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy_set" {
 			continue
@@ -125,7 +121,7 @@ func testAccCheckTFEWorkspacePolicySetExclusionDestroy(s *terraform.State) error
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		_, err := config.Client.PolicySets.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("policy Set %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_workspace_policy_set_exclusion_test.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_exclusion_test.go
@@ -26,9 +26,9 @@ func TestAccTFEWorkspacePolicySetExclusion_basic(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspacePolicySetExclusionDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspacePolicySetExclusionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspacePolicySetExclusion_basic(org.Name, rInt),
@@ -59,8 +59,8 @@ func TestAccTFEWorkspacePolicySetExclusion_incorrectImportSyntax(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspacePolicySetExclusion_basic(org.Name, rInt),

--- a/internal/provider/resource_tfe_workspace_policy_set_test.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_test.go
@@ -26,9 +26,9 @@ func TestAccTFEWorkspacePolicySet_basic(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspacePolicySetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspacePolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspacePolicySet_basic(org.Name, rInt),
@@ -59,8 +59,8 @@ func TestAccTFEWorkspacePolicySet_incorrectImportSyntax(t *testing.T) {
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspacePolicySet_basic(org.Name, rInt),

--- a/internal/provider/resource_tfe_workspace_policy_set_test.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_test.go
@@ -77,8 +77,6 @@ func TestAccTFEWorkspacePolicySet_incorrectImportSyntax(t *testing.T) {
 
 func testAccCheckTFEWorkspacePolicySetExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -99,7 +97,7 @@ func testAccCheckTFEWorkspacePolicySetExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No workspace id set")
 		}
 
-		policySet, err := config.Client.PolicySets.Read(ctx, policySetID)
+		policySet, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, policySetID)
 		if err != nil {
 			return fmt.Errorf("error reading polciy set %s: %w", policySetID, err)
 		}
@@ -114,8 +112,6 @@ func testAccCheckTFEWorkspacePolicySetExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckTFEWorkspacePolicySetDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_policy_set" {
 			continue
@@ -125,7 +121,7 @@ func testAccCheckTFEWorkspacePolicySetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.PolicySets.Read(ctx, rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Policy Set %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_workspace_run_task_test.go
+++ b/internal/provider/resource_tfe_workspace_run_task_test.go
@@ -262,8 +262,6 @@ func TestAccTFEWorkspaceRunTask_Read(t *testing.T) {
 
 func testAccCheckTFEWorkspaceRunTaskExists(n string, runTask *tfe.WorkspaceRunTask) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -277,7 +275,7 @@ func testAccCheckTFEWorkspaceRunTaskExists(n string, runTask *tfe.WorkspaceRunTa
 			return fmt.Errorf("No Workspace ID is set")
 		}
 
-		rt, err := config.Client.WorkspaceRunTasks.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
+		rt, err := testAccConfiguredClient.Client.WorkspaceRunTasks.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error reading Workspace Run Task: %w", err)
 		}
@@ -293,8 +291,6 @@ func testAccCheckTFEWorkspaceRunTaskExists(n string, runTask *tfe.WorkspaceRunTa
 }
 
 func testAccCheckTFEWorkspaceRunTaskDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_workspace_run_task" {
 			continue
@@ -307,7 +303,7 @@ func testAccCheckTFEWorkspaceRunTaskDestroy(s *terraform.State) error {
 			return fmt.Errorf("No Workspace ID is set")
 		}
 
-		_, err := config.Client.WorkspaceRunTasks.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
+		_, err := testAccConfiguredClient.Client.WorkspaceRunTasks.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Workspace Run Tasks %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_workspace_run_test.go
+++ b/internal/provider/resource_tfe_workspace_run_test.go
@@ -221,8 +221,6 @@ func setupWorkspacesWithConfig(t *testing.T, tfeClient *tfe.Client, rInt int, or
 
 func testAccCheckTFEWorkspaceRunExistWithExpectedStatus(n string, run *tfe.Run, expectedStatus tfe.RunStatus) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -232,7 +230,7 @@ func testAccCheckTFEWorkspaceRunExistWithExpectedStatus(n string, run *tfe.Run, 
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		runData, err := config.Client.Runs.Read(ctx, rs.Primary.ID)
+		runData, err := testAccConfiguredClient.Client.Runs.Read(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Unable to read run, %w", err)
 		}
@@ -257,10 +255,8 @@ func testAccCheckTFEWorkspaceRunExistWithExpectedStatus(n string, run *tfe.Run, 
 
 func testAccCheckTFEWorkspaceRunDestroy(workspaceID string, expectedDestroyCount int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		mustBeNil, err := retryFn(10, 1, func() (any, error) {
-			runList, err := config.Client.Runs.List(ctx, workspaceID, &tfe.RunListOptions{
+			runList, err := testAccConfiguredClient.Client.Runs.List(ctx, workspaceID, &tfe.RunListOptions{
 				Operation: "destroy",
 			})
 			if err != nil {

--- a/internal/provider/resource_tfe_workspace_run_test.go
+++ b/internal/provider/resource_tfe_workspace_run_test.go
@@ -35,7 +35,7 @@ func TestAccTFEWorkspaceRun_withApplyOnlyBlock(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			// only the workspace with destroy block should have a destroy run
 			testAccCheckTFEWorkspaceRunDestroy(parentWorkspace.ID, 0),
@@ -85,7 +85,7 @@ func TestAccTFEWorkspaceRun_withBothApplyAndDestroyBlocks(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckTFEWorkspaceRunDestroy(parentWorkspace.ID, 1),
 			testAccCheckTFEWorkspaceRunDestroy(childWorkspace.ID, 1),
@@ -144,7 +144,7 @@ func TestAccTFEWorkspaceRun_invalidParams(t *testing.T) {
 			PreCheck: func() {
 				testAccPreCheck(t)
 			},
-			Providers: testAccProviders,
+			ProtoV5ProviderFactories: testAccMuxedProviders,
 			Steps: []resource.TestStep{
 				{
 					Config:      invalidCase.Config,
@@ -172,7 +172,7 @@ func TestAccTFEWorkspaceRun_WhenRunErrors(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
-		Providers: testAccProviders,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEWorkspaceRun_WhenRunErrors(parentWorkspace.ID),

--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -247,41 +246,35 @@ func TestAccTFEWorkspaceSettingsImport_ByName(t *testing.T) {
 }
 
 func testAccCheckTFEWorkspaceSettingsDestroy(s *terraform.State) error {
-	return testAccCheckTFEWorkspaceSettingsDestroyProvider(testAccProvider)(s)
-}
-
-func testAccCheckTFEWorkspaceSettingsDestroyProvider(_ *schema.Provider) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		tfeClient, err := getClientUsingEnv()
-		if err != nil {
-			return err
-		}
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "tfe_workspace_settings" {
-				continue
-			}
-
-			if rs.Primary.ID == "" {
-				return fmt.Errorf("No instance ID is set")
-			}
-
-			ws, err := tfeClient.Workspaces.ReadByID(ctx, rs.Primary.ID)
-			if err != nil {
-				return fmt.Errorf("Workspace %s does not exist", rs.Primary.ID)
-			}
-
-			if ws.ExecutionMode != "remote" {
-				return fmt.Errorf("expected execution mode to be remote after destroy, but was %s", ws.ExecutionMode)
-			}
-
-			if ws.AgentPool != nil {
-				return errors.New("expected agent pool to be nil after destroy, but wasn't")
-			}
-		}
-
-		return nil
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		return err
 	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_workspace_settings" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		ws, err := tfeClient.Workspaces.ReadByID(ctx, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Workspace %s does not exist", rs.Primary.ID)
+		}
+
+		if ws.ExecutionMode != "remote" {
+			return fmt.Errorf("expected execution mode to be remote after destroy, but was %s", ws.ExecutionMode)
+		}
+
+		if ws.AgentPool != nil {
+			return errors.New("expected agent pool to be nil after destroy, but wasn't")
+		}
+	}
+
+	return nil
 }
 
 func testAccTFEWorkspaceSettingsUnknownIDRemoteState(orgName string) string {

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -129,12 +129,12 @@ func TestAccTFEWorkspaceProviderDefaultOrgChanged(t *testing.T) {
 	providersWithAnotherOrg := muxedProvidersWithDefaultOrganization(anotherOrg.Name)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: providers,
-		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspace_defaultOrg(),
+				ProtoV5ProviderFactories: providers,
+				Config:                   testAccTFEWorkspace_defaultOrg(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", defaultOrgName),

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -2246,15 +2246,13 @@ func testAccCheckTFEWorkspaceExists(n string, workspace *tfe.Workspace) resource
 // resource_tfe_workspace.go:208 resourceTFEWorkspaceRead(...)
 func testAccCheckTFEWorkspacePanic(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		// Grab the resource out of the state and delete it from HCP Terraform and Terraform Enterprise directly.
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		err := config.Client.Workspaces.DeleteByID(ctx, rs.Primary.ID)
+		err := testAccConfiguredClient.Client.Workspaces.DeleteByID(ctx, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Could not delete %s: %w", n, err)
 		}
@@ -2381,9 +2379,7 @@ func testAccCheckTFEWorkspaceMonorepoAttributes(
 
 func testAccCheckTFEWorkspaceRename(orgName string) func() {
 	return func() {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
-		w, err := config.Client.Workspaces.Update(
+		w, err := testAccConfiguredClient.Client.Workspaces.Update(
 			context.Background(),
 			orgName,
 			"workspace-test",

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -31,9 +31,9 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 	workspaceName := "workspace-test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -167,9 +167,9 @@ func TestAccTFEWorkspace_basicReadProjectId(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -188,9 +188,9 @@ func TestAccTFEWorkspace_customProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_orgProjectWorkspace(rInt),
@@ -209,9 +209,9 @@ func TestAccTFEWorkspace_HTMLURL(t *testing.T) {
 
 	// When name is changed, the html_url should be updated as well
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_HTMLURL(rInt),
@@ -264,9 +264,9 @@ func TestAccTFEWorkspace_panic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:             testAccTFEWorkspace_basic(rInt),
@@ -286,9 +286,9 @@ func TestAccTFEWorkspace_monorepo(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_monorepo(rInt),
@@ -322,9 +322,9 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -384,9 +384,9 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -449,9 +449,9 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -504,9 +504,9 @@ func TestAccTFEWorkspace_updateProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_orgProjectWorkspace(rInt),
@@ -529,9 +529,9 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -561,9 +561,9 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_triggerPrefixes(rInt),
@@ -598,9 +598,9 @@ func TestAccTFEWorkspace_overwriteTriggerPatternsWithPrefixes(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_triggerPatterns(rInt),
@@ -653,9 +653,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -694,9 +694,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -737,9 +737,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -778,9 +778,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -817,9 +817,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -858,9 +858,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -901,9 +901,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -946,9 +946,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -992,9 +992,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 		t.Run("and both trigger prefixes and patterns are populated", func(t *testing.T) {
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -1011,9 +1011,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 		t.Run("and both trigger prefixes and patterns are empty", func(t *testing.T) {
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -1032,9 +1032,9 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 			workspace := &tfe.Workspace{}
 			rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testAccPreCheck(t) },
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+				PreCheck:                 func() { testAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccMuxedProviders,
+				CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccTFEWorkspace_triggersConfigurationGenerator(
@@ -1180,9 +1180,9 @@ func TestAccTFEWorkspace_updateTriggerPatterns(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			// Create trigger prefixes first so we can verify they are being removed if we introduce trigger patterns
 			{
@@ -1243,9 +1243,9 @@ func TestAccTFEWorkspace_patternsAndPrefixesConflicting(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEWorkspace_prefixesAndPatternsConflicting(rInt),
@@ -1264,9 +1264,9 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				// create with 2 tags
@@ -1422,9 +1422,9 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -1454,9 +1454,9 @@ func TestAccTFEWorkspace_structuredRunOutputDisabled(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -1490,8 +1490,8 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
@@ -1567,8 +1567,8 @@ func TestAccTFEWorkspace_updateGitHubAppRepo(t *testing.T) {
 			testAccGithubPreCheck(t)
 			testAccGHAInstallationPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
@@ -1644,8 +1644,8 @@ func TestAccTFEWorkspace_updateVCSRepoTagsRegex(t *testing.T) {
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
@@ -1696,8 +1696,8 @@ func TestAccTFEWorkspace_updateVCSRepoChangeTagRegexToTriggerPattern(t *testing.
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
@@ -1748,8 +1748,8 @@ func TestAccTFEWorkspace_updateRemoveVCSRepoWithTagsRegex(t *testing.T) {
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
@@ -1830,9 +1830,9 @@ func TestAccTFEWorkspace_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -1864,8 +1864,8 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 			testAccPreCheck(t)
 			testAccGithubPreCheck(t)
 		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoBranch(rInt),
@@ -1897,9 +1897,9 @@ func TestAccTFEWorkspace_importProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_orgProjectWorkspace(rInt),
@@ -1928,9 +1928,9 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 	workspace := &tfe.Workspace{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_operationsTrue(org.Name),
@@ -2006,9 +2006,9 @@ func TestAccTFEWorkspace_globalRemoteState(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_globalRemoteStateFalse(rInt),
@@ -2043,9 +2043,9 @@ func TestAccTFEWorkspace_alterRemoteStateConsumers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -2100,9 +2100,9 @@ func TestAccTFEWorkspace_createWithRemoteStateConsumers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_TwoRemoteStateConsumers(rInt),
@@ -2124,9 +2124,9 @@ func TestAccTFEWorkspace_paginatedRemoteStateConsumers(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_OverAPageOfRemoteStateConsumers(rInt),
@@ -2144,9 +2144,9 @@ func TestAccTFEWorkspace_delete_forceDeleteSettingDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -2194,9 +2194,9 @@ func TestAccTFEWorkspace_delete_forceDeleteSettingEnabled(t *testing.T) {
 		t.Fatal(err)
 	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
@@ -2665,9 +2665,9 @@ func TestAccTFEWorkspace_basicAssessmentsEnabled(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -2700,9 +2700,9 @@ func TestAccTFEWorkspace_createWithAutoDestroyAt(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAt(rInt),
@@ -2719,9 +2719,9 @@ func TestAccTFEWorkspace_updateWithAutoDestroyAt(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
@@ -2746,9 +2746,9 @@ func TestAccTFEWorkspace_createWithAutoDestroyDuration(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDuration(rInt, "1d"),
@@ -2765,9 +2765,9 @@ func TestAccTFEWorkspace_updateWithAutoDestroyDuration(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDuration(rInt, "1d"),
@@ -2811,10 +2811,10 @@ func TestAccTFEWorkspace_validationAutoDestroyDuration(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
-		Steps:        steps,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
+		Steps:                    steps,
 	})
 }
 
@@ -2822,9 +2822,9 @@ func TestAccTFEWorkspace_createWithAutoDestroyDurationInProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDurationInProject(rInt, "1d", "3d"),
@@ -2842,9 +2842,9 @@ func TestAccTFEWorkspace_updateWithAutoDestroyDurationInProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDurationInProject(rInt, "1d", "3d"),
@@ -2878,9 +2878,9 @@ func TestAccTFEWorkspace_createWithAutoDestroyAtInProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAtInProject(rInt, "1d"),
@@ -2898,9 +2898,9 @@ func TestAccTFEWorkspace_updateWithAutoDestroyAtInProject(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAtInProject(rInt, "1d"),
@@ -2926,9 +2926,9 @@ func TestAccTFEWorkspace_createWithSourceURL(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEWorkspace_basicWithSourceURL(rInt),
@@ -2942,9 +2942,9 @@ func TestAccTFEWorkspace_createWithSourceName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEWorkspace_basicWithSourceName(rInt),
@@ -2959,9 +2959,9 @@ func TestAccTFEWorkspace_createWithSourceURLAndName(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspace_basicWithSourceURLAndName(rInt),

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -38,8 +38,7 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", workspaceName),
@@ -102,8 +101,7 @@ func TestAccTFEWorkspace_defaultOrg(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_defaultOrg(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", &workspace, providers["tfe"]),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", defaultOrgName),
 				),
 			},
@@ -137,8 +135,7 @@ func TestAccTFEWorkspaceProviderDefaultOrgChanged(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_defaultOrg(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, providers["tfe"]),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", defaultOrgName),
 				),
 			},
@@ -174,8 +171,7 @@ func TestAccTFEWorkspace_basicReadProjectId(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttrPair("tfe_workspace.foobar", "project_id", "tfe_organization.foobar", "default_project_id"),
 				),
 			},
@@ -195,8 +191,7 @@ func TestAccTFEWorkspace_customProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_orgProjectWorkspace(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttrPair("tfe_workspace.foobar", "project_id", "tfe_project.foobar", "id"),
 				),
 			},
@@ -272,8 +267,7 @@ func TestAccTFEWorkspace_panic(t *testing.T) {
 				Config:             testAccTFEWorkspace_basic(rInt),
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					testAccCheckTFEWorkspacePanic("tfe_workspace.foobar"),
 				),
 			},
@@ -293,8 +287,7 @@ func TestAccTFEWorkspace_monorepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_monorepo(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceMonorepoAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-monorepo"),
@@ -329,8 +322,7 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
@@ -357,8 +349,7 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "renamed-out-of-band"),
 					resource.TestCheckResourceAttr(
@@ -391,8 +382,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
@@ -412,8 +402,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributesUpdated(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-updated"),
@@ -456,8 +445,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
@@ -474,8 +462,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateAddWorkingDirectory(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributesUpdatedAddWorkingDirectory(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-updated"),
@@ -486,8 +473,7 @@ func TestAccTFEWorkspace_updateWorkingDirectory(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateRemoveWorkingDirectory(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributesUpdatedRemoveWorkingDirectory(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-updated"),
@@ -511,8 +497,7 @@ func TestAccTFEWorkspace_updateProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_orgProjectWorkspace(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttrPair("tfe_workspace.foobar", "project_id", "tfe_project.foobar", "id"),
 				),
 			},
@@ -536,8 +521,7 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "file_triggers_enabled", "true"),
 				),
@@ -546,8 +530,7 @@ func TestAccTFEWorkspace_updateFileTriggers(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicFileTriggersOff(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "file_triggers_enabled", "false"),
 				),
@@ -568,8 +551,7 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_triggerPrefixes(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_prefixes.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -582,8 +564,7 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateEmptyTriggerPrefixes(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
@@ -605,8 +586,7 @@ func TestAccTFEWorkspace_overwriteTriggerPatternsWithPrefixes(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_triggerPatterns(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_patterns.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -616,8 +596,7 @@ func TestAccTFEWorkspace_overwriteTriggerPatternsWithPrefixes(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_triggerPrefixes(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_prefixes.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -631,8 +610,7 @@ func TestAccTFEWorkspace_overwriteTriggerPatternsWithPrefixes(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateEmptyTriggerPrefixes(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
@@ -665,8 +643,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							true, `["/pattern1", "/pattern2"]`,
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_patterns.#", "2"),
 						),
@@ -679,8 +656,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
 							resource.TestCheckResourceAttr(
@@ -706,8 +682,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							true, `["/pattern1", "/pattern2"]`,
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_patterns.#", "2"),
 						),
@@ -720,8 +695,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "1"),
 							resource.TestCheckResourceAttr(
@@ -749,8 +723,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "1"),
 							resource.TestCheckResourceAttr(
@@ -790,8 +763,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "1"),
 							resource.TestCheckResourceAttr(
@@ -829,8 +801,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							true, `["/pattern1", "/pattern2"]`,
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_patterns.#", "2"),
 						),
@@ -843,8 +814,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
 							resource.TestCheckResourceAttr(
@@ -870,8 +840,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							true, `["/pattern1", "/pattern2"]`,
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_patterns.#", "2"),
 						),
@@ -884,8 +853,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "1"),
 							resource.TestCheckResourceAttr(
@@ -913,8 +881,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "2"),
 						),
@@ -927,8 +894,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							true, `["/patterns1", "/patterns2", "/patterns3"]`,
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_patterns.#", "3"),
 							resource.TestCheckResourceAttr(
@@ -958,8 +924,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "1"),
 							resource.TestCheckResourceAttr(
@@ -1044,8 +1009,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "2"),
 							resource.TestCheckResourceAttr(
@@ -1074,8 +1038,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							true, `["/pattern1", "/pattern2"]`,
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
 							resource.TestCheckResourceAttr(
@@ -1090,8 +1053,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "3"),
 							resource.TestCheckResourceAttr(
@@ -1106,8 +1068,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "[]",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "1"),
 							resource.TestCheckResourceAttr(
@@ -1122,8 +1083,7 @@ func TestAccTFEWorkspace_permutation_test_suite(t *testing.T) {
 							false, "",
 						),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckTFEWorkspaceExists(
-								"tfe_workspace.foobar", workspace, testAccProvider),
+							testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 							resource.TestCheckResourceAttr(
 								"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
 							resource.TestCheckResourceAttr(
@@ -1196,8 +1156,7 @@ func TestAccTFEWorkspace_updateTriggerPatterns(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_triggerPatterns(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_patterns.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -1212,8 +1171,7 @@ func TestAccTFEWorkspace_updateTriggerPatterns(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateTriggerPatterns(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_patterns.#", "3"),
 					resource.TestCheckResourceAttr(
@@ -1229,7 +1187,7 @@ func TestAccTFEWorkspace_updateTriggerPatterns(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateEmptyTriggerPatterns(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "trigger_patterns.#", "0"),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "trigger_prefixes.#", "0"),
@@ -1272,8 +1230,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				// create with 2 tags
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -1286,8 +1243,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				// remove 1
 				Config: testAccTFEWorkspace_basicRemoveTag(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -1298,8 +1254,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				// add 1
 				Config: testAccTFEWorkspace_basicChangeTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -1312,8 +1267,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				// remove 1 again
 				Config: testAccTFEWorkspace_basicRemoveTag(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -1324,8 +1278,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				// change unrelated attr
 				Config: testAccTFEWorkspace_basicRemoveTagAlt(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -1336,8 +1289,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				// remove 1, add 2
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -1350,8 +1302,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				// remove all
 				Config: testAccTFEWorkspace_basicNoTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "0"),
 				),
@@ -1360,8 +1311,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				// add 2
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -1388,8 +1338,7 @@ func TestAccTFEWorkspace_changeTags(t *testing.T) {
 				},
 				Config: testAccTFEWorkspace_ignoreAdditional(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "tag_names.#", "2"),
 					resource.TestCheckTypeSetElemAttr(
@@ -1429,8 +1378,7 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "speculative_enabled", "true"),
 				),
@@ -1439,8 +1387,7 @@ func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicSpeculativeOff(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "speculative_enabled", "false"),
 				),
@@ -1461,8 +1408,7 @@ func TestAccTFEWorkspace_structuredRunOutputDisabled(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "structured_run_output_enabled", "true"),
 				),
@@ -1471,8 +1417,7 @@ func TestAccTFEWorkspace_structuredRunOutputDisabled(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateStructuredRunOutput(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "structured_run_output_enabled", "false"),
 				),
@@ -1496,8 +1441,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
@@ -1514,7 +1458,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateAddVCSRepo(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedAddVCSRepoAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-add-vcs-repo"),
@@ -1531,7 +1475,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoBranch(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedUpdateVCSRepoBranchAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-branch"),
@@ -1546,7 +1490,7 @@ func TestAccTFEWorkspace_updateVCSRepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateRemoveVCSRepo(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedRemoveVCSRepoAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-remove-vcs-repo"),
@@ -1573,8 +1517,7 @@ func TestAccTFEWorkspace_updateGitHubAppRepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
@@ -1591,7 +1534,7 @@ func TestAccTFEWorkspace_updateGitHubAppRepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateAddGitHubAppRepo(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedAddVCSRepoAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-add-vcs-repo"),
@@ -1608,7 +1551,7 @@ func TestAccTFEWorkspace_updateGitHubAppRepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateUpdateGitHubAppRepoBranch(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedUpdateVCSRepoBranchAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-branch"),
@@ -1623,7 +1566,7 @@ func TestAccTFEWorkspace_updateGitHubAppRepo(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateRemoveVCSRepo(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedRemoveVCSRepoAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-remove-vcs-repo"),
@@ -1650,7 +1593,7 @@ func TestAccTFEWorkspace_updateVCSRepoTagsRegex(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-tags-regex"),
 					resource.TestCheckResourceAttr(
@@ -1668,7 +1611,7 @@ func TestAccTFEWorkspace_updateVCSRepoTagsRegex(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateRemoveVCSRepoTagsRegex(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-tags-regex"),
 					resource.TestCheckResourceAttr(
@@ -1702,7 +1645,7 @@ func TestAccTFEWorkspace_updateVCSRepoChangeTagRegexToTriggerPattern(t *testing.
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-tags-regex"),
 					resource.TestCheckResourceAttr(
@@ -1720,7 +1663,7 @@ func TestAccTFEWorkspace_updateVCSRepoChangeTagRegexToTriggerPattern(t *testing.
 			{
 				Config: testAccTFEWorkspace_updateToTriggerPatternsFromTagsRegex(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-tags-regex"),
 					resource.TestCheckResourceAttr(
@@ -1754,7 +1697,7 @@ func TestAccTFEWorkspace_updateRemoveVCSRepoWithTagsRegex(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoTagsRegex(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-tags-regex"),
 					resource.TestCheckResourceAttr(
@@ -1772,7 +1715,7 @@ func TestAccTFEWorkspace_updateRemoveVCSRepoWithTagsRegex(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateRemoveVCSBlockFromTagsRegex(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-tags-regex"),
 					resource.TestCheckResourceAttr(
@@ -1797,8 +1740,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 				),
 			},
@@ -1806,8 +1748,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_sshKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributesSSHKey(workspace),
 					resource.TestCheckResourceAttrSet(
 						"tfe_workspace.foobar", "ssh_key_id"),
@@ -1817,8 +1758,7 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_noSSHKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 				),
 			},
@@ -1870,7 +1810,7 @@ func TestAccTFEWorkspace_importVCSBranch(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateUpdateVCSRepoBranch(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceUpdatedUpdateVCSRepoBranchAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "description", "workspace-test-update-vcs-repo-branch"),
@@ -1935,8 +1875,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 			{
 				Config: testAccTFEWorkspace_operationsTrue(org.Name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "operations", "true"),
 					resource.TestCheckResourceAttr(
@@ -1948,8 +1887,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 			{
 				Config: testAccTFEWorkspace_executionModeLocal(org.Name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "operations", "false"),
 					resource.TestCheckResourceAttr(
@@ -1961,8 +1899,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 			{
 				Config: testAccTFEWorkspace_operationsFalse(org.Name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "operations", "false"),
 					resource.TestCheckResourceAttr(
@@ -1974,8 +1911,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 			{
 				Config: testAccTFEWorkspace_executionModeRemote(org.Name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "operations", "true"),
 					resource.TestCheckResourceAttr(
@@ -1987,8 +1923,7 @@ func TestAccTFEWorkspace_operationsAndExecutionModeInteroperability(t *testing.T
 			{
 				Config: testAccTFEWorkspace_executionModeAgent(org.Name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "operations", "true"),
 					resource.TestCheckResourceAttr(
@@ -2013,8 +1948,7 @@ func TestAccTFEWorkspace_globalRemoteState(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_globalRemoteStateFalse(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
@@ -2025,8 +1959,7 @@ func TestAccTFEWorkspace_globalRemoteState(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_globalRemoteStateTrue(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
@@ -2050,16 +1983,14 @@ func TestAccTFEWorkspace_alterRemoteStateConsumers(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "global_remote_state", "true"),
 				),
 			},
 			{
 				Config: testAccTFEWorkspace_OneRemoteStateConsumer(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "global_remote_state", "false"),
 					testAccCheckTFEWorkspaceHasRemoteConsumers("tfe_workspace.foobar", []string{"tfe_workspace.foobar_one"}),
 				),
@@ -2067,8 +1998,7 @@ func TestAccTFEWorkspace_alterRemoteStateConsumers(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_TwoRemoteStateConsumers(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "global_remote_state", "false"),
 					testAccCheckTFEWorkspaceHasRemoteConsumers("tfe_workspace.foobar", []string{"tfe_workspace.foobar_one", "tfe_workspace.foobar_two"}),
 				),
@@ -2076,8 +2006,7 @@ func TestAccTFEWorkspace_alterRemoteStateConsumers(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_OneRemoteStateConsumer(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "global_remote_state", "false"),
 					testAccCheckTFEWorkspaceHasRemoteConsumers("tfe_workspace.foobar", []string{"tfe_workspace.foobar_one"}),
 				),
@@ -2085,8 +2014,7 @@ func TestAccTFEWorkspace_alterRemoteStateConsumers(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_globalRemoteStateTrue(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "global_remote_state", "true"),
 					testAccCheckTFEWorkspaceHasRemoteConsumers("tfe_workspace.foobar", []string{}),
 				),
@@ -2107,8 +2035,7 @@ func TestAccTFEWorkspace_createWithRemoteStateConsumers(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_TwoRemoteStateConsumers(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "global_remote_state", "false"),
 					testAccCheckTFEWorkspaceHasRemoteConsumers("tfe_workspace.foobar", []string{"tfe_workspace.foobar_one", "tfe_workspace.foobar_two"}),
 				),
@@ -2151,8 +2078,7 @@ func TestAccTFEWorkspace_delete_forceDeleteSettingDisabled(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 				),
 			},
@@ -2166,8 +2092,7 @@ func TestAccTFEWorkspace_delete_forceDeleteSettingDisabled(t *testing.T) {
 				Config:      testAccTFEWorkspace_basicDeleted(rInt),
 				ExpectError: regexp.MustCompile(`.*Workspace is currently locked.`),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 				),
 			},
 			{
@@ -2201,8 +2126,7 @@ func TestAccTFEWorkspace_delete_forceDeleteSettingEnabled(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicForceDeleteEnabled(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 				),
 			},
@@ -2297,11 +2221,8 @@ func testAccCheckTFEWorkspaceHTMLURLHasSuffix(resourceName, suffix string) resou
 	}
 }
 
-func testAccCheckTFEWorkspaceExists(
-	n string, workspace *tfe.Workspace, p *schema.Provider) resource.TestCheckFunc {
+func testAccCheckTFEWorkspaceExists(n string, workspace *tfe.Workspace) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := p.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -2312,7 +2233,7 @@ func testAccCheckTFEWorkspaceExists(
 		}
 
 		// Get the workspace
-		w, err := config.Client.Workspaces.ReadByID(ctx, rs.Primary.ID)
+		w, err := testAccConfiguredClient.Client.Workspaces.ReadByID(ctx, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -2672,8 +2593,7 @@ func TestAccTFEWorkspace_basicAssessmentsEnabled(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-test"),
@@ -2684,8 +2604,7 @@ func TestAccTFEWorkspace_basicAssessmentsEnabled(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_updateAssessmentsEnabled(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "name", "workspace-updated"),
 					resource.TestCheckResourceAttr(
@@ -2707,7 +2626,7 @@ func TestAccTFEWorkspace_createWithAutoDestroyAt(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAt(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_at", "2100-01-01T00:00:00Z"),
 				),
 			},
@@ -2726,7 +2645,7 @@ func TestAccTFEWorkspace_updateWithAutoDestroyAt(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_at", ""),
 				),
 			},
@@ -2753,7 +2672,7 @@ func TestAccTFEWorkspace_createWithAutoDestroyDuration(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDuration(rInt, "1d"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_activity_duration", "1d"),
 				),
 			},
@@ -2772,7 +2691,7 @@ func TestAccTFEWorkspace_updateWithAutoDestroyDuration(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDuration(rInt, "1d"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_activity_duration", "1d"),
 				),
 			},
@@ -2829,7 +2748,7 @@ func TestAccTFEWorkspace_createWithAutoDestroyDurationInProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDurationInProject(rInt, "1d", "3d"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_activity_duration", "3d"),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "inherits_project_auto_destroy", "false"),
 				),
@@ -2849,7 +2768,7 @@ func TestAccTFEWorkspace_updateWithAutoDestroyDurationInProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDurationInProject(rInt, "1d", "3d"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_activity_duration", "3d"),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "inherits_project_auto_destroy", "false"),
 				),
@@ -2857,7 +2776,7 @@ func TestAccTFEWorkspace_updateWithAutoDestroyDurationInProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyDurationInProject(rInt, "2d", "5d"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_activity_duration", "5d"),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "inherits_project_auto_destroy", "false"),
 				),
@@ -2865,7 +2784,7 @@ func TestAccTFEWorkspace_updateWithAutoDestroyDurationInProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicInProject(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_activity_duration", ""),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "inherits_project_auto_destroy", "true"),
 				),
@@ -2885,7 +2804,7 @@ func TestAccTFEWorkspace_createWithAutoDestroyAtInProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAtInProject(rInt, "1d"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_at", "2100-01-01T00:00:00Z"),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "inherits_project_auto_destroy", "false"),
 				),
@@ -2905,7 +2824,7 @@ func TestAccTFEWorkspace_updateWithAutoDestroyAtInProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithAutoDestroyAtInProject(rInt, "1d"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_at", "2100-01-01T00:00:00Z"),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "inherits_project_auto_destroy", "false"),
 				),
@@ -2913,7 +2832,7 @@ func TestAccTFEWorkspace_updateWithAutoDestroyAtInProject(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicInProject(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", &tfe.Workspace{}),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "auto_destroy_at", ""),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "inherits_project_auto_destroy", "true"),
 				),
@@ -2966,8 +2885,7 @@ func TestAccTFEWorkspace_createWithSourceURLAndName(t *testing.T) {
 			{
 				Config: testAccTFEWorkspace_basicWithSourceURLAndName(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace, testAccProvider),
+					testAccCheckTFEWorkspaceExists("tfe_workspace.foobar", workspace),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "source_url", "https://example.com"),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "source_name", "Example Source"),
 				),

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -2262,7 +2262,7 @@ func testAccCheckTFEWorkspacePanic(n string) resource.TestCheckFunc {
 		rd := &schema.ResourceData{}
 		rd.SetId(rs.Primary.ID)
 
-		err = resourceTFEWorkspaceRead(rd, testAccProvider.Meta())
+		err = resourceTFEWorkspaceRead(rd, *testAccConfiguredClient)
 		if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
 			return fmt.Errorf("Could not re-read resource directly: %w", err)
 		}

--- a/internal/provider/resource_tfe_workspace_variable_set_test.go
+++ b/internal/provider/resource_tfe_workspace_variable_set_test.go
@@ -42,8 +42,6 @@ func TestAccTFEWorkspaceVariableSet_basic(t *testing.T) {
 
 func testAccCheckTFEWorkspaceVariableSetExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(ConfiguredClient)
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
@@ -59,7 +57,7 @@ func testAccCheckTFEWorkspaceVariableSetExists(n string) resource.TestCheckFunc 
 			return fmt.Errorf("error decoding ID (%s): %w", id, err)
 		}
 
-		vS, err := config.Client.VariableSets.Read(ctx, vSID, &tfe.VariableSetReadOptions{
+		vS, err := testAccConfiguredClient.Client.VariableSets.Read(ctx, vSID, &tfe.VariableSetReadOptions{
 			Include: &[]tfe.VariableSetIncludeOpt{tfe.VariableSetWorkspaces},
 		})
 		if err != nil {
@@ -76,8 +74,6 @@ func testAccCheckTFEWorkspaceVariableSetExists(n string) resource.TestCheckFunc 
 }
 
 func testAccCheckTFEWorkspaceVariableSetDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(ConfiguredClient)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "tfe_variable_set" {
 			continue
@@ -87,7 +83,7 @@ func testAccCheckTFEWorkspaceVariableSetDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := config.Client.VariableSets.Read(ctx, rs.Primary.ID, nil)
+		_, err := testAccConfiguredClient.Client.VariableSets.Read(ctx, rs.Primary.ID, nil)
 		if err == nil {
 			return fmt.Errorf("Variable Set %s still exists", rs.Primary.ID)
 		}

--- a/internal/provider/resource_tfe_workspace_variable_set_test.go
+++ b/internal/provider/resource_tfe_workspace_variable_set_test.go
@@ -19,9 +19,9 @@ func TestAccTFEWorkspaceVariableSet_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTFEWorkspaceVariableSetDestroy,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceVariableSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTFEWorkspaceVariableSet_basic(rInt),


### PR DESCRIPTION
## Description

This PR updates all existing acceptance tests to use framework provider factories. All remaining references to sdk provider factories have been removed.

This addresses many cases around the code base where `provider.Meta().(ConfiguredClient)` is used to perform a test check; once provider factories are migrated to the framework, this is no longer a valid way to access a configured TFE client from a test check.

Instead, tests now make use of a global `ConfiguredClient` instance defined in `provider_test.go` to perform checks that require use of a configured client.

Since the number of files touched by this PR is large, the commits have been staged and tightly focused to facilitate a commit-wise review. Most importantly, the commits that touch a large number of files should contain the same change over and over without variation.

## Testing plan

1.  Since this PR only touches test files, we will rely on acceptance tests.
