### PR TITLE
add an ephemeral resource for tfe_audit_trail_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 FEATURES:
 
+* **New Ephemeral Resource:** `tfe_audit_trail_token` is a new ephemeral
+  resource for creating and managing audit trail tokens, by
+  @uturunku1 [#1675](https://github.com/hashicorp/terraform-provider-tfe/pull/1675)
+
 * **New Ephemeral Resource:** `tfe_organization_token` is a new ephemeral
   resource for creating and managing organization tokens, by
   @ctrombley [#1616](https://github.com/hashicorp/terraform-provider-tfe/pull/1616)

--- a/internal/provider/ephemeral_resource_audit_trail_token.go
+++ b/internal/provider/ephemeral_resource_audit_trail_token.go
@@ -1,0 +1,126 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = &AuditTrailTokenEphemeralResource{}
+	_ ephemeral.EphemeralResourceWithConfigure = &AuditTrailTokenEphemeralResource{}
+)
+
+func NewAuditTrailTokenEphemeralResource() ephemeral.EphemeralResource {
+	return &AuditTrailTokenEphemeralResource{}
+}
+
+type AuditTrailTokenEphemeralResource struct {
+	config ConfiguredClient
+}
+
+type AuditTrailTokenEphemeralResourceModel struct {
+	Organization types.String      `tfsdk:"organization"`
+	Token        types.String      `tfsdk:"token"`
+	ExpiredAt    timetypes.RFC3339 `tfsdk:"expired_at"`
+}
+
+func (e *AuditTrailTokenEphemeralResource) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This ephemeral resource can be used to retrieve an audit trail token without saving its value in state. Using this ephemeral resource will generate a new token each time it is used, invalidating any existing audit trail token.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description: `Name of the organization. If omitted, organization must be defined in the provider config.`,
+				Optional:    true,
+				Computed:    true,
+			},
+			"token": schema.StringAttribute{
+				Description: `The generated token.`,
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"expired_at": schema.StringAttribute{
+				Description: `The token's expiration date. The expiration date must be a date/time string in RFC3339 format (e.g., "2024-12-31T23:59:59Z"). If no expiration date is supplied, the expiration date will default to null and never expire.`,
+				Optional:    true,
+				CustomType:  timetypes.RFC3339Type{},
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (e *AuditTrailTokenEphemeralResource) Configure(_ context.Context, req ephemeral.ConfigureRequest, resp *ephemeral.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Ephemeral Resource Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+
+	e.config = client
+}
+
+func (e *AuditTrailTokenEphemeralResource) Metadata(ctx context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_audit_trail_token"
+}
+
+func (e *AuditTrailTokenEphemeralResource) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	// Read Terraform config
+	var config AuditTrailTokenEphemeralResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get org name or default
+	var orgName string
+	resp.Diagnostics.Append(e.config.dataOrDefaultOrganization(ctx, req.Config, &orgName)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create options struct
+	tokenType := tfe.AuditTrailToken // "audit_trail"
+	opts := tfe.OrganizationTokenCreateOptions{
+		TokenType: &tokenType,
+	}
+
+	if !config.ExpiredAt.IsNull() {
+		expiredAt, diags := config.ExpiredAt.ValueRFC3339Time()
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+
+		opts.ExpiredAt = &expiredAt
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Creating audit trail token for organization %s", orgName))
+	result, err := e.config.Client.OrganizationTokens.CreateWithOptions(ctx, orgName, opts)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create organization audit trail token", err.Error())
+		return
+	}
+
+	// Set the token in the model
+	config.Token = types.StringValue(result.Token)
+
+	// Write the data back to the ephemeral resource
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &config)...)
+}

--- a/internal/provider/ephemeral_resource_audit_trail_token_test.go
+++ b/internal/provider/ephemeral_resource_audit_trail_token_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+func TestAccAuditTrailTokenEphemeralResource_basic(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"echo": echoprovider.NewProviderServer(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAuditTrailTokenEphemeralResourceConfig_basic(rInt),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("echo.this", tfjsonpath.New("data").AtMapKey("organization"), knownvalue.StringExact(orgName)),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAuditTrailTokenEphemeralResource_expiredAt(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"echo": echoprovider.NewProviderServer(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAuditTrailTokenEphemeralResourceConfig_expiredAt(rInt),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("echo.this", tfjsonpath.New("data").AtMapKey("expired_at"), knownvalue.StringExact("2100-01-01T00:00:00Z")),
+				},
+			},
+		},
+	})
+}
+
+func testAccAuditTrailTokenEphemeralResourceConfig_basic(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "this" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+ephemeral "tfe_audit_trail_token" "this" {
+  organization = tfe_organization.this.id
+}
+
+provider "echo" {
+	data = ephemeral.tfe_audit_trail_token.this
+}
+
+resource "echo" "this" {}
+`, rInt)
+}
+
+func testAccAuditTrailTokenEphemeralResourceConfig_expiredAt(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "this" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+ephemeral "tfe_audit_trail_token" "this" {
+  organization = tfe_organization.this.id
+	expired_at = "2100-01-01T00:00:00Z"
+}
+
+provider "echo" {
+	data = ephemeral.tfe_audit_trail_token.this
+}
+
+resource "echo" "this" {}
+`, rInt)
+}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -174,5 +174,6 @@ func (p *frameworkProvider) EphemeralResources(ctx context.Context) []func() eph
 		NewOrganizationTokenEphemeralResource,
 		NewOutputsEphemeralResource,
 		NewTeamTokenEphemeralResource,
+		NewAuditTrailTokenEphemeralResource,
 	}
 }

--- a/website/docs/ephemeral-resources/audit_trail.html.markdown
+++ b/website/docs/ephemeral-resources/audit_trail.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: Ephemeral: tfe_audit_trail_token"
+description: |-
+  Generates a new audit trail token that is guaranteed not to be written to
+  state.
+---
+
+# Ephemeral: tfe_audit_trail_token
+
+Terraform ephemeral resource for managing a TFE audit trail token. This
+resource is used to generate a new audit trail token that is guaranteed not to
+be written to state. Since audit trail tokens are singleton resources, using this ephemeral resource will replace any existing audit trail token, including those managed by `tfe_audit_trail_token`.
+
+~> **NOTE:** Ephemeral resources are a new feature and may evolve as we continue to explore their most effective uses. [Learn more](https://developer.hashicorp.com/terraform/language/v1.10.x/resources/ephemeral).
+
+## Example Usage
+
+### Generate a new audit trail token:
+
+This will invalidate any existing audit trail token.
+
+```hcl
+ephemeral "tfe_audit_trail_token" "example" {
+  organization = "my-org-name"
+}
+```
+
+### Generate a new audit trail token with 30 day expiration:
+
+This will invalidate any existing audit trail token.
+
+```hcl
+resource "time_rotating" "example" {
+  rotation_days = 30
+}
+
+ephemeral "tfe_audit_trail_token" "example" {
+  organization   = "my-org-name"
+  expired_at = time_rotating.example.rotation_rfc3339
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
+
+The following arguments are optional:
+
+* `expired_at` - (Optional) The token's expiration date. The expiration date must be a date/time string in RFC3339 
+format (e.g., "2024-12-31T23:59:59Z"). If no expiration date is supplied, the expiration date will default to null and 
+never expire.
+
+This ephemeral resource exports the following attributes in addition to the arguments above:
+
+* `token` - The generated token. This value is sensitive and will not be stored
+  in state.


### PR DESCRIPTION
## Description

Allow users to [create an ephemeral resource](https://developer.hashicorp.com/terraform/plugin/framework/ephemeral-resources) for `tfe_audit_trail_token`, so that the audit trail token is not stored in the Terraform state file and can be handled securely and temporarily during Terraform operations.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Create a terraform configuration that has a child module
1. In that module, try out a config similar to this:

```
data "tfe_organization" "org" {
  name = "hashicorp"
}

resource "time_rotating" "example" {
  rotation_days = 10
}

ephemeral "tfe_audit_trail_token" "test" {
  organization = data.tfe_organization.org.name
  expired_at = time_rotating.example.rotation_rfc3339
}

output "my-audit-trail-token" {
  value       = ephemeral.tfe_audit_trail_token.test.token
  description = "Ephemeral token for audit trail."
  ephemeral   = true
}
```

Then init and apply the configuration.
The state file should not include the ephemeral resource.
If you make changes to the ephemeral resource, for example changing it expired_at value, the plan or state will not report any changes. But you can go to Organization settings > API Token and view the panel under the "Audit trail Tokens" header to verify the change in expiration date.
Also, if you remove the ephemeral resource, no changes will be reported and the resource created by the ephemeral resource will NOT be destroyed.


## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccOrganizationTokenEphemeralResource" make testacc

...
```
