### PR TITLE
Migrate `tfe_team_token` to the provider framework

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -133,7 +133,6 @@ func Provider() *schema.Provider {
 			"tfe_team_project_access":            resourceTFETeamProjectAccess(),
 			"tfe_team_member":                    resourceTFETeamMember(),
 			"tfe_team_members":                   resourceTFETeamMembers(),
-			"tfe_team_token":                     resourceTFETeamToken(),
 			"tfe_terraform_version":              resourceTFETerraformVersion(),
 			"tfe_workspace":                      resourceTFEWorkspace(),
 			"tfe_variable_set":                   resourceTFEVariableSet(),

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -165,6 +165,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewTestVariableResource,
 		NewWorkspaceRunTaskResource,
 		NewNotificationConfigurationResource,
+		NewTeamTokenResource,
 	}
 }
 

--- a/internal/provider/resource_tfe_team_token.go
+++ b/internal/provider/resource_tfe_team_token.go
@@ -1,10 +1,5 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
-// NOTE: This is a legacy resource and should be migrated to the Plugin
-// Framework if substantial modifications are planned. See
-// docs/new-resources.md if planning to use this code as boilerplate for
-// a new resource.
+// // Copyright (c) HashiCorp, Inc.
+// // SPDX-License-Identifier: MPL-2.0
 
 package provider
 
@@ -12,138 +7,218 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func resourceTFETeamToken() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceTFETeamTokenCreate,
-		Read:   resourceTFETeamTokenRead,
-		Delete: resourceTFETeamTokenDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: resourceTFETeamTokenImporter,
+// import (
+// 	"context"
+// 	"errors"
+// 	"fmt"
+// 	"log"
+// 	"time"
+
+//	tfe "github.com/hashicorp/go-tfe"
+//	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+//
+// )
+var (
+	_ resource.ResourceWithConfigure   = &resourceTFETeamToken{}
+	_ resource.ResourceWithImportState = &resourceTFETeamToken{}
+)
+
+func NewTeamTokenResource() resource.Resource {
+	return &resourceTFETeamToken{}
+}
+
+type resourceTFETeamToken struct {
+	config ConfiguredClient
+}
+
+type modelTFETeamToken struct {
+	TeamID          types.String `tfsdk:"team_id"`
+	ForceRegenerate types.Bool   `tfsdk:"force_regenerate"`
+	Token           types.String `tfsdk:"token"`
+	ExpiredAt       types.String `tfsdk:"expired_at"`
+}
+
+func (r *resourceTFETeamToken) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Early exit if provider is unconfigured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	r.config = client
+}
+
+// Metadata implements resource.Resource.
+func (r *resourceTFETeamToken) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_team_token"
+}
+
+// Schema implements resource.Resource.
+func (r *resourceTFETeamToken) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"team_id": schema.StringAttribute{
+				Description: "", //TODO ADD DESCRIPTIONS
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"force_regenerate": schema.BoolAttribute{
+				Description: "",
+				Optional:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"token": schema.StringAttribute{
+				Description: "",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"expired_at": schema.StringAttribute{
+				Description: "",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 		},
-
-		Schema: map[string]*schema.Schema{
-			"team_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"force_regenerate": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"token": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-
-			"expired_at": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-		},
+		Description: "",
 	}
 }
 
-func resourceTFETeamTokenCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
+// Create implements resource.Resource.
+func (r *resourceTFETeamToken) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTFETeamToken
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	// Get the team ID.
-	teamID := d.Get("team_id").(string)
-
-	log.Printf("[DEBUG] Check if a token already exists for team: %s", teamID)
-	_, err := config.Client.TeamTokens.Read(ctx, teamID)
+	teamID := plan.TeamID.ValueString()
+	tflog.Debug(ctx, fmt.Sprintf("Check if a token already exists for team: %s", teamID))
+	_, err := r.config.Client.TeamTokens.Read(ctx, teamID)
 	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
-		return fmt.Errorf("error checking if a token exists for team %s: %w", teamID, err)
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error checking if a token exists for team %s: %s", teamID),
+			err.Error(),
+		)
+		return
 	}
-
-	// If error is nil, the token already exists.
 	if err == nil {
-		if !d.Get("force_regenerate").(bool) {
-			return fmt.Errorf("a token already exists for team: %s", teamID)
+		if !plan.ForceRegenerate.ValueBool() {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("A token already exists for team: %s", teamID),
+				"Set force_regenerate to true to regenerate the token.",
+			)
+			return
 		}
-		log.Printf("[DEBUG] Regenerating existing token for team: %s", teamID)
+		tflog.Debug(ctx, fmt.Sprintf("Regenerating existing token for team: %s", teamID))
 	}
-
-	// Get the token create options.
+	//TODO: use timetypes
+	expiredAt := plan.ExpiredAt.ValueString()
 	options := tfe.TeamTokenCreateOptions{}
-
-	// Check whether the optional expiry was provided.
-	expiredAt, expiredAtProvided := d.GetOk("expired_at")
-
-	// If an expiry was provided, parse it and update the options struct.
-	if expiredAtProvided {
-		expiry, err := time.Parse(time.RFC3339, expiredAt.(string))
-
-		options.ExpiredAt = &expiry
-
+	if !plan.ExpiredAt.IsNull() {
+		expiry, err := time.Parse(time.RFC3339, expiredAt)
 		if err != nil {
-			return fmt.Errorf("%s must be a valid date or time, provided in iso8601 format", expiredAt)
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("%s must be a valid date or time, provided in iso8601 format", expiredAt),
+				err.Error(),
+			)
+			return
 		}
+		options.ExpiredAt = &expiry
 	}
 
-	log.Printf("[DEBUG] Create new token for team: %s", teamID)
-	token, err := config.Client.TeamTokens.CreateWithOptions(ctx, teamID, options)
+	token, err := r.config.Client.TeamTokens.CreateWithOptions(ctx, teamID, options)
 	if err != nil {
-		return fmt.Errorf(
-			"error creating new token for team %s: %w", teamID, err)
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error creating new token for team %s", teamID),
+			err.Error(),
+		)
+		return
 	}
 
-	d.SetId(teamID)
-
-	// We need to set this here in the create function as this value will
-	// only be returned once during the creation of the token.
-	d.Set("token", token.Token)
-
-	return resourceTFETeamTokenRead(d, meta)
+	result := modelFromTFEToken(token, plan.TeamID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
-func resourceTFETeamTokenRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
-
-	log.Printf("[DEBUG] Read the token from team: %s", d.Id())
-	_, err := config.Client.TeamTokens.Read(ctx, d.Id())
-	if err != nil {
-		if err == tfe.ErrResourceNotFound {
-			log.Printf("[DEBUG] Token for team %s no longer exists", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("error reading token from team %s: %w", d.Id(), err)
+func modelFromTFEToken(token *tfe.TeamToken, teamID types.String) modelTFETeamToken {
+	return modelTFETeamToken{
+		TeamID: teamID,
+		Token:  types.StringValue(token.Token),
 	}
-
-	return nil
 }
 
-func resourceTFETeamTokenDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
-
-	log.Printf("[DEBUG] Delete token from team: %s", d.Id())
-	err := config.Client.TeamTokens.Delete(ctx, d.Id())
-	if err != nil {
-		if err == tfe.ErrResourceNotFound {
-			return nil
-		}
-		return fmt.Errorf("error deleting token from team %s: %w", d.Id(), err)
+func (r *resourceTFETeamToken) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFETeamToken
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return nil
+	teamID := state.TeamID.ValueString()
+	tflog.Debug(ctx, fmt.Sprintf("Read the token from team: %s", teamID))
+	token, err := r.config.Client.TeamTokens.Read(ctx, teamID)
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Token for team %s no longer exists", teamID))
+			resp.State.RemoveResource(ctx)
+			return
+		}
+	}
+	result := modelFromTFEToken(token, state.TeamID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
-func resourceTFETeamTokenImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	// Set the team ID field.
-	d.Set("team_id", d.Id())
+func (r *resourceTFETeamToken) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// This should never be called, based on the schema
+	resp.Diagnostics.AddError("Update not supported.", "Please recreate the resource")
+}
 
-	return []*schema.ResourceData{d}, nil
+func (r *resourceTFETeamToken) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFETeamToken
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	teamID := state.TeamID.ValueString()
+	tflog.Debug(ctx, fmt.Sprintf("Delete the token from team: %s", teamID))
+	if err := r.config.Client.TeamTokens.Delete(ctx, teamID); err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Token for team %s no longer exists", teamID))
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error deleting token from team %s", teamID),
+			err.Error(),
+		)
+	}
+}
+
+func (r *resourceTFETeamToken) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/resource_tfe_team_token.go
+++ b/internal/provider/resource_tfe_team_token.go
@@ -20,17 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// import (
-// 	"context"
-// 	"errors"
-// 	"fmt"
-// 	"log"
-// 	"time"
-
-//	tfe "github.com/hashicorp/go-tfe"
-//	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-//
-// )
 var (
 	_ resource.ResourceWithConfigure   = &resourceTFETeamToken{}
 	_ resource.ResourceWithImportState = &resourceTFETeamToken{}
@@ -67,54 +56,51 @@ func (r *resourceTFETeamToken) Configure(_ context.Context, req resource.Configu
 	r.config = client
 }
 
-// Metadata implements resource.Resource.
 func (r *resourceTFETeamToken) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_team_token"
 }
 
-// Schema implements resource.Resource.
 func (r *resourceTFETeamToken) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Description: "", //TODO ADD DESCRIPTIONS
+				Description: "The ID of the token",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"team_id": schema.StringAttribute{
-				Description: "", //TODO ADD DESCRIPTIONS
+				Description: "ID of the team.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"force_regenerate": schema.BoolAttribute{
-				Description: "",
+				Description: "When set to true will force the audit trail token to be recreated.",
 				Optional:    true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplace(),
 				},
 			},
 			"token": schema.StringAttribute{
-				Description: "",
+				Description: "The generated token.",
 				Computed:    true,
 				Sensitive:   true,
 			},
 			"expired_at": schema.StringAttribute{
-				Description: "",
+				Description: "The token's expiration date.",
 				Optional:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 		},
-		Description: "",
+		Description: "Generates a new team token and overrides existing token if one exists.",
 	}
 }
 
-// Create implements resource.Resource.
 func (r *resourceTFETeamToken) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan modelTFETeamToken
 	diags := req.Plan.Get(ctx, &plan)
@@ -143,7 +129,7 @@ func (r *resourceTFETeamToken) Create(ctx context.Context, req resource.CreateRe
 		}
 		tflog.Debug(ctx, fmt.Sprintf("Regenerating existing token for team: %s", teamID))
 	}
-	//TODO: use timetypes
+
 	expiredAt := plan.ExpiredAt.ValueString()
 	options := tfe.TeamTokenCreateOptions{}
 	if !plan.ExpiredAt.IsNull() && expiredAt != "" {


### PR DESCRIPTION
## Description

This PR migrates the `tfe_team_token` resource to the provider framework.

## Testing plan
Run acceptance tests

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFETeamToken_" make testacc

=== RUN   TestAccTFETeamToken_basic
--- PASS: TestAccTFETeamToken_basic (3.97s)
=== RUN   TestAccTFETeamToken_existsWithoutForce
--- PASS: TestAccTFETeamToken_existsWithoutForce (4.79s)
=== RUN   TestAccTFETeamToken_existsWithForce
--- PASS: TestAccTFETeamToken_existsWithForce (6.97s)
=== RUN   TestAccTFETeamToken_withBlankExpiry
--- PASS: TestAccTFETeamToken_withBlankExpiry (4.01s)
=== RUN   TestAccTFETeamToken_withValidExpiry
--- PASS: TestAccTFETeamToken_withValidExpiry (3.97s)
=== RUN   TestAccTFETeamToken_withInvalidExpiry
--- PASS: TestAccTFETeamToken_withInvalidExpiry (2.00s)
=== RUN   TestAccTFETeamToken_import
--- PASS: TestAccTFETeamToken_import (3.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	30.240s

```
