### PR TITLE
Support multiple team tokens for a single team with `tfe_team_token`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 BUG FIXES:
 * `d/tfe_outputs`: fixes 'error inferring type for key' for output objects that had a key with null value.  (#1709), by @uturunku1 [#1699](https://github.com/hashicorp/terraform-provider-tfe/pull/1709)
 
+FEATURES:
+
+* `r/tfe_team_token`: Adds support for creating multiple team tokens for a single team by adding the `description` attribute, which must be unique per team, by @mkam [#1698](https://github.com/hashicorp/terraform-provider-tfe/pull/1698)
+
 ## v0.65.2
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-slug v0.16.5
-	github.com/hashicorp/go-tfe v1.78.1-0.20250418170002-da71abb96c5a
+	github.com/hashicorp/go-tfe v1.79.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-slug v0.16.5
-	github.com/hashicorp/go-tfe v1.78.0
+	github.com/hashicorp/go-tfe v1.78.1-0.20250418170002-da71abb96c5a
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISH
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-slug v0.16.5 h1:L3frr/NptQ9/HLlIWoTmv4tx3Lh+Gx0o5XINGet3cN0=
 github.com/hashicorp/go-slug v0.16.5/go.mod h1:X5fm++dL59cDOX8j48CqHr4KARTQau7isGh0ZVxJB5I=
-github.com/hashicorp/go-tfe v1.78.0 h1:RMkrEO3N4hbnXqoMWl44TnSCkMXpON5iEOOJf+UxWAo=
-github.com/hashicorp/go-tfe v1.78.0/go.mod h1:6dUFMBKh0jkxlRsrw7bYD2mby0efdwE4dtlAuTogIzA=
+github.com/hashicorp/go-tfe v1.78.1-0.20250418170002-da71abb96c5a h1:NOAwqEnCuXNqMNdeFRV4NxEutcmxGE1/3ML0AbXQ15I=
+github.com/hashicorp/go-tfe v1.78.1-0.20250418170002-da71abb96c5a/go.mod h1:6dUFMBKh0jkxlRsrw7bYD2mby0efdwE4dtlAuTogIzA=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISH
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-slug v0.16.5 h1:L3frr/NptQ9/HLlIWoTmv4tx3Lh+Gx0o5XINGet3cN0=
 github.com/hashicorp/go-slug v0.16.5/go.mod h1:X5fm++dL59cDOX8j48CqHr4KARTQau7isGh0ZVxJB5I=
-github.com/hashicorp/go-tfe v1.78.1-0.20250418170002-da71abb96c5a h1:NOAwqEnCuXNqMNdeFRV4NxEutcmxGE1/3ML0AbXQ15I=
-github.com/hashicorp/go-tfe v1.78.1-0.20250418170002-da71abb96c5a/go.mod h1:6dUFMBKh0jkxlRsrw7bYD2mby0efdwE4dtlAuTogIzA=
+github.com/hashicorp/go-tfe v1.79.0 h1:9V48ssu+foL3+wB7+5/FC5wOWH1TiRoHMdpW1w6zynM=
+github.com/hashicorp/go-tfe v1.79.0/go.mod h1:6dUFMBKh0jkxlRsrw7bYD2mby0efdwE4dtlAuTogIzA=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/resource_tfe_team_token.go
+++ b/internal/provider/resource_tfe_team_token.go
@@ -170,9 +170,14 @@ func (r *resourceTFETeamToken) Create(ctx context.Context, req resource.CreateRe
 
 	token, err := r.config.Client.TeamTokens.CreateWithOptions(ctx, teamID, options)
 	if err != nil {
+		errDetails := err.Error()
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			errDetails = fmt.Sprintf("%s, team does not exist or version of Terraform Enterprise "+
+				"does not support multiple team tokens with descriptions", errDetails)
+		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error creating new token for team %s", teamID),
-			err.Error(),
+			errDetails,
 		)
 		return
 	}

--- a/internal/provider/resource_tfe_team_token_test.go
+++ b/internal/provider/resource_tfe_team_token_test.go
@@ -214,6 +214,40 @@ func TestAccTFETeamToken_import(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamToken_importByTokenID(t *testing.T) {
+	skipUnlessBeta(t)
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamToken_withMultipleTokens(rInt),
+			},
+			{
+				ResourceName:            "tfe_team_token.multi_token_1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+			},
+			{
+				ResourceName:            "tfe_team_token.multi_token_2",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+			},
+			{
+				ResourceName:            "tfe_team_token.legacy",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+			},
+		},
+	})
+}
+
 func testAccCheckTFETeamTokenExists(
 	n string, token *tfe.TeamToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/internal/provider/resource_tfe_team_token_test.go
+++ b/internal/provider/resource_tfe_team_token_test.go
@@ -248,6 +248,24 @@ func TestAccTFETeamToken_importByTokenID(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamToken_withNonexistentTeam(t *testing.T) {
+	conf := `
+resource "tfe_team_token" "invalid" {
+  team_id    = "invalid"
+}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      conf,
+				ExpectError: regexp.MustCompile("resource not found, team does not exist or version of Terraform Enterprise\ndoes not support multiple team tokens with descriptions"),
+			},
+		},
+	})
+}
+
 func testAccCheckTFETeamTokenExists(
 	n string, token *tfe.TeamToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -7,7 +7,8 @@ description: |-
 
 # tfe_team_token
 
-Generates a new team token and overrides existing token if one exists.
+Generates a new team token. If a description is not set, then it follows the legacy behavior to override
+the single team token without a description if it exists.
 
 ## Example Usage
 
@@ -20,7 +21,13 @@ resource "tfe_team" "test" {
 }
 
 resource "tfe_team_token" "test" {
-  team_id = tfe_team.test.id
+  team_id     = tfe_team.test.id
+  description = "my team token"
+}
+
+resource "tfe_team_token" "ci" {
+  team_id     = tfe_team.test.id
+  description = "my second team token"
 }
 ```
 
@@ -29,12 +36,14 @@ resource "tfe_team_token" "test" {
 The following arguments are supported:
 
 * `team_id` - (Required) ID of the team.
-* `force_regenerate` - (Optional) If set to `true`, a new token will be
-  generated even if a token already exists. This will invalidate the existing
-  token!
+* `description` - (Optional) The token's description, which must be unique per team. Required if creating multiple
+  tokens for a single team.
 * `expired_at` - (Optional) The token's expiration date. The expiration date must be a date/time string in RFC3339 
 format (e.g., "2024-12-31T23:59:59Z"). If no expiration date is supplied, the expiration date will default to null and 
 never expire.
+* `force_regenerate` - (Optional) Only applies to legacy tokens without descriptions. If set to `true`, a new
+  token will be generated even if a token already exists. This will invalidate the existing token! This cannot
+  be set with `description`.
 
 ## Example Usage
 
@@ -52,6 +61,7 @@ resource "time_rotating" "example" {
 
 resource "tfe_team_token" "test" {
   team_id = tfe_team.test.id
+  description = "my team token"
   expired_at = time_rotating.example.rotation_rfc3339
 }
 ```
@@ -63,8 +73,12 @@ resource "tfe_team_token" "test" {
 
 ## Import
 
-Team tokens can be imported; use `<TEAM ID>` as the import ID. For example:
+Team tokens can be imported either by `<TOKEN ID>` or by `<TEAM ID>`. Using the team ID will follow the
+legacy behavior where the imported token is the single token of the team that has no description.
+
+For example:
 
 ```shell
+terraform import tfe_team_token.test at-47qC3LmA47piVan7
 terraform import tfe_team_token.test team-47qC3LmA47piVan7
 ```


### PR DESCRIPTION
## Description

This PR adds support to create multiple team tokens for a single team using `tfe_team_token` by adding the `description` attribute. If no description is provided, it follows the previous behavior of `tfe_team_token`, which uses the old team token API that assumes there is only one token per team.

Some other notable differences:
- The new API for team tokens that supports multiple tokens does not support regenerating tokens with a single API request (i.e., they must be rotated via separate delete and create requests). That means `force_regenerate` cannot be used when `description` is set.
- The ID of the resource was previously the team ID since there was only ever one token per team. For tokens without descriptions, this will continue to be the team ID to preserve backwards compatibility. For tokens with descriptions, the ID is the ID of the authentication token itself. This is distinguished by inspecting the the prefix of the ID (`team-` vs. `at-`)

Also, adding support for creating multiple ephemeral team tokens is out of scope for this PR. This will be added in a separate, follow-up PR.

~This feature is not GA yet, so I've labeled this PR as "do not merge" for now.~

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Create a team.
2. Create multiple tokens for the team with unique descriptions, including one without a description. 
3. Modify the description of a token and validate that the token is recreated.
4. Import a team token by team ID and a team token by token ID.

```
resource "tfe_team" "this" {
  organization = data.tfe_organization.test.name
  name         = "test-team"
}

resource "time_rotating" "example" {
  rotation_days = 30
}

resource "tfe_team_token" "multi_token_1" {
  team_id     = tfe_team.this.id
  description = "test1"
}


resource "tfe_team_token" "multi_token_2" {
  team_id     = tfe_team.this.id
  description = "test2"
  expired_at  = time_rotating.example.rotation_rfc3339
}


resource "tfe_team_token" "legacy" {
  team_id     = tfe_team.this.id
}

```


```
terraform import tfe_team_token.import_by_team_id team-1234
terraform import tfe_team_token.import_by_token_id at-1234

resource "tfe_team_token" "import_by_team_id" {
  team_id = "team-1234"
  expired_at = time_rotating.example.rotation_rfc3339
}

resource "tfe_team_token" "import_by_token_id" {
  team_id = "team-1234"
  description = "test-updated"
}
```

## Output from acceptance tests
<details><summary>Test results with beta enabled</summary>

```
-> % ENABLE_BETA=1 go test ./... -v -run "TestAccTFETeamToken"
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	(cached) [no tests to run]
=== RUN   TestAccTFETeamToken_basic
--- PASS: TestAccTFETeamToken_basic (5.95s)
=== RUN   TestAccTFETeamToken_multiple_team_tokens
--- PASS: TestAccTFETeamToken_multiple_team_tokens (7.97s)
=== RUN   TestAccTFETeamToken_existsWithoutForce
--- PASS: TestAccTFETeamToken_existsWithoutForce (6.32s)
=== RUN   TestAccTFETeamToken_existsWithForce
--- PASS: TestAccTFETeamToken_existsWithForce (8.84s)
=== RUN   TestAccTFETeamToken_invalidWithForceGenerateAndDescription
--- PASS: TestAccTFETeamToken_invalidWithForceGenerateAndDescription (0.36s)
=== RUN   TestAccTFETeamToken_withBlankExpiry
--- PASS: TestAccTFETeamToken_withBlankExpiry (4.95s)
=== RUN   TestAccTFETeamToken_withValidExpiry
--- PASS: TestAccTFETeamToken_withValidExpiry (5.37s)
=== RUN   TestAccTFETeamToken_withInvalidExpiry
--- PASS: TestAccTFETeamToken_withInvalidExpiry (3.01s)
=== RUN   TestAccTFETeamToken_import
--- PASS: TestAccTFETeamToken_import (7.04s)
=== RUN   TestAccTFETeamToken_importByTokenID
--- PASS: TestAccTFETeamToken_importByTokenID (9.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	60.387s
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
```
</details>

## Output from documentation preview
<details><summary>Docs changes</summary>

![Screenshot 2025-04-18 at 4 26 49 PM](https://github.com/user-attachments/assets/6929cc6c-a6b5-427e-ae5d-42acff7bd0d4)

![Screenshot 2025-04-18 at 4 27 02 PM](https://github.com/user-attachments/assets/7de12ba8-fade-4e69-8cad-5a3eddfae204)

![Screenshot 2025-04-18 at 4 27 14 PM](https://github.com/user-attachments/assets/e6467e3d-a9af-4871-97da-73e10724de6a)

<details>




