### PR TITLE
Revert tfe_outputs to pre-framework state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v0.65.1
+
+BUG FIXES:
+* `d/tfe_outputs`: fix regression after framework upgrade (#1697), by @ctrombley [#1699](https://github.com/hashicorp/terraform-provider-tfe/pull/1699)
+
 ## v0.65.0
 
 FEATURES:

--- a/internal/provider/data_source_outputs.go
+++ b/internal/provider/data_source_outputs.go
@@ -1,369 +1,247 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+// NOTE: This resource uses the low level plugin framework in order to
+// deal with sensitive values. It may be possible to migrate this to the
+// Plugin Framework. Do not use this code as boilerplate for new resources.
+
 package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
-	"math/big"
-	"reflect"
 
-	"github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
-var (
-	_ datasource.DataSource              = &outputsDataSource{}
-	_ datasource.DataSourceWithConfigure = &outputsDataSource{}
-)
-
-func NewOutputsDataSource() datasource.DataSource {
-	return &outputsDataSource{}
+type dataSourceOutputs struct {
+	tfeClient    *tfe.Client
+	organization string
 }
 
-type outputsDataSource struct {
-	config ConfiguredClient
-}
-
-type outputsModel struct {
-	ID                 types.String  `tfsdk:"id"`
-	Organization       types.String  `tfsdk:"organization"`
-	Workspace          types.String  `tfsdk:"workspace"`
-	Values             types.Dynamic `tfsdk:"values"`
-	NonSensitiveValues types.Dynamic `tfsdk:"nonsensitive_values"`
-}
-
-func modelFromOutputs(v *tfe.Workspace, sensitiveOutputs types.Dynamic, nonSensitiveOutputs types.Dynamic) outputsModel {
-	orgName := v.Organization.Name
-	wsName := v.Name
-
-	return outputsModel{
-		ID:                 types.StringValue(fmt.Sprintf("%s-%s", orgName, wsName)),
-		Organization:       types.StringValue(orgName),
-		Workspace:          types.StringValue(wsName),
-		Values:             sensitiveOutputs,
-		NonSensitiveValues: nonSensitiveOutputs,
+func newDataSourceOutputs(config ConfiguredClient) tfprotov5.DataSourceServer {
+	return dataSourceOutputs{
+		tfeClient:    config.Client,
+		organization: config.Organization,
 	}
 }
 
-func (d *outputsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Description: "This data source can be used to retrieve a workspace's state outputs.",
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Description: `System-generated unique identifier for the resource.`,
-				Computed:    true,
-			},
-			"organization": schema.StringAttribute{
-				Description: `Name of the organization.`,
-				Optional:    true,
-			},
-			"workspace": schema.StringAttribute{
-				Description: `Name of the workspace.`,
-				Required:    true,
-			},
-			"values": schema.DynamicAttribute{
-				Description: `Values of the workspace outputs.`,
-				Computed:    true,
-				Sensitive:   true,
-			},
-			"nonsensitive_values": schema.DynamicAttribute{
-				Description: `Non-sensitive values of the workspace outputs.`,
-				Computed:    true,
-			},
+func (d dataSourceOutputs) ReadDataSource(ctx context.Context, req *tfprotov5.ReadDataSourceRequest) (*tfprotov5.ReadDataSourceResponse, error) {
+	resp := &tfprotov5.ReadDataSourceResponse{
+		Diagnostics: []*tfprotov5.Diagnostic{},
+	}
+
+	orgName, wsName, err := d.readConfigValues(req)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Error retrieving values from the config",
+			Detail:   fmt.Sprintf("Error retrieving values from the config: %v", err),
+		})
+		return resp, nil
+	}
+
+	remoteStateOutput, err := d.readStateOutput(ctx, orgName, wsName)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Error reading remote state output",
+			Detail:   fmt.Sprintf("Error reading remote state output: %v", err),
+		})
+		return resp, nil
+	}
+
+	tftypesValues, stateTypes, tftypesNonsensitiveValues, nonsensitiveStateTypes, err := parseStateOutput(remoteStateOutput)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Error parsing remote state output",
+			Detail:   fmt.Sprintf("Error parsing remote state output: %v", err),
+		})
+		return resp, nil
+	}
+
+	id := fmt.Sprintf("%s-%s", orgName, wsName)
+	state, err := tfprotov5.NewDynamicValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"workspace":           tftypes.String,
+			"organization":        tftypes.String,
+			"values":              tftypes.DynamicPseudoType,
+			"nonsensitive_values": tftypes.DynamicPseudoType,
+			"id":                  tftypes.String,
 		},
+	}, tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"workspace":           tftypes.String,
+			"organization":        tftypes.String,
+			"values":              tftypes.Object{AttributeTypes: stateTypes},
+			"nonsensitive_values": tftypes.Object{AttributeTypes: nonsensitiveStateTypes},
+			"id":                  tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"workspace":           tftypes.NewValue(tftypes.String, wsName),
+		"organization":        tftypes.NewValue(tftypes.String, orgName),
+		"values":              tftypes.NewValue(tftypes.Object{AttributeTypes: stateTypes}, tftypesValues),
+		"nonsensitive_values": tftypes.NewValue(tftypes.Object{AttributeTypes: nonsensitiveStateTypes}, tftypesNonsensitiveValues),
+		"id":                  tftypes.NewValue(tftypes.String, id),
+	}))
+
+	if err != nil {
+		return &tfprotov5.ReadDataSourceResponse{
+			Diagnostics: []*tfprotov5.Diagnostic{
+				{
+					Severity: tfprotov5.DiagnosticSeverityError,
+					Summary:  "Error encoding state",
+					Detail:   fmt.Sprintf("Error encoding state: %s", err.Error()),
+				},
+			},
+		}, nil
 	}
+	return &tfprotov5.ReadDataSourceResponse{
+		State: &state,
+	}, nil
 }
 
-// Configure adds the provider configured client to the data source.
-func (d *outputsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(ConfiguredClient)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Ephemeral Resource Configure Type",
-			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
-		)
-
-		return
-	}
-
-	d.config = client
+func (d dataSourceOutputs) ValidateDataSourceConfig(ctx context.Context, req *tfprotov5.ValidateDataSourceConfigRequest) (*tfprotov5.ValidateDataSourceConfigResponse, error) {
+	return &tfprotov5.ValidateDataSourceConfigResponse{}, nil
 }
 
-func (d *outputsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_outputs"
-}
-
-func (d *outputsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	config := outputsModel{}
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Get org name or default
+func (d dataSourceOutputs) readConfigValues(req *tfprotov5.ReadDataSourceRequest) (string, string, error) {
 	var orgName string
-	resp.Diagnostics.Append(d.config.dataOrDefaultOrganization(ctx, req.Config, &orgName)...)
-	if resp.Diagnostics.HasError() {
-		return
+	var wsName string
+	var err error
+
+	config := req.Config
+	val, err := config.Unmarshal(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"workspace":           tftypes.String,
+			"organization":        tftypes.String,
+			"values":              tftypes.DynamicPseudoType,
+			"nonsensitive_values": tftypes.DynamicPseudoType,
+			"id":                  tftypes.String,
+		}})
+	if err != nil {
+		return "", "", fmt.Errorf("Error unmarshalling config: %w", err)
 	}
 
-	log.Printf("[DEBUG] Reading the workspace %s in organization %s", config.Workspace.ValueString(), orgName)
+	var valMap map[string]tftypes.Value
+	err = val.As(&valMap)
+	if err != nil {
+		return "", "", fmt.Errorf("error assigning configuration attributes to map: %w", err)
+	}
+
+	err = valMap["organization"].As(&orgName)
+	if err != nil || orgName == "" {
+		if d.organization == "" {
+			return "", "", errMissingOrganization
+		}
+		orgName = d.organization
+	}
+
+	if valMap["workspace"].IsNull() {
+		return orgName, "", fmt.Errorf("workspace cannot be nil: %w", err)
+	}
+
+	err = valMap["workspace"].As(&wsName)
+	if err != nil {
+		return orgName, wsName, fmt.Errorf("error assigning 'workspace' value to string: %w", err)
+	}
+
+	return orgName, wsName, nil
+}
+
+type stateData struct {
+	outputs map[string]*outputData
+}
+
+type outputData struct {
+	Value     cty.Value
+	Sensitive cty.Value
+}
+
+func (d dataSourceOutputs) readStateOutput(ctx context.Context, orgName, wsName string) (*stateData, error) {
+	log.Printf("[DEBUG] Reading the Workspace %s in Organization %s", wsName, orgName)
 	opts := &tfe.WorkspaceReadOptions{
 		Include: []tfe.WSIncludeOpt{tfe.WSOutputs},
 	}
-
-	ws, err := d.config.Client.Workspaces.ReadWithOptions(ctx, orgName, config.Workspace.ValueString(), opts)
+	ws, err := d.tfeClient.Workspaces.ReadWithOptions(ctx, orgName, wsName, opts)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to read workspace", err.Error())
-		return
+		return nil, fmt.Errorf("error reading workspace: %w", err)
 	}
 
-	sensitiveTypes := map[string]attr.Type{}
-	sensitiveValues := map[string]attr.Value{}
-	nonSensitiveTypes := map[string]attr.Type{}
-	nonSensitiveValues := map[string]attr.Value{}
+	sd := &stateData{
+		outputs: map[string]*outputData{},
+	}
 
 	for _, op := range ws.Outputs {
 		if op.Sensitive {
-			// An additional API call is required to read sensitive output values.
-			result, err := d.config.Client.StateVersionOutputs.Read(ctx, op.ID)
+			sensitiveOutput, err := d.tfeClient.StateVersionOutputs.Read(ctx, op.ID)
 			if err != nil {
-				resp.Diagnostics.AddError("Unable to read resource", err.Error())
-				return
+				return nil, fmt.Errorf("could not read sensitive output: %w", err)
 			}
-
-			op.Value = result.Value
+			op.Value = sensitiveOutput.Value
 		}
 
-		attrType, err := inferAttrType(op.Value)
+		buf, err := json.Marshal(op.Value)
 		if err != nil {
-			resp.Diagnostics.AddError("Error inferring attribute type", err.Error())
-			return
+			return nil, fmt.Errorf("could not marshal output value: %w", err)
 		}
 
-		attrValue, diags := convertToAttrValue(op.Value, attrType)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
+		v := ctyjson.SimpleJSONValue{}
+		err = v.UnmarshalJSON(buf)
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal output value: %w", err)
 		}
-
-		sensitiveTypes[op.Name] = attrType
-		sensitiveValues[op.Name] = attrValue
-
-		if !op.Sensitive {
-			nonSensitiveTypes[op.Name] = attrType
-			nonSensitiveValues[op.Name] = attrValue
+		sd.outputs[op.Name] = &outputData{
+			Value:     v.Value,
+			Sensitive: cty.BoolVal(op.Sensitive),
 		}
 	}
 
-	// Create dynamic attribute value for `sensitive_values`
-	obj, diags := types.ObjectValue(sensitiveTypes, sensitiveValues)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	sensitiveOutputs := types.DynamicValue(obj)
-
-	// Create dynamic attribute value for `nonsensitive_values`
-	obj, diags = types.ObjectValue(nonSensitiveTypes, nonSensitiveValues)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	nonSensitiveOutputs := types.DynamicValue(obj)
-
-	diags.Append(resp.State.Set(ctx, modelFromOutputs(ws, sensitiveOutputs, nonSensitiveOutputs))...)
+	return sd, nil
 }
 
-func inferAttrType(raw interface{}) (attr.Type, error) {
-	switch v := raw.(type) {
-	case bool:
-		return types.BoolType, nil
-	case int, int8, int16, int32, int64, float32, float64:
-		return types.NumberType, nil
-	case string:
-		return types.StringType, nil
-	case []interface{}:
-		// For slices, if the slice is empty return a List with a dynamic element type.
-		if len(v) == 0 {
-			return types.ListType{ElemType: types.DynamicType}, nil
-		}
+func parseStateOutput(stateOutput *stateData) (map[string]tftypes.Value, map[string]tftypes.Type, map[string]tftypes.Value, map[string]tftypes.Type, error) {
+	tftypesValues := map[string]tftypes.Value{}
+	stateTypes := map[string]tftypes.Type{}
 
-		// Infer the type for the first element.
-		firstType, err := inferAttrType(v[0])
+	tftypesNonsensitiveValues := map[string]tftypes.Value{}
+	nonsensitiveStateTypes := map[string]tftypes.Type{}
+
+	for name, output := range stateOutput.outputs {
+		marshData, err := output.Value.Type().MarshalJSON()
 		if err != nil {
-			return nil, err
+			return nil, nil, nil, nil, fmt.Errorf("could not marshal output type: %w", err)
+		}
+		tfType, err := tftypes.ParseJSONType(marshData)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("could not parse json type data: %w", err)
+		}
+		mByte, err := ctyjson.Marshal(output.Value, output.Value.Type())
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("could not marshal output value and output type: %w", err)
+		}
+		tfRawState := tfprotov5.RawState{
+			JSON: mByte,
+		}
+		newVal, err := tfRawState.Unmarshal(tfType)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("could not unmarshal tftype into value: %w", err)
+		}
+		if output.Sensitive.False() {
+			tftypesNonsensitiveValues[name] = newVal
+			nonsensitiveStateTypes[name] = tfType
 		}
 
-		// Check if all elements are of the same type.
-		homogeneous := true
-		for i := 1; i < len(v); i++ {
-			currType, err := inferAttrType(v[i])
-			if err != nil {
-				return nil, err
-			}
-			if !reflect.DeepEqual(firstType, currType) {
-				homogeneous = false
-				break
-			}
-		}
-		if homogeneous {
-			return types.ListType{ElemType: firstType}, nil
-		}
-
-		// If not homogeneous, build a Tuple with each element’s inferred type.
-		tupleTypes := make([]attr.Type, len(v))
-		for i, elem := range v {
-			t, err := inferAttrType(elem)
-			if err != nil {
-				return nil, err
-			}
-			tupleTypes[i] = t
-		}
-		return types.TupleType{ElemTypes: tupleTypes}, nil
-	case map[string]interface{}:
-		// Build an Object type by inferring each attribute's type.
-		attrTypes := make(map[string]attr.Type)
-		for key, value := range v {
-			inferred, err := inferAttrType(value)
-			if err != nil {
-				return nil, fmt.Errorf("error inferring type for key %q: %w", key, err)
-			}
-			attrTypes[key] = inferred
-		}
-		return types.ObjectType{AttrTypes: attrTypes}, nil
-	default:
-		return nil, fmt.Errorf("unsupported type %T", raw)
-	}
-}
-
-func convertToAttrValue(raw interface{}, t attr.Type) (attr.Value, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	if t == types.BoolType {
-		b, ok := raw.(bool)
-		if !ok {
-			diags.AddError("Conversion Error", "expected bool")
-			return types.BoolNull(), diags
-		}
-		return types.BoolValue(b), diags
+		tftypesValues[name] = newVal
+		stateTypes[name] = tfType
 	}
 
-	if t == types.NumberType {
-		// Use a float64 conversion to handle all numeric types.
-		n, ok := raw.(float64)
-		if !ok {
-			diags.AddError("Conversion Error", "expected number")
-			return types.NumberNull(), diags
-		}
-		return types.NumberValue(big.NewFloat(n)), diags
-	}
-
-	if t == types.StringType {
-		s, ok := raw.(string)
-		if !ok {
-			diags.AddError("Conversion Error", "expected string")
-			return types.StringNull(), diags
-		}
-		return types.StringValue(s), diags
-	}
-
-	// For composite types, use a type switch on the expected type.
-	switch tt := t.(type) {
-	case types.ListType:
-		// Expect raw to be a slice.
-		slice, ok := raw.([]interface{})
-		if !ok {
-			diags.AddError("Conversion Error", "expected slice for ListType")
-			return types.ListNull(tt.ElemType), diags
-		}
-
-		var elems []attr.Value
-		for _, elem := range slice {
-			v, ds := convertToAttrValue(elem, tt.ElemType)
-			diags.Append(ds...)
-			elems = append(elems, v)
-		}
-		return types.ListValue(tt.ElemType, elems)
-
-	case types.TupleType:
-		// Expect raw to be a slice.
-		slice, ok := raw.([]interface{})
-		if !ok {
-			diags.AddError("Conversion Error", "expected slice for TupleType")
-			return types.TupleNull(tt.ElemTypes), diags
-		}
-		if len(slice) != len(tt.ElemTypes) {
-			diags.AddError("Conversion Error", "tuple length mismatch")
-			return types.TupleNull(tt.ElemTypes), diags
-		}
-
-		var elems []attr.Value
-		for i, elem := range slice {
-			v, ds := convertToAttrValue(elem, tt.ElemTypes[i])
-			diags.Append(ds...)
-			elems = append(elems, v)
-		}
-		return types.TupleValue(tt.ElemTypes, elems)
-
-	case types.ObjectType:
-		// Expect raw to be a map[string]interface{}.
-		m, ok := raw.(map[string]interface{})
-		if !ok {
-			diags.AddError("Conversion Error", "expected map for ObjectType")
-			return types.ObjectNull(tt.AttrTypes), diags
-		}
-
-		objValues := make(map[string]attr.Value)
-		// Iterate over the expected attributes defined in the ObjectType.
-		for key, expectedType := range tt.AttrTypes {
-			value := m[key]
-			v, ds := convertToAttrValue(value, expectedType)
-			diags.Append(ds...)
-			if ds.HasError() {
-				return types.ObjectNull(tt.AttrTypes), diags
-			}
-
-			objValues[key] = v
-		}
-		return types.ObjectValue(tt.AttrTypes, objValues)
-
-	case types.MapType:
-		// Expect raw to be a map[string]interface{}.
-		m, ok := raw.(map[string]interface{})
-		if !ok {
-			diags.AddError("Conversion Error", "expected map for MapType")
-			return types.MapValue(tt.ElemType, nil)
-		}
-
-		mapValues := make(map[string]attr.Value)
-		for key, value := range m {
-			v, ds := convertToAttrValue(value, tt.ElemType)
-			diags.Append(ds...)
-			if ds.HasError() {
-				return types.MapValue(tt.ElemType, nil)
-			}
-
-			mapValues[key] = v
-		}
-		return types.MapValue(tt.ElemType, mapValues)
-
-	default:
-		diags.AddError("Conversion Error", fmt.Sprintf("unsupported type %T", t))
-	}
-
-	return nil, diags
+	return tftypesValues, stateTypes, tftypesNonsensitiveValues, nonsensitiveStateTypes, nil
 }

--- a/internal/provider/data_source_outputs_next.go
+++ b/internal/provider/data_source_outputs_next.go
@@ -1,0 +1,369 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/big"
+	"reflect"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ datasource.DataSource              = &outputsDataSource{}
+	_ datasource.DataSourceWithConfigure = &outputsDataSource{}
+)
+
+func NewOutputsDataSource() datasource.DataSource {
+	return &outputsDataSource{}
+}
+
+type outputsDataSource struct {
+	config ConfiguredClient
+}
+
+type outputsModel struct {
+	ID                 types.String  `tfsdk:"id"`
+	Organization       types.String  `tfsdk:"organization"`
+	Workspace          types.String  `tfsdk:"workspace"`
+	Values             types.Dynamic `tfsdk:"values"`
+	NonSensitiveValues types.Dynamic `tfsdk:"nonsensitive_values"`
+}
+
+func modelFromOutputs(v *tfe.Workspace, sensitiveOutputs types.Dynamic, nonSensitiveOutputs types.Dynamic) outputsModel {
+	orgName := v.Organization.Name
+	wsName := v.Name
+
+	return outputsModel{
+		ID:                 types.StringValue(fmt.Sprintf("%s-%s", orgName, wsName)),
+		Organization:       types.StringValue(orgName),
+		Workspace:          types.StringValue(wsName),
+		Values:             sensitiveOutputs,
+		NonSensitiveValues: nonSensitiveOutputs,
+	}
+}
+
+func (d *outputsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source can be used to retrieve a workspace's state outputs.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: `System-generated unique identifier for the resource.`,
+				Computed:    true,
+			},
+			"organization": schema.StringAttribute{
+				Description: `Name of the organization.`,
+				Optional:    true,
+			},
+			"workspace": schema.StringAttribute{
+				Description: `Name of the workspace.`,
+				Required:    true,
+			},
+			"values": schema.DynamicAttribute{
+				Description: `Values of the workspace outputs.`,
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"nonsensitive_values": schema.DynamicAttribute{
+				Description: `Non-sensitive values of the workspace outputs.`,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *outputsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Ephemeral Resource Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.config = client
+}
+
+func (d *outputsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_outputs"
+}
+
+func (d *outputsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	config := outputsModel{}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get org name or default
+	var orgName string
+	resp.Diagnostics.Append(d.config.dataOrDefaultOrganization(ctx, req.Config, &orgName)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	log.Printf("[DEBUG] Reading the workspace %s in organization %s", config.Workspace.ValueString(), orgName)
+	opts := &tfe.WorkspaceReadOptions{
+		Include: []tfe.WSIncludeOpt{tfe.WSOutputs},
+	}
+
+	ws, err := d.config.Client.Workspaces.ReadWithOptions(ctx, orgName, config.Workspace.ValueString(), opts)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read workspace", err.Error())
+		return
+	}
+
+	sensitiveTypes := map[string]attr.Type{}
+	sensitiveValues := map[string]attr.Value{}
+	nonSensitiveTypes := map[string]attr.Type{}
+	nonSensitiveValues := map[string]attr.Value{}
+
+	for _, op := range ws.Outputs {
+		if op.Sensitive {
+			// An additional API call is required to read sensitive output values.
+			result, err := d.config.Client.StateVersionOutputs.Read(ctx, op.ID)
+			if err != nil {
+				resp.Diagnostics.AddError("Unable to read resource", err.Error())
+				return
+			}
+
+			op.Value = result.Value
+		}
+
+		attrType, err := inferAttrType(op.Value)
+		if err != nil {
+			resp.Diagnostics.AddError("Error inferring attribute type", err.Error())
+			return
+		}
+
+		attrValue, diags := convertToAttrValue(op.Value, attrType)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		sensitiveTypes[op.Name] = attrType
+		sensitiveValues[op.Name] = attrValue
+
+		if !op.Sensitive {
+			nonSensitiveTypes[op.Name] = attrType
+			nonSensitiveValues[op.Name] = attrValue
+		}
+	}
+
+	// Create dynamic attribute value for `sensitive_values`
+	obj, diags := types.ObjectValue(sensitiveTypes, sensitiveValues)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	sensitiveOutputs := types.DynamicValue(obj)
+
+	// Create dynamic attribute value for `nonsensitive_values`
+	obj, diags = types.ObjectValue(nonSensitiveTypes, nonSensitiveValues)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	nonSensitiveOutputs := types.DynamicValue(obj)
+
+	diags.Append(resp.State.Set(ctx, modelFromOutputs(ws, sensitiveOutputs, nonSensitiveOutputs))...)
+}
+
+func inferAttrType(raw interface{}) (attr.Type, error) {
+	switch v := raw.(type) {
+	case bool:
+		return types.BoolType, nil
+	case int, int8, int16, int32, int64, float32, float64:
+		return types.NumberType, nil
+	case string:
+		return types.StringType, nil
+	case []interface{}:
+		// For slices, if the slice is empty return a List with a dynamic element type.
+		if len(v) == 0 {
+			return types.ListType{ElemType: types.DynamicType}, nil
+		}
+
+		// Infer the type for the first element.
+		firstType, err := inferAttrType(v[0])
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if all elements are of the same type.
+		homogeneous := true
+		for i := 1; i < len(v); i++ {
+			currType, err := inferAttrType(v[i])
+			if err != nil {
+				return nil, err
+			}
+			if !reflect.DeepEqual(firstType, currType) {
+				homogeneous = false
+				break
+			}
+		}
+		if homogeneous {
+			return types.ListType{ElemType: firstType}, nil
+		}
+
+		// If not homogeneous, build a Tuple with each element’s inferred type.
+		tupleTypes := make([]attr.Type, len(v))
+		for i, elem := range v {
+			t, err := inferAttrType(elem)
+			if err != nil {
+				return nil, err
+			}
+			tupleTypes[i] = t
+		}
+		return types.TupleType{ElemTypes: tupleTypes}, nil
+	case map[string]interface{}:
+		// Build an Object type by inferring each attribute's type.
+		attrTypes := make(map[string]attr.Type)
+		for key, value := range v {
+			inferred, err := inferAttrType(value)
+			if err != nil {
+				return nil, fmt.Errorf("error inferring type for key %q: %w", key, err)
+			}
+			attrTypes[key] = inferred
+		}
+		return types.ObjectType{AttrTypes: attrTypes}, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T", raw)
+	}
+}
+
+func convertToAttrValue(raw interface{}, t attr.Type) (attr.Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if t == types.BoolType {
+		b, ok := raw.(bool)
+		if !ok {
+			diags.AddError("Conversion Error", "expected bool")
+			return types.BoolNull(), diags
+		}
+		return types.BoolValue(b), diags
+	}
+
+	if t == types.NumberType {
+		// Use a float64 conversion to handle all numeric types.
+		n, ok := raw.(float64)
+		if !ok {
+			diags.AddError("Conversion Error", "expected number")
+			return types.NumberNull(), diags
+		}
+		return types.NumberValue(big.NewFloat(n)), diags
+	}
+
+	if t == types.StringType {
+		s, ok := raw.(string)
+		if !ok {
+			diags.AddError("Conversion Error", "expected string")
+			return types.StringNull(), diags
+		}
+		return types.StringValue(s), diags
+	}
+
+	// For composite types, use a type switch on the expected type.
+	switch tt := t.(type) {
+	case types.ListType:
+		// Expect raw to be a slice.
+		slice, ok := raw.([]interface{})
+		if !ok {
+			diags.AddError("Conversion Error", "expected slice for ListType")
+			return types.ListNull(tt.ElemType), diags
+		}
+
+		var elems []attr.Value
+		for _, elem := range slice {
+			v, ds := convertToAttrValue(elem, tt.ElemType)
+			diags.Append(ds...)
+			elems = append(elems, v)
+		}
+		return types.ListValue(tt.ElemType, elems)
+
+	case types.TupleType:
+		// Expect raw to be a slice.
+		slice, ok := raw.([]interface{})
+		if !ok {
+			diags.AddError("Conversion Error", "expected slice for TupleType")
+			return types.TupleNull(tt.ElemTypes), diags
+		}
+		if len(slice) != len(tt.ElemTypes) {
+			diags.AddError("Conversion Error", "tuple length mismatch")
+			return types.TupleNull(tt.ElemTypes), diags
+		}
+
+		var elems []attr.Value
+		for i, elem := range slice {
+			v, ds := convertToAttrValue(elem, tt.ElemTypes[i])
+			diags.Append(ds...)
+			elems = append(elems, v)
+		}
+		return types.TupleValue(tt.ElemTypes, elems)
+
+	case types.ObjectType:
+		// Expect raw to be a map[string]interface{}.
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			diags.AddError("Conversion Error", "expected map for ObjectType")
+			return types.ObjectNull(tt.AttrTypes), diags
+		}
+
+		objValues := make(map[string]attr.Value)
+		// Iterate over the expected attributes defined in the ObjectType.
+		for key, expectedType := range tt.AttrTypes {
+			value := m[key]
+			v, ds := convertToAttrValue(value, expectedType)
+			diags.Append(ds...)
+			if ds.HasError() {
+				return types.ObjectNull(tt.AttrTypes), diags
+			}
+
+			objValues[key] = v
+		}
+		return types.ObjectValue(tt.AttrTypes, objValues)
+
+	case types.MapType:
+		// Expect raw to be a map[string]interface{}.
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			diags.AddError("Conversion Error", "expected map for MapType")
+			return types.MapValue(tt.ElemType, nil)
+		}
+
+		mapValues := make(map[string]attr.Value)
+		for key, value := range m {
+			v, ds := convertToAttrValue(value, tt.ElemType)
+			diags.Append(ds...)
+			if ds.HasError() {
+				return types.MapValue(tt.ElemType, nil)
+			}
+
+			mapValues[key] = v
+		}
+		return types.MapValue(tt.ElemType, mapValues)
+
+	default:
+		diags.AddError("Conversion Error", fmt.Sprintf("unsupported type %T", t))
+	}
+
+	return nil, diags
+}

--- a/internal/provider/plugin_provider.go
+++ b/internal/provider/plugin_provider.go
@@ -1,0 +1,387 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-tfe/internal/client"
+)
+
+type pluginProviderServer struct {
+	providerSchema     *tfprotov5.Schema
+	providerMetaSchema *tfprotov5.Schema
+	resourceSchemas    map[string]*tfprotov5.Schema
+	dataSourceSchemas  map[string]*tfprotov5.Schema
+	tfeClient          *tfe.Client
+	organization       string
+
+	dataSourceRouter map[string]func(ConfiguredClient) tfprotov5.DataSourceServer
+	ephemeralValuesRouter
+	functionRouter
+	resourceRouter
+}
+
+type errUnsupportedDataSource string
+
+func (e errUnsupportedDataSource) Error() string {
+	return "unsupported data source: " + string(e)
+}
+
+type errUnsupportedResource string
+
+func (e errUnsupportedResource) Error() string {
+	return "unsupported resource: " + string(e)
+}
+
+type errUnsupportedFunction string
+
+func (e errUnsupportedFunction) Error() string {
+	return "unsupported function: " + string(e)
+}
+
+type errUnsupportedEphemeralValue string
+
+func (e errUnsupportedEphemeralValue) Error() string {
+	return "unsupported ephemeral value: " + string(e)
+}
+
+type providerMeta struct {
+	token         string
+	hostname      string
+	sslSkipVerify bool
+	organization  string
+}
+
+func (p *pluginProviderServer) GetMetadata(ctx context.Context, req *tfprotov5.GetMetadataRequest) (*tfprotov5.GetMetadataResponse, error) {
+	return &tfprotov5.GetMetadataResponse{
+		ServerCapabilities: &tfprotov5.ServerCapabilities{
+			GetProviderSchemaOptional: true,
+		},
+		DataSources: []tfprotov5.DataSourceMetadata{
+			{
+				TypeName: "tfe_outputs",
+			},
+		},
+	}, nil
+}
+
+func (p *pluginProviderServer) GetProviderSchema(ctx context.Context, req *tfprotov5.GetProviderSchemaRequest) (*tfprotov5.GetProviderSchemaResponse, error) {
+	return &tfprotov5.GetProviderSchemaResponse{
+		Provider:          p.providerSchema,
+		ProviderMeta:      p.providerMetaSchema,
+		ResourceSchemas:   p.resourceSchemas,
+		DataSourceSchemas: p.dataSourceSchemas,
+	}, nil
+}
+
+func (p *pluginProviderServer) PrepareProviderConfig(ctx context.Context, req *tfprotov5.PrepareProviderConfigRequest) (*tfprotov5.PrepareProviderConfigResponse, error) {
+	return nil, nil
+}
+
+func (p *pluginProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov5.ConfigureProviderRequest) (*tfprotov5.ConfigureProviderResponse, error) {
+	resp := &tfprotov5.ConfigureProviderResponse{
+		Diagnostics: []*tfprotov5.Diagnostic{},
+	}
+	meta, err := retrieveProviderMeta(req)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Error retrieving provider meta values for internal provider.",
+			Detail:   fmt.Sprintf("This should never happen; please report it to https://github.com/hashicorp/terraform-provider-tfe/issues\n\nThe error received was: %q", err.Error()),
+		})
+		return resp, nil
+	}
+
+	tfeClient, err := client.GetClient(meta.hostname, meta.token, meta.sslSkipVerify)
+	if err != nil {
+		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Error getting client",
+			Detail:   fmt.Sprintf("Error getting client: %v", err),
+		})
+		return resp, nil
+	}
+
+	if meta.organization == "" {
+		meta.organization = os.Getenv("TFE_ORGANIZATION")
+	}
+
+	p.tfeClient = tfeClient
+	p.organization = meta.organization
+	return resp, nil
+}
+
+func (p *pluginProviderServer) StopProvider(ctx context.Context, req *tfprotov5.StopProviderRequest) (*tfprotov5.StopProviderResponse, error) {
+	return &tfprotov5.StopProviderResponse{}, nil
+}
+
+func (p *pluginProviderServer) ValidateDataSourceConfig(ctx context.Context, req *tfprotov5.ValidateDataSourceConfigRequest) (*tfprotov5.ValidateDataSourceConfigResponse, error) {
+	ds, ok := p.dataSourceRouter[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedDataSource(req.TypeName)
+	}
+	return ds(ConfiguredClient{p.tfeClient, p.organization}).ValidateDataSourceConfig(ctx, req)
+}
+
+func (p *pluginProviderServer) ReadDataSource(ctx context.Context, req *tfprotov5.ReadDataSourceRequest) (*tfprotov5.ReadDataSourceResponse, error) {
+	ds, ok := p.dataSourceRouter[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedDataSource(req.TypeName)
+	}
+	return ds(ConfiguredClient{p.tfeClient, p.organization}).ReadDataSource(ctx, req)
+}
+
+type ephemeralValuesRouter map[string]tfprotov5.EphemeralResourceServer
+
+func (r ephemeralValuesRouter) ValidateEphemeralResourceConfig(ctx context.Context, req *tfprotov5.ValidateEphemeralResourceConfigRequest) (*tfprotov5.ValidateEphemeralResourceConfigResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedEphemeralValue(req.TypeName)
+	}
+	return res.ValidateEphemeralResourceConfig(ctx, req)
+}
+
+func (r ephemeralValuesRouter) OpenEphemeralResource(ctx context.Context, req *tfprotov5.OpenEphemeralResourceRequest) (*tfprotov5.OpenEphemeralResourceResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedEphemeralValue(req.TypeName)
+	}
+	return res.OpenEphemeralResource(ctx, req)
+}
+
+func (r ephemeralValuesRouter) RenewEphemeralResource(ctx context.Context, req *tfprotov5.RenewEphemeralResourceRequest) (*tfprotov5.RenewEphemeralResourceResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedEphemeralValue(req.TypeName)
+	}
+	return res.RenewEphemeralResource(ctx, req)
+}
+
+func (r ephemeralValuesRouter) CloseEphemeralResource(ctx context.Context, req *tfprotov5.CloseEphemeralResourceRequest) (*tfprotov5.CloseEphemeralResourceResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedEphemeralValue(req.TypeName)
+	}
+	return res.CloseEphemeralResource(ctx, req)
+}
+
+type functionRouter map[string]tfprotov5.FunctionServer
+
+func (r functionRouter) CallFunction(ctx context.Context, req *tfprotov5.CallFunctionRequest) (*tfprotov5.CallFunctionResponse, error) {
+	res, ok := r[req.Name]
+	if !ok {
+		return nil, errUnsupportedFunction(req.Name)
+	}
+
+	return res.CallFunction(ctx, req)
+}
+
+func (r functionRouter) GetFunctions(ctx context.Context, req *tfprotov5.GetFunctionsRequest) (*tfprotov5.GetFunctionsResponse, error) {
+	return &tfprotov5.GetFunctionsResponse{
+		Functions: map[string]*tfprotov5.Function{},
+	}, nil
+}
+
+type resourceRouter map[string]tfprotov5.ResourceServer
+
+func (r resourceRouter) ValidateResourceTypeConfig(ctx context.Context, req *tfprotov5.ValidateResourceTypeConfigRequest) (*tfprotov5.ValidateResourceTypeConfigResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedResource(req.TypeName)
+	}
+	return res.ValidateResourceTypeConfig(ctx, req)
+}
+
+func (r resourceRouter) UpgradeResourceState(ctx context.Context, req *tfprotov5.UpgradeResourceStateRequest) (*tfprotov5.UpgradeResourceStateResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedResource(req.TypeName)
+	}
+	return res.UpgradeResourceState(ctx, req)
+}
+
+func (r resourceRouter) ReadResource(ctx context.Context, req *tfprotov5.ReadResourceRequest) (*tfprotov5.ReadResourceResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedResource(req.TypeName)
+	}
+	return res.ReadResource(ctx, req)
+}
+
+func (r resourceRouter) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedResource(req.TypeName)
+	}
+	return res.PlanResourceChange(ctx, req)
+}
+
+func (r resourceRouter) ApplyResourceChange(ctx context.Context, req *tfprotov5.ApplyResourceChangeRequest) (*tfprotov5.ApplyResourceChangeResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedResource(req.TypeName)
+	}
+	return res.ApplyResourceChange(ctx, req)
+}
+
+func (r resourceRouter) ImportResourceState(ctx context.Context, req *tfprotov5.ImportResourceStateRequest) (*tfprotov5.ImportResourceStateResponse, error) {
+	res, ok := r[req.TypeName]
+	if !ok {
+		return nil, errUnsupportedResource(req.TypeName)
+	}
+	return res.ImportResourceState(ctx, req)
+}
+
+func (r resourceRouter) MoveResourceState(ctx context.Context, req *tfprotov5.MoveResourceStateRequest) (*tfprotov5.MoveResourceStateResponse, error) {
+	return &tfprotov5.MoveResourceStateResponse{}, nil
+}
+
+// PluginProviderServer returns the implementation of an interface for a lower
+// level usage of the Provider to Terraform protocol.
+// This relies on the terraform-plugin-go library, which provides low level
+// bindings for the Terraform plugin protocol.
+func PluginProviderServer() tfprotov5.ProviderServer {
+	return &pluginProviderServer{
+		providerSchema: &tfprotov5.Schema{
+			Block: &tfprotov5.SchemaBlock{
+				Attributes: []*tfprotov5.SchemaAttribute{
+					{
+						Name:        "hostname",
+						Type:        tftypes.String,
+						Description: descriptions["hostname"],
+						Optional:    true,
+					},
+					{
+						Name:        "token",
+						Type:        tftypes.String,
+						Description: descriptions["token"],
+						Optional:    true,
+					},
+					{
+						Name:        "ssl_skip_verify",
+						Type:        tftypes.Bool,
+						Description: descriptions["ssl_skip_verify"],
+						Optional:    true,
+					},
+					{
+						Name:        "organization",
+						Type:        tftypes.String,
+						Description: descriptions["organization"],
+						Optional:    true,
+					},
+				},
+			},
+		},
+		dataSourceSchemas: map[string]*tfprotov5.Schema{
+			"tfe_outputs": {
+				Version: 1,
+				Block: &tfprotov5.SchemaBlock{
+					Version: 1,
+					Attributes: []*tfprotov5.SchemaAttribute{
+						{
+							Name:     "id",
+							Type:     tftypes.String,
+							Computed: true,
+						},
+						{
+							Name:            "workspace",
+							Type:            tftypes.String,
+							Description:     "The workspace to fetch the remote state from.",
+							DescriptionKind: tfprotov5.StringKindPlain,
+							Required:        true,
+						},
+						{
+							Name:            "organization",
+							Type:            tftypes.String,
+							Description:     "The organization to fetch the remote state from.",
+							DescriptionKind: tfprotov5.StringKindPlain,
+							Optional:        true,
+						},
+						{
+							Name:      "values",
+							Type:      tftypes.DynamicPseudoType,
+							Optional:  true,
+							Computed:  true,
+							Sensitive: true,
+						},
+						{
+							Name:      "nonsensitive_values",
+							Type:      tftypes.DynamicPseudoType,
+							Computed:  true,
+							Sensitive: false,
+						},
+					},
+				},
+			},
+		},
+		dataSourceRouter: map[string]func(ConfiguredClient) tfprotov5.DataSourceServer{
+			"tfe_outputs": newDataSourceOutputs,
+		},
+		ephemeralValuesRouter: map[string]tfprotov5.EphemeralResourceServer{},
+	}
+}
+
+func retrieveProviderMeta(req *tfprotov5.ConfigureProviderRequest) (providerMeta, error) {
+	meta := providerMeta{}
+	config := req.Config
+	val, err := config.Unmarshal(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"hostname":        tftypes.String,
+			"token":           tftypes.String,
+			"ssl_skip_verify": tftypes.Bool,
+			"organization":    tftypes.String,
+		}})
+
+	if err != nil {
+		return meta, fmt.Errorf("could not unmarshal ConfigureProviderRequest %w", err)
+	}
+	var hostname string
+	var token string
+	var sslSkipVerify bool
+	var organization string
+	var valMap map[string]tftypes.Value
+	err = val.As(&valMap)
+	if err != nil {
+		return meta, fmt.Errorf("could not set the schema attributes to map %w", err)
+	}
+	if !valMap["hostname"].IsNull() {
+		err = valMap["hostname"].As(&hostname)
+		if err != nil {
+			return meta, fmt.Errorf("could not set the hostname value to string %w", err)
+		}
+	}
+	if !valMap["token"].IsNull() {
+		err = valMap["token"].As(&token)
+		if err != nil {
+			return meta, fmt.Errorf("could not set the token value to string %w", err)
+		}
+	}
+	if !valMap["ssl_skip_verify"].IsNull() {
+		err = valMap["ssl_skip_verify"].As(&sslSkipVerify)
+		if err != nil {
+			return meta, fmt.Errorf("could not set the ssl_skip_verify value to boolean %w", err)
+		}
+	} else {
+		sslSkipVerify = defaultSSLSkipVerify
+	}
+	if !valMap["organization"].IsNull() {
+		err = valMap["organization"].As(&organization)
+		if err != nil {
+			return meta, fmt.Errorf("failed to set the organization value to string: %w", err)
+		}
+	}
+
+	meta.hostname = hostname
+	meta.token = token
+	meta.sslSkipVerify = sslSkipVerify
+	meta.organization = organization
+
+	return meta, nil
+}

--- a/internal/provider/plugin_provider_test.go
+++ b/internal/provider/plugin_provider_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestPluginProvider_providerMeta(t *testing.T) {
+	cases := map[string]struct {
+		hostname      string
+		token         string
+		sslSkipVerify bool
+		organization  string
+		err           error
+	}{
+		"has none": {},
+		"has only hostname": {
+			hostname: "terraform.io",
+		},
+		"has only token": {
+			token: "secret",
+		},
+		"has only ssl_skip_verify": {
+			sslSkipVerify: true,
+		},
+		"has hostname and token": {
+			hostname: "terraform.io",
+			token:    "secret",
+		},
+		"has hostname and ssl_skip_verify": {
+			hostname:      "terraform.io",
+			sslSkipVerify: true,
+		},
+		"has token and ssl_skip_verify": {
+			token:         "secret",
+			sslSkipVerify: true,
+		},
+		"has organization": {
+			organization: "hashicorp",
+		},
+	}
+
+	for name, tc := range cases {
+		config, err := tfprotov5.NewDynamicValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"hostname":        tftypes.String,
+				"token":           tftypes.String,
+				"ssl_skip_verify": tftypes.Bool,
+				"organization":    tftypes.String,
+			},
+		}, tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"hostname":        tftypes.String,
+				"token":           tftypes.String,
+				"ssl_skip_verify": tftypes.Bool,
+				"organization":    tftypes.String,
+			},
+		}, map[string]tftypes.Value{
+			"hostname":        tftypes.NewValue(tftypes.String, tc.hostname),
+			"token":           tftypes.NewValue(tftypes.String, tc.token),
+			"ssl_skip_verify": tftypes.NewValue(tftypes.Bool, tc.sslSkipVerify),
+			"organization":    tftypes.NewValue(tftypes.String, tc.organization),
+		}))
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		req := &tfprotov5.ConfigureProviderRequest{
+			Config: &config,
+		}
+
+		meta, err := retrieveProviderMeta(req)
+		if !errors.Is(err, tc.err) {
+			t.Fatalf("Test %s: should not be error, got %v", name, err)
+		}
+
+		if tc.hostname == "" && meta.hostname != "" {
+			t.Fatalf("Test %s: hostname was not set in config and meta hostname should be empty in this moment (in retrieveProviderMeta). It is parsed later in within the `getClient` function", name)
+		}
+
+		if tc.hostname != "" && meta.hostname != tc.hostname {
+			t.Fatalf("Test %s: hostname was set in config and meta hostname %s  has not been set to what was given %s", name, meta.hostname, tc.hostname)
+		}
+
+		if tc.token == "" && meta.token != "" {
+			t.Fatalf("Test %s: token was not set in config and meta.token %s has been incorrectly set", name, meta.token)
+		}
+
+		if tc.token != "" && meta.token != tc.token {
+			t.Fatalf("Test %s: token was set in config and input token %s  does not have the same value in meta %s", name, tc.token, meta.token)
+		}
+
+		if tc.sslSkipVerify == false && meta.sslSkipVerify != defaultSSLSkipVerify {
+			t.Fatalf("Test %s: ssl_skip_verify was not set in config and has not been set to default", name)
+		}
+
+		if tc.organization != meta.organization {
+			t.Fatalf("Test %s: default organization was set in config and input default organization %s does not have the same value in meta %s", name, tc.token, meta.token)
+		}
+
+		if tc.sslSkipVerify != false {
+			if meta.sslSkipVerify != tc.sslSkipVerify {
+				t.Fatalf("Test %s: ssl_skip_verify was set in config but does not have the same value in meta %t", name, meta.sslSkipVerify)
+			}
+		}
+	}
+}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -133,7 +133,6 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewNoCodeModuleDataSource,
 		NewOrganizationRunTaskDataSource,
 		NewOrganizationRunTaskGlobalSettingsDataSource,
-		NewOutputsDataSource,
 		NewProjectDataSource,
 		NewProjectsDataSource,
 		NewRegistryGPGKeyDataSource,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -49,7 +49,7 @@ func init() {
 			}
 
 			mux, err := tf5muxserver.NewMuxServer(
-				ctx, nextProvider, sdkProvider.GRPCProvider,
+				ctx, nextProvider, PluginProviderServer, testAccProvider.GRPCProvider,
 			)
 			if err != nil {
 				return nil, err

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -49,7 +49,7 @@ func init() {
 			}
 
 			mux, err := tf5muxserver.NewMuxServer(
-				ctx, nextProvider, PluginProviderServer, testAccProvider.GRPCProvider,
+				ctx, nextProvider, PluginProviderServer, sdkProvider.GRPCProvider,
 			)
 			if err != nil {
 				return nil, err

--- a/main.go
+++ b/main.go
@@ -47,8 +47,9 @@ func main() {
 	//   not proven that out yet.
 	nextProvider := providerserver.NewProtocol5(provider.NewFrameworkProvider())
 	classicProvider := provider.Provider().GRPCProvider
+	lowLevelProvider := provider.PluginProviderServer
 	mux, err := tf5muxserver.NewMuxServer(
-		ctx, nextProvider, classicProvider,
+		ctx, nextProvider, classicProvider, lowLevelProvider,
 	)
 	if err != nil {
 		log.Printf("[ERROR] Could not setup a mux server using the internal providers: %v", err)


### PR DESCRIPTION
Addresses #1697, a regression found following the release of v0.65.0.

This PR reverts the `tfe_outputs` data source to a known prior working state, but leaves the `tfe_output` ephemeral resource intact.

The framework-upgraded `tfe_outputs` data source has been retained in `data_source_outputs_next.go`.


