### PR TITLE
Use the correct form of `sha256.Sum256`.

### DIFF
--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -52,7 +52,8 @@ type ClientConfiguration struct {
 
 // Key returns a string that is comparable to other ClientConfiguration values
 func (c ClientConfiguration) Key() string {
-	return fmt.Sprintf("%x %s/%v", sha256.New().Sum([]byte(c.Token)), c.TFEHost, c.Insecure)
+	h := sha256.Sum256([]byte(c.Token))
+	return fmt.Sprintf("%x %s/%v", h[:], c.TFEHost, c.Insecure)
 }
 
 // cliConfig tries to find and parse the configuration of the Terraform CLI.


### PR DESCRIPTION
## Description

`sha256.New().Sum(foo)` appends the SHA-256 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk

I think was only used for comparisons, which meant it worked just fine but your comparisons were less efficient and the SHA256 did nothing for you.

I'm making this change as part of a cleanup of invalid hash.Hash uses across Github.

## Testing plan

Acceptance tests in the CI should cover it.

## Output from acceptance tests

I spent a while trying to work out how to set up a test environment and gave up after it took substantially longer than the actual fixing of the bug. Seems like I'd need to set up a Terraform instance. If this is insufficient, lemme know and I'll close the PR and flip this to an issue for someone else to take.