### PR TITLE
remove the isUnknown value check to allow users to set a variable ref…

### DIFF
--- a/internal/provider/resource_tfe_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_notification_configuration_test.go
@@ -871,10 +871,14 @@ resource "tfe_workspace" "foobar" {
   organization = tfe_organization.foobar.id
 }
 
+variable "url" {
+  default = "%s"
+}
+
 resource "tfe_notification_configuration" "foobar" {
   name             = "notification_basic"
   destination_type = "generic"
-  url              = "%s"
+  url              = var.url
   workspace_id     = tfe_workspace.foobar.id
 }`, rInt, runTasksURL())
 }

--- a/internal/provider/resource_tfe_team_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_team_notification_configuration_test.go
@@ -1006,10 +1006,14 @@ resource "tfe_team" "foobar" {
   organization = data.tfe_organization.foobar.name
 }
 
+variable "url" {
+  default = "%s"
+}
+
 resource "tfe_team_notification_configuration" "foobar" {
   name             = "notification_basic"
   destination_type = "generic"
-	url              = "%s"
+	url              = var.url
   team_id          = tfe_team.foobar.id
 }`, orgName, runTasksURL())
 }

--- a/internal/provider/validators/attribute_required_if_value_string.go
+++ b/internal/provider/validators/attribute_required_if_value_string.go
@@ -34,7 +34,7 @@ func (v attributeRequiredIfValueStringValidator) ValidateString(ctx context.Cont
 	}
 
 	for _, requiredValue := range v.requiredValues {
-		if attributeValue.ValueString() == requiredValue && (req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown()) {
+		if attributeValue.ValueString() == requiredValue && req.ConfigValue.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				req.Path,
 				"Missing Required Attribute",


### PR DESCRIPTION

## Description

It removes the isUnknown value check to allow users to set a variable reference as value for the url attribute.
It fixes [this github issue](https://github.com/hashicorp/terraform-provider-tfe/issues/1696).

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Some tests were updated to use a variable reference for the url value. Without the fix, these tests would have failed.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```
