### PR TITLE
Fix several regressions in v0.65.x

### DIFF
--- a/internal/provider/resource_tfe_policy_set_parameter.go
+++ b/internal/provider/resource_tfe_policy_set_parameter.go
@@ -97,7 +97,7 @@ func (r *resourceTFEPolicySetParameter) Metadata(_ context.Context, req resource
 func (r *resourceTFEPolicySetParameter) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Creates, updates and destroys policy set parameters.",
-		Version:     1,
+		Version:     0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Service-generated identifier for the parameter.",


### PR DESCRIPTION
## Description

The recent releases of v0.65.0 and v0.65.1 contain several regressions:

- `tfe_team_token` clears token from state after upgrade (#1700)
-  `tfe_policy_set_parameter` errors attempting to unnecessarily upgrade schema version
- `url` attribute validation doesn't work as expected for `tfe_notification_configuration` (#1696)

This PR provides resolution for the first two issues, and #1705 resolves the third.

## Testing plan
#### `tfe_policy_set_parameter` clears token from state after upgrade

##### Test config
```
resource "tfe_policy_set" "test" {
  name         = "my-policy-set-name"
}

resource "tfe_policy_set_parameter" "test" {
  key          = "my_key_name"
  value        = "my_value_name"
  policy_set_id = tfe_policy_set.test.id
}
```
1. Use v0.64 to create a policy set param with the config above
1. Re-apply the config with the provider version in this PR
1. Ensure no errors are thrown relating to the schema version

#### `tfe_team_token` clears token from state after upgrade

##### Test config
```
resource "tfe_team" "test" {
  name         = "test-team"
}

resource "tfe_team_token" "test" {
  team_id = tfe_team.test.id
}
```
1. Use v0.64 to create a team token with the config above
1. Re-apply the config with the provider version in this PR
1. Check the state file and ensure the token string is still visible
