### PR TITLE
fix: default remote_state_consumer_ids to empty set of strings, not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 * `d/tfe_outputs`: fixes 'error inferring type for key' for output objects that had a key with null value.  (#1709), by @uturunku1 [#1699](https://github.com/hashicorp/terraform-provider-tfe/pull/1709)
+* `r/tfe_workspace_settings`: fixes `Provider produced inconsistent result after apply` error when setting `remote_state_consumer_ids` to an empty set in config. [#1728](https://github.com/hashicorp/terraform-provider-tfe/pull/1728)
 
 ## v0.65.2
 

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -355,7 +355,7 @@ func (r *workspaceSettings) workspaceSettingsModelFromTFEWorkspace(ws *tfe.Works
 		result.AgentPoolID = types.StringValue(ws.AgentPool.ID)
 	}
 
-	result.RemoteStateConsumerIDs = types.SetNull(types.StringType)
+	result.RemoteStateConsumerIDs = types.SetValueMust(types.StringType, []attr.Value{})
 
 	if !ws.GlobalRemoteState {
 		_, remoteStateConsumerIDs, err := readWorkspaceStateConsumers(ws.ID, r.config.Client)

--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -151,6 +151,8 @@ func TestAccTFEWorkspaceSettingsRemoteState(t *testing.T) {
 						"tfe_workspace_settings.foobar", "global_remote_state", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace_settings.foobar", "remote_state_consumer_ids.0", ws2.ID),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.foobar", "remote_state_consumer_ids.#", "1"),
 				),
 			},
 			// Unset remote state consumer ids and set global remote state
@@ -163,6 +165,8 @@ func TestAccTFEWorkspaceSettingsRemoteState(t *testing.T) {
 						"tfe_workspace_settings.foobar", "workspace_id"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace_settings.foobar", "global_remote_state", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.foobar", "remote_state_consumer_ids.#", "0"),
 				),
 			},
 			// Unset execution mode


### PR DESCRIPTION
## Description

Addresses `Error: Provider produced inconsistent result after apply` for remote_state_consumer_ids as reported in #1688 

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEWorkspaceSettingsRemoteState" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceSettingsRemoteState -timeout 15m
--- PASS: TestAccTFEWorkspaceSettingsRemoteState (8.57s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   9.195s
```
