### PR TITLE
Make `tags` a computed attribute on workspace resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+ENHANCEMENTS:
+* `r/tfe_workspace` update `tags` to be a computed attribute, by @Maed223 [#1767](https://github.com/hashicorp/terraform-provider-tfe/pull/1767)
+
 ## v0.67.0
 
 ENHANCEMENTS:

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -250,6 +250,7 @@ func resourceTFEWorkspace() *schema.Resource {
 			"tags": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
## Description

We saw an issue where planning a tfe_workspace with  tag_names (relating to single value tags) and not tags (for KV), we'd sometimes see a diff like so:
```terraform
~ tags = {
  - "example-tag"  = null
  - "example-tag2" = null
}
```

This occurs when a separate configuration uses the provisioned tfe_workspace , as targeted by the tags given in its cloud block.
```terraform 
  cloud {
    organization = "hashicorp"
    hostname     = "tfcdev-2cdff5a5.ngrok.app"
    workspaces {
      tags = ["example-tag", "example-tag2"]
    }
  }
```

In the Cloud block, we're checking if the feature is available (by whether it 404s on the list tag binding endpoint), and if it is, the workspace's single value tags are added as KV tags. So now that the KV tag FF has been fully lifted, customers are hitting that code path and seeing that there are KV tags being unexpectedly created (alongside the existing single value tags)

Making the `tags` attribute computed on the workspace resource makes it so that if you don't specify tags in your config then terraform will just accept whatever is in there, so we can't get rid of those pesky diffs that customers are seeing. This seems to have already been done with the project resource, so porting that over here.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Create a workspace with just the `tag_names` attribute. In a separate configuration, target that workspace using the single value tag names in the cloud block. In the UI you'll notice that both single value tags and KV tags are present for those tags. Now, back to the configuration that created this workspace– run a plan and you shouldn't see a planned deletion of the  KV `tags` that were created by the cloud block in the separate configuration.

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/IPL-8290?atlOrigin=eyJpIjoiMzkxYzUwNzIyYjY0NGM1YWFkN2U2Yjc1MDNlMzQxMjEiLCJwIjoiaiJ9)


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
