### PR TITLE
remove provider schema default for auto_apply

### DIFF
--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -355,7 +354,6 @@ func (r *workspaceSettings) Schema(ctx context.Context, req resource.SchemaReque
 				Optional:    true,
 				Computed:    true,
 				Description: "If set to false a human will have to manually confirm a plan in HCP Terraform's UI to start an apply. If set to true, this resource will be automatically applied.",
-				Default:     booldefault.StaticBool(false),
 			},
 
 			"assessments_enabled": schema.BoolAttribute{


### PR DESCRIPTION
## Description

It doesn't make sense to allow a provider default when there are two resources that manage the same setting.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

```hcl
resource "tfe_workspace_settings" "self" {
  workspace_id        = tfe_workspace.name.id
}

resource "tfe_workspace" "name" {
    organization = "Yordanh-Tfc4b"
    name="permanent_auto_apply_drift"
    auto_apply= true
}
```

Apply this config twice

## External links

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEWorkspaceSettings" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceSettings -timeout 15m
=== RUN   TestAccTFEWorkspaceSettings_basic
2025/07/21 11:18:34 [DEBUG] Configuring client for host "tfcdev-xxx.ngrok.app"
2025/07/21 11:18:34 [DEBUG] Service discovery for tfcdev-xxx.ngrok.app at https://tfcdev-xxx.ngrok.app/.well-known/terraform.json
--- PASS: TestAccTFEWorkspaceSettings_basic (14.81s)
=== RUN   TestAccTFEWorkspaceSettings_stateSharing
--- PASS: TestAccTFEWorkspaceSettings_stateSharing (7.83s)
=== RUN   TestAccTFEWorkspaceSettings_basicOptions
--- PASS: TestAccTFEWorkspaceSettings_basicOptions (9.73s)
=== RUN   TestAccTFEWorkspaceSettingsRemoteState
--- PASS: TestAccTFEWorkspaceSettingsRemoteState (9.17s)
=== RUN   TestAccTFEWorkspaceSettings_import
--- PASS: TestAccTFEWorkspaceSettings_import (6.90s)
=== RUN   TestAccTFEWorkspaceSettings_importByName
--- PASS: TestAccTFEWorkspaceSettings_importByName (6.63s)
=== RUN   TestAccTFEWorkspaceSettings_basicTags
--- PASS: TestAccTFEWorkspaceSettings_basicTags (18.95s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   74.747s
```

