### PR TITLE
docs: fixed tfe_workspace & tfe_workspace_run examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 BUG FIXES:
 * `r/tfe_notification_configuration`: update url attribute to be sensitive, by @jillirami [#1799](https://github.com/hashicorp/terraform-provider-tfe/pull/1799)
+* `r/tfe_workspace`: fixed documentation Example Usages to use the `tfe_organization.test-organization.name` as organization name 
+* `r/tfe_workspace_run`: fixed documentation Example Usages to use the `tfe_organization.test-organization.name` as organization name 
 
+  
 ## v0.68.2
 
 BUG FIXES:

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -40,7 +40,7 @@ resource "tfe_organization" "test-organization" {
 }
 
 resource "tfe_oauth_client" "test" {
-  organization     = tfe_organization.test-organization
+  organization     = tfe_organization.test-organization.name
   api_url          = "https://api.github.com"
   http_url         = "https://github.com"
   oauth_token      = "oauth_token_id"
@@ -49,7 +49,7 @@ resource "tfe_oauth_client" "test" {
 
 resource "tfe_workspace" "parent" {
   name                 = "parent-ws"
-  organization         = tfe_organization.test-organization
+  organization         = tfe_organization.test-organization.name
   queue_all_runs       = false
   vcs_repo {
     branch             = "main"

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -30,7 +30,7 @@ resource "tfe_organization" "test-organization" {
 }
 
 resource "tfe_oauth_client" "test" {
-  organization     = tfe_organization.test-organization
+  organization     = tfe_organization.test-organization.name
   api_url          = "https://api.github.com"
   http_url         = "https://github.com"
   oauth_token      = "oauth_token_id"
@@ -39,7 +39,7 @@ resource "tfe_oauth_client" "test" {
 
 resource "tfe_workspace" "parent" {
   name                 = "parent-ws"
-  organization         = tfe_organization.test-organization
+  organization         = tfe_organization.test-organization.name
   queue_all_runs       = false
   vcs_repo {
     branch             = "main"
@@ -50,7 +50,7 @@ resource "tfe_workspace" "parent" {
 
 resource "tfe_workspace" "child" {
   name                 = "child-ws"
-  organization         = tfe_organization.test-organization
+  organization         = tfe_organization.test-organization.name
   queue_all_runs       = false
   vcs_repo {
     branch             = "main"
@@ -105,7 +105,7 @@ resource "tfe_organization" "test-organization" {
 }
 
 resource "tfe_oauth_client" "test" {
-  organization     = tfe_organization.test-organization
+  organization     = tfe_organization.test-organization.name
   api_url          = "https://api.github.com"
   http_url         = "https://github.com"
   oauth_token      = "oauth_token_id"
@@ -114,7 +114,7 @@ resource "tfe_oauth_client" "test" {
 
 resource "tfe_workspace" "parent" {
   name                 = "parent-ws"
-  organization         = tfe_organization.test-organization
+  organization         = tfe_organization.test-organization.name
   queue_all_runs       = false
   vcs_repo {
     branch             = "main"
@@ -147,7 +147,7 @@ resource "tfe_organization" "test-organization" {
 }
 
 resource "tfe_oauth_client" "test" {
-  organization     = tfe_organization.test-organization
+  organization     = tfe_organization.test-organization.name
   api_url          = "https://api.github.com"
   http_url         = "https://github.com"
   oauth_token      = "oauth_token_id"
@@ -156,7 +156,7 @@ resource "tfe_oauth_client" "test" {
 
 resource "tfe_workspace" "parent" {
   name                 = "parent-ws"
-  organization         = tfe_organization.test-organization
+  organization         = tfe_organization.test-organization.name
   queue_all_runs       = false
   vcs_repo {
     branch             = "main"


### PR DESCRIPTION
## Description

This PR fixes some incorrect usages of `tfe_workspace` and `tfe_workspce_run` in the documentation examples, originally by @StamatisChr (#1813) 

_Describe why you're making this change._

Using the documentation example as is, `terraform plan` gives the error:
```
│ Error: Incorrect attribute value type
│ 
│   on main.tf line 12, in resource "tfe_oauth_client" "test":
│   12:   organization     = tfe_organization.test-organization
│     ├────────────────
│     │ tfe_organization.test-organization is object with 14 attributes
│ 
│ Inappropriate value for attribute "organization": string required.
```

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan
N/A

## External links
N/A

## Output from acceptance tests
N/A

## Rollback Plan
N/A

Screenshots from https://registry.terraform.io/tools/doc-preview:

<img width="2520" height="13779" alt="image" src="https://github.com/user-attachments/assets/3a851a66-e2b9-4e55-b201-a1d7adbe79bc" />

<img width="2520" height="13913" alt="image" src="https://github.com/user-attachments/assets/b3cf35d2-b80e-402a-99b6-7c66e24bec26" />
