### PR TITLE
Remove ForceNew from oauth_token attribute of r/tfe_oauth_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+ENHANCEMENTS:
+* `r/tfe_oauth_client`: The `oauth_token` attribute no longer triggers resource replacement unless combined with other replacement-triggering attributes. Use `terraform apply -replace` to force replacement.
+
 ## v0.68.3
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ENHANCEMENTS:
-* `r/tfe_oauth_client`: The `oauth_token` attribute no longer triggers resource replacement unless combined with other replacement-triggering attributes. Use `terraform apply -replace` to force replacement.
+* `r/tfe_oauth_client`: The `oauth_token` attribute no longer triggers resource replacement unless combined with other replacement-triggering attributes. Use `terraform apply -replace` to force replacement. By @lilincmu [#1825](https://github.com/hashicorp/terraform-provider-tfe/pull/1825)
 
 ## v0.68.3
 

--- a/internal/provider/resource_tfe_oauth_client.go
+++ b/internal/provider/resource_tfe_oauth_client.go
@@ -63,7 +63,6 @@ func resourceTFEOAuthClient() *schema.Resource {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
-				ForceNew:  true,
 			},
 
 			"private_key": {

--- a/internal/provider/resource_tfe_oauth_client_test.go
+++ b/internal/provider/resource_tfe_oauth_client_test.go
@@ -172,8 +172,8 @@ func TestAccTFEOAuthClient_updateOAuthTokenID(t *testing.T) {
 					testAccCheckTFEOAuthClientExists("tfe_oauth_client.foobar", oc),
 					resource.TestCheckResourceAttrSet("tfe_oauth_client.foobar", "oauth_token_id"),
 					func(s *terraform.State) error {
-						if initialOAuthTokenID == oc.OAuthTokens[0].ID {
-							return fmt.Errorf("oauth_token_id did not change")
+						if initialOAuthTokenID != oc.OAuthTokens[0].ID {
+							return fmt.Errorf("oauth_token_id changed")
 						}
 						return nil
 					},


### PR DESCRIPTION
## Description

Remove the `ForceNew` flag from the `oauth_token` attribute of `r/tfe_oauth_client` to allow in-place updates of the OAuth client during token rotation. This prevents the OAuth client from being replaced, avoiding re-establishment of VCS connections with workspaces and preventing runs from being triggered unnecessarily.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

- Run the acceptance test command below with the required environment variables (`TFE_TOKEN`, `TFE_HOSTNAME`, `GITHUB_TOKEN` and `GITHUB_TOKEN2`).
- The acceptance test should pass.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [JIRA](https://hashicorp.atlassian.net/browse/TF-28073)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEOAuthClient_updateOAuthTokenID" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEOAuthClient_updateOAuthTokenID -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/client     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/logging    (cached) [no tests to run]
=== RUN   TestAccTFEOAuthClient_updateOAuthTokenID
--- PASS: TestAccTFEOAuthClient_updateOAuthTokenID (4.42s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   (cached)
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers   [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers     [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/validators        [no test files]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
