### PR TITLE
Update feature set name Plus (entitlement) to Standard (entitlement)

### DIFF
--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -66,13 +66,13 @@ func createBusinessOrganization(t *testing.T, client *tfe.Client) (*tfe.Organiza
 	return org, orgCleanup
 }
 
-func createPlusOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
+func createStandardOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
 	org, orgCleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
 		Name:  tfe.String("tst-" + randomString(t)),
 		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
 	})
 
-	newSubscriptionUpdater(org).WithPlusEntitlementPlan().Update(t)
+	newSubscriptionUpdater(org).WithStandardEntitlementPlan().Update(t)
 
 	return org, orgCleanup
 }

--- a/internal/provider/resource_tfe_team_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_team_notification_configuration_test.go
@@ -24,7 +24,7 @@ func TestAccTFETeamNotificationConfiguration_basic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -63,7 +63,7 @@ func TestAccTFETeamNotificationConfiguration_emailUserIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -102,7 +102,7 @@ func TestAccTFETeamNotificationConfiguration_update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -163,7 +163,7 @@ func TestAccTFETeamNotificationConfiguration_updateEmailUserIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -221,7 +221,7 @@ func TestAccTFETeamNotificationConfiguration_validateSchemaAttributesEmail(t *te
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	resource.Test(t, resource.TestCase{
@@ -246,7 +246,7 @@ func TestAccTFETeamNotificationConfiguration_validateSchemaAttributesGeneric(t *
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	resource.Test(t, resource.TestCase{
@@ -275,7 +275,7 @@ func TestAccTFETeamNotificationConfiguration_validateSchemaAttributesSlack(t *te
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	resource.Test(t, resource.TestCase{
@@ -308,7 +308,7 @@ func TestAccTFETeamNotificationConfiguration_validateSchemaAttributesMicrosoftTe
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	resource.Test(t, resource.TestCase{
@@ -341,7 +341,7 @@ func TestAccTFETeamNotificationConfiguration_validateSchemaAttributesBadDestinat
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	resource.Test(t, resource.TestCase{
@@ -363,7 +363,7 @@ func TestAccTFETeamNotificationConfiguration_updateValidateSchemaAttributesEmail
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -413,7 +413,7 @@ func TestAccTFETeamNotificationConfiguration_updateValidateSchemaAttributesGener
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -467,7 +467,7 @@ func TestAccTFETeamNotificationConfiguration_updateValidateSchemaAttributesSlack
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -525,7 +525,7 @@ func TestAccTFETeamNotificationConfiguration_updateValidateSchemaAttributesMicro
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -579,7 +579,7 @@ func TestAccTFETeamNotificationConfiguration_duplicateTriggers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	notificationConfiguration := &tfe.NotificationConfiguration{}
@@ -618,7 +618,7 @@ func TestAccTFETeamNotificationConfigurationImport_basic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	resource.Test(t, resource.TestCase{
@@ -647,7 +647,7 @@ func TestAccTFETeamNotificationConfigurationImport_emailUserIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	resource.Test(t, resource.TestCase{
@@ -676,7 +676,7 @@ func TestAccTFETeamNotificationConfigurationImport_emptyEmailUserIDs(t *testing.
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	resource.Test(t, resource.TestCase{
@@ -936,7 +936,7 @@ func TestAccTFETeamNotificationConfiguration_tokenWO(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createPlusOrganization(t, tfeClient)
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
 	t.Cleanup(cleanupOrg)
 
 	// Create the value comparer so we can add state values to it during the test steps

--- a/internal/provider/subscription_updater_test.go
+++ b/internal/provider/subscription_updater_test.go
@@ -50,7 +50,7 @@ func newSubscriptionUpdater(organization *tfe.Organization) *organizationSubscri
 	}
 }
 
-func (b *organizationSubscriptionUpdater) WithPlusEntitlementPlan() *organizationSubscriptionUpdater {
+func (b *organizationSubscriptionUpdater) WithStandardEntitlementPlan() *organizationSubscriptionUpdater {
 	b.planName = "Standard (entitlement)"
 
 	start := time.Now()


### PR DESCRIPTION
## Description

The feature set name in HCP Terraform was recently changed from `Plus (entitlement)` to `Standard (entitlement)`. This PR updates related tests to align with the new name.

## Testing
- Before the change, some acceptance tests failed
```
=== FAIL: internal/provider TestAccTFETeamNotificationConfiguration_validateSchemaAttributesEmail (0.35s)
    subscription_updater_test.go:114: feature set response was empty
```

- After the change, the tests passes
```
  PASS internal/provider.TestAccTFETeamNotificationConfiguration_validateSchemaAttributesEmail (1.75s)
```

## External links

- [Related PR](https://github.com/hashicorp/atlas/pull/24571)
