### PR TITLE
fix: prevent duplicate set element error in project data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## v0.68.3
 
 BUG FIXES:
+
 * `r/tfe_notification_configuration`: update url attribute to be sensitive, by @jillirami [#1799](https://github.com/hashicorp/terraform-provider-tfe/pull/1799)
+* `d/tfe_project`: fixes: 'duplicate set element' error, as workspaces can appear multiple times in get /workspaces, by @lewis-catley [#1817](https://github.com/hashicorp/terraform-provider-tfe/pull/1817)
 * `r/tfe_workspace`: fixed documentation Example Usages to use the `tfe_organization.test-organization.name` as organization name 
 * `r/tfe_workspace_run`: fixed documentation Example Usages to use the `tfe_organization.test-organization.name` as organization name 
 


### PR DESCRIPTION
## Description

The GET /workspaces API call is ordered by run.created-at. It's possible that between retrieving the first page, and the next page that a workspace will appear on both pages.
This then ultimately causes a 'Duplicate Set Element' error in the TF plan.

This fix converts storing the API response as 2 lists to a single map, with the key being the workspace ID ensuring we overwrite any duplicates.


_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
