### PR TITLE
feat: add projects and workspace exclusions support for policyset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+ENHANCEMENTS:
+* `r/tfe_policy_set`: Add support for `workspace_exclusion_ids` and `project_ids` attributes ([#1684](https://github.com/hashicorp/terraform-provider-tfe/issues/1684))
+
 ## v0.69.0
 
 BREAKING CHANGES:

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -54,6 +54,21 @@ resource "tfe_policy_set" "test" {
 }
 ```
 
+Using projects and workspace exclusions:
+
+```hcl
+resource "tfe_policy_set" "test" {
+  name                    = "my-policy-set"
+  description             = "A brand new policy set"
+  organization            = "my-org-name"
+  kind                    = "sentinel"
+  policy_tool_version     = "0.24.1"
+  policy_ids              = [tfe_sentinel_policy.test.id]
+  project_ids             = [tfe_project.test.id]
+  workspace_exclusion_ids = [tfe_workspace.excluded.id]
+}
+```
+
 Manually uploaded policy set, in lieu of VCS:
 
 ```hcl
@@ -101,6 +116,8 @@ The following arguments are supported:
   new resource if changed. This value _must not_ be provided if `policy_ids` are provided.
 * `workspace_ids` - (Optional) A list of workspace IDs. This value _must not_ be provided
   if `global` is provided.
+* `workspace_exclusion_ids` - (Optional) A list of workspace IDs to exclude from this policy set.
+* `project_ids` - (Optional) A list of project IDs that this policy set should be enforced on.
 * `slug` - (Optional) A reference to the `tfe_slug` data source that contains
   the `source_path` to where the local policies are located. This is used when
 policies are located locally, and can only be used when there is no VCS repo or


### PR DESCRIPTION
## Description

Added support for projects under scope and workspace id exclusion support .
Closes #1684

## Testing plan

1.  Use a TFE_TOKEN with access to create policysets
2. Sample configuration. Set workspace_ids which need to be excluded and project ids which need to be in scope
```
resource "tfe_policy_set" "test" {
  name                    = "my-policy-set"
  description             = "A brand new policy set"
  organization            = "my-org-name"
  kind                    = "sentinel"
  policy_tool_version     = "0.24.1"
  policy_ids              = [tfe_sentinel_policy.test.id]
  project_ids             = [tfe_project.test.id]
  workspace_exclusion_ids = [tfe_workspace.excluded.id]
}

```
3. Run terraform apply.


## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
