### PR TITLE
[TF-28673] Adding HYOK related attributes to Organizations and Workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ FEATURES:
 * **New resource**: `r/tfe_hyok_configuration` for managing HYOK configurations. [#1835](https://github.com/hashicorp/terraform-provider-tfe/pull/1841)
 * **New Data Source:** `d/hyok_customer_key_version` is a new data source for finding HYOK customer key versions by @dominicretli [#1842](https://github.com/hashicorp/terraform-provider-tfe/pull/1842)
 * **New Data Source:** `d/hyok_encrypted_data_key` is a new data source for finding HYOK encrypted data keys by @dominicretli [#1842](https://github.com/hashicorp/terraform-provider-tfe/pull/1842)
+* `r/tfe_organization`, `d/organization`: Added enforce_hyok boolean attribute.
+* `r/tfe_workspace`, `d/workspace`: Added hyok_enabled boolean attribute.
 
 ## v0.70.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ FEATURES:
 * **New resource**: `r/tfe_hyok_configuration` for managing HYOK configurations. [#1835](https://github.com/hashicorp/terraform-provider-tfe/pull/1841)
 * **New Data Source:** `d/hyok_customer_key_version` is a new data source for finding HYOK customer key versions by @dominicretli [#1842](https://github.com/hashicorp/terraform-provider-tfe/pull/1842)
 * **New Data Source:** `d/hyok_encrypted_data_key` is a new data source for finding HYOK encrypted data keys by @dominicretli [#1842](https://github.com/hashicorp/terraform-provider-tfe/pull/1842)
-* `r/tfe_organization`, `d/organization`: Added enforce_hyok boolean attribute.
-* `r/tfe_workspace`, `d/workspace`: Added hyok_enabled boolean attribute.
+* `r/tfe_organization`: Adds the `enforce_hyok` boolean attribute, by @iuri-slywitch-hashicorp.
+* `d/organization`: Adds the `enforce_hyok` boolean attribute, by @iuri-slywitch-hashicorp.
+* `r/tfe_workspace`: Adds the `hyok_enabled` read-only boolean attribute, by @iuri-slywitch-hashicorp.
+* `d/workspace`: Adds the `hyok_enabled` read-only boolean attribute, by @iuri-slywitch-hashicorp.
 
 ## v0.70.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ FEATURES:
 * `r/tfe_organization`: Adds the `enforce_hyok` boolean attribute, by @iuri-slywitch-hashicorp.
 * `d/tfe_organization`: Adds the `enforce_hyok` boolean attribute, by @iuri-slywitch-hashicorp.
 * `r/tfe_workspace`: Adds the `hyok_enabled` read-only boolean attribute, by @iuri-slywitch-hashicorp.
-* `d/workspace`: Adds the `hyok_enabled` read-only boolean attribute, by @iuri-slywitch-hashicorp.
+* `d/tfe_workspace`: Adds the `hyok_enabled` read-only boolean attribute, by @iuri-slywitch-hashicorp.
 
 ## v0.70.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ FEATURES:
 * **New Data Source:** `d/hyok_customer_key_version` is a new data source for finding HYOK customer key versions by @dominicretli [#1842](https://github.com/hashicorp/terraform-provider-tfe/pull/1842)
 * **New Data Source:** `d/hyok_encrypted_data_key` is a new data source for finding HYOK encrypted data keys by @dominicretli [#1842](https://github.com/hashicorp/terraform-provider-tfe/pull/1842)
 * `r/tfe_organization`: Adds the `enforce_hyok` boolean attribute, by @iuri-slywitch-hashicorp.
-* `d/organization`: Adds the `enforce_hyok` boolean attribute, by @iuri-slywitch-hashicorp.
+* `d/tfe_organization`: Adds the `enforce_hyok` boolean attribute, by @iuri-slywitch-hashicorp.
 * `r/tfe_workspace`: Adds the `hyok_enabled` read-only boolean attribute, by @iuri-slywitch-hashicorp.
 * `d/workspace`: Adds the `hyok_enabled` read-only boolean attribute, by @iuri-slywitch-hashicorp.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,6 +51,7 @@ these values with the environment variables specified below:
 1. `GITHUB_APP_INSTALLATION_NAME` - GitHub App installation name. Required for running tfe_github_app_installation data source test.
 1. `ENABLE_HYOK` - Set `ENABLE_HYOK=1` to enable HYOK-related tests.
 1. `HYOK_ORGANIZATION_NAME` - Name of an organization entitled to use HYOK. Required to run tests for HYOK resources and data sources.
+1. `HYOK_WORKSPACE_NAME` - Name of a workspace entitled to use HYOK. Required to run tests for HYOK resources and data sources.
 1. `HYOK_ENCRYPTED_DATA_KEY_ID` - HYOK encrypted data key id. Required for running hyok_encrypted_data_key data source test.
 1. `HYOK_CUSTOMER_KEY_VERSION_ID` - HYOK customer key version id. Required for running hyok_customer_key_version data source test.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,7 +50,6 @@ these values with the environment variables specified below:
 1. `GITHUB_APP_INSTALLATION_ID` - GitHub App installation internal id in the format `ghain-xxxxxxx`. Required for running any tests that use GitHub App VCS (workspace, policy sets, registry module).
 1. `GITHUB_APP_INSTALLATION_NAME` - GitHub App installation name. Required for running tfe_github_app_installation data source test.
 1. `ENABLE_HYOK` - Set `ENABLE_HYOK=1` to enable HYOK-related tests.
-1. `HYOK_ORGANIZATION_NAME` - Name of an organization entitled to use HYOK. Required to run tests for HYOK resources and data sources.
 1. `HYOK_ENCRYPTED_DATA_KEY_ID` - HYOK encrypted data key id. Required for running hyok_encrypted_data_key data source test.
 1. `HYOK_CUSTOMER_KEY_VERSION_ID` - HYOK customer key version id. Required for running hyok_customer_key_version data source test.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,7 +51,6 @@ these values with the environment variables specified below:
 1. `GITHUB_APP_INSTALLATION_NAME` - GitHub App installation name. Required for running tfe_github_app_installation data source test.
 1. `ENABLE_HYOK` - Set `ENABLE_HYOK=1` to enable HYOK-related tests.
 1. `HYOK_ORGANIZATION_NAME` - Name of an organization entitled to use HYOK. Required to run tests for HYOK resources and data sources.
-1. `HYOK_WORKSPACE_NAME` - Name of a workspace entitled to use HYOK. Required to run tests for HYOK resources and data sources.
 1. `HYOK_ENCRYPTED_DATA_KEY_ID` - HYOK encrypted data key id. Required for running hyok_encrypted_data_key data source test.
 1. `HYOK_CUSTOMER_KEY_VERSION_ID` - HYOK customer key version id. Required for running hyok_customer_key_version data source test.
 

--- a/internal/provider/data_source_organization.go
+++ b/internal/provider/data_source_organization.go
@@ -80,6 +80,11 @@ func dataSourceTFEOrganization() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+
+			"enforce_hyok": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -119,6 +124,7 @@ func dataSourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("aggregated_commit_status_enabled", org.AggregatedCommitStatusEnabled)
 	d.Set("assessments_enforced", org.AssessmentsEnforced)
 	d.Set("speculative_plan_management_enabled", org.SpeculativePlanManagementEnabled)
+	d.Set("enforce_hyok", org.EnforceHYOK)
 
 	return nil
 }

--- a/internal/provider/data_source_organization_test.go
+++ b/internal/provider/data_source_organization_test.go
@@ -99,7 +99,7 @@ func TestAccTFEOrganizationDataSource_readEnforceHYOK(t *testing.T) {
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEHYOKOrganizationDataSourceConfig(orgName),
+				Config: testAccTFEOrganizationDataSourceConfig_withName(orgName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.tfe_organization.test", "name", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_organization.test", "enforce_hyok"),
@@ -128,7 +128,7 @@ data "tfe_organization" "foo" {
 }`
 }
 
-func testAccTFEHYOKOrganizationDataSourceConfig(orgName string) string {
+func testAccTFEOrganizationDataSourceConfig_withName(orgName string) string {
 	return `
 data "tfe_organization" "test" {
   name = "` + orgName + `"

--- a/internal/provider/data_source_organization_test.go
+++ b/internal/provider/data_source_organization_test.go
@@ -103,7 +103,6 @@ func TestAccTFEOrganizationDataSource_readEnforceHYOK(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.tfe_organization.test", "name", orgName),
 					resource.TestCheckResourceAttrSet("data.tfe_organization.test", "enforce_hyok"),
-					resource.TestCheckResourceAttr("data.tfe_organization.test", "enforce_hyok", "true"),
 				),
 			},
 		},

--- a/internal/provider/data_source_workspace.go
+++ b/internal/provider/data_source_workspace.go
@@ -231,6 +231,10 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"hyok_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -317,6 +321,7 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("trigger_patterns", workspace.TriggerPatterns)
 	d.Set("working_directory", workspace.WorkingDirectory)
 	d.Set("execution_mode", workspace.ExecutionMode)
+	d.Set("hyok_enabled", workspace.HYOKEnabled)
 
 	if workspace.Links["self-html"] != nil {
 		baseAPI := config.Client.BaseURL()

--- a/internal/provider/data_source_workspace_test.go
+++ b/internal/provider/data_source_workspace_test.go
@@ -280,19 +280,22 @@ func TestAccTFEWorkspaceDataSource_readProjectIDNonDefault(t *testing.T) {
 func TestAccTFEWorkspaceDataSource_readHYOKEnabled(t *testing.T) {
 	skipUnlessHYOKEnabled(t)
 
-	orgName := os.Getenv("HYOK_ORGANIZATION_NAME")
-	if orgName == "" {
-		t.Skip("HYOK_ORGANIZATION_NAME environment variable must be set to run this test")
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	org, orgCleanup := createPremiumOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEHYOKWorkspaceDataSourceConfig(orgName),
+				Config: testAccTFEHYOKWorkspaceDataSourceConfig(org.Name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "organization", org.Name),
 					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "name", "tf-provider-tfe-hyok-enabled-workspace-test"),
 					resource.TestCheckResourceAttrSet("data.tfe_workspace.foobar", "hyok_enabled"),
 				),

--- a/internal/provider/data_source_workspace_test.go
+++ b/internal/provider/data_source_workspace_test.go
@@ -300,7 +300,6 @@ func TestAccTFEWorkspaceDataSource_readHYOKEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr("data.tfe_workspace.test", "organization", orgName),
 					resource.TestCheckResourceAttr("data.tfe_workspace.test", "name", workspaceName),
 					resource.TestCheckResourceAttrSet("data.tfe_workspace.test", "hyok_enabled"),
-					resource.TestCheckResourceAttr("data.tfe_workspace.test", "hyok_enabled", "true"),
 				),
 			},
 		},

--- a/internal/provider/data_source_workspace_test.go
+++ b/internal/provider/data_source_workspace_test.go
@@ -285,21 +285,16 @@ func TestAccTFEWorkspaceDataSource_readHYOKEnabled(t *testing.T) {
 		t.Skip("HYOK_ORGANIZATION_NAME environment variable must be set to run this test")
 	}
 
-	workspaceName := os.Getenv("HYOK_WORKSPACE_NAME")
-	if workspaceName == "" {
-		t.Skip("HYOK_WORKSPACE_NAME environment variable must be set to run this test")
-	}
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEHYOKWorkspaceDataSourceConfig(orgName, workspaceName),
+				Config: testAccTFEHYOKWorkspaceDataSourceConfig(orgName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.tfe_workspace.test", "organization", orgName),
-					resource.TestCheckResourceAttr("data.tfe_workspace.test", "name", workspaceName),
-					resource.TestCheckResourceAttrSet("data.tfe_workspace.test", "hyok_enabled"),
+					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr("data.tfe_workspace.foobar", "name", "tf-provider-tfe-hyok-enabled-workspace-test"),
+					resource.TestCheckResourceAttrSet("data.tfe_workspace.foobar", "hyok_enabled"),
 				),
 			},
 		},
@@ -488,11 +483,16 @@ data "tfe_workspace" "foobar" {
 `, rInt, rInt)
 }
 
-func testAccTFEHYOKWorkspaceDataSourceConfig(orgName string, workspaceName string) string {
+func testAccTFEHYOKWorkspaceDataSourceConfig(orgName string) string {
 	return `
-data "tfe_workspace" "test" {
+resource "tfe_workspace" "foobar" {
   organization = "` + orgName + `"
-  name         = "` + workspaceName + `"
+  name         = "tf-provider-tfe-hyok-enabled-workspace-test"
+}
+
+data "tfe_workspace" "foobar" {
+  organization = "` + orgName + `"
+  name         = tfe_workspace.foobar.name
 }
 `
 }

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -67,6 +67,17 @@ func createBusinessOrganization(t *testing.T, client *tfe.Client) (*tfe.Organiza
 	return org, orgCleanup
 }
 
+func createPremiumOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
+	org, orgCleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+
+	newSubscriptionUpdater(org).WithPremiumPlan().Update(t)
+
+	return org, orgCleanup
+}
+
 func createStandardOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
 	org, orgCleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
 		Name:  tfe.String("tst-" + randomString(t)),

--- a/internal/provider/resource_tfe_organization.go
+++ b/internal/provider/resource_tfe_organization.go
@@ -108,6 +108,12 @@ func resourceTFEOrganization() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+
+			"enforce_hyok": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -164,6 +170,7 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("assessments_enforced", org.AssessmentsEnforced)
 	d.Set("allow_force_delete_workspaces", org.AllowForceDeleteWorkspaces)
 	d.Set("speculative_plan_management_enabled", org.SpeculativePlanManagementEnabled)
+	d.Set("enforce_hyok", org.EnforceHYOK)
 
 	if org.DefaultProject != nil {
 		d.Set("default_project_id", org.DefaultProject.ID)
@@ -231,6 +238,11 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 	// If speculative_plan_management_enabled is supplied, set it using the options struct.
 	if speculativePlanManagementEnabled, ok := d.GetOkExists("speculative_plan_management_enabled"); ok {
 		options.SpeculativePlanManagementEnabled = tfe.Bool(speculativePlanManagementEnabled.(bool))
+	}
+
+	// If enforce_hyok is supplied, set it using the options struct.
+	if enforceHYOK, ok := d.GetOkExists("enforce_hyok"); ok {
+		options.EnforceHYOK = tfe.Bool(enforceHYOK.(bool))
 	}
 
 	log.Printf("[DEBUG] Update configuration of organization: %s", d.Id())

--- a/internal/provider/resource_tfe_organization_test.go
+++ b/internal/provider/resource_tfe_organization_test.go
@@ -482,7 +482,7 @@ func testAccTFEOrganization_updateEnforceHYOK(orgName string, enforceHYOK bool) 
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name         = "%s"
-  email        = admin@company.com
+  email        = "admin@company.com"
   enforce_hyok = %t
 }`, orgName, enforceHYOK)
 }

--- a/internal/provider/resource_tfe_organization_test.go
+++ b/internal/provider/resource_tfe_organization_test.go
@@ -220,7 +220,7 @@ func TestAccTFEOrganization_EnforceHYOK(t *testing.T) {
 		CheckDestroy:             testAccCheckTFEOrganizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEOrganization_updateEnforceHYOK(orgName, "admin@company.com", true),
+				Config: testAccTFEOrganization_updateEnforceHYOK(orgName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", &tfe.Organization{}),
@@ -229,7 +229,7 @@ func TestAccTFEOrganization_EnforceHYOK(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEOrganization_updateEnforceHYOK(orgName, "admin@company.com", false),
+				Config: testAccTFEOrganization_updateEnforceHYOK(orgName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEOrganizationExists(
 						"tfe_organization.foobar", &tfe.Organization{}),
@@ -478,11 +478,11 @@ resource "tfe_organization" "foobar" {
 }`, orgName, orgEmail, costEstimationEnabled, assessmentsEnforced, allowForceDeleteWorkspaces)
 }
 
-func testAccTFEOrganization_updateEnforceHYOK(orgName string, orgEmail string, enforceHYOK bool) string {
+func testAccTFEOrganization_updateEnforceHYOK(orgName string, enforceHYOK bool) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
   name         = "%s"
-  email        = "%s"
+  email        = admin@company.com
   enforce_hyok = %t
-}`, orgName, orgEmail, enforceHYOK)
+}`, orgName, enforceHYOK)
 }

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -356,7 +356,6 @@ func resourceTFEWorkspace() *schema.Resource {
 			},
 			"hyok_enabled": {
 				Type:     schema.TypeBool,
-				Default:  false,
 				Optional: true,
 			},
 		},

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -354,6 +354,11 @@ func resourceTFEWorkspace() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"hyok_enabled": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -518,6 +523,10 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		options.Tags = append(options.Tags, &tfe.Tag{Name: name})
 	}
 
+	if v, ok := d.GetOkExists("hyok_enabled"); ok {
+		options.HYOKEnabled = tfe.Bool(v.(bool))
+	}
+
 	log.Printf("[DEBUG] Create workspace %s for organization: %s", name, organization)
 	workspace, err := config.Client.Workspaces.Create(ctx, organization, options)
 	if err != nil {
@@ -614,6 +623,7 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("organization", workspace.Organization.Name)
 	d.Set("resource_count", workspace.ResourceCount)
 	d.Set("inherits_project_auto_destroy", workspace.InheritsProjectAutoDestroy)
+	d.Set("hyok_enabled", workspace.HYOKEnabled)
 
 	if workspace.Links["self-html"] != nil {
 		baseAPI := config.Client.BaseURL()
@@ -747,6 +757,12 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		if d.HasChange("description") {
 			if v, ok := d.GetOk("description"); ok {
 				options.Description = tfe.String(v.(string))
+			}
+		}
+
+		if d.HasChange("hyok_enabled") {
+			if v, ok := d.GetOkExists("enforce_hyok"); ok {
+				options.HYOKEnabled = tfe.Bool(v.(bool))
 			}
 		}
 

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -523,10 +523,6 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		options.Tags = append(options.Tags, &tfe.Tag{Name: name})
 	}
 
-	if v, ok := d.GetOkExists("hyok_enabled"); ok {
-		options.HYOKEnabled = tfe.Bool(v.(bool))
-	}
-
 	log.Printf("[DEBUG] Create workspace %s for organization: %s", name, organization)
 	workspace, err := config.Client.Workspaces.Create(ctx, organization, options)
 	if err != nil {
@@ -757,12 +753,6 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		if d.HasChange("description") {
 			if v, ok := d.GetOk("description"); ok {
 				options.Description = tfe.String(v.(string))
-			}
-		}
-
-		if d.HasChange("hyok_enabled") {
-			if v, ok := d.GetOkExists("enforce_hyok"); ok {
-				options.HYOKEnabled = tfe.Bool(v.(bool))
 			}
 		}
 

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -2965,7 +2965,6 @@ func TestAccTFEWorkspace_HYOKEnabled(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", orgName),
 					resource.TestCheckResourceAttrSet("tfe_workspace.foobar", "hyok_enabled"),
-					resource.TestCheckResourceAttr("tfe_workspace.foobar", "hyok_enabled", "false"),
 				),
 			},
 		},

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -2955,63 +2955,17 @@ func TestAccTFEWorkspace_HYOKEnabled(t *testing.T) {
 		t.Skip("HYOK_ORGANIZATION_NAME environment variable must be set to run this test")
 	}
 
-	// Testing workspace hyok enabled going from false to true.
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
-			// Create workspace with hyok_enabled set to false
 			{
-				Config: testAccTFEWorkspaceHYOKEnabledConfig(orgName, false),
+				Config: testAccTFEWorkspaceConfig(orgName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", orgName),
+					resource.TestCheckResourceAttrSet("tfe_workspace.foobar", "hyok_enabled"),
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "hyok_enabled", "false"),
-				),
-			},
-			// Import
-			{
-				ResourceName:      "tfe_workspace.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update hyok_enabled to true
-			{
-				Config: testAccTFEWorkspaceHYOKEnabledConfig(orgName, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", orgName),
-					resource.TestCheckResourceAttr("tfe_workspace.foobar", "hyok_enabled", "true"),
-				),
-			},
-		},
-	})
-
-	// Testing workspace hyok enabled going from true to false.
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
-		Steps: []resource.TestStep{
-			// Create workspace with hyok_enabled set to true
-			{
-				Config: testAccTFEWorkspaceHYOKEnabledConfig(orgName, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", orgName),
-					resource.TestCheckResourceAttr("tfe_workspace.foobar", "hyok_enabled", "true"),
-				),
-			},
-			// Import
-			{
-				ResourceName:      "tfe_workspace.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update hyok_enabled to false, however hyok_enabled cannot be disabled once enabled.
-			{
-				Config: testAccTFEWorkspaceHYOKEnabledConfig(orgName, false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", orgName),
-					resource.TestCheckResourceAttr("tfe_workspace.foobar", "hyok_enabled", "true"),
 				),
 			},
 		},
@@ -4228,12 +4182,11 @@ resource "tfe_workspace" "foobar" {
 }`, rInt)
 }
 
-func testAccTFEWorkspaceHYOKEnabledConfig(orgName string, hyokEnabled bool) string {
+func testAccTFEWorkspaceConfig(orgName string) string {
 	return fmt.Sprintf(`
 resource "tfe_workspace" "foobar" {
   organization = "%s"
   name         = "tfe-provider-test-workspace-hyok-enabled"
-  hyok_enabled = %t
 }
-`, orgName, hyokEnabled)
+`, orgName)
 }

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -2950,10 +2950,13 @@ func TestAccTFEWorkspace_createWithSourceURLAndName(t *testing.T) {
 func TestAccTFEWorkspace_HYOKEnabled(t *testing.T) {
 	skipUnlessHYOKEnabled(t)
 
-	orgName := os.Getenv("HYOK_ORGANIZATION_NAME")
-	if orgName == "" {
-		t.Skip("HYOK_ORGANIZATION_NAME environment variable must be set to run this test")
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	org, orgCleanup := createPremiumOrganization(t, tfeClient)
+	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -2961,9 +2964,9 @@ func TestAccTFEWorkspace_HYOKEnabled(t *testing.T) {
 		CheckDestroy:             testAccCheckTFEWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEWorkspaceConfig(orgName),
+				Config: testAccTFEWorkspaceConfig(org.Name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", orgName),
+					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", org.Name),
 					resource.TestCheckResourceAttrSet("tfe_workspace.foobar", "hyok_enabled"),
 				),
 			},

--- a/internal/provider/subscription_updater_test.go
+++ b/internal/provider/subscription_updater_test.go
@@ -29,6 +29,7 @@ type featureSetListOptions struct {
 type updateFeatureSetOptions struct {
 	Type                          string     `jsonapi:"primary,subscription"`
 	RunsCeiling                   *int       `jsonapi:"attr,runs-ceiling,omitempty"`
+	AgentsCeiling                 *int       `jsonapi:"attr,agents-ceiling,omitempty"`
 	ContractStartAt               *time.Time `jsonapi:"attr,contract-start-at,iso8601,omitempty"`
 	ContractUserLimit             *int       `jsonapi:"attr,contract-user-limit,omitempty"`
 	ContractApplyLimit            *int       `jsonapi:"attr,contract-apply-limit,omitempty"`
@@ -75,6 +76,20 @@ func (b *organizationSubscriptionUpdater) WithBusinessPlan() *organizationSubscr
 	b.updateOpts.ContractStartAt = &start
 	b.updateOpts.ContractUserLimit = &userLimit
 	b.updateOpts.ContractApplyLimit = &applyLimit
+	return b
+}
+
+func (b *organizationSubscriptionUpdater) WithPremiumPlan() *organizationSubscriptionUpdater {
+	b.planName = "Premium (entitlement)"
+
+	ceiling := 10
+	start := time.Now()
+	managedResourcesLimit := 1000
+
+	b.updateOpts.RunsCeiling = &ceiling
+	b.updateOpts.AgentsCeiling = &ceiling
+	b.updateOpts.ContractStartAt = &start
+	b.updateOpts.ContractManagedResourcesLimit = &managedResourcesLimit
 	return b
 }
 

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -31,6 +31,7 @@ In addition to all arguments above, the following attributes are exported:
 * `assessments_enforced` - (Available only in HCP Terraform) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
 * `collaborator_auth_policy` - Authentication policy (`password` or `two_factor_mandatory`). Defaults to `password`.
 * `cost_estimation_enabled` - Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a HCP Terraform organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
+* `enforce_hyok` - (Optional) Whether HYOK Enforcement is enabled for the organization.
 * `owners_team_saml_role_id` - The name of the "owners" team.
 * `send_passing_statuses_for_untriggered_speculative_plans` - Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to true. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.
 * `aggregated_commit_status_enabled` - Whether or not to enable Aggregated Status Checks. This can be useful for monorepo repositories with multiple workspaces receiving status checks for events such as a pull request.

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -31,7 +31,7 @@ In addition to all arguments above, the following attributes are exported:
 * `assessments_enforced` - (Available only in HCP Terraform) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
 * `collaborator_auth_policy` - Authentication policy (`password` or `two_factor_mandatory`). Defaults to `password`.
 * `cost_estimation_enabled` - Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a HCP Terraform organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
-* `enforce_hyok` - (Optional) Whether HYOK Enforcement is enabled for the organization.
+* `enforce_hyok` - (Available only in HCP Terraform) Whether HYOK is enforced for all new workspaces in the organization.
 * `owners_team_saml_role_id` - The name of the "owners" team.
 * `send_passing_statuses_for_untriggered_speculative_plans` - Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to true. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.
 * `aggregated_commit_status_enabled` - Whether or not to enable Aggregated Status Checks. This can be useful for monorepo repositories with multiple workspaces receiving status checks for events such as a pull request.

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -40,6 +40,7 @@ In addition to all arguments above, the following attributes are exported:
 * `assessments_enabled` - (Available only in HCP Terraform) Indicates whether health assessments such as drift detection are enabled for the workspace.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument).
+* `hyok_enabled` - (Optional) Whether HYOK is enabled for the workspace.
 * `inherits_project_auto_destroy` - Indicates whether this workspace inherits project auto destroy settings.
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` is set to `true`.
 * `operations` - Indicates whether the workspace is using remote execution mode. Set to `false` to switch execution mode to local. `true` by default.
@@ -66,7 +67,6 @@ In addition to all arguments above, the following attributes are exported:
 * `working_directory` - A relative path that Terraform will execute within.
 * `execution_mode` - Indicates the [execution mode](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#execution-mode) of the workspace. **Note:** This value might be derived from an organization-level default or set on the workspace itself; see the [`tfe_workspace_settings` resource](tfe_workspace_settings) for details.
 * `html_url` - The URL to the browsable HTML overview of the workspace
-
 
 The `vcs_repo` block contains:
 

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
   `20160`.
 * `collaborator_auth_policy` - (Optional) Authentication policy (`password`
   or `two_factor_mandatory`). Defaults to `password`.
-* `enforce_hyok` - (Optional) Whether or not to enable HYOK Enforcement for the organization.
+* `enforce_hyok` - (Optional) (Available only in HCP Terraform) Whether HYOK is enabled for all new workspaces in the organization. Defaults to false.
 * `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
 * `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a HCP Terraform organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `send_passing_statuses_for_untriggered_speculative_plans` - (Optional) Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
   `20160`.
 * `collaborator_auth_policy` - (Optional) Authentication policy (`password`
   or `two_factor_mandatory`). Defaults to `password`.
+* `enforce_hyok` - (Optional) Whether or not to enable HYOK Enforcement for the organization.
 * `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
 * `cost_estimation_enabled` - (Optional) Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a HCP Terraform organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `send_passing_statuses_for_untriggered_speculative_plans` - (Optional) Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -82,7 +82,6 @@ The following arguments are supported:
   VCS push to trigger a run. If disabled, any push will trigger a run.
 * `force_delete` - (Optional) If this attribute is present on a workspace that is being deleted through the provider, it will use the existing force delete API. If this attribute is not present or false it will safe delete the workspace.
 * `global_remote_state` - (Optional) **Deprecated** Whether the workspace allows all workspaces in the organization to access its state data during runs. Use [tfe_workspace_settings](workspace_settings) instead.
-* `hyok_enabled` - (Optional) Whether HYOK is enabled for the workspace.
 * `operations` - **Deprecated** Whether to use remote execution mode.
   Defaults to `true`. When set to `false`, the workspace will be used for
   state storage only. This value _must not_ be provided if `execution_mode` is
@@ -169,6 +168,7 @@ In addition to all arguments above, the following attributes are exported:
 * `html_url` - The URL to the browsable HTML overview of the workspace.
 * `inherits_project_auto_destroy` - Indicates whether this workspace inherits project auto destroy settings.
 * `effective_tags` - A map of key value tags for this workspace, including any tags inherited from the parent project.
+* `hyok_enabled` - (Available only in HCP Terraform) Whether HYOK is enabled for the workspace.
 
 ## Import
 

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
   VCS push to trigger a run. If disabled, any push will trigger a run.
 * `force_delete` - (Optional) If this attribute is present on a workspace that is being deleted through the provider, it will use the existing force delete API. If this attribute is not present or false it will safe delete the workspace.
 * `global_remote_state` - (Optional) **Deprecated** Whether the workspace allows all workspaces in the organization to access its state data during runs. Use [tfe_workspace_settings](workspace_settings) instead.
-* `hyok_enabled` - (Optional) Whether or not to enable HYOK for the workspace.
+* `hyok_enabled` - (Optional) Whether HYOK is enabled for the workspace.
 * `operations` - **Deprecated** Whether to use remote execution mode.
   Defaults to `true`. When set to `false`, the workspace will be used for
   state storage only. This value _must not_ be provided if `execution_mode` is

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -82,6 +82,7 @@ The following arguments are supported:
   VCS push to trigger a run. If disabled, any push will trigger a run.
 * `force_delete` - (Optional) If this attribute is present on a workspace that is being deleted through the provider, it will use the existing force delete API. If this attribute is not present or false it will safe delete the workspace.
 * `global_remote_state` - (Optional) **Deprecated** Whether the workspace allows all workspaces in the organization to access its state data during runs. Use [tfe_workspace_settings](workspace_settings) instead.
+* `hyok_enabled` - (Optional) Whether or not to enable HYOK for the workspace.
 * `operations` - **Deprecated** Whether to use remote execution mode.
   Defaults to `true`. When set to `false`, the workspace will be used for
   state storage only. This value _must not_ be provided if `execution_mode` is


### PR DESCRIPTION
## Description

Updating the attributes for `Organization` and `Workspace` to support HYOK related attributes.

_Remember to:_
- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Using a version of https://github.com/hashicorp/go-tfe/pull/1201 and using an organization with access to HYOK
2. Use a terraform configuration with resources to create and update Organizations and Workspaces with HYOK options via `terraform plan`, and `terraform apply`.
```
resource "tfe_organization" "provider-tfe-hyok-test" {
  name         = "provider-tfe-hyok-test"
  email        = "YOUR-EMAIL"
  enforce_hyok = true
}

resource "tfe_workspace" "test-workspace-hyok-enabled" {
  organization = "YOUR-ORG"
  name         = "test-workspace-hyok-enabled"
}
```
3. Use a terraform configuration with data sources to read Organizations and Workspaces with HYOK options via `terraform plan`, and `terraform apply`.
```
data "tfe_organization" "tfe_organization_test" {
  name = "YOUR-ORG"
}

output "tfe_organization" {
  value = data.tfe_organization.tfe_organization_test
}

data "tfe_workspace" "tfe_workspace_test" {
  organization = "YOUR-ORG"
  name = "YOUR-NAME"
}

output "tfe_workspace" {
  value = data.tfe_workspace.tfe_workspace_test
}
```

## External links
- JIRA
   - [TF-28673](https://hashicorp.atlassian.net/browse/TF-28673)
- HYOK Documentation
   - [Key Version API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/key-versions)
   - [Encrypted Data Keys API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/encrypted-data-keys)

## Output from acceptance tests
TestAccTFEOrganizationDataSource_readEnforceHYOK:
```
=== RUN   TestAccTFEOrganizationDataSource_readEnforceHYOK
--- PASS: TestAccTFEOrganizationDataSource_readEnforceHYOK (2.85s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   3.246s
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers   [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers     [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/validators        [no test files]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

TestAccTFEWorkspaceDataSource_readHYOKEnabled:
```
=== RUN   TestAccTFEWorkspaceDataSource_readHYOKEnabled
--- PASS: TestAccTFEWorkspaceDataSource_readHYOKEnabled (2.38s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   3.008s
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers   [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers     [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/validators        [no test files]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

TestAccTFEWorkspace_HYOKEnabled:
```
=== RUN   TestAccTFEWorkspace_HYOKEnabled
--- PASS: TestAccTFEWorkspace_HYOKEnabled (3.43s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   4.094s
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers   [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers     [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/validators        [no test files]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls


[TF-28673]: https://hashicorp.atlassian.net/browse/TF-28673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ