### PR TITLE
fix(tfe_workspace_run_tasks): allow semantic-style (1.x.x) TFE versions

### DIFF
--- a/internal/provider/resource_tfe_workspace_run_task.go
+++ b/internal/provider/resource_tfe_workspace_run_task.go
@@ -12,6 +12,7 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"golang.org/x/mod/semver"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -332,7 +333,10 @@ func (r *resourceWorkspaceRunTask) supportsStagesProperty() bool {
 	// The version comparison here can use plain string comparisons due to the nature of the naming scheme. If
 	// TFE every changes its scheme, the comparison will be problematic.
 	if r.supportsStages == nil {
-		value := r.capabilities.IsCloud() || r.capabilities.RemoteTFEVersion() > "v202404"
+		value := r.capabilities.IsCloud() ||
+			semver.IsValid("v"+r.capabilities.RemoteTFEVersion()) ||
+			r.capabilities.RemoteTFEVersion() > "v202404"
+
 		r.supportsStages = &value
 	}
 	return *r.supportsStages

--- a/internal/provider/resource_tfe_workspace_run_task_test.go
+++ b/internal/provider/resource_tfe_workspace_run_task_test.go
@@ -25,6 +25,8 @@ func TestTFEWorkspaceRunTask_stagesSupport(t *testing.T) {
 		"when Enterprise v202402":            {false, "v202402-2", false},
 		"when Enterprise v202404-1":          {false, "v202404-1", true},
 		"when Enterprise v202408-1":          {false, "v202408-1", true},
+		"when Enterprise v1.0.0":             {false, "1.0.0", true},
+		"when Enterprise < 1.0.0":            {false, "1.1.0", true},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
## Description

This fixes workspace run tasks for users of TFE >= 1.0.0.

## Testing plan

Provision a `tfe_workspace_run_task` against a TFE instance with version gte 1.0.0. It should not fail.

## Output from acceptance tests

❯ envchain local go test ./... -v -run=TestTFEWorkspaceRunTask_stagesSupport

=== RUN   TestTFEWorkspaceRunTask_stagesSupport
=== RUN   TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_v202404-1
=== RUN   TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_v202408-1
=== RUN   TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_v1.0.0
=== RUN   TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_<_1.0.0
=== RUN   TestTFEWorkspaceRunTask_stagesSupport/when_HCP_Terraform
=== RUN   TestTFEWorkspaceRunTask_stagesSupport/when_HCP_Terraform_but_TFE_version
=== RUN   TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_<_v202208-3
=== RUN   TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_v202402
--- PASS: TestTFEWorkspaceRunTask_stagesSupport (0.00s)
    --- PASS: TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_v202404-1 (0.00s)
    --- PASS: TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_v202408-1 (0.00s)
    --- PASS: TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_v1.0.0 (0.00s)
    --- PASS: TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_<_1.0.0 (0.00s)
    --- PASS: TestTFEWorkspaceRunTask_stagesSupport/when_HCP_Terraform (0.00s)
    --- PASS: TestTFEWorkspaceRunTask_stagesSupport/when_HCP_Terraform_but_TFE_version (0.00s)
    --- PASS: TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_<_v202208-3 (0.00s)
    --- PASS: TestTFEWorkspaceRunTask_stagesSupport/when_Enterprise_v202402 (0.00s)
PASS
```