### PR TITLE
Add datadog test optimization workflow

### DIFF
--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: The mock run tasks URL to use for testing.
     required: false
     default: "http://testing-mocks.tfe:22180/runtasks/pass"
+  datadog-workflow-token:
+    description: Datadog API key for test optimization
+    required: false
+  
 
 runs:
   using: composite
@@ -89,6 +93,13 @@ runs:
         junit-summary: ./ci-summary-provider.xml
         # When tests are split and run concurrently, lists_tests arg in ci.yml will skip the TestAccTFESAMLSettings_omnibus test suite
         list: ${{ inputs.list_tests }}
+    
+    - name: Configure Datadog Test Optimization
+      uses: datadog/test-visibility-github-action@v2
+      with:
+        languages: go
+        api_key: ${{ inputs.datadog-workflow-token }}
+        site: datadoghq.com 
 
     - name: Run Tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
+          datadog-workflow-token: ${{ secrets.TF_WORKFLOW_DATADOG_API_KEY }}
           admin_configuration_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.configuration }}
           admin_provision_licenses_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.provision-licenses }}
           admin_security_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.security-maintenance }}
@@ -89,6 +90,13 @@ jobs:
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
+
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: go
+          api_key: ${{ secrets.TF_WORKFLOW_DATADOG_API_KEY }}
+          site: datadoghq.com 
 
       - name: Run TestAccTFEWorkspaceRun Tests Sequentially
         env:


### PR DESCRIPTION
## Description

Add the Datadog test optimization action to our CI tests. Currently we won't get the bot PR comments about tests as there's some needed org level access to do so.

## Testing plan

You can take [a look here](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Aterraform-provider-tfe&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1760633570647&end=1761238370647&paused=false) to see the test runs in DD (currently only for this PR)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
