### PR TITLE
Fix a typo in an import command for `tfe_agent_pool`.

### DIFF
--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -51,5 +51,5 @@ terraform import tfe_agent_pool.test apool-rW0KoLSlnuNb5adB
 ```
 
 ```shell
-terraform import tfe_workspace.test my-org-name/my-agent-pool-name
+terraform import tfe_agent_pool.test my-org-name/my-agent-pool-name
 ```


### PR DESCRIPTION
## Description
It looks like the documentation for `tfe_agent_pool` has a typo. The command provided is to import a `tfe_workspace`, instead of a `tfe_agent_pool`.