### PR TITLE
chore: prepare for v0.71.0 release

### DIFF
--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -100,6 +100,7 @@ runs:
         languages: go
         api_key: ${{ inputs.datadog-workflow-token }}
         site: datadoghq.com 
+        go-tracer-version: v1.5.0
 
     - name: Run Tests
       shell: bash

--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -93,14 +93,14 @@ runs:
         junit-summary: ./ci-summary-provider.xml
         # When tests are split and run concurrently, lists_tests arg in ci.yml will skip the TestAccTFESAMLSettings_omnibus test suite
         list: ${{ inputs.list_tests }}
-    
+
     - name: Configure Datadog Test Optimization
-      uses: datadog/test-visibility-github-action@v2
+      uses: datadog/test-visibility-github-action@4d09028b08a1f4431663b1de1550249cd4764051 # v2.4.1
       with:
         languages: go
         api_key: ${{ inputs.datadog-workflow-token }}
-        site: datadoghq.com 
-        go-tracer-version: v1.5.0
+        site: datadoghq.com
+        go-tracer-version: 1.5.0
 
     - name: Run Tests
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           version: ${{ needs.set-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -102,7 +102,7 @@ jobs:
 
           cp "$source" "$destination"
           echo "filename=$destination" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: terraform-registry-manifest.json
           path: ${{ steps.terraform-registry-manifest.outputs.filename }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           node-version: 20
 
       - name: Download artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
 
       - name: Install junit-report-merger
         run: npm install -g junit-report-merger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
             -v -timeout=30m -parallel=1 -run "TestAccTFEWorkspaceRun"
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: junit-test-summary-workspace-run
           path: workspace-run-summary.xml
@@ -154,7 +154,7 @@ jobs:
         run: jrm ./ci-summary-provider.xml "junit-test-summary-0/*.xml" "junit-test-summary-1/*.xml" "junit-test-summary-2/*.xml" "junit-test-summary-3/*.xml" "junit-test-summary-4/*.xml" "junit-test-summary-5/*.xml" "junit-test-summary-6/*.xml" "junit-test-summary-7/*.xml" "junit-test-summary-workspace-run/*.xml"
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: junit-test-summary
           path: ./ci-summary-provider.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     needs: [ tests, tests-workspace-run-sequential ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 20
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -89,7 +89,7 @@ jobs:
         run: npm install -g cdktf-registry-docs@1.10.1
 
       - name: Download artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: terraform-provider-tfe
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -81,7 +81,7 @@ jobs:
           key: ${{ runner.os }}-integration-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "20.x"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+
+## v0.71.0
+
 FEATURES:
 * **New resource**: `r/tfe_vault_oidc_configuration` for managing Vault OIDC configurations. by @helenjw [#1835](https://github.com/hashicorp/terraform-provider-tfe/pull/1835)
 * **New resource**: `r/tfe_aws_oidc_configuration` for managing AWS OIDC configurations. by @helenjw [#1835](https://github.com/hashicorp/terraform-provider-tfe/pull/1835)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-slug v0.16.8
-	github.com/hashicorp/go-tfe v1.94.0
+	github.com/hashicorp/go-tfe v1.95.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/hashicorp/go-tfe v1.93.0 h1:hJubwn1xNCo1iBO66iQkjyC+skR61cK1AQUj4O9vv
 github.com/hashicorp/go-tfe v1.93.0/go.mod h1:QwqgCD5seztgp76CP7F0POJPflQNSqjIvBpVohg9X50=
 github.com/hashicorp/go-tfe v1.94.0 h1:EjUo5kEV5m9BSfAduSbttGfR4M2TE0O5vJV3RNBArdw=
 github.com/hashicorp/go-tfe v1.94.0/go.mod h1:hTnfAzkwOMvWL4sVKNPzUYTjrbwKIWnRWYSIC/Zh5SA=
+github.com/hashicorp/go-tfe v1.95.0 h1:vx1X6SlSHBnJzoy8Wy+0OyXcNmbdUt3wIk+Ll6mQLgo=
+github.com/hashicorp/go-tfe v1.95.0/go.mod h1:hTnfAzkwOMvWL4sVKNPzUYTjrbwKIWnRWYSIC/Zh5SA=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=


### PR DESCRIPTION
## Description

This PR batches the dependency updates and updates the changelog for the v0.71.0 release.

Dependency updates:
- [build(deps): bump actions/upload-artifact from 4.6.2 to 5.0.0](https://github.com/hashicorp/terraform-provider-tfe/commit/931ac72c49f5825195bbc624a5c8d26db036d95e), formerly #1884
- [build(deps): bump actions/download-artifact from 5.0.0 to 6.0.0](https://github.com/hashicorp/terraform-provider-tfe/commit/187bcd4e7b8aaf57138a29d3b26a1376d395ee80), formerly #1883 
- [build(deps): bump github.com/hashicorp/go-tfe from 1.94.0 to 1.95.0](https://github.com/hashicorp/terraform-provider-tfe/commit/4c6203919f8c07bd9f2f54e40a9440f70e474a63), formerly #1877
- [build(deps): bump actions/setup-node from 5.0.0 to 6.0.0](https://github.com/hashicorp/terraform-provider-tfe/commit/a95556fee1187f63e9b67f958894c3791b77d7d2), formerly #1875