### PR TITLE
fix: some settings being unset by tfe_workspace_settings

### DIFF
--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -495,9 +495,21 @@ func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorks
 			ExecutionMode: tfe.Bool(false),
 			AgentPool:     tfe.Bool(false),
 		},
-		Description:        tfe.String(data.Description.ValueString()),
-		AutoApply:          tfe.Bool(data.AutoApply.ValueBool()),
-		AssessmentsEnabled: tfe.Bool(data.AssessmentsEnabled.ValueBool()),
+	}
+
+	description := tfe.String(data.Description.ValueString())
+	if description != nil && *description != "" {
+		updateOptions.Description = description
+	}
+
+	assessmentsEnabled := tfe.Bool(data.AssessmentsEnabled.ValueBool())
+	if assessmentsEnabled != nil {
+		updateOptions.AssessmentsEnabled = assessmentsEnabled
+	}
+
+	autoApply := tfe.Bool(data.AutoApply.ValueBool())
+	if autoApply != nil {
+		updateOptions.AutoApply = autoApply
 	}
 
 	executionMode := data.ExecutionMode.ValueString()

--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -98,6 +98,27 @@ func TestAccTFEWorkspaceSettings_basic(t *testing.T) {
 	})
 }
 
+func TestAccTFEWorkspaceSettings_noArguments(t *testing.T) {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspaceSettings_noArgs(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"tfe_workspace_settings.test", "id"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.test", "description", "A workspace description",
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFEWorkspaceSettings_stateSharing(t *testing.T) {
 	tfeClient, err := getClientUsingEnv()
 	if err != nil {
@@ -558,7 +579,7 @@ resource "tfe_project" "test" {
 resource "tfe_workspace" "test" {
 	name         = "tfe-provider-test-workspace-%d"
 	organization = tfe_organization.test.name
-    project_id   = tfe_project.test.id 
+	project_id   = tfe_project.test.id
 }
 `, rInt, rInt, rInt)
 }
@@ -593,6 +614,26 @@ resource "tfe_workspace_settings" "test" {
 	tags = {}
 }
 `
+}
+
+func testAccTFEWorkspaceSettings_noArgs(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "test" {
+  name  = "tst-tfeprovider-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "test" {
+	name         = "tfe-provider-test-workspace-%d"
+	organization = tfe_organization.test.name
+	description  = "A workspace description"
+}
+
+resource "tfe_workspace_settings" "test" {
+	workspace_id = tfe_workspace.test.id
+	# Description defined on tfe_workspace
+}
+`, rInt, rInt)
 }
 
 func TestAccTFEWorkspaceSettings_preservesWorkspaceTagsOnFirstApply(t *testing.T) {


### PR DESCRIPTION
## Description

We should not always set the assessmentsEnabled, autoApply, or description if those arguments are not set explicitly by the tfe_workspace_settings resource

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Try this config:

```terraform
resource "tfe_workspace" "this" {
  name               = "dimpy_test_workspace"
  organization       = "bcroft"
  description        = "this is the test workspace"
  allow_destroy_plan = true
  auto_apply         = true
  file_triggers_enabled = false
  source_name                   = null
  source_url                    = null
  speculative_enabled           = true
  structured_run_output_enabled = true
  trigger_prefixes = null
  trigger_patterns = null
  ssh_key_id       = null
  tags = {
    environment = "dev"
    team_owner  = "my-team"
  }
}
resource "tfe_workspace_settings" "this" {
  workspace_id   = tfe_workspace.this.id
  execution_mode = "remote"
}
```

On the first apply, the description is unset by tfe_workspace_settings, on the second apply, it's re-planned.

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspaceSettings_noArguments" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspaceSettings_noArguments -timeout 15m
=== RUN   TestAccTFEWorkspaceSettings_noArguments
--- PASS: TestAccTFEWorkspaceSettings_noArguments (4.02s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   4.664s
```

