### PR TITLE
Fix double 'uses:' in nightly-tfe-test workflow

### DIFF
--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -99,7 +99,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: go.mod


### PR DESCRIPTION
## Description

The nightlies have been failing silently for the past two months following [this change](https://github.com/hashicorp/terraform-provider-tfe/pull/1840/files#diff-1fcace23565d1f508047b38693c7c0b894923a9936ef57ff4f1ae9fe4c196617:~:text=%2B-,uses%3A%20actions/setup%2Dgo%4044694675825211faa026b3c33043df3e48a5fa00%20%23%20v6.0.0,-103). The failures have been silent since the reporting of a failure is within the workflow itself, which doesn't run due to the file being invalid. This PR removes the double declaration of `uses:` so this can start working again.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
