### PR TITLE
Added global_provider_sharing to tfe_admin_organization_settings

### DIFF
--- a/internal/provider/resource_tfe_admin_organization_settings.go
+++ b/internal/provider/resource_tfe_admin_organization_settings.go
@@ -41,6 +41,10 @@ func resourceTFEAdminOrganizationSettings() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"global_provider_sharing": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"sso_enabled": {
 				Computed: true,
 				Type:     schema.TypeBool,
@@ -87,6 +91,7 @@ func resourceTFEAdminOrganizationSettingsRead(d *schema.ResourceData, meta inter
 	d.Set("organization", org.Name)
 	d.Set("access_beta_tools", org.AccessBetaTools)
 	d.Set("global_module_sharing", org.GlobalModuleSharing)
+	d.Set("global_provider_sharing", org.GlobalProviderSharing)
 	d.Set("sso_enabled", org.SsoEnabled)
 	d.Set("workspace_limit", org.WorkspaceLimit)
 	d.SetId(org.Name)
@@ -140,11 +145,13 @@ func resourceTFEAdminOrganizationSettingsUpdate(d *schema.ResourceData, meta int
 		return err
 	}
 	globalModuleSharing := d.Get("global_module_sharing").(bool)
+	globalProviderSharing := d.Get("global_provider_sharing").(bool)
 
 	_, err = config.Client.Admin.Organizations.Update(ctx, name, tfe.AdminOrganizationUpdateOptions{
-		AccessBetaTools:     tfe.Bool(d.Get("access_beta_tools").(bool)),
-		GlobalModuleSharing: tfe.Bool(globalModuleSharing),
-		WorkspaceLimit:      tfe.Int(d.Get("workspace_limit").(int)),
+		AccessBetaTools:       tfe.Bool(d.Get("access_beta_tools").(bool)),
+		GlobalModuleSharing:   tfe.Bool(globalModuleSharing),
+		GlobalProviderSharing: tfe.Bool(globalProviderSharing),
+		WorkspaceLimit:        tfe.Int(d.Get("workspace_limit").(int)),
 	})
 
 	if err != nil {

--- a/internal/provider/resource_tfe_admin_organization_settings_test.go
+++ b/internal/provider/resource_tfe_admin_organization_settings_test.go
@@ -34,6 +34,8 @@ func TestAccTFEAdminOrganizationSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_admin_organization_settings.settings", "global_module_sharing", "false"),
 					resource.TestCheckResourceAttr(
+						"tfe_admin_organization_settings.settings", "global_provider_sharing", "false"),
+					resource.TestCheckResourceAttr(
 						"tfe_admin_organization_settings.settings", "access_beta_tools", "true"),
 
 					// module_consumers attribute
@@ -58,6 +60,8 @@ func TestAccTFEAdminOrganizationSettings_basic(t *testing.T) {
 						"tfe_admin_organization_settings.settings", "organization", fmt.Sprintf("tst-terraform-%d", rInt1)),
 					resource.TestCheckResourceAttr(
 						"tfe_admin_organization_settings.settings", "global_module_sharing", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_admin_organization_settings.settings", "global_provider_sharing", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_admin_organization_settings.settings", "access_beta_tools", "true"),
 
@@ -94,6 +98,7 @@ resource "tfe_organization" "bar" {
 resource "tfe_admin_organization_settings" "settings" {
 	organization = tfe_organization.foobar.id
 	global_module_sharing = false
+	global_provider_sharing = false
 	access_beta_tools = true
 
 	module_sharing_consumer_organizations = [tfe_organization.foo.id, tfe_organization.bar.id]

--- a/website/docs/r/admin_organization_settings.markdown
+++ b/website/docs/r/admin_organization_settings.markdown
@@ -44,6 +44,7 @@ resource "tfe_admin_organization_settings" "test-settings" {
   workspace_limit                       = 15
   access_beta_tools                     = false
   global_module_sharing                 = false
+  global_provider_sharing               = false
   module_sharing_consumer_organizations = [
     tfe_organization.a-module-consumer.name
   ]
@@ -58,6 +59,7 @@ The following arguments are supported:
 * `access_beta_tools` - (Optional) True if the organization has access to beta tool versions.
 * `workspace_limit` - (Optional) Maximum number of workspaces for this organization. If this number is set to a value lower than the number of workspaces the organization has, it will prevent additional workspaces from being created, but existing workspaces will not be affected. If set to 0, this limit will have no effect.
 * `global_module_sharing` - (Optional) If true, modules in the organization's private module repository will be available to all other organizations. Enabling this will disable any previously configured module_sharing_consumer_organizations. Cannot be true if module_sharing_consumer_organizations is set.
+* `global_provider_sharing` - (Optional) If true, provider in the organization's private provider registry will be available to all other organizations.
 * `module_sharing_consumer_organizations` - (Optional) A list of organization names to share modules in the organization's private module repository with. Cannot be set if global_module_sharing is true.
 
 ## Attributes Reference


### PR DESCRIPTION
See https://developer.hashicorp.com/terraform/enterprise/application-administration/registry-sharing

## Description

In `tfe_admin_organization_settings` its currently not possible to set `global_provider_sharing`.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [X] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
