### PR TITLE
TF-33374 Project Notification Configuration Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 * **New Data Source:** `d/tfe_scim_group`: Adds a data source to retrieve a SCIM group from Terraform Enterprise. By @skj-skj [#2083](https://github.com/hashicorp/terraform-provider-tfe/pull/2083)
 * **New Resource:** `r/tfe_provider_set` for managing shared provider configurations for internal testing. NOTE: This resource is subject to change and has limited support in HCP Terraform. By @mogrogan [#2086](https://github.com/hashicorp/terraform-provider-tfe/pull/2086)
 * **New Resource:** `r/tfe_scim_group_mapping`: Adds a resource to map a SCIM group to a team on Terraform Enterprise. By @skj-skj [#2090](https://github.com/hashicorp/terraform-provider-tfe/pull/2090)
+* **New Resource:** `r/tfe_project_notification_configuration`: Adds a resource for managing project notification configurations, by @jillirami ([#1958](https://github.com/hashicorp/terraform-provider-tfe/pull/1958))
 
 ENHANCEMENTS:
 * `d/tfe_team`: Expose SCIM attributes (`scim_linked`, `scim_group_name`, `scim_sync_paused`, `scim_updated_at`) as computed read-only fields. These are only populated when SCIM is enabled on the TFE instance [#2088](https://github.com/hashicorp/terraform-provider-tfe/pull/2088)

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -193,6 +193,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewTestVariableResource,
 		NewWorkspaceRunTaskResource,
 		NewNotificationConfigurationResource,
+		NewProjectNotificationConfigurationResource,
 		NewTeamTokenResource,
 		NewProjectSettingsResource,
 		NewTerraformVersionResource,

--- a/internal/provider/resource_tfe_project_notification_configuration.go
+++ b/internal/provider/resource_tfe_project_notification_configuration.go
@@ -1,0 +1,558 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-tfe/internal/provider/validators"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &resourceTFEProjectNotificationConfiguration{}
+var _ resource.ResourceWithConfigure = &resourceTFEProjectNotificationConfiguration{}
+var _ resource.ResourceWithImportState = &resourceTFEProjectNotificationConfiguration{}
+
+func NewProjectNotificationConfigurationResource() resource.Resource {
+	return &resourceTFEProjectNotificationConfiguration{}
+}
+
+// resourceTFEProjectNotificationConfiguration implements the tfe_project_notification_configuration resource type
+type resourceTFEProjectNotificationConfiguration struct {
+	config ConfiguredClient
+}
+
+func (r *resourceTFEProjectNotificationConfiguration) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project_notification_configuration"
+}
+
+type modelTFEProjectNotificationConfiguration struct {
+	ID              types.String `tfsdk:"id"`
+	Name            types.String `tfsdk:"name"`
+	DestinationType types.String `tfsdk:"destination_type"`
+	EmailAddresses  types.Set    `tfsdk:"email_addresses"`
+	EmailUserIDs    types.Set    `tfsdk:"email_user_ids"`
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	Token           types.String `tfsdk:"token"`
+	TokenWO         types.String `tfsdk:"token_wo"`
+	TokenWOVersion  types.Int64  `tfsdk:"token_wo_version"`
+	Triggers        types.Set    `tfsdk:"triggers"`
+	URL             types.String `tfsdk:"url"`
+	ProjectID       types.String `tfsdk:"project_id"`
+}
+
+// modelFromTFEProjectNotificationConfiguration builds a modelTFEProjectNotificationConfiguration
+// struct from a tfe.NotificationConfiguration value.
+func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfiguration, tokenWOVersion types.Int64, lastValue types.String) (*modelTFEProjectNotificationConfiguration, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	result := modelTFEProjectNotificationConfiguration{
+		ID:              types.StringValue(v.ID),
+		Name:            types.StringValue(v.Name),
+		DestinationType: types.StringValue(string(v.DestinationType)),
+		Enabled:         types.BoolValue(v.Enabled),
+		ProjectID:       types.StringValue(v.SubscribableChoice.Project.ID),
+		TokenWOVersion:  tokenWOVersion,
+		Token:           types.StringValue(""),
+	}
+
+	if len(v.EmailAddresses) == 0 {
+		result.EmailAddresses = types.SetNull(types.StringType)
+	} else {
+		emailAddresses, diags := types.SetValueFrom(ctx, types.StringType, v.EmailAddresses)
+		if diags != nil && diags.HasError() {
+			return nil, diags
+		}
+		result.EmailAddresses = emailAddresses
+	}
+
+	if len(v.Triggers) == 0 {
+		result.Triggers = types.SetNull(types.StringType)
+	} else {
+		triggers, diags := types.SetValueFrom(ctx, types.StringType, v.Triggers)
+		if diags != nil && diags.HasError() {
+			return nil, diags
+		}
+		result.Triggers = triggers
+	}
+
+	if len(v.EmailUsers) == 0 {
+		result.EmailUserIDs = types.SetNull(types.StringType)
+	} else {
+		emailUserIDs := make([]attr.Value, len(v.EmailUsers))
+		for i, emailUser := range v.EmailUsers {
+			emailUserIDs[i] = types.StringValue(emailUser.ID)
+		}
+		result.EmailUserIDs = types.SetValueMust(types.StringType, emailUserIDs)
+	}
+
+	if lastValue.ValueString() != "" {
+		result.Token = lastValue
+	}
+
+	if !tokenWOVersion.IsNull() {
+		result.Token = types.StringNull()
+	}
+
+	if v.URL != "" {
+		result.URL = types.StringValue(v.URL)
+	}
+
+	return &result, diags
+}
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFEProjectNotificationConfiguration) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Early exit if provider is unconfigured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	r.config = client
+}
+
+// Schema implements resource.Resource
+func (r *resourceTFEProjectNotificationConfiguration) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Defines a project notification configuration resource.",
+		Version:     0,
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "ID of the project notification configuration.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+
+			"name": schema.StringAttribute{
+				Description: "Name of the project notification configuration.",
+				Required:    true,
+			},
+
+			"destination_type": schema.StringAttribute{
+				Description: "The type of notification configuration payload to send.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						string(tfe.NotificationDestinationTypeEmail),
+						string(tfe.NotificationDestinationTypeGeneric),
+						string(tfe.NotificationDestinationTypeSlack),
+						string(tfe.NotificationDestinationTypeMicrosoftTeams),
+					),
+				},
+			},
+
+			"email_addresses": schema.SetAttribute{
+				Description: "A list of email addresses. This value must not be provided if `destination_type` is `generic`, `microsoft-teams`, or `slack`.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Validators: []validator.Set{
+					validators.AttributeValueConflictValidator(
+						"destination_type",
+						[]string{"generic", "microsoft-teams", "slack"},
+					),
+				},
+			},
+
+			"email_user_ids": schema.SetAttribute{
+				Description: "A list of user IDs. This value must not be provided if `destination_type` is `generic`, `microsoft-teams`, or `slack`.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Validators: []validator.Set{
+					validators.AttributeValueConflictValidator(
+						"destination_type",
+						[]string{"generic", "microsoft-teams", "slack"},
+					),
+				},
+			},
+
+			"enabled": schema.BoolAttribute{
+				Description: "Whether the project notification configuration should be enabled or not. Disabled configurations will not send any notifications. Defaults to `false`.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"token": schema.StringAttribute{
+				Description: "A write-only secure token for the notification configuration, which can be used by the receiving server to verify request authenticity when configured for notification configurations with a destination type of `generic`. Defaults to `null`. This value _must not_ be provided if `destination_type` is `email`, `microsoft-teams`, or `slack`.",
+				Optional:    true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					validators.AttributeValueConflictValidator(
+						"destination_type",
+						[]string{"email", "microsoft-teams", "slack"},
+					),
+					stringvalidator.ConflictsWith(path.MatchRoot("token_wo")),
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("token_wo")),
+				},
+			},
+
+			"token_wo": schema.StringAttribute{
+				Description: "A write-only secure token for the notification configuration, guaranteed not to be written to plan or state artifacts.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					validators.AttributeValueConflictValidator(
+						"destination_type",
+						[]string{"email", "microsoft-teams", "slack"},
+					),
+					stringvalidator.ConflictsWith(path.MatchRoot("token")),
+					stringvalidator.AlsoRequires(path.MatchRoot("token_wo_version")),
+				},
+			},
+			"token_wo_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Version of the write-only token to trigger updates",
+				Validators: []validator.Int64{
+					int64validator.ConflictsWith(path.MatchRoot("token")),
+					int64validator.AlsoRequires(path.MatchRoot("token_wo")),
+				},
+			},
+
+			"triggers": schema.SetAttribute{
+				Description: "The array of triggers for which this project notification configuration will send notifications. If omitted, no notification triggers are configured.",
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(
+						stringvalidator.OneOf(
+							string(tfe.NotificationTriggerCreated),
+							string(tfe.NotificationTriggerPlanning),
+							string(tfe.NotificationTriggerNeedsAttention),
+							string(tfe.NotificationTriggerApplying),
+							string(tfe.NotificationTriggerCompleted),
+							string(tfe.NotificationTriggerErrored),
+							string(tfe.NotificationTriggerAssessmentCheckFailed),
+							string(tfe.NotificationTriggerAssessmentDrifted),
+							string(tfe.NotificationTriggerAssessmentFailed),
+							string(tfe.NotificationTriggerWorkspaceAutoDestroyReminder),
+							string(tfe.NotificationTriggerWorkspaceAutoDestroyRunResults),
+						),
+					),
+				},
+			},
+
+			"url": schema.StringAttribute{
+				Description: "The HTTP or HTTPS URL where notification requests will be made. This value must not be provided if `email_addresses` or `email_user_ids` is present, or if `destination_type` is `email`.",
+				Optional:    true,
+				Validators: []validator.String{
+					validators.AttributeRequiredIfValueString(
+						"destination_type",
+						[]string{"generic", "microsoft-teams", "slack"},
+					),
+					validators.AttributeValueConflictValidator(
+						"destination_type",
+						[]string{"email"},
+					),
+					stringvalidator.ConflictsWith(
+						path.MatchRelative().AtParent().AtName("email_addresses"),
+						path.MatchRelative().AtParent().AtName("email_user_ids"),
+					),
+				},
+			},
+
+			"project_id": schema.StringAttribute{
+				Description: "The ID of the project that owns the notification configuration.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+// Create implements resource.Resource
+func (r *resourceTFEProjectNotificationConfiguration) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan, config modelTFEProjectNotificationConfiguration
+
+	// Read Terraform plan and config data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectID := plan.ProjectID.ValueString()
+
+	// Create a new options struct
+	options := tfe.NotificationConfigurationCreateOptions{
+		DestinationType: tfe.NotificationDestination(tfe.NotificationDestinationType(plan.DestinationType.ValueString())),
+		Enabled:         plan.Enabled.ValueBoolPointer(),
+		Name:            plan.Name.ValueStringPointer(),
+		URL:             plan.URL.ValueStringPointer(),
+		SubscribableChoice: &tfe.NotificationConfigurationSubscribableChoice{
+			Project: &tfe.Project{ID: projectID},
+		},
+	}
+
+	lastTokenValue := types.StringValue("")
+	// Set Token from `token_wo` if set, otherwise use the normal value
+	if !config.TokenWO.IsNull() {
+		options.Token = config.TokenWO.ValueStringPointer()
+	} else {
+		options.Token = plan.Token.ValueStringPointer()
+		lastTokenValue = plan.Token
+	}
+
+	// Add triggers set to the options struct
+	var triggers []types.String
+	if diags := plan.Triggers.ElementsAs(ctx, &triggers, true); diags != nil && diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	options.Triggers = []tfe.NotificationTriggerType{}
+	for _, trigger := range triggers {
+		options.Triggers = append(options.Triggers, tfe.NotificationTriggerType(trigger.ValueString()))
+	}
+
+	// Add email_addresses set to the options struct
+	emailAddresses := make([]types.String, len(plan.EmailAddresses.Elements()))
+	if diags := plan.EmailAddresses.ElementsAs(ctx, &emailAddresses, true); diags != nil && diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	options.EmailAddresses = []string{}
+	for _, emailAddress := range emailAddresses {
+		options.EmailAddresses = append(options.EmailAddresses, emailAddress.ValueString())
+	}
+
+	// Add email_user_ids set to the options struct
+	emailUserIDs := make([]types.String, len(plan.EmailUserIDs.Elements()))
+	if diags := plan.EmailUserIDs.ElementsAs(ctx, &emailUserIDs, true); diags != nil && diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	options.EmailUsers = []*tfe.User{}
+	for _, emailUserID := range emailUserIDs {
+		options.EmailUsers = append(options.EmailUsers, &tfe.User{ID: emailUserID.ValueString()})
+	}
+
+	tflog.Debug(ctx, "Creating project notification configuration")
+	pnc, err := r.config.Client.NotificationConfigurations.Create(ctx, projectID, options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create project notification configuration", err.Error())
+		return
+	} else if len(pnc.EmailUsers) != len(plan.EmailUserIDs.Elements()) {
+		resp.Diagnostics.AddError("Email user IDs produced an inconsistent result", "API returned a different number of email user IDs than were provided in the plan.")
+		return
+	}
+
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// Read implements resource.Resource
+func (r *resourceTFEProjectNotificationConfiguration) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFEProjectNotificationConfiguration
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading project notification configuration %q", state.ID.ValueString()))
+	pnc, err := r.config.Client.NotificationConfigurations.Read(ctx, state.ID.ValueString())
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Project notification configuration %s no longer exists", state.ID))
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError("Error reading project notification configuration", "Could not read project notification configuration, unexpected error: "+err.Error())
+		}
+		return
+	}
+
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, state.TokenWOVersion, state.Token)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// Update implements resource.Resource
+func (r *resourceTFEProjectNotificationConfiguration) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan modelTFEProjectNotificationConfiguration
+	var state modelTFEProjectNotificationConfiguration
+	var config modelTFEProjectNotificationConfiguration
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	// Read Terraform configuration data into the model so write-only values are available.
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create a new options struct
+	options := tfe.NotificationConfigurationUpdateOptions{
+		Enabled: plan.Enabled.ValueBoolPointer(),
+		Name:    plan.Name.ValueStringPointer(),
+		URL:     plan.URL.ValueStringPointer(),
+	}
+
+	// Preserve the previously known token unless this update explicitly changes token or token_wo.
+	// The API never returns token values, so we must carry it forward in state to avoid sensitive value drift
+	// when updates are triggered by unrelated attributes.
+	lastTokenValue := state.Token
+
+	tkn, isWOVal := r.determineTokenForUpdate(plan, state, config)
+	// check is needed to prevent accidentally unsetting the token when no changes to token or token_wo were made
+	// this is important when an update is triggered by changes in other attributes
+	if tkn != nil {
+		options.Token = tkn
+
+		if !isWOVal {
+			lastTokenValue = types.StringValue(*tkn)
+		}
+	}
+
+	// Add triggers set to the options struct
+	triggers := make([]types.String, len(plan.Triggers.Elements()))
+	if diags := plan.Triggers.ElementsAs(ctx, &triggers, true); diags != nil && diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	options.Triggers = []tfe.NotificationTriggerType{}
+	for _, trigger := range triggers {
+		options.Triggers = append(options.Triggers, tfe.NotificationTriggerType(trigger.ValueString()))
+	}
+
+	// Add email_addresses set to the options struct
+	emailAddresses := make([]types.String, len(plan.EmailAddresses.Elements()))
+	if diags := plan.EmailAddresses.ElementsAs(ctx, &emailAddresses, true); diags != nil && diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	options.EmailAddresses = []string{}
+	for _, emailAddress := range emailAddresses {
+		options.EmailAddresses = append(options.EmailAddresses, emailAddress.ValueString())
+	}
+
+	// Add email_user_ids set to the options struct
+	emailUserIDs := make([]types.String, len(plan.EmailUserIDs.Elements()))
+	if diags := plan.EmailUserIDs.ElementsAs(ctx, &emailUserIDs, true); diags != nil && diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	options.EmailUsers = []*tfe.User{}
+	for _, emailUserID := range emailUserIDs {
+		options.EmailUsers = append(options.EmailUsers, &tfe.User{ID: emailUserID.ValueString()})
+	}
+
+	tflog.Debug(ctx, "Updating project notification configuration")
+	pnc, err := r.config.Client.NotificationConfigurations.Update(ctx, state.ID.ValueString(), options)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to update project notification configuration", err.Error())
+		return
+	} else if len(pnc.EmailUsers) != len(plan.EmailUserIDs.Elements()) {
+		resp.Diagnostics.AddError("Email user IDs produced an inconsistent result", "API returned a different number of email user IDs than were provided in the plan.")
+		return
+	}
+
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// Delete implements resource.Resource
+func (r *resourceTFEProjectNotificationConfiguration) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFEProjectNotificationConfiguration
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Deleting project notification configuration")
+	err := r.config.Client.NotificationConfigurations.Delete(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to delete project notification configuration", err.Error())
+		return
+	}
+}
+
+func (r *resourceTFEProjectNotificationConfiguration) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+}
+
+// determineTokenForUpdate is invoked only after terraform determines that an attribute update is needed.
+// note that the update can be triggered by other attributes outside of the token/token_wo attributes.
+// this function compares the TokenWOVersion vs Token to ensure that during api update call, token is not mistakenly unset.
+// Returns nil if no token update is needed.
+func (r *resourceTFEProjectNotificationConfiguration) determineTokenForUpdate(plan, state, config modelTFEProjectNotificationConfiguration) (updateToken *string, isWOVal bool) {
+	// Determine if we're using write-only token in plan vs state
+	usingWriteOnlyInPlan := !plan.TokenWOVersion.IsNull()
+	usingWriteOnlyInState := !state.TokenWOVersion.IsNull()
+
+	// Case 1: Switching FROM token TO token_wo
+	if !usingWriteOnlyInState && usingWriteOnlyInPlan && !config.TokenWO.IsNull() {
+		return config.TokenWO.ValueStringPointer(), true
+	}
+	// Case 2: Switching FROM token_wo TO token
+	if usingWriteOnlyInState && !usingWriteOnlyInPlan && !plan.Token.IsNull() {
+		return plan.Token.ValueStringPointer(), false
+	}
+	// Case 3: token_wo version changed in plan
+	if usingWriteOnlyInPlan && plan.TokenWOVersion.ValueInt64() != state.TokenWOVersion.ValueInt64() && !config.TokenWO.IsNull() {
+		return config.TokenWO.ValueStringPointer(), true
+	}
+	// Case 4: Regular token changed. Only set Token if our planned value would be a CHANGE from
+	// the prior state. This prevents accidentally resetting the token on unrelated changes.
+	if state.Token.ValueString() != plan.Token.ValueString() {
+		return plan.Token.ValueStringPointer(), false
+	}
+	return nil, false
+}

--- a/internal/provider/resource_tfe_project_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_project_notification_configuration_test.go
@@ -1,0 +1,440 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccTFEProjectNotificationConfiguration_basic(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	notificationConfiguration := &tfe.NotificationConfiguration{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectNotificationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProjectNotificationConfiguration_basic(org.Name, project.ID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProjectNotificationConfigurationExists(
+						"tfe_project_notification_configuration.foobar", notificationConfiguration),
+					testAccCheckTFEProjectNotificationConfigurationAttributes(notificationConfiguration),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "destination_type", "generic"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "name", "notification_basic"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "triggers.#", "0"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url", runTasksURL()),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProjectNotificationConfiguration_emailUserIDs(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	notificationConfiguration := &tfe.NotificationConfiguration{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectNotificationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProjectNotificationConfiguration_emailUserIDs(org.Name, project.ID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProjectNotificationConfigurationExists(
+						"tfe_project_notification_configuration.foobar", notificationConfiguration),
+					testAccCheckTFEProjectNotificationConfigurationAttributesEmailUserIDs(notificationConfiguration),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "destination_type", "email"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "name", "notification_email"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "triggers.#", "0"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "email_user_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProjectNotificationConfiguration_update(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	notificationConfiguration := &tfe.NotificationConfiguration{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectNotificationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProjectNotificationConfiguration_basic(org.Name, project.ID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProjectNotificationConfigurationExists(
+						"tfe_project_notification_configuration.foobar", notificationConfiguration),
+					testAccCheckTFEProjectNotificationConfigurationAttributes(notificationConfiguration),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "destination_type", "generic"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "name", "notification_basic"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "triggers.#", "0"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url", runTasksURL()),
+				),
+			},
+			{
+				Config: testAccTFEProjectNotificationConfiguration_update(org.Name, project.ID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProjectNotificationConfigurationExists(
+						"tfe_project_notification_configuration.foobar", notificationConfiguration),
+					testAccCheckTFEProjectNotificationConfigurationAttributesUpdate(notificationConfiguration),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "destination_type", "generic"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "name", "notification_update"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "token", "1234567890_update"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "triggers.#", "1"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url", runTasksURL()),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProjectNotificationConfiguration_validateSchemaAttributesSlack(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEProjectNotificationConfiguration_slackWithEmailAddresses(org.Name, project.ID),
+				ExpectError: regexp.MustCompile(`(?s).*The attribute 'email_addresses' cannot be set when 'destination_type' is.*'slack'`),
+			},
+			{
+				Config:      testAccTFEProjectNotificationConfiguration_slackWithEmailUserIDs(org.Name, project.ID),
+				ExpectError: regexp.MustCompile(`(?s).*The attribute 'email_user_ids' cannot be set when 'destination_type' is.*'slack'`),
+			},
+			{
+				Config:      testAccTFEProjectNotificationConfiguration_slackWithToken(org.Name, project.ID),
+				ExpectError: regexp.MustCompile(`The attribute 'token' cannot be set when 'destination_type' is 'slack'`),
+			},
+			{
+				Config:      testAccTFEProjectNotificationConfiguration_slackWithoutURL(org.Name, project.ID),
+				ExpectError: regexp.MustCompile(`The attribute 'url' is required when 'destination_type' is 'slack'`),
+			},
+		},
+	})
+}
+
+func testAccCheckTFEProjectNotificationConfigurationExists(n string, notificationConfiguration *tfe.NotificationConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		nc, err := testAccConfiguredClient.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if nc == nil {
+			return fmt.Errorf("project notification configuration not found")
+		}
+
+		*notificationConfiguration = *nc
+
+		return nil
+	}
+}
+
+func testAccCheckTFEProjectNotificationConfigurationAttributes(notificationConfiguration *tfe.NotificationConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if notificationConfiguration.Name != "notification_basic" {
+			return fmt.Errorf("bad name: %s", notificationConfiguration.Name)
+		}
+
+		if notificationConfiguration.DestinationType != tfe.NotificationDestinationTypeGeneric {
+			return fmt.Errorf("bad destination type: %s", notificationConfiguration.DestinationType)
+		}
+
+		if notificationConfiguration.Enabled {
+			return fmt.Errorf("bad enabled: %t", notificationConfiguration.Enabled)
+		}
+
+		if notificationConfiguration.Token != "1234567890" {
+			return fmt.Errorf("bad token: %s", notificationConfiguration.Token)
+		}
+
+		if len(notificationConfiguration.Triggers) != 0 {
+			return fmt.Errorf("bad triggers: %v", notificationConfiguration.Triggers)
+		}
+
+		if notificationConfiguration.URL != runTasksURL() {
+			return fmt.Errorf("bad URL: %s", notificationConfiguration.URL)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEProjectNotificationConfigurationAttributesEmailUserIDs(notificationConfiguration *tfe.NotificationConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if notificationConfiguration.Name != "notification_email" {
+			return fmt.Errorf("bad name: %s", notificationConfiguration.Name)
+		}
+
+		if notificationConfiguration.DestinationType != tfe.NotificationDestinationTypeEmail {
+			return fmt.Errorf("bad destination type: %s", notificationConfiguration.DestinationType)
+		}
+
+		if notificationConfiguration.Enabled {
+			return fmt.Errorf("bad enabled: %t", notificationConfiguration.Enabled)
+		}
+
+		if len(notificationConfiguration.Triggers) != 0 {
+			return fmt.Errorf("bad triggers: %v", notificationConfiguration.Triggers)
+		}
+
+		if len(notificationConfiguration.EmailUsers) != 0 {
+			return fmt.Errorf("bad email users: %v", notificationConfiguration.EmailUsers)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEProjectNotificationConfigurationAttributesUpdate(notificationConfiguration *tfe.NotificationConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if notificationConfiguration.Name != "notification_update" {
+			return fmt.Errorf("bad name: %s", notificationConfiguration.Name)
+		}
+
+		if notificationConfiguration.DestinationType != tfe.NotificationDestinationTypeGeneric {
+			return fmt.Errorf("bad destination type: %s", notificationConfiguration.DestinationType)
+		}
+
+		if !notificationConfiguration.Enabled {
+			return fmt.Errorf("bad enabled: %t", notificationConfiguration.Enabled)
+		}
+
+		if notificationConfiguration.Token != "1234567890_update" {
+			return fmt.Errorf("bad token: %s", notificationConfiguration.Token)
+		}
+
+		if len(notificationConfiguration.Triggers) != 1 {
+			return fmt.Errorf("bad triggers: %v", notificationConfiguration.Triggers)
+		}
+
+		if !reflect.DeepEqual(notificationConfiguration.Triggers, []string{"change_request:created"}) {
+			return fmt.Errorf("bad triggers: %v", notificationConfiguration.Triggers)
+		}
+
+		if notificationConfiguration.URL != runTasksURL() {
+			return fmt.Errorf("bad URL: %s", notificationConfiguration.URL)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEProjectNotificationConfigurationDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_project_notification_configuration" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no instance ID is set")
+		}
+
+		_, err := testAccConfiguredClient.Client.NotificationConfigurations.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("project notification configuration %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccTFEProjectNotificationConfiguration_basic(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_basic"
+  destination_type = "generic"
+  enabled          = false
+  token            = "1234567890"
+  triggers         = []
+  url              = "%s"
+  project_id       = "%s"
+}`, orgName, runTasksURL(), projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_emailUserIDs(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_email"
+  destination_type = "email"
+  email_user_ids   = []
+  project_id       = "%s"
+}`, orgName, projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_update(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_update"
+  destination_type = "generic"
+  enabled          = true
+  token            = "1234567890_update"
+  triggers         = ["change_request:created"]
+  url              = "%s"
+  project_id       = "%s"
+}`, orgName, runTasksURL(), projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_slackWithEmailAddresses(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_slack_with_email_addresses"
+  destination_type = "slack"
+  email_addresses  = ["test@example.com", "test2@example.com"]
+  project_id       = "%s"
+}`, orgName, projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_slackWithEmailUserIDs(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_slack_with_email_user_ids"
+  destination_type = "slack"
+  email_user_ids   = ["user-abc123"]
+  project_id       = "%s"
+}`, orgName, projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_slackWithToken(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_slack_with_token"
+  destination_type = "slack"
+  token            = "1234567890"
+  url              = "%s"
+  project_id       = "%s"
+}`, orgName, runTasksURL(), projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_slackWithoutURL(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_slack_without_url"
+  destination_type = "slack"
+  project_id       = "%s"
+}`, orgName, projectID)
+}
+
+func preCheckTFEProjectNotificationConfiguration(t *testing.T) {
+	testAccPreCheck(t)
+	skipIfEnterprise(t)
+}

--- a/internal/provider/subscription_updater_test.go
+++ b/internal/provider/subscription_updater_test.go
@@ -110,7 +110,8 @@ func (b *organizationSubscriptionUpdater) WithFreePlan() *organizationSubscripti
 // Attempts to change an organization's subscription to a different plan. Requires a user token with admin access.
 func (b *organizationSubscriptionUpdater) Update(t *testing.T) {
 	if enterpriseEnabled() {
-		t.Skip("Cannot upgrade an organization's subscription when enterprise is enabled. Set ENABLE_TFE=0 to run.")
+		t.Log("Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)")
+		return
 	}
 
 	if b.planName == "" {


### PR DESCRIPTION
## Description

This pull request introduces a new resource for managing project notification configurations in Terraform Enterprise and HCP Terraform. The main change is the addition of the `tfe_project_notification_configuration` resource, along with its provider registration and documentation. There are also minor improvements to test logic for organization subscriptions.

**New Resource: Project Notification Configuration**

* Added the `tfe_project_notification_configuration` resource, enabling management of project-level notification configurations, including support for various destination types and triggers. (`CHANGELOG.md`, `website/docs/r/project_notification_configuration.html.markdown`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11) [[2]](diffhunk://#diff-9836e8a95336cfbeb6bb4ce404ab58e4732ef829fea6a4b814727c4aeff9aea9R1-R139)
* Registered the new resource in the provider so it is available for use. (`internal/provider/provider_next.go`)

**Documentation**

* Created comprehensive documentation for `tfe_project_notification_configuration`, including usage examples, argument descriptions, and import instructions. (`website/docs/r/project_notification_configuration.html.markdown`)

**Testing/Developer Experience**

* Improved test logic for organization subscription updates to log and return when enterprise mode is enabled, rather than skipping the test with a hard error. (`internal/provider/subscription_updater_test.go`)

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/1350)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

jillianne.ramirez@jillianne terraform-provider-tfe % TFE_HOSTNAME="tfcdev-acae0288.ngrok.io" \
TFE_TOKEN="" \
TFE_ADMIN_PROVISION_LICENSES_TOKEN="" \
TF_ACC=1 \
ENABLE_BETA=1 \
ENABLE_TFE=1 \
go test ./internal/provider/ -run TestAccTFEProjectNotificationConfiguration -v -count=1
=== RUN   TestAccTFEProjectNotificationConfiguration_basic
2026/06/11 12:13:53 [DEBUG] Configuring client for host "tfcdev-acae0288.ngrok.io"
2026/06/11 12:13:53 [WARN] Unable to read CLI config or credentials file /Users/jillianne.ramirez/.terraformrc: open /Users/jillianne.ramirez/.terraformrc: no such file or directory
2026/06/11 12:13:53 [WARN] Unable to read CLI config or credentials file /Users/jillianne.ramirez/.terraform.d/credentials.tfrc.json: open /Users/jillianne.ramirez/.terraform.d/credentials.tfrc.json: no such file or directory
2026/06/11 12:13:53 [DEBUG] Service discovery for tfcdev-acae0288.ngrok.io at https://tfcdev-acae0288.ngrok.io/.well-known/terraform.json
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
    helper_test.go:243: Skipping test for a feature unavailable in Terraform Enterprise. Set 'ENABLE_TFE=0' to run.
--- SKIP: TestAccTFEProjectNotificationConfiguration_basic (1.20s)
=== RUN   TestAccTFEProjectNotificationConfiguration_emailUserIDs
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
    helper_test.go:243: Skipping test for a feature unavailable in Terraform Enterprise. Set 'ENABLE_TFE=0' to run.
--- SKIP: TestAccTFEProjectNotificationConfiguration_emailUserIDs (0.83s)
=== RUN   TestAccTFEProjectNotificationConfiguration_update
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
    helper_test.go:243: Skipping test for a feature unavailable in Terraform Enterprise. Set 'ENABLE_TFE=0' to run.
--- SKIP: TestAccTFEProjectNotificationConfiguration_update (0.77s)
=== RUN   TestAccTFEProjectNotificationConfiguration_validateSchemaAttributesSlack
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
    helper_test.go:243: Skipping test for a feature unavailable in Terraform Enterprise. Set 'ENABLE_TFE=0' to run.
--- SKIP: TestAccTFEProjectNotificationConfiguration_validateSchemaAttributesSlack (0.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	4.354s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->

<img width="1728" height="911" alt="Screenshot 2026-06-01 at 17 56 59" src="https://github.com/user-attachments/assets/401c0e4f-622f-43db-84f8-fc5725ed773e" />
