### PR TITLE
chore: remove CI dependencies on personal repos

### DIFF
--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -119,8 +119,8 @@ runs:
         ENABLE_TFE: "${{ inputs.enterprise }}"
         RUN_TASKS_URL: "${{ inputs.run_tasks_url }}"
         GITHUB_POLICY_SET_IDENTIFIER: "hashicorp/test-policy-set"
-        GITHUB_REGISTRY_MODULE_IDENTIFIER: "hashicorp/terraform-random-module"
-        GITHUB_WORKSPACE_IDENTIFIER: "hashicorp/terraform-random-module"
+        GITHUB_REGISTRY_MODULE_IDENTIFIER: "svc-team-tf-core-cloud/terraform-random-module"
+        GITHUB_WORKSPACE_IDENTIFIER: "svc-team-tf-core-cloud/terraform-random-module"
         GITHUB_WORKSPACE_BRANCH: "main"
         GITHUB_TOKEN: "${{ inputs.testing-github-token }}"
         MOD_PROVIDER: github.com/hashicorp/terraform-provider-tfe


### PR DESCRIPTION
## Description

This PR removes all repos in the `ctrombley` org from the pool of CI dependencies. Their references are being replaced with refs to a service-user-owned-fork.
