### PR TITLE
Fix flaky test due to order of schema validation runs

### DIFF
--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -305,7 +305,7 @@ func TestAccTFEWorkspaceSettingsRemoteState(t *testing.T) {
 			},
 			// Set both global and project remote state
 			{
-				Config:      testAccTFEWorkspaceSettingsRemoteState_GlobalProjectConflict(ws.ID, ws2.ID),
+				Config:      testAccTFEWorkspaceSettingsRemoteState_GlobalProjectConflict(ws.ID),
 				ExpectError: regexp.MustCompile("Invalid configuration"),
 			},
 		},
@@ -557,15 +557,14 @@ resource "tfe_workspace_settings" "foobar" {
 `, workspaceID, workspaceID2)
 }
 
-func testAccTFEWorkspaceSettingsRemoteState_GlobalProjectConflict(workspaceID, workspaceID2 string) string {
+func testAccTFEWorkspaceSettingsRemoteState_GlobalProjectConflict(workspaceID string) string {
 	return fmt.Sprintf(`
 resource "tfe_workspace_settings" "foobar" {
 	workspace_id              = "%s"
 	global_remote_state       = true
   	project_remote_state      = true
-	remote_state_consumer_ids = ["%s"]
 }
-`, workspaceID, workspaceID2)
+`, workspaceID)
 }
 
 func testAccTFEWorkspaceSettings_basic(workspaceID string) string {
@@ -661,7 +660,7 @@ resource "tfe_workspace_settings" "test" {
 	workspace_id = tfe_workspace.test.id
 	tags = {
 	  keyA = "valueA"
-	  keyB = "valueB"	
+	  keyB = "valueB"
 	}
 }
 `


### PR DESCRIPTION
## Description

**This is a DEV only change:**

The config in `testAccTFEWorkspaceSettingsRemoteState_GlobalProjectConflict` sets all three conflicting attributes: `global_remote_state = true`, `project_remote_state = true`, AND `remote_state_consumer_ids`. This results in 2 validation failure possibility depending on which schema validator gets fired first.

The two validators are:
validateRemoteStateConsumerIDs on `remote_state_consumer_ids` — produces error `"Invalid remote_state_consumer_ids"`
validateRemoteStateExclusion on `global_remote_state/project_remote_state` — produces error `"Invalid configuration"`
 
The test expects only `"Invalid configuration"`, but whenever `validateRemoteStateConsumerIDs` fires first, the actual error contains `"Invalid remote_state_consumer_ids"` instead.

This PR updates the test to target the expected error scenario of `global + project remote state`

_Remember to:_
**DEV only change, not required**
- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->
Revert PR

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
