### PR TITLE
Fix missing identity on read-after-delete for variables and stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+BUG FIXES:
+* `r/tfe_variable`: Preserve or backfill resource identity on deleted-resource reads to avoid missing identity errors after remote deletion.
+* `r/tfe_project`: Preserve or backfill resource identity on deleted-resource reads to avoid missing identity errors after remote deletion.
+* `r/tfe_stack`: Preserve or backfill resource identity on deleted-resource reads and treat remotely deleted stacks as removed resources instead of read errors.
+
 ## v0.76.0
 
 FEATURES:

--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -258,6 +258,7 @@ func (r *resourceTFEProject) Read(ctx context.Context, req resource.ReadRequest,
 	})
 	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Project %s no longer exists", id))
+		r.setReadIdentity(ctx, req, resp, id)
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -266,6 +267,7 @@ func (r *resourceTFEProject) Read(ctx context.Context, req resource.ReadRequest,
 		project, err = r.config.Client.Projects.Read(ctx, id)
 		if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
 			tflog.Debug(ctx, fmt.Sprintf("Project %s no longer exists", id))
+			r.setReadIdentity(ctx, req, resp, id)
 			resp.State.RemoveResource(ctx)
 			return
 		} else if err != nil {
@@ -310,6 +312,29 @@ func (r *resourceTFEProject) Read(ctx context.Context, req resource.ReadRequest,
 
 	identity := modelProjectIdentity{
 		ID:       result.ID,
+		Hostname: types.StringValue(r.config.Client.BaseURL().Host),
+	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identity)...)
+}
+
+func (r *resourceTFEProject) setReadIdentity(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse, projectID string) {
+	if resp.Identity == nil {
+		return
+	}
+
+	if req.Identity != nil {
+		currentIdentity := &modelProjectIdentity{}
+		resp.Diagnostics.Append(req.Identity.Get(ctx, &currentIdentity)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if currentIdentity != nil && !currentIdentity.ID.IsNull() {
+			return
+		}
+	}
+
+	identity := modelProjectIdentity{
+		ID:       types.StringValue(projectID),
 		Hostname: types.StringValue(r.config.Client.BaseURL().Host),
 	}
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identity)...)

--- a/internal/provider/resource_tfe_project_test.go
+++ b/internal/provider/resource_tfe_project_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -16,8 +17,54 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	tfe "github.com/hashicorp/go-tfe"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+type notFoundProjects struct{}
+
+func (notFoundProjects) List(_ context.Context, _ string, _ *tfe.ProjectListOptions) (*tfe.ProjectList, error) {
+	return nil, nil
+}
+
+func (notFoundProjects) Create(_ context.Context, _ string, _ tfe.ProjectCreateOptions) (*tfe.Project, error) {
+	return nil, nil
+}
+
+func (notFoundProjects) Read(_ context.Context, _ string) (*tfe.Project, error) {
+	return nil, tfe.ErrResourceNotFound
+}
+
+func (notFoundProjects) ReadWithOptions(_ context.Context, _ string, _ tfe.ProjectReadOptions) (*tfe.Project, error) {
+	return nil, tfe.ErrResourceNotFound
+}
+
+func (notFoundProjects) Update(_ context.Context, _ string, _ tfe.ProjectUpdateOptions) (*tfe.Project, error) {
+	return nil, nil
+}
+
+func (notFoundProjects) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func (notFoundProjects) ListTagBindings(_ context.Context, _ string) ([]*tfe.TagBinding, error) {
+	return nil, nil
+}
+
+func (notFoundProjects) ListEffectiveTagBindings(_ context.Context, _ string) ([]*tfe.EffectiveTagBinding, error) {
+	return nil, nil
+}
+
+func (notFoundProjects) AddTagBindings(_ context.Context, _ string, _ tfe.ProjectAddTagBindingsOptions) ([]*tfe.TagBinding, error) {
+	return nil, nil
+}
+
+func (notFoundProjects) DeleteAllTagBindings(_ context.Context, _ string) error {
+	return nil
+}
 
 func TestAccTFEProject_basic(t *testing.T) {
 	project := &tfe.Project{}
@@ -301,6 +348,122 @@ func TestAccTFEProject_importByIdentity(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestResourceTFEProjectRead_RemovedProjectBackfillsIdentity(t *testing.T) {
+	ctx := context.Background()
+	client := testTfeClient(t, testClientOptions{})
+	client.Projects = notFoundProjects{}
+
+	r := &resourceTFEProject{config: ConfiguredClient{Client: client}}
+
+	readResp := runRemovedProjectRead(t, ctx, r, modelTFEProject{
+		ID:                          types.StringValue("prj-123"),
+		Name:                        types.StringValue("projecttest"),
+		Description:                 types.StringValue("project description"),
+		Organization:                types.StringValue("example-org"),
+		AutoDestroyActivityDuration: types.StringNull(),
+		Tags:                        types.MapNull(types.StringType),
+		IgnoreAdditionalTags:        types.BoolValue(false),
+	})
+
+	assertRemovedProjectRead(t, ctx, readResp, modelProjectIdentity{
+		ID:       types.StringValue("prj-123"),
+		Hostname: types.StringValue(client.BaseURL().Host),
+	})
+}
+
+func TestResourceTFEProjectRead_RemovedProjectPreservesExistingIdentity(t *testing.T) {
+	ctx := context.Background()
+	client := testTfeClient(t, testClientOptions{})
+	client.Projects = notFoundProjects{}
+
+	r := &resourceTFEProject{config: ConfiguredClient{Client: client}}
+	existingIdentity := &modelProjectIdentity{
+		ID:       types.StringValue("prj-existing"),
+		Hostname: types.StringValue("preserve.example.com"),
+	}
+
+	readResp := runRemovedProjectRead(t, ctx, r, modelTFEProject{
+		ID:                          types.StringValue("prj-123"),
+		Name:                        types.StringValue("projecttest"),
+		Description:                 types.StringValue("project description"),
+		Organization:                types.StringValue("example-org"),
+		AutoDestroyActivityDuration: types.StringNull(),
+		Tags:                        types.MapNull(types.StringType),
+		IgnoreAdditionalTags:        types.BoolValue(false),
+	}, existingIdentity)
+
+	assertRemovedProjectRead(t, ctx, readResp, *existingIdentity)
+}
+
+func runRemovedProjectRead(t *testing.T, ctx context.Context, r *resourceTFEProject, stateData modelTFEProject, existingIdentity ...*modelProjectIdentity) fwresource.ReadResponse {
+	t.Helper()
+
+	schemaResp := &fwresource.SchemaResponse{}
+	r.Schema(ctx, fwresource.SchemaRequest{}, schemaResp)
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := state.Set(ctx, &stateData); diags.HasError() {
+		t.Fatalf("unexpected state set diagnostics: %v", diags)
+	}
+
+	identitySchemaResp := &fwresource.IdentitySchemaResponse{}
+	r.IdentitySchema(ctx, fwresource.IdentitySchemaRequest{}, identitySchemaResp)
+	nullIdentity := tftypes.NewValue(identitySchemaResp.IdentitySchema.Type().TerraformType(ctx), nil)
+
+	requestIdentity := &tfsdk.ResourceIdentity{Schema: identitySchemaResp.IdentitySchema, Raw: nullIdentity.Copy()}
+	responseIdentity := &tfsdk.ResourceIdentity{Schema: identitySchemaResp.IdentitySchema, Raw: nullIdentity.Copy()}
+
+	if len(existingIdentity) > 0 && existingIdentity[0] != nil {
+		if diags := requestIdentity.Set(ctx, existingIdentity[0]); diags.HasError() {
+			t.Fatalf("unexpected request identity diagnostics: %v", diags)
+		}
+		if diags := responseIdentity.Set(ctx, existingIdentity[0]); diags.HasError() {
+			t.Fatalf("unexpected response identity diagnostics: %v", diags)
+		}
+	}
+
+	readResp := fwresource.ReadResponse{
+		State:    tfsdk.State{Schema: schemaResp.Schema, Raw: state.Raw.Copy()},
+		Identity: responseIdentity,
+	}
+
+	r.Read(ctx, fwresource.ReadRequest{
+		State:    tfsdk.State{Schema: schemaResp.Schema, Raw: state.Raw.Copy()},
+		Identity: requestIdentity,
+	}, &readResp)
+
+	return readResp
+}
+
+func assertRemovedProjectRead(t *testing.T, ctx context.Context, readResp fwresource.ReadResponse, expectedIdentity modelProjectIdentity) {
+	t.Helper()
+
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected read diagnostics: %v", readResp.Diagnostics)
+	}
+
+	if !readResp.State.Raw.IsFullyNull() {
+		t.Fatalf("expected resource to be removed from state, got %s", readResp.State.Raw.String())
+	}
+
+	if readResp.Identity == nil || readResp.Identity.Raw.IsFullyNull() {
+		t.Fatal("expected project identity to be preserved for removed resource")
+	}
+
+	var gotIdentity modelProjectIdentity
+	if diags := readResp.Identity.Get(ctx, &gotIdentity); diags.HasError() {
+		t.Fatalf("unexpected identity diagnostics: %v", diags)
+	}
+
+	if gotIdentity.ID.ValueString() != expectedIdentity.ID.ValueString() {
+		t.Fatalf("expected identity id %q, got %q", expectedIdentity.ID.ValueString(), gotIdentity.ID.ValueString())
+	}
+
+	if gotIdentity.Hostname.ValueString() != expectedIdentity.Hostname.ValueString() {
+		t.Fatalf("expected hostname %q, got %q", expectedIdentity.Hostname.ValueString(), gotIdentity.Hostname.ValueString())
+	}
 }
 
 func TestAccTFEProject_withAutoDestroy(t *testing.T) {

--- a/internal/provider/resource_tfe_stack.go
+++ b/internal/provider/resource_tfe_stack.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-tfe"
@@ -156,6 +157,29 @@ func (r *resourceTFEStack) Configure(ctx context.Context, req resource.Configure
 	r.config = client
 }
 
+func (r *resourceTFEStack) setReadIdentity(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse, stackID string) {
+	if resp.Identity == nil {
+		return
+	}
+
+	if req.Identity != nil {
+		currentIdentity := &modelTFEStackIdentity{}
+		resp.Diagnostics.Append(req.Identity.Get(ctx, &currentIdentity)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if currentIdentity != nil && !currentIdentity.ID.IsNull() {
+			return
+		}
+	}
+
+	identity := modelTFEStackIdentity{
+		ID:       types.StringValue(stackID),
+		Hostname: types.StringValue(r.config.Client.BaseURL().Host),
+	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identity)...)
+}
+
 func (r *resourceTFEStack) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan modelTFEStack
 
@@ -239,6 +263,11 @@ func (r *resourceTFEStack) Read(ctx context.Context, req resource.ReadRequest, r
 	tflog.Debug(ctx, fmt.Sprintf("Reading stack %q", state.ID.ValueString()))
 	stack, err := r.config.Client.Stacks.Read(ctx, state.ID.ValueString())
 	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			r.setReadIdentity(ctx, req, resp, state.ID.ValueString())
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Unable to read stack", err.Error())
 		return
 	}

--- a/internal/provider/resource_tfe_stack_test.go
+++ b/internal/provider/resource_tfe_stack_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -11,10 +12,45 @@ import (
 	"testing"
 	"time"
 
+	tfe "github.com/hashicorp/go-tfe"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 )
+
+type notFoundStacks struct{}
+
+func (notFoundStacks) List(_ context.Context, _ string, _ *tfe.StackListOptions) (*tfe.StackList, error) {
+	return nil, nil
+}
+
+func (notFoundStacks) Read(_ context.Context, _ string) (*tfe.Stack, error) {
+	return nil, tfe.ErrResourceNotFound
+}
+
+func (notFoundStacks) Create(_ context.Context, _ tfe.StackCreateOptions) (*tfe.Stack, error) {
+	return nil, nil
+}
+
+func (notFoundStacks) Update(_ context.Context, _ string, _ tfe.StackUpdateOptions) (*tfe.Stack, error) {
+	return nil, nil
+}
+
+func (notFoundStacks) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func (notFoundStacks) ForceDelete(_ context.Context, _ string) error {
+	return nil
+}
+
+func (notFoundStacks) FetchLatestFromVcs(_ context.Context, _ string) (*tfe.Stack, error) {
+	return nil, nil
+}
 
 func TestAccTFEStackResource_basic(t *testing.T) {
 	skipUnlessBeta(t)
@@ -241,6 +277,148 @@ resource "tfe_stack" "foobar" {
     agent_pool_id = tfe_agent_pool.foobar.id
 }
 `, orgName)
+}
+
+func TestResourceTFEStackRead_RemovedStackBackfillsIdentity(t *testing.T) {
+	ctx := context.Background()
+	client := testTfeClient(t, testClientOptions{})
+	client.Stacks = notFoundStacks{}
+
+	r := &resourceTFEStack{config: ConfiguredClient{Client: client}}
+
+	readResp := runRemovedStackRead(t, ctx, r, modelTFEStack{
+		ID:                 types.StringValue("stack-123"),
+		ProjectID:          types.StringValue("prj-123"),
+		AgentPoolID:        types.StringNull(),
+		Name:               types.StringValue("test-stack"),
+		Migration:          types.BoolValue(false),
+		SpeculativeEnabled: types.BoolValue(false),
+		CreationSource:     types.StringNull(),
+		Description:        types.StringValue(""),
+		VCSRepo:            nil,
+		CreatedAt:          types.StringValue("2026-01-01T00:00:00Z"),
+		UpdatedAt:          types.StringValue("2026-01-01T00:00:00Z"),
+	})
+
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected read diagnostics: %v", readResp.Diagnostics)
+	}
+
+	if !readResp.State.Raw.IsFullyNull() {
+		t.Fatalf("expected stack to be removed from state, got %s", readResp.State.Raw.String())
+	}
+
+	if readResp.Identity == nil || readResp.Identity.Raw.IsFullyNull() {
+		t.Fatal("expected stack identity to be preserved for removed resource")
+	}
+
+	var gotIdentity modelTFEStackIdentity
+	if diags := readResp.Identity.Get(ctx, &gotIdentity); diags.HasError() {
+		t.Fatalf("unexpected identity diagnostics: %v", diags)
+	}
+
+	if gotIdentity.ID.ValueString() != "stack-123" {
+		t.Fatalf("expected identity id %q, got %q", "stack-123", gotIdentity.ID.ValueString())
+	}
+
+	if gotIdentity.Hostname.ValueString() != client.BaseURL().Host {
+		t.Fatalf("expected hostname %q, got %q", client.BaseURL().Host, gotIdentity.Hostname.ValueString())
+	}
+}
+
+func TestResourceTFEStackRead_RemovedStackPreservesExistingIdentity(t *testing.T) {
+	ctx := context.Background()
+	client := testTfeClient(t, testClientOptions{})
+	client.Stacks = notFoundStacks{}
+
+	r := &resourceTFEStack{config: ConfiguredClient{Client: client}}
+	existingIdentity := &modelTFEStackIdentity{
+		ID:       types.StringValue("stack-existing"),
+		Hostname: types.StringValue("preserve.example.com"),
+	}
+
+	readResp := runRemovedStackRead(t, ctx, r, modelTFEStack{
+		ID:                 types.StringValue("stack-123"),
+		ProjectID:          types.StringValue("prj-123"),
+		AgentPoolID:        types.StringNull(),
+		Name:               types.StringValue("test-stack"),
+		Migration:          types.BoolValue(false),
+		SpeculativeEnabled: types.BoolValue(false),
+		CreationSource:     types.StringNull(),
+		Description:        types.StringValue(""),
+		VCSRepo:            nil,
+		CreatedAt:          types.StringValue("2026-01-01T00:00:00Z"),
+		UpdatedAt:          types.StringValue("2026-01-01T00:00:00Z"),
+	}, existingIdentity)
+
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected read diagnostics: %v", readResp.Diagnostics)
+	}
+
+	var gotIdentity modelTFEStackIdentity
+	if diags := readResp.Identity.Get(ctx, &gotIdentity); diags.HasError() {
+		t.Fatalf("unexpected identity diagnostics: %v", diags)
+	}
+
+	if gotIdentity.ID.ValueString() != existingIdentity.ID.ValueString() {
+		t.Fatalf("expected identity id %q, got %q", existingIdentity.ID.ValueString(), gotIdentity.ID.ValueString())
+	}
+
+	if gotIdentity.Hostname.ValueString() != existingIdentity.Hostname.ValueString() {
+		t.Fatalf("expected hostname %q, got %q", existingIdentity.Hostname.ValueString(), gotIdentity.Hostname.ValueString())
+	}
+}
+
+func runRemovedStackRead(t *testing.T, ctx context.Context, r *resourceTFEStack, stateData modelTFEStack, existingIdentity ...*modelTFEStackIdentity) fwresource.ReadResponse {
+	t.Helper()
+
+	schemaResp := &fwresource.SchemaResponse{}
+	r.Schema(ctx, fwresource.SchemaRequest{}, schemaResp)
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := state.Set(ctx, &stateData); diags.HasError() {
+		t.Fatalf("unexpected state set diagnostics: %v", diags)
+	}
+
+	identitySchemaResp := &fwresource.IdentitySchemaResponse{}
+	r.IdentitySchema(ctx, fwresource.IdentitySchemaRequest{}, identitySchemaResp)
+	nullIdentity := tftypes.NewValue(identitySchemaResp.IdentitySchema.Type().TerraformType(ctx), nil)
+
+	requestIdentity := &tfsdk.ResourceIdentity{
+		Schema: identitySchemaResp.IdentitySchema,
+		Raw:    nullIdentity.Copy(),
+	}
+	responseIdentity := &tfsdk.ResourceIdentity{
+		Schema: identitySchemaResp.IdentitySchema,
+		Raw:    nullIdentity.Copy(),
+	}
+
+	if len(existingIdentity) > 0 && existingIdentity[0] != nil {
+		if diags := requestIdentity.Set(ctx, existingIdentity[0]); diags.HasError() {
+			t.Fatalf("unexpected request identity diagnostics: %v", diags)
+		}
+		if diags := responseIdentity.Set(ctx, existingIdentity[0]); diags.HasError() {
+			t.Fatalf("unexpected response identity diagnostics: %v", diags)
+		}
+	}
+
+	readResp := fwresource.ReadResponse{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+			Raw:    state.Raw.Copy(),
+		},
+		Identity: responseIdentity,
+	}
+
+	r.Read(ctx, fwresource.ReadRequest{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+			Raw:    state.Raw.Copy(),
+		},
+		Identity: requestIdentity,
+	}, &readResp)
+
+	return readResp
 }
 
 func TestAccTFEStackResource_noVCSRepo(t *testing.T) {

--- a/internal/provider/resource_tfe_variable.go
+++ b/internal/provider/resource_tfe_variable.go
@@ -455,6 +455,30 @@ func (r *resourceTFEVariable) Read(ctx context.Context, req resource.ReadRequest
 	}
 }
 
+func (r *resourceTFEVariable) setReadIdentity(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse, variableID string, configurableID string) {
+	if resp.Identity == nil {
+		return
+	}
+
+	if req.Identity != nil {
+		currentIdentity := &modelTFEVariableIdentity{}
+		resp.Diagnostics.Append(req.Identity.Get(ctx, &currentIdentity)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if currentIdentity != nil && !currentIdentity.ID.IsNull() {
+			return
+		}
+	}
+
+	identity := modelTFEVariableIdentity{
+		ID:             types.StringValue(variableID),
+		Hostname:       types.StringValue(r.config.Client.BaseURL().Host),
+		ConfigurableID: types.StringValue(configurableID),
+	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, &identity)...)
+}
+
 // readWithWorkspace is the workspace version of Read.
 func (r *resourceTFEVariable) readWithWorkspace(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data modelTFEVariable
@@ -471,6 +495,7 @@ func (r *resourceTFEVariable) readWithWorkspace(ctx context.Context, req resourc
 		// If it's gone: that's not an error, but we are done.
 		if errors.Is(err, tfe.ErrResourceNotFound) {
 			log.Printf("[DEBUG] Variable %s no longer exists", variableID)
+			r.setReadIdentity(ctx, req, resp, variableID, workspaceID)
 			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
@@ -510,6 +535,7 @@ func (r *resourceTFEVariable) readWithVariableSet(ctx context.Context, req resou
 		if errors.Is(err, tfe.ErrResourceNotFound) {
 			// If it's gone: that's not an error, but we are done.
 			log.Printf("[DEBUG] Variable %s no longer exists", variableID)
+			r.setReadIdentity(ctx, req, resp, variableID, variableSetID)
 			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(

--- a/internal/provider/resource_tfe_variable_test.go
+++ b/internal/provider/resource_tfe_variable_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -14,6 +15,10 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/go-version"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -620,6 +625,231 @@ func TestAccTFEVariable_mutableIdentity(t *testing.T) {
 			},
 		},
 	})
+}
+
+type notFoundVariables struct{}
+
+func (notFoundVariables) List(_ context.Context, _ string, _ *tfe.VariableListOptions) (*tfe.VariableList, error) {
+	return nil, nil
+}
+
+func (notFoundVariables) ListAll(_ context.Context, _ string, _ *tfe.VariableListOptions) (*tfe.VariableList, error) {
+	return nil, nil
+}
+
+func (notFoundVariables) Create(_ context.Context, _ string, _ tfe.VariableCreateOptions) (*tfe.Variable, error) {
+	return nil, nil
+}
+
+func (notFoundVariables) Read(_ context.Context, _ string, _ string) (*tfe.Variable, error) {
+	return nil, tfe.ErrResourceNotFound
+}
+
+func (notFoundVariables) Update(_ context.Context, _ string, _ string, _ tfe.VariableUpdateOptions) (*tfe.Variable, error) {
+	return nil, nil
+}
+
+func (notFoundVariables) Delete(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+type notFoundVariableSetVariables struct{}
+
+func (notFoundVariableSetVariables) List(_ context.Context, _ string, _ *tfe.VariableSetVariableListOptions) (*tfe.VariableSetVariableList, error) {
+	return nil, nil
+}
+
+func (notFoundVariableSetVariables) Create(_ context.Context, _ string, _ *tfe.VariableSetVariableCreateOptions) (*tfe.VariableSetVariable, error) {
+	return nil, nil
+}
+
+func (notFoundVariableSetVariables) Read(_ context.Context, _ string, _ string) (*tfe.VariableSetVariable, error) {
+	return nil, tfe.ErrResourceNotFound
+}
+
+func (notFoundVariableSetVariables) Update(_ context.Context, _ string, _ string, _ *tfe.VariableSetVariableUpdateOptions) (*tfe.VariableSetVariable, error) {
+	return nil, nil
+}
+
+func (notFoundVariableSetVariables) Delete(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func TestResourceTFEVariableRead_RemovedWorkspaceVariableBackfillsIdentity(t *testing.T) {
+	ctx := context.Background()
+	client := testTfeClient(t, testClientOptions{})
+	client.Variables = notFoundVariables{}
+
+	r := &resourceTFEVariable{config: ConfiguredClient{Client: client}}
+
+	readResp := runRemovedVariableRead(t, ctx, r, modelTFEVariable{
+		ID:             types.StringValue("var-123"),
+		Key:            types.StringValue("key_test"),
+		Value:          types.StringValue("value_test"),
+		ValueWO:        types.StringNull(),
+		ValueWOVersion: types.Int64Null(),
+		ReadableValue:  types.StringValue("value_test"),
+		Category:       types.StringValue(string(tfe.CategoryEnv)),
+		Description:    types.StringValue(""),
+		HCL:            types.BoolValue(false),
+		Sensitive:      types.BoolValue(false),
+		WorkspaceID:    types.StringValue("ws-123"),
+		VariableSetID:  types.StringNull(),
+	})
+
+	assertRemovedVariableRead(t, ctx, readResp, modelTFEVariableIdentity{
+		ID:             types.StringValue("var-123"),
+		ConfigurableID: types.StringValue("ws-123"),
+		Hostname:       types.StringValue(client.BaseURL().Host),
+	})
+}
+
+func TestResourceTFEVariableRead_RemovedVariableSetVariableBackfillsIdentity(t *testing.T) {
+	ctx := context.Background()
+	client := testTfeClient(t, testClientOptions{})
+	client.VariableSetVariables = notFoundVariableSetVariables{}
+
+	r := &resourceTFEVariable{config: ConfiguredClient{Client: client}}
+
+	readResp := runRemovedVariableRead(t, ctx, r, modelTFEVariable{
+		ID:             types.StringValue("var-456"),
+		Key:            types.StringValue("key_test"),
+		Value:          types.StringValue("value_test"),
+		ValueWO:        types.StringNull(),
+		ValueWOVersion: types.Int64Null(),
+		ReadableValue:  types.StringValue("value_test"),
+		Category:       types.StringValue(string(tfe.CategoryEnv)),
+		Description:    types.StringValue(""),
+		HCL:            types.BoolValue(false),
+		Sensitive:      types.BoolValue(false),
+		WorkspaceID:    types.StringNull(),
+		VariableSetID:  types.StringValue("varset-123"),
+	})
+
+	assertRemovedVariableRead(t, ctx, readResp, modelTFEVariableIdentity{
+		ID:             types.StringValue("var-456"),
+		ConfigurableID: types.StringValue("varset-123"),
+		Hostname:       types.StringValue(client.BaseURL().Host),
+	})
+}
+
+func TestResourceTFEVariableRead_RemovedWorkspaceVariablePreservesExistingIdentity(t *testing.T) {
+	ctx := context.Background()
+	client := testTfeClient(t, testClientOptions{})
+	client.Variables = notFoundVariables{}
+
+	r := &resourceTFEVariable{config: ConfiguredClient{Client: client}}
+	existingIdentity := &modelTFEVariableIdentity{
+		ID:             types.StringValue("var-existing"),
+		ConfigurableID: types.StringValue("ws-existing"),
+		Hostname:       types.StringValue("preserve.example.com"),
+	}
+
+	readResp := runRemovedVariableRead(t, ctx, r, modelTFEVariable{
+		ID:             types.StringValue("var-123"),
+		Key:            types.StringValue("key_test"),
+		Value:          types.StringValue("value_test"),
+		ValueWO:        types.StringNull(),
+		ValueWOVersion: types.Int64Null(),
+		ReadableValue:  types.StringValue("value_test"),
+		Category:       types.StringValue(string(tfe.CategoryEnv)),
+		Description:    types.StringValue(""),
+		HCL:            types.BoolValue(false),
+		Sensitive:      types.BoolValue(false),
+		WorkspaceID:    types.StringValue("ws-123"),
+		VariableSetID:  types.StringNull(),
+	}, existingIdentity)
+
+	assertRemovedVariableRead(t, ctx, readResp, *existingIdentity)
+}
+
+func runRemovedVariableRead(t *testing.T, ctx context.Context, r *resourceTFEVariable, stateData modelTFEVariable, existingIdentity ...*modelTFEVariableIdentity) fwresource.ReadResponse {
+	t.Helper()
+
+	schemaResp := &fwresource.SchemaResponse{}
+	r.Schema(ctx, fwresource.SchemaRequest{}, schemaResp)
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diags := state.Set(ctx, &stateData); diags.HasError() {
+		t.Fatalf("unexpected state set diagnostics: %v", diags)
+	}
+
+	identitySchemaResp := &fwresource.IdentitySchemaResponse{}
+	r.IdentitySchema(ctx, fwresource.IdentitySchemaRequest{}, identitySchemaResp)
+	nullIdentity := tftypes.NewValue(identitySchemaResp.IdentitySchema.Type().TerraformType(ctx), nil)
+
+	requestIdentity := &tfsdk.ResourceIdentity{
+		Schema: identitySchemaResp.IdentitySchema,
+		Raw:    nullIdentity.Copy(),
+	}
+	responseIdentity := &tfsdk.ResourceIdentity{
+		Schema: identitySchemaResp.IdentitySchema,
+		Raw:    nullIdentity.Copy(),
+	}
+
+	if len(existingIdentity) > 0 && existingIdentity[0] != nil {
+		if diags := requestIdentity.Set(ctx, existingIdentity[0]); diags.HasError() {
+			t.Fatalf("unexpected request identity diagnostics: %v", diags)
+		}
+		if diags := responseIdentity.Set(ctx, existingIdentity[0]); diags.HasError() {
+			t.Fatalf("unexpected response identity diagnostics: %v", diags)
+		}
+	}
+
+	readResp := fwresource.ReadResponse{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+			Raw:    state.Raw.Copy(),
+		},
+		Identity: responseIdentity,
+	}
+
+	r.Read(ctx, fwresource.ReadRequest{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+			Raw:    state.Raw.Copy(),
+		},
+		Identity: requestIdentity,
+	}, &readResp)
+
+	return readResp
+}
+
+func assertRemovedVariableRead(t *testing.T, ctx context.Context, readResp fwresource.ReadResponse, expectedIdentity modelTFEVariableIdentity) {
+	t.Helper()
+
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected read diagnostics: %v", readResp.Diagnostics)
+	}
+
+	if !readResp.State.Raw.IsFullyNull() {
+		t.Fatalf("expected resource to be removed from state, got %s", readResp.State.Raw.String())
+	}
+
+	if readResp.Identity == nil {
+		t.Fatal("expected resource identity to be preserved")
+	}
+
+	if readResp.Identity.Raw.IsFullyNull() {
+		t.Fatal("expected resource identity to be backfilled for removed resource")
+	}
+
+	var gotIdentity modelTFEVariableIdentity
+	if diags := readResp.Identity.Get(ctx, &gotIdentity); diags.HasError() {
+		t.Fatalf("unexpected identity diagnostics: %v", diags)
+	}
+
+	if gotIdentity.ID.ValueString() != expectedIdentity.ID.ValueString() {
+		t.Fatalf("expected identity id %q, got %q", expectedIdentity.ID.ValueString(), gotIdentity.ID.ValueString())
+	}
+
+	if gotIdentity.ConfigurableID.ValueString() != expectedIdentity.ConfigurableID.ValueString() {
+		t.Fatalf("expected configurable_id %q, got %q", expectedIdentity.ConfigurableID.ValueString(), gotIdentity.ConfigurableID.ValueString())
+	}
+
+	if gotIdentity.Hostname.ValueString() != expectedIdentity.Hostname.ValueString() {
+		t.Fatalf("expected hostname %q, got %q", expectedIdentity.Hostname.ValueString(), gotIdentity.Hostname.ValueString())
+	}
 }
 
 // Verify that the rewritten framework version of the resource results in no


### PR DESCRIPTION
Backfill resource identity before removing state when remote objects are not found, and add regression coverage

## Description

This change fixes resource identity handling for deleted-resource reads in `tfe_variable`, `tfe_project` and `tfe_stack`.

The provider could return a successful `Read` response after a remote resource had been deleted, remove the resource from state, and still leave the identity empty. When that happened, Terraform raised `Missing Resource Identity After Read`.

The fix updates the deleted-resource `Read` path to preserve an existing identity when one is already present, and backfill identity only when it is missing before removing state. This aligns the `Read` behavior with the provider's existing `Update` identity handling and prevents the framework error reported by customers.


_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Reproduce the issue with a `tfe_variable`, `tfe_project` or `tfe_stack` resource managed by `terraform-provider-tfe` with identity support enabled.
1. Apply a Terraform configuration to create the resource, then manually delete the resource in TFC/TFE outside Terraform.
1. Run `terraform plan` again and confirm the provider handles the deleted-resource `Read` without returning `Missing Resource Identity After Read`.
1. Verify the deleted-resource `Read` path removes state and preserves or backfills identity correctly using focused provider tests:
   - `go test ./internal/provider -run 'TestResourceTFE(ProjectRead_RemovedProject(BackfillsIdentity|PreservesExistingIdentity)|VariableRead_Removed(WorkspaceVariable|VariableSetVariable)(BackfillsIdentity|PreservesExistingIdentity)|StackRead_RemovedStack(BackfillsIdentity|PreservesExistingIdentity))''`

Example Terraform configs used for reproduction:

```hcl
resource "tfe_variable" "example" {
  key          = "key_test"
  value        = "value_test"
  category     = "env"
  workspace_id = tfe_workspace.example.id
}

resource "tfe_stack" "example" {
  name        = "example-stack"
  description = "example"
  project_id  = tfe_project.example.id
}

resource "tfe_project" "example" {
  name         = "example-project"
  organization = "example-org"
}

## Output from acceptance tests

Acceptance tests were not run for this change.

This change was validated with focused provider tests covering the deleted-resource Read path and identity preservation/backfill behavior:


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan


If this change needs to be rolled back, revert the commit that modify the deleted-resource Read identity handling in the tfe_variable, tfe_project and tfe_stack resources and restore the previous test expectations. The rollback is low risk because the change is limited to provider-side identity handling during Read for not-found resources.

## Changes to Security Controls

No changes to security controls. This pull request does not modify access controls, encryption behavior, logging controls, or authentication flows.
