### PR TITLE
Add docs note about deprecated tfe_sentinel_policy resource

### DIFF
--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -7,6 +7,8 @@ description: |-
 
 # tfe_sentinel_policy
 
+-> **Note:** `tfe_sentinel_policy` is deprecated, please use `tfe_policy` instead.
+
 Sentinel Policy as Code is an embedded policy as code framework integrated
 with Terraform Enterprise.
 


### PR DESCRIPTION
## Description

When running `terraform validate` on a config file that uses a `tfe_sentinel_policy` resource, you get the following error:

```
Warning: Deprecated Resource

  with tfe_sentinel_policy.test,
  on main.tf line 13, in resource "tfe_sentinel_policy" "test":
  13: resource "tfe_sentinel_policy" "test" {

tfe_sentinel_policy is deprecated, please use tfe_policy instead
Success! The configuration is valid, but there were some validation warnings
as shown above.
```

This PR updates the docs to make it more visible for folks who might be looking for sample config.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  n/a - docs only
