### PR TITLE
Update authentication warning when using config/credentials files on cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+ENHANCEMENTS:
 * Updates warning when using credentials/config file for authentication and running on cloud to be clearer, by @christian-doucette [#2036](https://github.com/hashicorp/terraform-provider-tfe/pull/2036)
 
 ## v0.76.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Updates warning when using credentials/config file for authentication and running on cloud to be clearer, by @christian-doucette [#2036](https://github.com/hashicorp/terraform-provider-tfe/pull/2036)
+
 ## v0.76.2
 
 FEATURES:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -191,7 +191,7 @@ func configure() schema.ConfigureContextFunc {
 				diag.Diagnostic{
 					Severity: diag.Warning,
 					Summary:  "Authentication method has limited TFE provider permissions",
-					Detail:   "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To ensure consistent behavior, authenticate using the token argument to the provider block or the TFE_TOKEN environment variable.",
+					Detail:   "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To avoid this, authenticate using the provider token argument or the TFE_TOKEN environment variable.",
 				},
 			}
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -190,8 +190,8 @@ func configure() schema.ConfigureContextFunc {
 			diagnosticWarnings = diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Warning,
-					Summary:  "Authentication with configuration files is invalid for TFE Provider running on HCP Terraform or Terraform Enterprise",
-					Detail:   "Use a TFE_TOKEN variable in the workspace or the token argument for the provider. This authentication method will be deprecated in a future version.",
+					Summary:  "Authentication method has limited TFE provider permissions",
+					Detail:   "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To ensure consistent behavior, authenticate using the token argument to the provider block or the TFE_TOKEN environment variable.",
 				},
 			}
 		}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -121,7 +121,7 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 	}
 
 	if providerClient.SendAuthenticationWarning() {
-		res.Diagnostics.AddWarning("Authentication with configuration files is invalid for TFE Provider running on HCP Terraform or Terraform Enterprise", "Use a TFE_TOKEN variable in the workspace or the token argument for the provider. This authentication method will be deprecated in a future version.")
+		res.Diagnostics.AddWarning("Authentication method has limited TFE provider permissions", "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To ensure consistent behavior, authenticate using the token argument to the provider block or the TFE_TOKEN environment variable.")
 	}
 
 	configuredClient := ConfiguredClient{

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -121,7 +121,7 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 	}
 
 	if providerClient.SendAuthenticationWarning() {
-		res.Diagnostics.AddWarning("Authentication method has limited TFE provider permissions", "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To ensure consistent behavior, authenticate using the token argument to the provider block or the TFE_TOKEN environment variable.")
+		res.Diagnostics.AddWarning("Authentication method has limited TFE provider permissions", "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To avoid this, authenticate using the provider token argument or the TFE_TOKEN environment variable.")
 	}
 
 	configuredClient := ConfiguredClient{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -344,8 +344,8 @@ func TestConfigureEnvOnCloudUsingConfigFiles(t *testing.T) {
 		t.Fatalf("Expected 1 diagnostic, received %d", len(diags))
 	}
 	expectedSeverity := diag.Warning
-	expectedSummary := "Authentication with configuration files is invalid for TFE Provider running on HCP Terraform or Terraform Enterprise"
-	expectedDetail := "Use a TFE_TOKEN variable in the workspace or the token argument for the provider. This authentication method will be deprecated in a future version."
+	expectedSummary := "Authentication method has limited TFE provider permissions"
+	expectedDetail := "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To ensure consistent behavior, authenticate using the token argument to the provider block or the TFE_TOKEN environment variable."
 
 	onlyDiag := diags[0]
 	t.Logf("Want to see if this shows up in Datadog flaky test")

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -345,7 +345,7 @@ func TestConfigureEnvOnCloudUsingConfigFiles(t *testing.T) {
 	}
 	expectedSeverity := diag.Warning
 	expectedSummary := "Authentication method has limited TFE provider permissions"
-	expectedDetail := "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To ensure consistent behavior, authenticate using the token argument to the provider block or the TFE_TOKEN environment variable."
+	expectedDetail := "When running in HCP Terraform or Terraform Enterprise, the current authentication method may not have sufficient permissions for all TFE provider operations. Data sources and plans may work, but resource create, update, or delete operations can fail. To avoid this, authenticate using the provider token argument or the TFE_TOKEN environment variable."
 
 	onlyDiag := diags[0]
 	t.Logf("Want to see if this shows up in Datadog flaky test")


### PR DESCRIPTION
## Description

Updates authentication warning to make it clearer for users

I removed the specific reference to the config file authentication (since that happens automatically). Also added a reference that this might not affect plans or data sources, so people won't think the warning is a bug in those cases. 

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Create a workspace in Terraform cloud.
2. Ensure that TFE_TOKEN is not set in the workspace (not really a step but this is important for reproducing the result)
3. Run terraform code on that workspace to create a different workspace with the TFE provider. Sample: 
```
terraform { 
  cloud { 
    hostname = "my-hostname.com" 
    organization = "hashicorp" 

    workspaces { 
      name = "workspace-already-created-in-step-one" 
    } 
  } 

  required_providers {
    tfe = {
        version = "0.73.0"
    }
  }
}

provider "tfe" {
    hostname = "myhostname.com"
    //token must also not be set here
}

resource "tfe_workspace" "example" {
  name          = "new-workspace-to-be-created"
  organization  = "hashicorp"
}
```

4. Ensure that the new version of the warning is received.  

## Output from acceptance tests



```
christiandoucette@mac terraform-provider-tfe % TESTARGS="-run TestConfigureEnvOnCloudUsingConfigFiles" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestConfigureEnvOnCloudUsingConfigFiles -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	(cached) [no tests to run]
=== RUN   TestConfigureEnvOnCloudUsingConfigFiles
2026/04/13 19:28:35 [DEBUG] Configuring client for host "app.terraform.io"
2026/04/13 19:28:35 [DEBUG] Attempting to fetch token from Terraform CLI configuration for hostname "app.terraform.io"...
2026/04/13 19:28:35 [DEBUG] Service discovery for app.terraform.io at https://app.terraform.io/.well-known/terraform.json
    provider_test.go:351: Want to see if this shows up in Datadog flaky test
--- PASS: TestConfigureEnvOnCloudUsingConfigFiles (0.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	(cached)
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]

...
```

