### PR TITLE
fix: treat omitted remote_state_consumer_ids as an empty set during updates

### DIFF
--- a/internal/provider/data_source_workspace_test.go
+++ b/internal/provider/data_source_workspace_test.go
@@ -491,20 +491,19 @@ resource "tfe_workspace" "buzz" {
 resource "tfe_workspace" "foobar" {
   name                      = "workspace-test-%d"
   organization              = tfe_organization.foobar.id
-	global_remote_state       = false
-	remote_state_consumer_ids = [resource.tfe_workspace.buzz.id]
 }
 
 resource "tfe_workspace_settings" "foobar_settings" {
 	workspace_id         = tfe_workspace.foobar.id
 	project_remote_state = false
 	global_remote_state  = false
+	remote_state_consumer_ids = [tfe_workspace.buzz.id]
 }
 
 data "tfe_workspace" "foobar" {
   name         = tfe_workspace.foobar.name
   organization = tfe_workspace.foobar.organization
-	depends_on   = [tfe_workspace.foobar]
+	depends_on   = [tfe_workspace_settings.foobar_settings]
 }`, rInt1, rInt2, rInt1)
 }
 

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -93,6 +93,8 @@ type validateRemoteStateConsumerIDs struct{}
 // explicit empty set when it is removed from configuration after being set.
 type unsetRemoteStateConsumerIDsIfOmitted struct{}
 
+const remoteStateConsumerIDsConfiguredKey = "remote_state_consumer_ids_configured"
+
 // validate global and remote state mutual exclusion
 type validateRemoteStateExclusion struct{}
 
@@ -107,12 +109,23 @@ var _ planmodifier.Set = (*unsetRemoteStateConsumerIDsIfOmitted)(nil)
 var _ planmodifier.Set = (*validateRemoteStateConsumerIDs)(nil)
 var _ planmodifier.Bool = (*validateRemoteStateExclusion)(nil)
 
-func (m unsetRemoteStateConsumerIDsIfOmitted) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
-	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+func (m unsetRemoteStateConsumerIDsIfOmitted) PlanModifySet(ctx context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	if req.Plan.Raw.IsNull() {
 		return
 	}
 
-	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+	if !req.ConfigValue.IsNull() {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, remoteStateConsumerIDsConfiguredKey, []byte("true"))...)
+		return
+	}
+
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	wasConfigured, diags := req.Private.GetKey(ctx, remoteStateConsumerIDsConfiguredKey)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() || len(wasConfigured) == 0 {
 		return
 	}
 
@@ -558,7 +571,7 @@ func (r *workspaceSettings) readSettings(ctx context.Context, workspaceID string
 	return r.workspaceSettingsModelFromTFEWorkspace(ws), nil
 }
 
-func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorkspaceSettings, state *tfsdk.State) error {
+func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorkspaceSettings, priorState, targetState *tfsdk.State) error {
 	workspaceID := data.WorkspaceID.ValueString()
 
 	updateOptions := tfe.WorkspaceUpdateOptions{
@@ -625,16 +638,18 @@ func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorks
 	}
 
 	if !data.GlobalRemoteState.ValueBool() && !data.ProjectRemoteState.ValueBool() {
-		r.addAndRemoveRemoteStateConsumers(workspaceID, data.RemoteStateConsumerIDs, state)
+		if err := r.addAndRemoveRemoteStateConsumers(workspaceID, data.RemoteStateConsumerIDs, priorState); err != nil {
+			return err
+		}
 	}
 
 	model, err := r.readSettings(ctx, ws.ID)
 	if errors.Is(err, errWorkspaceNoLongerExists) {
-		state.RemoveResource(ctx)
+		targetState.RemoveResource(ctx)
 	}
 
 	if err == nil {
-		state.Set(ctx, model)
+		targetState.Set(ctx, model)
 	}
 
 	return err
@@ -642,23 +657,22 @@ func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorks
 
 func (r *workspaceSettings) addAndRemoveRemoteStateConsumers(workspaceID string, newWorkspaceIDsSet types.Set, state *tfsdk.State) error {
 	var oldWorkspaceIDsSet types.Set
-	diags := state.GetAttribute(ctx, path.Root("remote_state_consumer_ids"), &oldWorkspaceIDsSet)
-	if diags.HasError() {
-		return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
+	if state != nil && !state.Raw.IsNull() {
+		if diags := state.GetAttribute(ctx, path.Root("remote_state_consumer_ids"), &oldWorkspaceIDsSet); diags.HasError() {
+			return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
+		}
 	}
 
 	var oldWorkspaceIDs []string
 	if !oldWorkspaceIDsSet.IsNull() {
-		diags = oldWorkspaceIDsSet.ElementsAs(ctx, &oldWorkspaceIDs, true)
-		if diags.HasError() {
+		if diags := oldWorkspaceIDsSet.ElementsAs(ctx, &oldWorkspaceIDs, true); diags.HasError() {
 			return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
 		}
 	}
 
 	var newWorkspaceIDs []string
 	if !newWorkspaceIDsSet.IsNull() {
-		diags = newWorkspaceIDsSet.ElementsAs(ctx, &newWorkspaceIDs, true)
-		if diags.HasError() {
+		if diags := newWorkspaceIDsSet.ElementsAs(ctx, &newWorkspaceIDs, true); diags.HasError() {
 			return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
 		}
 	}
@@ -740,6 +754,10 @@ func (r *workspaceSettings) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	if !planned.RemoteStateConsumerIDs.IsNull() {
+		resp.Diagnostics.Append(resp.Private.SetKey(ctx, remoteStateConsumerIDsConfiguredKey, []byte("true"))...)
+	}
+
 	// Prefer the read value if there is no config value
 	if autoApply.IsNull() {
 		tflog.Debug(ctx, fmt.Sprintf("auto_apply is not set in config, overwrite with the read value %v", model.AutoApply.ValueBool()))
@@ -762,16 +780,28 @@ func (r *workspaceSettings) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	if err := r.updateSettings(ctx, &planned, &resp.State); err != nil {
+	if err := r.updateSettings(ctx, &planned, nil, &resp.State); err != nil {
 		resp.Diagnostics.AddError("Error updating workspace", err.Error())
 	}
 }
 
 func (r *workspaceSettings) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data modelWorkspaceSettings
+	var data, configured modelWorkspaceSettings
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configured)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	if err := r.updateSettings(ctx, &data, &resp.State); err != nil {
+	if configured.ExecutionMode.IsNull() {
+		data.ExecutionMode = types.StringNull()
+	}
+
+	if configured.AgentPoolID.IsNull() {
+		data.AgentPoolID = types.StringNull()
+	}
+
+	if err := r.updateSettings(ctx, &data, &req.State, &resp.State); err != nil {
 		resp.Diagnostics.AddError("Error updating workspace", err.Error())
 	}
 }
@@ -785,7 +815,7 @@ func (r *workspaceSettings) Delete(ctx context.Context, req resource.DeleteReque
 		WorkspaceID: data.ID,
 	}
 
-	if err := r.updateSettings(ctx, &noneModel, &resp.State); err == nil {
+	if err := r.updateSettings(ctx, &noneModel, &req.State, &resp.State); err == nil {
 		resp.State.RemoveResource(ctx)
 	}
 }

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -125,11 +125,23 @@ func (m unsetRemoteStateConsumerIDsIfOmitted) PlanModifySet(ctx context.Context,
 
 	wasConfigured, diags := req.Private.GetKey(ctx, remoteStateConsumerIDsConfiguredKey)
 	resp.Diagnostics.Append(diags...)
-	if diags.HasError() || len(wasConfigured) == 0 {
+	if diags.HasError() {
 		return
 	}
 
+	// If the private key was never set (e.g. after an import), fall back to
+	// checking whether the state already has explicit consumers. If it does,
+	// we still need to plan their removal.
+	if len(wasConfigured) == 0 {
+		if req.StateValue.IsNull() || len(req.StateValue.Elements()) == 0 {
+			return
+		}
+	}
+
 	resp.PlanValue = types.SetValueMust(types.StringType, []attr.Value{})
+	// Clear the private key so subsequent plans don't keep treating the
+	// attribute as "was configured, now omitted" indefinitely.
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, remoteStateConsumerIDsConfiguredKey, nil)...)
 }
 
 func (m unsetRemoteStateConsumerIDsIfOmitted) Description(_ context.Context) string {
@@ -786,19 +798,10 @@ func (r *workspaceSettings) Create(ctx context.Context, req resource.CreateReque
 }
 
 func (r *workspaceSettings) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data, configured modelWorkspaceSettings
+	var data modelWorkspaceSettings
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	resp.Diagnostics.Append(req.Config.Get(ctx, &configured)...)
 	if resp.Diagnostics.HasError() {
 		return
-	}
-
-	if configured.ExecutionMode.IsNull() {
-		data.ExecutionMode = types.StringNull()
-	}
-
-	if configured.AgentPoolID.IsNull() {
-		data.AgentPoolID = types.StringNull()
 	}
 
 	if err := r.updateSettings(ctx, &data, &req.State, &resp.State); err != nil {

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -89,6 +89,10 @@ type unknownIfExecutionModeUnset struct{}
 // true, remote_state_consumer_ids is not set.
 type validateRemoteStateConsumerIDs struct{}
 
+// unsetRemoteStateConsumerIDsIfOmitted ensures the attribute is treated as an
+// explicit empty set when it is removed from configuration after being set.
+type unsetRemoteStateConsumerIDsIfOmitted struct{}
+
 // validate global and remote state mutual exclusion
 type validateRemoteStateExclusion struct{}
 
@@ -99,8 +103,29 @@ type validateSelfReference struct{}
 var _ planmodifier.String = (*validateAgentExecutionMode)(nil)
 var _ planmodifier.List = (*revertOverwritesIfExecutionModeUnset)(nil)
 var _ planmodifier.String = (*unknownIfExecutionModeUnset)(nil)
+var _ planmodifier.Set = (*unsetRemoteStateConsumerIDsIfOmitted)(nil)
 var _ planmodifier.Set = (*validateRemoteStateConsumerIDs)(nil)
 var _ planmodifier.Bool = (*validateRemoteStateExclusion)(nil)
+
+func (m unsetRemoteStateConsumerIDsIfOmitted) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = types.SetValueMust(types.StringType, []attr.Value{})
+}
+
+func (m unsetRemoteStateConsumerIDsIfOmitted) Description(_ context.Context) string {
+	return "Treats omitted remote_state_consumer_ids as an empty set during updates"
+}
+
+func (m unsetRemoteStateConsumerIDsIfOmitted) MarkdownDescription(_ context.Context) string {
+	return "Treats omitted `remote_state_consumer_ids` as an empty set during updates"
+}
 
 func (m validateAgentExecutionMode) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	// Check if the resource is being created.
@@ -385,6 +410,7 @@ func (r *workspaceSettings) Schema(ctx context.Context, req resource.SchemaReque
 				Computed:    true,
 				ElementType: types.StringType,
 				PlanModifiers: []planmodifier.Set{
+					unsetRemoteStateConsumerIDsIfOmitted{},
 					validateRemoteStateConsumerIDs{},
 					validateSelfReference{},
 				},

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -614,20 +614,16 @@ func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorks
 	if executionMode != "" {
 		updateOptions.ExecutionMode = tfe.String(executionMode)
 
-		// Determine whether to mark execution_mode as overwritten. During
-		// Create the overwrites field is null/unknown (computed, not in config)
-		// so we always send the override. During Update, only send the
-		// override when the planned overwrites confirm it — this avoids
-		// inconsistencies when execution_mode is merely inherited from state.
-		sendOverwrite := data.Overwrites.IsNull() || data.Overwrites.IsUnknown()
-		if !sendOverwrite {
-			var overwritesPlanned []modelOverwrites
-			data.Overwrites.ElementsAs(ctx, &overwritesPlanned, true)
-			sendOverwrite = len(overwritesPlanned) > 0 && overwritesPlanned[0].ExecutionMode.ValueBool()
-		}
-		if sendOverwrite {
+		if data.Overwrites.IsNull() || data.Overwrites.IsUnknown() {
 			updateOptions.SettingOverwrites.ExecutionMode = tfe.Bool(true)
 			updateOptions.SettingOverwrites.AgentPool = tfe.Bool(true)
+		} else {
+			var overwritesPlanned []modelOverwrites
+			data.Overwrites.ElementsAs(ctx, &overwritesPlanned, true)
+			if len(overwritesPlanned) > 0 && overwritesPlanned[0].ExecutionMode.ValueBool() {
+				updateOptions.SettingOverwrites.ExecutionMode = tfe.Bool(true)
+				updateOptions.SettingOverwrites.AgentPool = tfe.Bool(true)
+			}
 		}
 
 		agentPoolID := data.AgentPoolID.ValueString() // may be empty

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -614,21 +614,16 @@ func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorks
 	if executionMode != "" {
 		updateOptions.ExecutionMode = tfe.String(executionMode)
 
-		if data.Overwrites.IsNull() || data.Overwrites.IsUnknown() {
+		if shouldSendExecutionModeOverwrite(ctx, data.Overwrites) {
 			updateOptions.SettingOverwrites.ExecutionMode = tfe.Bool(true)
 			updateOptions.SettingOverwrites.AgentPool = tfe.Bool(true)
-		} else {
-			var overwritesPlanned []modelOverwrites
-			data.Overwrites.ElementsAs(ctx, &overwritesPlanned, true)
-			if len(overwritesPlanned) > 0 && overwritesPlanned[0].ExecutionMode.ValueBool() {
-				updateOptions.SettingOverwrites.ExecutionMode = tfe.Bool(true)
-				updateOptions.SettingOverwrites.AgentPool = tfe.Bool(true)
-			}
 		}
 
 		agentPoolID := data.AgentPoolID.ValueString() // may be empty
 		updateOptions.AgentPoolID = tfe.String(agentPoolID)
-	} else if executionMode == "" && data.Overwrites.IsNull() {
+	}
+
+	if executionMode == "" && data.Overwrites.IsNull() {
 		// Not supported by TFE
 		updateOptions.ExecutionMode = tfe.String("remote")
 	}
@@ -677,27 +672,50 @@ func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorks
 	return err
 }
 
-func (r *workspaceSettings) addAndRemoveRemoteStateConsumers(workspaceID string, newWorkspaceIDsSet types.Set, state *tfsdk.State) error {
-	var oldWorkspaceIDs []string
+func shouldSendExecutionModeOverwrite(ctx context.Context, overwrites types.List) bool {
+	if overwrites.IsNull() || overwrites.IsUnknown() {
+		return true
+	}
 
-	if state != nil && !state.Raw.IsNull() {
-		var oldWorkspaceIDsSet types.Set
-		if diags := state.GetAttribute(ctx, path.Root("remote_state_consumer_ids"), &oldWorkspaceIDsSet); diags.HasError() {
-			return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
-		}
-		if !oldWorkspaceIDsSet.IsNull() {
-			if diags := oldWorkspaceIDsSet.ElementsAs(ctx, &oldWorkspaceIDs, true); diags.HasError() {
-				return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
-			}
-		}
-	} else {
+	var overwritesPlanned []modelOverwrites
+	overwrites.ElementsAs(ctx, &overwritesPlanned, true)
+
+	return len(overwritesPlanned) > 0 && overwritesPlanned[0].ExecutionMode.ValueBool()
+}
+
+func (r *workspaceSettings) oldRemoteStateConsumerIDs(workspaceID string, state *tfsdk.State) ([]string, error) {
+	if state == nil || state.Raw.IsNull() {
 		// No prior state (e.g. during Create after import). Read current
 		// consumers from the API so we can remove any that aren't desired.
 		_, currentIDs, err := readWorkspaceStateConsumers(workspaceID, r.config.Client)
 		if err != nil {
-			return fmt.Errorf("error reading current remote state consumers for workspace %s: %w", workspaceID, err)
+			return nil, fmt.Errorf("error reading current remote state consumers for workspace %s: %w", workspaceID, err)
 		}
-		oldWorkspaceIDs = currentIDs
+
+		return currentIDs, nil
+	}
+
+	var oldWorkspaceIDsSet types.Set
+	if diags := state.GetAttribute(ctx, path.Root("remote_state_consumer_ids"), &oldWorkspaceIDsSet); diags.HasError() {
+		return nil, fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
+	}
+
+	if oldWorkspaceIDsSet.IsNull() {
+		return nil, nil
+	}
+
+	var oldWorkspaceIDs []string
+	if diags := oldWorkspaceIDsSet.ElementsAs(ctx, &oldWorkspaceIDs, true); diags.HasError() {
+		return nil, fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
+	}
+
+	return oldWorkspaceIDs, nil
+}
+
+func (r *workspaceSettings) addAndRemoveRemoteStateConsumers(workspaceID string, newWorkspaceIDsSet types.Set, state *tfsdk.State) error {
+	oldWorkspaceIDs, err := r.oldRemoteStateConsumerIDs(workspaceID, state)
+	if err != nil {
+		return err
 	}
 
 	var newWorkspaceIDs []string
@@ -721,7 +739,7 @@ func (r *workspaceSettings) addAndRemoveRemoteStateConsumers(workspaceID string,
 		}
 	}
 
-	// First add the new consumerss
+	// First add the new consumers
 	if len(workspaceIDsToAdd) > 0 {
 		options := tfe.WorkspaceAddRemoteStateConsumersOptions{}
 

--- a/internal/provider/resource_tfe_workspace_settings.go
+++ b/internal/provider/resource_tfe_workspace_settings.go
@@ -613,8 +613,22 @@ func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorks
 	executionMode := data.ExecutionMode.ValueString()
 	if executionMode != "" {
 		updateOptions.ExecutionMode = tfe.String(executionMode)
-		updateOptions.SettingOverwrites.ExecutionMode = tfe.Bool(true)
-		updateOptions.SettingOverwrites.AgentPool = tfe.Bool(true)
+
+		// Determine whether to mark execution_mode as overwritten. During
+		// Create the overwrites field is null/unknown (computed, not in config)
+		// so we always send the override. During Update, only send the
+		// override when the planned overwrites confirm it — this avoids
+		// inconsistencies when execution_mode is merely inherited from state.
+		sendOverwrite := data.Overwrites.IsNull() || data.Overwrites.IsUnknown()
+		if !sendOverwrite {
+			var overwritesPlanned []modelOverwrites
+			data.Overwrites.ElementsAs(ctx, &overwritesPlanned, true)
+			sendOverwrite = len(overwritesPlanned) > 0 && overwritesPlanned[0].ExecutionMode.ValueBool()
+		}
+		if sendOverwrite {
+			updateOptions.SettingOverwrites.ExecutionMode = tfe.Bool(true)
+			updateOptions.SettingOverwrites.AgentPool = tfe.Bool(true)
+		}
 
 		agentPoolID := data.AgentPoolID.ValueString() // may be empty
 		updateOptions.AgentPoolID = tfe.String(agentPoolID)
@@ -668,18 +682,26 @@ func (r *workspaceSettings) updateSettings(ctx context.Context, data *modelWorks
 }
 
 func (r *workspaceSettings) addAndRemoveRemoteStateConsumers(workspaceID string, newWorkspaceIDsSet types.Set, state *tfsdk.State) error {
-	var oldWorkspaceIDsSet types.Set
+	var oldWorkspaceIDs []string
+
 	if state != nil && !state.Raw.IsNull() {
+		var oldWorkspaceIDsSet types.Set
 		if diags := state.GetAttribute(ctx, path.Root("remote_state_consumer_ids"), &oldWorkspaceIDsSet); diags.HasError() {
 			return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
 		}
-	}
-
-	var oldWorkspaceIDs []string
-	if !oldWorkspaceIDsSet.IsNull() {
-		if diags := oldWorkspaceIDsSet.ElementsAs(ctx, &oldWorkspaceIDs, true); diags.HasError() {
-			return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
+		if !oldWorkspaceIDsSet.IsNull() {
+			if diags := oldWorkspaceIDsSet.ElementsAs(ctx, &oldWorkspaceIDs, true); diags.HasError() {
+				return fmt.Errorf("error comparing remote state consumer IDs: %s", diags.Errors())
+			}
 		}
+	} else {
+		// No prior state (e.g. during Create after import). Read current
+		// consumers from the API so we can remove any that aren't desired.
+		_, currentIDs, err := readWorkspaceStateConsumers(workspaceID, r.config.Client)
+		if err != nil {
+			return fmt.Errorf("error reading current remote state consumers for workspace %s: %w", workspaceID, err)
+		}
+		oldWorkspaceIDs = currentIDs
 	}
 
 	var newWorkspaceIDs []string

--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -271,7 +271,6 @@ func TestAccTFEWorkspaceSettingsRemoteState(t *testing.T) {
 						"tfe_workspace_settings.foobar", []string{ws2.ID}),
 				),
 			},
-			// Removing remote_state_consumer_ids from config should clear all explicit consumers.
 			{
 				Config: testAccTFEWorkspaceSettingsRemoteState_UnsetConsumers(ws.ID),
 				Check: resource.ComposeTestCheckFunc(
@@ -493,6 +492,111 @@ func testAccCheckTFEWorkspaceSettingsDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+// TestAccTFEWorkspaceSettingsRemoteState_idempotentAfterClear verifies that
+// once remote_state_consumer_ids has been removed from config and the consumers
+// have been cleared, subsequent plans do not produce a spurious diff.
+func TestAccTFEWorkspaceSettingsRemoteState_idempotentAfterClear(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	t.Cleanup(cleanupOrg)
+
+	ws := createTempWorkspace(t, tfeClient, org.Name)
+	ws2 := createTempWorkspace(t, tfeClient, org.Name)
+
+	configWithConsumers := testAccTFEWorkspaceSettingsRemoteState(ws.ID, ws2.ID)
+	configWithoutConsumers := testAccTFEWorkspaceSettingsRemoteState_UnsetConsumers(ws.ID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithConsumers,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceSettingsHasRemoteConsumers(
+						"tfe_workspace_settings.foobar", []string{ws2.ID},
+					),
+				),
+			},
+			{
+				Config: configWithoutConsumers,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceSettingsHasRemoteConsumers(
+						"tfe_workspace_settings.foobar", []string{},
+					),
+				),
+			},
+			{
+				Config:             configWithoutConsumers,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccTFEWorkspaceSettingsRemoteState_importClearsOutOfBandConsumers
+// verifies that importing a workspace whose remote state consumers were added
+// out-of-band (via the UI or API) and then applying a config that omits
+// remote_state_consumer_ids correctly removes those consumers.
+func TestAccTFEWorkspaceSettingsRemoteState_importClearsOutOfBandConsumers(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	t.Cleanup(cleanupOrg)
+
+	ws := createTempWorkspace(t, tfeClient, org.Name)
+	ws2 := createTempWorkspace(t, tfeClient, org.Name)
+
+	// Add ws2 as a remote state consumer out-of-band (simulating the UI/API).
+	err = tfeClient.Workspaces.AddRemoteStateConsumers(ctx, ws.ID,
+		tfe.WorkspaceAddRemoteStateConsumersOptions{
+			Workspaces: []*tfe.Workspace{{ID: ws2.ID}},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Config deliberately omits remote_state_consumer_ids.
+	configWithoutConsumers := testAccTFEWorkspaceSettingsRemoteState_UnsetConsumers(ws.ID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEWorkspaceSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:            configWithoutConsumers,
+				ResourceName:      "tfe_workspace_settings.foobar",
+				ImportState:       true,
+				ImportStateId:     ws.ID,
+				ImportStateVerify: false, // state has consumers, config does not
+			},
+			{
+				Config: configWithoutConsumers,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceSettingsHasRemoteConsumers(
+						"tfe_workspace_settings.foobar", []string{},
+					),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckTFEWorkspaceSettingsHasRemoteConsumers(ws string, expectedConsumerIDs []string) resource.TestCheckFunc {

--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -237,7 +237,10 @@ func TestAccTFEWorkspaceSettingsRemoteState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	org, cleanupOrg := createBusinessOrganization(t, tfeClient)
+	org, cleanupOrg := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
 	t.Cleanup(cleanupOrg)
 
 	ws := createTempWorkspace(t, tfeClient, org.Name)

--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
+	"slices"
 	"testing"
 	"time"
 
@@ -263,6 +264,26 @@ func TestAccTFEWorkspaceSettingsRemoteState(t *testing.T) {
 						"tfe_workspace_settings.foobar", "remote_state_consumer_ids.0", ws2.ID),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace_settings.foobar", "remote_state_consumer_ids.#", "1"),
+					testAccCheckTFEWorkspaceSettingsHasRemoteConsumers(
+						"tfe_workspace_settings.foobar", []string{ws2.ID}),
+				),
+			},
+			// Removing remote_state_consumer_ids from config should clear all explicit consumers.
+			{
+				Config: testAccTFEWorkspaceSettingsRemoteState_UnsetConsumers(ws.ID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"tfe_workspace_settings.foobar", "id"),
+					resource.TestCheckResourceAttrSet(
+						"tfe_workspace_settings.foobar", "workspace_id"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.foobar", "global_remote_state", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.foobar", "project_remote_state", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace_settings.foobar", "remote_state_consumer_ids.#", "0"),
+					testAccCheckTFEWorkspaceSettingsHasRemoteConsumers(
+						"tfe_workspace_settings.foobar", []string{}),
 				),
 			},
 			// Unset remote state consumer ids and set global remote state
@@ -471,6 +492,35 @@ func testAccCheckTFEWorkspaceSettingsDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckTFEWorkspaceSettingsHasRemoteConsumers(ws string, expectedConsumerIDs []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rsWorkspaceSettings, ok := s.RootModule().Resources[ws]
+		if !ok {
+			return fmt.Errorf("Not found: %s", ws)
+		}
+
+		tfeClient, err := getClientUsingEnv()
+		if err != nil {
+			return err
+		}
+
+		_, actualConsumerIDs, err := readWorkspaceStateConsumers(rsWorkspaceSettings.Primary.ID, tfeClient)
+		if err != nil {
+			return fmt.Errorf("error reading remote state consumers for workspace %s: %w", rsWorkspaceSettings.Primary.ID, err)
+		}
+
+		expected := append([]string(nil), expectedConsumerIDs...)
+		slices.Sort(expected)
+		slices.Sort(actualConsumerIDs)
+
+		if !slices.Equal(actualConsumerIDs, expected) {
+			return fmt.Errorf("expected remote state consumers %v for workspace %s, got %v", expected, rsWorkspaceSettings.Primary.ID, actualConsumerIDs)
+		}
+
+		return nil
+	}
+}
+
 func testAccTFEWorkspaceSettingsOverlappingBooleans(orgName string) string {
 	return fmt.Sprintf(`
 resource "tfe_workspace_settings" "self" {
@@ -531,6 +581,16 @@ func testAccTFEWorkspaceSettingsRemoteState_Global(workspaceID string) string {
 resource "tfe_workspace_settings" "foobar" {
 	workspace_id              = "%s"
 	global_remote_state       = true
+}
+`, workspaceID)
+}
+
+func testAccTFEWorkspaceSettingsRemoteState_UnsetConsumers(workspaceID string) string {
+	return fmt.Sprintf(`
+resource "tfe_workspace_settings" "foobar" {
+	workspace_id         = "%s"
+	global_remote_state  = false
+	project_remote_state = false
 }
 `, workspaceID)
 }

--- a/internal/provider/resource_tfe_workspace_settings_test.go
+++ b/internal/provider/resource_tfe_workspace_settings_test.go
@@ -563,6 +563,14 @@ func TestAccTFEWorkspaceSettingsRemoteState_importClearsOutOfBandConsumers(t *te
 	ws := createTempWorkspace(t, tfeClient, org.Name)
 	ws2 := createTempWorkspace(t, tfeClient, org.Name)
 
+	// Disable global remote state so we can add specific consumers.
+	_, err = tfeClient.Workspaces.UpdateByID(ctx, ws.ID, tfe.WorkspaceUpdateOptions{
+		GlobalRemoteState: tfe.Bool(false),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Add ws2 as a remote state consumer out-of-band (simulating the UI/API).
 	err = tfeClient.Workspaces.AddRemoteStateConsumers(ctx, ws.ID,
 		tfe.WorkspaceAddRemoteStateConsumersOptions{


### PR DESCRIPTION
## Description

This fix PR resolves #2000.

## Testing plan

1.  Reproduce with a config similar to that provided in #2000
2. Ensure that with the fix in place, omitting `remote_state_consumer_ids` from a config that previously used it clears out the relationships successfully.
