### PR TITLE
Adding Post Apply Status Constants in Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * Updates warning when using credentials/config file for authentication and running on cloud to be clearer, by @christian-doucette [#2036](https://github.com/hashicorp/terraform-provider-tfe/pull/2036)
 * Support trigger patterns and working directories in stacks by @aaabdelgany [#2048](https://github.com/hashicorp/terraform-provider-tfe/pull/2048)
+* Adds `RunPostApplyRunning`,`RunPostApplyCompleted` run status by @jose-kunnel [#2046](https://github.com/hashicorp/terraform-provider-tfe/pull/2046)
 
 BUG FIXES:
 * `r/tfe_team`: Fixed a `Missing Identity After Update` error on resource update by @sebasslash [#2045](https://github.com/hashicorp/terraform-provider-tfe/pull/2045)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-slug v1.0.0
-	github.com/hashicorp/go-tfe v1.104.0
+	github.com/hashicorp/go-tfe v1.105.0
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW3o=
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
-github.com/hashicorp/go-tfe v1.104.0 h1:IT4FJVk6mKRFado/Ciaqh6RFYDMQY0RaXypZbjtFIBI=
-github.com/hashicorp/go-tfe v1.104.0/go.mod h1:h9zoGyk0+5YCxuahXVppZ5kUNxqHhdZ21jrnLPDPNS4=
+github.com/hashicorp/go-tfe v1.105.0 h1:PXuWC9EWz+5sG/EC+tJO2i+lRamAe+A6tKt2XUImhPs=
+github.com/hashicorp/go-tfe v1.105.0/go.mod h1:d8js2OmMnCq58gEh26mCS81nD8Aj7HmG6IO1b80gM78=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/resource_tfe_workspace_run.go
+++ b/internal/provider/resource_tfe_workspace_run.go
@@ -23,14 +23,16 @@ var (
 )
 
 var applyPendingStatuses = map[tfe.RunStatus]bool{
-	tfe.RunConfirmed:         true,
-	tfe.RunApplyQueued:       true,
-	tfe.RunApplying:          true,
-	tfe.RunQueuing:           true,
-	tfe.RunFetching:          true,
-	tfe.RunQueuingApply:      true,
-	tfe.RunPreApplyRunning:   true,
-	tfe.RunPreApplyCompleted: true,
+	tfe.RunConfirmed:          true,
+	tfe.RunApplyQueued:        true,
+	tfe.RunApplying:           true,
+	tfe.RunQueuing:            true,
+	tfe.RunFetching:           true,
+	tfe.RunQueuingApply:       true,
+	tfe.RunPreApplyRunning:    true,
+	tfe.RunPreApplyCompleted:  true,
+	tfe.RunPostApplyRunning:   true,
+	tfe.RunPostApplyCompleted: true,
 }
 
 var applyDoneStatuses = map[tfe.RunStatus]bool{


### PR DESCRIPTION
## Description

This PR adds support for new run status values introduced in the TFE API.

Currently, the provider does not recognize the following run statuses:

post_apply_running
post_apply_completed

These statuses are not included in the applyPendingStatuses list within resource_tfe_workspace_run.go, which causes runs with post-apply run tasks to fail. When such a run enters the post_apply_running state, it is treated as an invalid status and results in an error.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Before this change

Creating a run with a post-apply run task would fail when transitioning to post_apply_running, as the provider does not recognize this state.

After this change

Runs with post-apply run tasks are handled correctly, and transitions through post_apply_running and post_apply_completed no longer cause errors.

## External links
- [JIRA] (https://hashicorp.atlassian.net/browse/IPL-9456)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/1323)