### PR TITLE
Support trigger patterns and working directory in stacks resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ENHANCEMENTS:
 * Updates warning when using credentials/config file for authentication and running on cloud to be clearer, by @christian-doucette [#2036](https://github.com/hashicorp/terraform-provider-tfe/pull/2036)
+* Support trigger patterns and working directories in stacks by @aaabdelgany [#2048](https://github.com/hashicorp/terraform-provider-tfe/pull/2048)
 
 ## v0.76.2
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-slug v1.0.0
-	github.com/hashicorp/go-tfe v1.103.0
+	github.com/hashicorp/go-tfe v1.104.0
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW3o=
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
-github.com/hashicorp/go-tfe v1.103.0 h1:2sx/8733WdFoEhrKbRkVhrlR+Z3Jkv2juFNFvr9AYQs=
-github.com/hashicorp/go-tfe v1.103.0/go.mod h1:h9zoGyk0+5YCxuahXVppZ5kUNxqHhdZ21jrnLPDPNS4=
+github.com/hashicorp/go-tfe v1.104.0 h1:IT4FJVk6mKRFado/Ciaqh6RFYDMQY0RaXypZbjtFIBI=
+github.com/hashicorp/go-tfe v1.104.0/go.mod h1:h9zoGyk0+5YCxuahXVppZ5kUNxqHhdZ21jrnLPDPNS4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/resource_tfe_stack.go
+++ b/internal/provider/resource_tfe_stack.go
@@ -107,6 +107,15 @@ func (r *resourceTFEStack) Schema(ctx context.Context, req resource.SchemaReques
 				Description: "Description of the Stack",
 				Optional:    true,
 			},
+			"working_directory": schema.StringAttribute{
+				Description: "The working directory of the Stack.",
+				Optional:    true,
+			},
+			"trigger_patterns": schema.ListAttribute{
+				Description: "List of trigger patterns for the Stack.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 			"speculative_enabled": schema.BoolAttribute{
 				Description: "Indicates if speculative plans are enabled on this Stack.",
 				Optional:    true,
@@ -228,6 +237,14 @@ func (r *resourceTFEStack) Create(ctx context.Context, req resource.CreateReques
 		options.Description = tfe.String(plan.Description.ValueString())
 	}
 
+	if !plan.WorkingDirectory.IsNull() {
+		options.WorkingDirectory = tfe.String(plan.WorkingDirectory.ValueString())
+	}
+
+	if !plan.TriggerPatterns.IsNull() {
+		options.TriggerPatterns = triggerPatternsFromList(ctx, plan.TriggerPatterns)
+	}
+
 	tflog.Debug(ctx, "Creating stack")
 	stack, err := r.config.Client.Stacks.Create(ctx, options)
 	if err != nil {
@@ -306,6 +323,18 @@ func (r *resourceTFEStack) Update(ctx context.Context, req resource.UpdateReques
 		Name:               tfe.String(plan.Name.ValueString()),
 		Description:        tfe.String(plan.Description.ValueString()),
 		SpeculativeEnabled: tfe.Bool(plan.SpeculativeEnabled.ValueBool()),
+	}
+
+	if !plan.WorkingDirectory.IsNull() {
+		options.WorkingDirectory = tfe.String(plan.WorkingDirectory.ValueString())
+	} else {
+		options.WorkingDirectory = tfe.String("")
+	}
+
+	if !plan.TriggerPatterns.IsNull() {
+		options.TriggerPatterns = triggerPatternsFromList(ctx, plan.TriggerPatterns)
+	} else {
+		options.TriggerPatterns = []string{}
 	}
 
 	if plan.VCSRepo != nil {

--- a/internal/provider/resource_tfe_stack_test.go
+++ b/internal/provider/resource_tfe_stack_test.go
@@ -55,14 +55,13 @@ func (notFoundStacks) FetchLatestFromVcs(_ context.Context, _ string) (*tfe.Stac
 func TestAccTFEStackResource_basic(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-	speculativeEnabledFalse := false
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", true, speculativeEnabledFalse),
+				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "id"),
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "project_id"),
@@ -90,62 +89,6 @@ func TestAccTFEStackResource_basic(t *testing.T) {
 	})
 }
 
-func TestAccTFEStackResource_omitSpeculativeEnabled(t *testing.T) {
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccMuxedProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", false, false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_stack.foobar", "speculative_enabled", "false"),
-				),
-			},
-			{
-				ResourceName:            "tfe_stack.foobar",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"migration"},
-			},
-		},
-	})
-}
-
-func TestAccTFEStackResource_updateSpeculativeEnabled(t *testing.T) {
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
-	speculativeEnabledFalse := false
-	speculativeEnabledTrue := true
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccMuxedProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", false, speculativeEnabledFalse),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_stack.foobar", "speculative_enabled", "false"),
-				),
-			},
-			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", true, speculativeEnabledFalse),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_stack.foobar", "speculative_enabled", "false"),
-				),
-			},
-			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", true, speculativeEnabledTrue),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_stack.foobar", "speculative_enabled", "true"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccTFEStackResource_importByIdentity(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
@@ -155,7 +98,7 @@ func TestAccTFEStackResource_importByIdentity(t *testing.T) {
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEStackResourceConfigFull(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", false, true, true),
+				Config: testAccTFEStackResourceConfigFull(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentity("tfe_stack.foobar", map[string]knownvalue.Check{
 						"id":       knownvalue.NotNull(),
@@ -172,11 +115,11 @@ func TestAccTFEStackResource_importByIdentity(t *testing.T) {
 	})
 }
 
-func testAccTFEStackResourceConfig(orgName, ghToken, ghRepoIdentifier string, includeSpeculativeEnabled bool, speculativeEnabled bool) string {
-	return testAccTFEStackResourceConfigFull(orgName, ghToken, ghRepoIdentifier, true, includeSpeculativeEnabled, speculativeEnabled)
+func testAccTFEStackResourceConfig(orgName, ghToken, ghRepoIdentifier string) string {
+	return testAccTFEStackResourceConfigFull(orgName, ghToken, ghRepoIdentifier)
 }
 
-func testAccTFEStackResourceConfigFull(orgName, ghToken, ghRepoIdentifier string, migration bool, includeSpeculativeEnabled bool, speculativeEnabled bool) string {
+func testAccTFEStackResourceConfigFull(orgName, ghToken, ghRepoIdentifier string) string {
 	var builder strings.Builder
 	builder.WriteString(fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
@@ -210,15 +153,13 @@ resource "tfe_stack" "foobar" {
   agent_pool_id = tfe_agent_pool.foobar.id
 	working_directory = "envs"
 	trigger_patterns  = ["/**/*"]
+	speculative_enabled = true
 	vcs_repo {
     identifier         = "%s"
     oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
   }
 `, orgName, ghToken, ghRepoIdentifier))
-	if includeSpeculativeEnabled {
-		builder.WriteString(fmt.Sprintf(`	speculative_enabled = "%t"`, speculativeEnabled))
-	}
-	builder.WriteString("\n}")
+	builder.WriteString("}")
 	return builder.String()
 }
 

--- a/internal/provider/resource_tfe_stack_test.go
+++ b/internal/provider/resource_tfe_stack_test.go
@@ -155,7 +155,7 @@ func TestAccTFEStackResource_importByIdentity(t *testing.T) {
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", true, true),
+				Config: testAccTFEStackResourceConfigFull(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", false, true, true),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentity("tfe_stack.foobar", map[string]knownvalue.Check{
 						"id":       knownvalue.NotNull(),
@@ -173,6 +173,10 @@ func TestAccTFEStackResource_importByIdentity(t *testing.T) {
 }
 
 func testAccTFEStackResourceConfig(orgName, ghToken, ghRepoIdentifier string, includeSpeculativeEnabled bool, speculativeEnabled bool) string {
+	return testAccTFEStackResourceConfigFull(orgName, ghToken, ghRepoIdentifier, true, includeSpeculativeEnabled, speculativeEnabled)
+}
+
+func testAccTFEStackResourceConfigFull(orgName, ghToken, ghRepoIdentifier string, migration bool, includeSpeculativeEnabled bool, speculativeEnabled bool) string {
 	var builder strings.Builder
 	builder.WriteString(fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
@@ -204,7 +208,6 @@ resource "tfe_stack" "foobar" {
 	description = "Just an ordinary stack"
   project_id  = tfe_project.example.id
   agent_pool_id = tfe_agent_pool.foobar.id
-	migration = true
 	working_directory = "envs"
 	trigger_patterns  = ["/**/*"]
 	vcs_repo {
@@ -253,6 +256,7 @@ func testAccTFEStackResourceConfigWithAgentPool(orgName string) string {
 resource "tfe_organization" "foobar" {
   name  = "%s"
   email = "admin@tfe.local"
+	stacks_enabled = true
 }
 
 resource "tfe_agent_pool" "foobar" {
@@ -453,6 +457,7 @@ func testAccTFEStackResourceConfigNoVCSRepo(orgName string) string {
 resource "tfe_organization" "foobar" {
   name  = "%s"
   email = "admin@tfe.local"
+  stacks_enabled = true
 }
 
 resource "tfe_project" "example" {

--- a/internal/provider/resource_tfe_stack_test.go
+++ b/internal/provider/resource_tfe_stack_test.go
@@ -73,7 +73,7 @@ func TestAccTFEStackResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "trigger_patterns.#", "1"),
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "trigger_patterns.0", "/**/*"),
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "vcs_repo.identifier", "svc-team-tf-core-cloud/tf-stacks-pet-nulls"),
-					resource.TestCheckResourceAttr("tfe_stack.foobar", "creation_source", "migration-api"),
+					resource.TestCheckResourceAttr("tfe_stack.foobar", "creation_source", "api"),
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "vcs_repo.oauth_token_id"),
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "speculative_enabled"),
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "created_at"),

--- a/internal/provider/resource_tfe_stack_test.go
+++ b/internal/provider/resource_tfe_stack_test.go
@@ -53,8 +53,6 @@ func (notFoundStacks) FetchLatestFromVcs(_ context.Context, _ string) (*tfe.Stac
 }
 
 func TestAccTFEStackResource_basic(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 	speculativeEnabledFalse := false
@@ -64,14 +62,17 @@ func TestAccTFEStackResource_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "arunatibm/pet-nulls-stack", true, speculativeEnabledFalse),
+				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", true, speculativeEnabledFalse),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "id"),
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "project_id"),
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "agent_pool_id"),
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "name", "example-stack"),
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "description", "Just an ordinary stack"),
-					resource.TestCheckResourceAttr("tfe_stack.foobar", "vcs_repo.identifier", "arunatibm/pet-nulls-stack"),
+					resource.TestCheckResourceAttr("tfe_stack.foobar", "working_directory", "envs"),
+					resource.TestCheckResourceAttr("tfe_stack.foobar", "trigger_patterns.#", "1"),
+					resource.TestCheckResourceAttr("tfe_stack.foobar", "trigger_patterns.0", "/**/*"),
+					resource.TestCheckResourceAttr("tfe_stack.foobar", "vcs_repo.identifier", "svc-team-tf-core-cloud/tf-stacks-pet-nulls"),
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "creation_source", "migration-api"),
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "vcs_repo.oauth_token_id"),
 					resource.TestCheckResourceAttrSet("tfe_stack.foobar", "speculative_enabled"),
@@ -90,8 +91,6 @@ func TestAccTFEStackResource_basic(t *testing.T) {
 }
 
 func TestAccTFEStackResource_omitSpeculativeEnabled(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
@@ -100,7 +99,7 @@ func TestAccTFEStackResource_omitSpeculativeEnabled(t *testing.T) {
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "arunatibm/pet-nulls-stack", false, false),
+				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "speculative_enabled", "false"),
 				),
@@ -116,8 +115,6 @@ func TestAccTFEStackResource_omitSpeculativeEnabled(t *testing.T) {
 }
 
 func TestAccTFEStackResource_updateSpeculativeEnabled(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 	speculativeEnabledFalse := false
@@ -128,19 +125,19 @@ func TestAccTFEStackResource_updateSpeculativeEnabled(t *testing.T) {
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "arunatibm/pet-nulls-stack", false, speculativeEnabledFalse),
+				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", false, speculativeEnabledFalse),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "speculative_enabled", "false"),
 				),
 			},
 			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "arunatibm/pet-nulls-stack", true, speculativeEnabledFalse),
+				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", true, speculativeEnabledFalse),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "speculative_enabled", "false"),
 				),
 			},
 			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "arunatibm/pet-nulls-stack", true, speculativeEnabledTrue),
+				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", true, speculativeEnabledTrue),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tfe_stack.foobar", "speculative_enabled", "true"),
 				),
@@ -150,8 +147,6 @@ func TestAccTFEStackResource_updateSpeculativeEnabled(t *testing.T) {
 }
 
 func TestAccTFEStackResource_importByIdentity(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
@@ -160,7 +155,7 @@ func TestAccTFEStackResource_importByIdentity(t *testing.T) {
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "arunatibm/pet-nulls-stack", true, true),
+				Config: testAccTFEStackResourceConfig(orgName, envGithubToken, "svc-team-tf-core-cloud/tf-stacks-pet-nulls", true, true),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectIdentity("tfe_stack.foobar", map[string]knownvalue.Check{
 						"id":       knownvalue.NotNull(),
@@ -210,6 +205,8 @@ resource "tfe_stack" "foobar" {
   project_id  = tfe_project.example.id
   agent_pool_id = tfe_agent_pool.foobar.id
 	migration = true
+	working_directory = "envs"
+	trigger_patterns  = ["/**/*"]
 	vcs_repo {
     identifier         = "%s"
     oauth_token_id     = tfe_oauth_client.foobar.oauth_token_id
@@ -223,8 +220,6 @@ resource "tfe_stack" "foobar" {
 }
 
 func TestAccTFEStackResource_withAgentPool(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
@@ -295,6 +290,8 @@ func TestResourceTFEStackRead_RemovedStackBackfillsIdentity(t *testing.T) {
 		SpeculativeEnabled: types.BoolValue(false),
 		CreationSource:     types.StringNull(),
 		Description:        types.StringValue(""),
+		WorkingDirectory:   types.StringNull(),
+		TriggerPatterns:    types.ListNull(types.StringType),
 		VCSRepo:            nil,
 		CreatedAt:          types.StringValue("2026-01-01T00:00:00Z"),
 		UpdatedAt:          types.StringValue("2026-01-01T00:00:00Z"),
@@ -346,6 +343,8 @@ func TestResourceTFEStackRead_RemovedStackPreservesExistingIdentity(t *testing.T
 		SpeculativeEnabled: types.BoolValue(false),
 		CreationSource:     types.StringNull(),
 		Description:        types.StringValue(""),
+		WorkingDirectory:   types.StringNull(),
+		TriggerPatterns:    types.ListNull(types.StringType),
 		VCSRepo:            nil,
 		CreatedAt:          types.StringValue("2026-01-01T00:00:00Z"),
 		UpdatedAt:          types.StringValue("2026-01-01T00:00:00Z"),
@@ -422,8 +421,6 @@ func runRemovedStackRead(t *testing.T, ctx context.Context, r *resourceTFEStack,
 }
 
 func TestAccTFEStackResource_noVCSRepo(t *testing.T) {
-	skipUnlessBeta(t)
-
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 

--- a/internal/provider/stack.go
+++ b/internal/provider/stack.go
@@ -4,9 +4,11 @@
 package provider
 
 import (
+	"context"
 	"time"
 
 	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -28,6 +30,8 @@ type modelTFEStack struct {
 	SpeculativeEnabled types.Bool            `tfsdk:"speculative_enabled"`
 	CreationSource     types.String          `tfsdk:"creation_source"`
 	Description        types.String          `tfsdk:"description"`
+	WorkingDirectory   types.String          `tfsdk:"working_directory"`
+	TriggerPatterns    types.List            `tfsdk:"trigger_patterns"`
 	VCSRepo            *modelTFEStackVCSRepo `tfsdk:"vcs_repo"`
 	CreatedAt          types.String          `tfsdk:"created_at"`
 	UpdatedAt          types.String          `tfsdk:"updated_at"`
@@ -41,6 +45,8 @@ type modelTFEStackIdentity struct {
 // modelFromTFEStack builds a modelTFEStack struct from a
 // tfe.Stack value.“
 func modelFromTFEStack(v *tfe.Stack) modelTFEStack {
+	triggerPatterns := triggerPatternsToList(v.TriggerPatterns)
+
 	result := modelTFEStack{
 		ID:                 types.StringValue(v.ID),
 		ProjectID:          types.StringValue(v.Project.ID),
@@ -50,6 +56,8 @@ func modelFromTFEStack(v *tfe.Stack) modelTFEStack {
 		SpeculativeEnabled: types.BoolValue(v.SpeculativeEnabled),
 		CreationSource:     types.StringNull(),
 		Description:        types.StringNull(),
+		WorkingDirectory:   types.StringNull(),
+		TriggerPatterns:    triggerPatterns,
 		CreatedAt:          types.StringValue(v.CreatedAt.Format(time.RFC3339)),
 		UpdatedAt:          types.StringValue(v.UpdatedAt.Format(time.RFC3339)),
 	}
@@ -71,6 +79,10 @@ func modelFromTFEStack(v *tfe.Stack) modelTFEStack {
 		result.Description = types.StringValue(v.Description)
 	}
 
+	if v.WorkingDirectory != "" {
+		result.WorkingDirectory = types.StringValue(v.WorkingDirectory)
+	}
+
 	if v.VCSRepo != nil {
 		if v.VCSRepo.GHAInstallationID != "" {
 			result.VCSRepo.GHAInstallationID = types.StringValue(v.VCSRepo.GHAInstallationID)
@@ -89,5 +101,30 @@ func modelFromTFEStack(v *tfe.Stack) modelTFEStack {
 		result.CreationSource = types.StringValue(v.CreationSource)
 	}
 
+	return result
+}
+
+func triggerPatternsToList(patterns []string) types.List {
+	if len(patterns) == 0 {
+		return types.ListNull(types.StringType)
+	}
+	elems := make([]attr.Value, len(patterns))
+	for i, p := range patterns {
+		elems[i] = types.StringValue(p)
+	}
+	list, _ := types.ListValue(types.StringType, elems)
+	return list
+}
+
+func triggerPatternsFromList(ctx context.Context, list types.List) []string {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+	elems := make([]types.String, 0, len(list.Elements()))
+	list.ElementsAs(ctx, &elems, false)
+	result := make([]string, len(elems))
+	for i, e := range elems {
+		result[i] = e.ValueString()
+	}
 	return result
 }


### PR DESCRIPTION
## Description

This PR:
1. Enables working directory and trigger pattern support in the stacks resource. 
2. Unskips and fixes the stacks resource tests
3. Removes any special handling around the `speculativeEnabled` and `migration` fields on stacks resource - those are pretty standard fields and don't need to have any sort of weirdness around them.

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan
1. Set trigger patterns and a working directory on a vcs backed stack
2. push a commit that matches the trigger pattern to trigger a stack configuration
3. observe that the created configuration is operating out of the supplied working directory
## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

https://github.com/hashicorp/go-tfe/pull/1305
## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
TESTARGS="-run TestAccTFEStack" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEStack -timeout 15m
?   	github.com/hashicorp/terraform-provider-tfe	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/client	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/logging	(cached) [no tests to run]
=== RUN   TestAccTFEStackResource_basic
--- PASS: TestAccTFEStackResource_basic (4.62s)
=== RUN   TestAccTFEStackResource_importByIdentity
--- PASS: TestAccTFEStackResource_importByIdentity (4.87s)
=== RUN   TestAccTFEStackResource_withAgentPool
--- PASS: TestAccTFEStackResource_withAgentPool (2.83s)
=== RUN   TestAccTFEStackResource_noVCSRepo
--- PASS: TestAccTFEStackResource_noVCSRepo (2.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	15.418s
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/version	[no test files]
...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
