### PR TITLE
Update Access from Admin to Custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased
+
+BUG FIXES:
+* `r/tfe_team_access`: Fixed a bug where switching from `access` attribute to `permissions` block with identical permission values showed "No changes" instead of updating the resource. The fix detects when `access` is removed from configuration, even when both `access` and `permissions` exist in state. By @sana-faraz [#2049]https://github.com/hashicorp/terraform-provider-tfe/pull/2049/
+
 ENHANCEMENTS:
 * Updates warning when using credentials/config file for authentication and running on cloud to be clearer, by @christian-doucette [#2036](https://github.com/hashicorp/terraform-provider-tfe/pull/2036)
 * Support trigger patterns and working directories in stacks by @aaabdelgany [#2048](https://github.com/hashicorp/terraform-provider-tfe/pull/2048)

--- a/internal/provider/resource_tfe_team_access.go
+++ b/internal/provider/resource_tfe_team_access.go
@@ -19,6 +19,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+const (
+	// Schema field names for tfe_team_access resource
+	teamAccessAccessKey      = "access"
+	teamAccessPermissionsKey = "permissions"
+	teamAccessTeamIDKey      = "team_id"
+	teamAccessWorkspaceIDKey = "workspace_id"
+
+	// Permission field names
+	permissionsRunsKey             = "runs"
+	permissionsVariablesKey        = "variables"
+	permissionsStateVersionsKey    = "state_versions"
+	permissionsSentinelMocksKey    = "sentinel_mocks"
+	permissionsWorkspaceLockingKey = "workspace_locking"
+	permissionsRunTasksKey         = "run_tasks"
+)
+
 func resourceTFETeamAccess() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTFETeamAccessCreate,
@@ -40,13 +56,13 @@ func resourceTFETeamAccess() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"access": {
+			teamAccessAccessKey: {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				// This should be moved to the Resource level when possible:
 				// https://github.com/hashicorp/terraform-plugin-sdk/issues/470
-				ExactlyOneOf: []string{"access", "permissions"},
+				ExactlyOneOf: []string{teamAccessAccessKey, teamAccessPermissionsKey},
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						string(tfe.AccessAdmin),
@@ -58,13 +74,13 @@ func resourceTFETeamAccess() *schema.Resource {
 				),
 			},
 
-			"permissions": {
+			teamAccessPermissionsKey: {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"runs": {
+						permissionsRunsKey: {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice(
@@ -77,7 +93,7 @@ func resourceTFETeamAccess() *schema.Resource {
 							),
 						},
 
-						"variables": {
+						permissionsVariablesKey: {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice(
@@ -90,7 +106,7 @@ func resourceTFETeamAccess() *schema.Resource {
 							),
 						},
 
-						"state_versions": {
+						permissionsStateVersionsKey: {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice(
@@ -104,7 +120,7 @@ func resourceTFETeamAccess() *schema.Resource {
 							),
 						},
 
-						"sentinel_mocks": {
+						permissionsSentinelMocksKey: {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice(
@@ -116,12 +132,12 @@ func resourceTFETeamAccess() *schema.Resource {
 							),
 						},
 
-						"workspace_locking": {
+						permissionsWorkspaceLockingKey: {
 							Type:     schema.TypeBool,
 							Required: true,
 						},
 
-						"run_tasks": {
+						permissionsRunTasksKey: {
 							Type:     schema.TypeBool,
 							Required: true,
 						},
@@ -129,13 +145,13 @@ func resourceTFETeamAccess() *schema.Resource {
 				},
 			},
 
-			"team_id": {
+			teamAccessTeamIDKey: {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"workspace_id": {
+			teamAccessWorkspaceIDKey: {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -152,10 +168,10 @@ func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error
 	config := meta.(ConfiguredClient)
 
 	// Get the access level
-	access := d.Get("access").(string)
+	access := d.Get(teamAccessAccessKey).(string)
 
 	// Get the workspace
-	workspaceID := d.Get("workspace_id").(string)
+	workspaceID := d.Get(teamAccessWorkspaceIDKey).(string)
 	ws, err := config.Client.Workspaces.ReadByID(ctx, workspaceID)
 	if err != nil {
 		return fmt.Errorf(
@@ -163,7 +179,7 @@ func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Get the team.
-	teamID := d.Get("team_id").(string)
+	teamID := d.Get(teamAccessTeamIDKey).(string)
 	tm, err := config.Client.Teams.Read(ctx, teamID)
 	if err != nil {
 		return fmt.Errorf("Error retrieving team %s: %w", teamID, err)
@@ -176,38 +192,44 @@ func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error
 		Workspace: ws,
 	}
 
-	if d.HasChange("permissions.0.runs") {
-		if v, ok := d.GetOk("permissions.0.runs"); ok {
+	permissionsRunsPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsRunsKey)
+	if d.HasChange(permissionsRunsPath) {
+		if v, ok := d.GetOk(permissionsRunsPath); ok {
 			options.Runs = tfe.RunsPermission(tfe.RunsPermissionType(v.(string)))
 		}
 	}
 
-	if d.HasChange("permissions.0.variables") {
-		if v, ok := d.GetOk("permissions.0.variables"); ok {
+	permissionsVariablesPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsVariablesKey)
+	if d.HasChange(permissionsVariablesPath) {
+		if v, ok := d.GetOk(permissionsVariablesPath); ok {
 			options.Variables = tfe.VariablesPermission(tfe.VariablesPermissionType(v.(string)))
 		}
 	}
 
-	if d.HasChange("permissions.0.state_versions") {
-		if v, ok := d.GetOk("permissions.0.state_versions"); ok {
+	permissionsStateVersionsPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsStateVersionsKey)
+	if d.HasChange(permissionsStateVersionsPath) {
+		if v, ok := d.GetOk(permissionsStateVersionsPath); ok {
 			options.StateVersions = tfe.StateVersionsPermission(tfe.StateVersionsPermissionType(v.(string)))
 		}
 	}
 
-	if d.HasChange("permissions.0.sentinel_mocks") {
-		if v, ok := d.GetOk("permissions.0.sentinel_mocks"); ok {
+	permissionsSentinelMocksPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsSentinelMocksKey)
+	if d.HasChange(permissionsSentinelMocksPath) {
+		if v, ok := d.GetOk(permissionsSentinelMocksPath); ok {
 			options.SentinelMocks = tfe.SentinelMocksPermission(tfe.SentinelMocksPermissionType(v.(string)))
 		}
 	}
 
-	if d.HasChange("permissions.0.workspace_locking") {
-		if v, ok := d.GetOkExists("permissions.0.workspace_locking"); ok {
+	permissionsWorkspaceLockingPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsWorkspaceLockingKey)
+	if d.HasChange(permissionsWorkspaceLockingPath) {
+		if v, ok := d.GetOkExists(permissionsWorkspaceLockingPath); ok {
 			options.WorkspaceLocking = tfe.Bool(v.(bool))
 		}
 	}
 
-	if d.HasChange("permissions.0.run_tasks") {
-		if v, ok := d.GetOkExists("permissions.0.run_tasks"); ok {
+	permissionsRunTasksPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsRunTasksKey)
+	if d.HasChange(permissionsRunTasksPath) {
+		if v, ok := d.GetOkExists(permissionsRunTasksPath); ok {
 			options.RunTasks = tfe.Bool(v.(bool))
 		}
 	}
@@ -239,23 +261,23 @@ func resourceTFETeamAccessRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Update config.
-	d.Set("access", string(tmAccess.Access))
+	d.Set(teamAccessAccessKey, string(tmAccess.Access))
 	permissions := []map[string]interface{}{{
-		"runs":              tmAccess.Runs,
-		"variables":         tmAccess.Variables,
-		"state_versions":    tmAccess.StateVersions,
-		"sentinel_mocks":    tmAccess.SentinelMocks,
-		"workspace_locking": tmAccess.WorkspaceLocking,
-		"run_tasks":         tmAccess.RunTasks,
+		permissionsRunsKey:             tmAccess.Runs,
+		permissionsVariablesKey:        tmAccess.Variables,
+		permissionsStateVersionsKey:    tmAccess.StateVersions,
+		permissionsSentinelMocksKey:    tmAccess.SentinelMocks,
+		permissionsWorkspaceLockingKey: tmAccess.WorkspaceLocking,
+		permissionsRunTasksKey:         tmAccess.RunTasks,
 	}}
-	if err := d.Set("permissions", permissions); err != nil {
+	if err := d.Set(teamAccessPermissionsKey, permissions); err != nil {
 		return fmt.Errorf("error setting permissions for team access %s: %w", d.Id(), err)
 	}
 
 	if tmAccess.Team != nil {
-		d.Set("team_id", tmAccess.Team.ID)
+		d.Set(teamAccessTeamIDKey, tmAccess.Team.ID)
 	} else {
-		d.Set("team_id", "")
+		d.Set(teamAccessTeamIDKey, "")
 	}
 
 	return nil
@@ -268,41 +290,47 @@ func resourceTFETeamAccessUpdate(d *schema.ResourceData, meta interface{}) error
 	options := tfe.TeamAccessUpdateOptions{}
 
 	// Set access level
-	access := d.Get("access").(string)
+	access := d.Get(teamAccessAccessKey).(string)
 	options.Access = tfe.Access(tfe.AccessType(access))
 
-	if d.HasChange("permissions.0.runs") {
-		if v, ok := d.GetOk("permissions.0.runs"); ok {
+	permissionsRunsPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsRunsKey)
+	if d.HasChange(permissionsRunsPath) {
+		if v, ok := d.GetOk(permissionsRunsPath); ok {
 			options.Runs = tfe.RunsPermission(tfe.RunsPermissionType(v.(string)))
 		}
 	}
 
-	if d.HasChange("permissions.0.variables") {
-		if v, ok := d.GetOk("permissions.0.variables"); ok {
+	permissionsVariablesPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsVariablesKey)
+	if d.HasChange(permissionsVariablesPath) {
+		if v, ok := d.GetOk(permissionsVariablesPath); ok {
 			options.Variables = tfe.VariablesPermission(tfe.VariablesPermissionType(v.(string)))
 		}
 	}
 
-	if d.HasChange("permissions.0.state_versions") {
-		if v, ok := d.GetOk("permissions.0.state_versions"); ok {
+	permissionsStateVersionsPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsStateVersionsKey)
+	if d.HasChange(permissionsStateVersionsPath) {
+		if v, ok := d.GetOk(permissionsStateVersionsPath); ok {
 			options.StateVersions = tfe.StateVersionsPermission(tfe.StateVersionsPermissionType(v.(string)))
 		}
 	}
 
-	if d.HasChange("permissions.0.sentinel_mocks") {
-		if v, ok := d.GetOk("permissions.0.sentinel_mocks"); ok {
+	permissionsSentinelMocksPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsSentinelMocksKey)
+	if d.HasChange(permissionsSentinelMocksPath) {
+		if v, ok := d.GetOk(permissionsSentinelMocksPath); ok {
 			options.SentinelMocks = tfe.SentinelMocksPermission(tfe.SentinelMocksPermissionType(v.(string)))
 		}
 	}
 
-	if d.HasChange("permissions.0.workspace_locking") {
-		if v, ok := d.GetOkExists("permissions.0.workspace_locking"); ok {
+	permissionsWorkspaceLockingPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsWorkspaceLockingKey)
+	if d.HasChange(permissionsWorkspaceLockingPath) {
+		if v, ok := d.GetOkExists(permissionsWorkspaceLockingPath); ok {
 			options.WorkspaceLocking = tfe.Bool(v.(bool))
 		}
 	}
 
-	if d.HasChange("permissions.0.run_tasks") {
-		if v, ok := d.GetOkExists("permissions.0.run_tasks"); ok {
+	permissionsRunTasksPath := fmt.Sprintf("%s.0.%s", teamAccessPermissionsKey, permissionsRunTasksKey)
+	if d.HasChange(permissionsRunTasksPath) {
+		if v, ok := d.GetOkExists(permissionsRunTasksPath); ok {
 			options.RunTasks = tfe.Bool(v.(bool))
 		}
 	}
@@ -316,14 +344,14 @@ func resourceTFETeamAccessUpdate(d *schema.ResourceData, meta interface{}) error
 
 	// Update permissions, in the case that they were marked to be recomputed.
 	permissions := []map[string]interface{}{{
-		"runs":              tmAccess.Runs,
-		"variables":         tmAccess.Variables,
-		"state_versions":    tmAccess.StateVersions,
-		"sentinel_mocks":    tmAccess.SentinelMocks,
-		"workspace_locking": tmAccess.WorkspaceLocking,
-		"run_tasks":         tmAccess.RunTasks,
+		permissionsRunsKey:             tmAccess.Runs,
+		permissionsVariablesKey:        tmAccess.Variables,
+		permissionsStateVersionsKey:    tmAccess.StateVersions,
+		permissionsSentinelMocksKey:    tmAccess.SentinelMocks,
+		permissionsWorkspaceLockingKey: tmAccess.WorkspaceLocking,
+		permissionsRunTasksKey:         tmAccess.RunTasks,
 	}}
-	if err := d.Set("permissions", permissions); err != nil {
+	if err := d.Set(teamAccessPermissionsKey, permissions); err != nil {
 		return fmt.Errorf("error setting permissions for team access %s: %w", d.Id(), err)
 	}
 
@@ -362,7 +390,7 @@ func resourceTFETeamAccessImporter(ctx context.Context, d *schema.ResourceData, 
 		return nil, fmt.Errorf(
 			"error retrieving workspace %s from organization %s: %w", s[1], s[0], err)
 	}
-	d.Set("workspace_id", workspaceID)
+	d.Set(teamAccessWorkspaceIDKey, workspaceID)
 	d.SetId(s[2])
 
 	return []*schema.ResourceData{d}, nil
@@ -379,13 +407,27 @@ func resourceTFETeamAccessImporter(ctx context.Context, d *schema.ResourceData, 
 // limitations, rooting out the user's intentions to figure out when to automatically assign 'access' to custom and/or
 // recompute 'permissions'.
 func setCustomOrComputedPermissions(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	if _, ok := d.GetOk("access"); ok {
-		if d.HasChange("access") {
+	// Check if access is being removed from config (exists in old but not in new config)
+	oldAccess, _ := d.GetChange(teamAccessAccessKey)
+	accessRemovedFromConfig := oldAccess != nil && oldAccess.(string) != "" && !d.NewValueKnown(teamAccessAccessKey)
+
+	// If access was removed from config and permissions block is present, set to custom
+	if accessRemovedFromConfig {
+		if _, ok := d.GetOk(teamAccessPermissionsKey); ok {
+			if err := setCustomAccess(d); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	if _, ok := d.GetOk(teamAccessAccessKey); ok {
+		if d.HasChange(teamAccessAccessKey) {
 			// If access is being added or changed to a known value, all permissions
 			// will be read-only and computed by the API (access is never marked as 'custom' in the
 			// configuration).
-			d.SetNewComputed("permissions")
-		} else if d.HasChange("permissions.0") {
+			d.SetNewComputed(teamAccessPermissionsKey)
+		} else if d.HasChange(fmt.Sprintf("%s.0", teamAccessPermissionsKey)) {
 			// If access is present, not being explicitly changed, but permissions are being
 			// changed, the user might be switching from using a fixed access level
 			// (read/plan/write/admin) to a permissions block ('custom' access).
@@ -394,13 +436,13 @@ func setCustomOrComputedPermissions(_ context.Context, d *schema.ResourceDiff, m
 				return err
 			}
 		}
-	} else if !d.NewValueKnown("access") {
+	} else if !d.NewValueKnown(teamAccessAccessKey) {
 		if d.Id() != "" {
 			// If the value for access isn't known on an existing resource, the user must have set the
 			// access attribute to an interpolated value not known at plan time.
 			// Set permissions as computed.
-			d.SetNewComputed("permissions")
-		} else if _, ok := d.GetOk("permissions"); ok {
+			d.SetNewComputed(teamAccessPermissionsKey)
+		} else if _, ok := d.GetOk(teamAccessPermissionsKey); ok {
 			// If the resource is new, the value for access isn't known, and permissions are
 			// present, the user must be creating a new resource with custom access.
 			// Set access to custom.

--- a/internal/provider/resource_tfe_team_access.go
+++ b/internal/provider/resource_tfe_team_access.go
@@ -407,18 +407,19 @@ func resourceTFETeamAccessImporter(ctx context.Context, d *schema.ResourceData, 
 // limitations, rooting out the user's intentions to figure out when to automatically assign 'access' to custom and/or
 // recompute 'permissions'.
 func setCustomOrComputedPermissions(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	// Check if access is being removed from config (exists in old but not in new config)
-	oldAccess, _ := d.GetChange(teamAccessAccessKey)
-	accessRemovedFromConfig := oldAccess != nil && oldAccess.(string) != "" && !d.NewValueKnown(teamAccessAccessKey)
+	// Check if permissions block is present in new config
+	_, hasPermissionsInNew := d.GetOk(teamAccessPermissionsKey)
 
-	// If access was removed from config and permissions block is present, set to custom
-	if accessRemovedFromConfig {
-		if _, ok := d.GetOk(teamAccessPermissionsKey); ok {
-			if err := setCustomAccess(d); err != nil {
-				return err
-			}
-			return nil
+	// Check if access is in the raw config as state may have both access and permissions
+	rawConfig := d.GetRawConfig()
+	accessInConfig := !rawConfig.GetAttr(teamAccessAccessKey).IsNull()
+
+	// User removed 'access' from config and has 'permissions' block in new config
+	if !accessInConfig && hasPermissionsInNew {
+		if err := setCustomAccess(d); err != nil {
+			return err
 		}
+		return nil
 	}
 
 	if _, ok := d.GetOk(teamAccessAccessKey); ok {

--- a/internal/provider/resource_tfe_team_access_test.go
+++ b/internal/provider/resource_tfe_team_access_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -259,6 +260,56 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamAccess_updateAdminToCustomWithSamePermissions(t *testing.T) {
+	tmAccess := &tfe.TeamAccess{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	// Admin permissions that match the custom permissions we'll use
+	adminPermissions := map[string]interface{}{
+		"runs":              tfe.RunsPermissionApply,
+		"variables":         tfe.VariablesPermissionWrite,
+		"state_versions":    tfe.StateVersionsPermissionWrite,
+		"sentinel_mocks":    tfe.SentinelMocksPermissionRead,
+		"workspace_locking": true,
+		"run_tasks":         true,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETeamAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamAccess_admin(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamAccessExists(
+						"tfe_team_access.foobar", tmAccess),
+					testAccCheckTFETeamAccessAttributesAccessIs(tmAccess, tfe.AccessAdmin),
+					testAccCheckTFETeamAccessAttributesPermissionsAre(tmAccess, adminPermissions),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "admin"),
+				),
+			},
+			{
+				// Remove access attribute and use permissions block with same values as admin
+				Config: testAccTFETeamAccess_customAdminEquivalent(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamAccessExists(
+						"tfe_team_access.foobar", tmAccess),
+					testAccCheckTFETeamAccessAttributesAccessIs(tmAccess, tfe.AccessCustom),
+					testAccCheckTFETeamAccessAttributesPermissionsAre(tmAccess, adminPermissions),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "custom"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "true"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.run_tasks", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFETeamAccess_import(t *testing.T) {
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 
@@ -461,4 +512,34 @@ resource "tfe_team_access" "foobar" {
   team_id      = tfe_team.foobar.id
   workspace_id = tfe_workspace.foobar.id
 }`, rInt)
+}
+
+func testAccTFETeamAccess_customAdminEquivalent(rInt int) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_team" "foobar" {
+  name         = "team-test-%d"
+  organization = data.tfe_organization.foobar.name
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test-%d"
+  organization = data.tfe_organization.foobar.name
+}
+
+resource "tfe_team_access" "foobar" {
+  permissions {
+    runs = "apply"
+    variables = "write"
+    state_versions = "write"
+    sentinel_mocks = "read"
+    workspace_locking = true
+    run_tasks = true
+  }
+  team_id      = tfe_team.foobar.id
+  workspace_id = tfe_workspace.foobar.id
+}`, os.Getenv("TFE_ORGANIZATION"), rInt, rInt)
 }

--- a/internal/provider/resource_tfe_team_access_test.go
+++ b/internal/provider/resource_tfe_team_access_test.go
@@ -261,6 +261,7 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 }
 
 func TestAccTFETeamAccess_updateAdminToCustomWithSamePermissions(t *testing.T) {
+	skipUnlessBeta(t)
 	tmAccess := &tfe.TeamAccess{}
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 


### PR DESCRIPTION
## Description

Updating _tfe_team_access_ resource from access-admin to permission block with same permissions as the admin does not update access to custom. This change addresses this bug

## Testing plan

1. Keep an initial config of _tfe_team_access_ with access admin
2. Remove access field and replace with permission
3. Permission block to have same permissions as admin
4. Plan says update of access to custom

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/IPL-8456)
 

## Config

```
resource "tfe_team_access" "admin" {
  team_id      = data.tfe_team.test.id
  workspace_id = tfe_workspace.test.id
  # access       = "admin"

   permissions {
     runs              = "apply"
     variables         = "write"
     state_versions    = "write"
     sentinel_mocks    = "read"
     workspace_locking = true
     run_tasks         = true
   }
}
```

Output:

```
sanafaraz@Sanas-MacBook-Pro access_team_check % terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/tfe in /Users/sanafaraz/Documents/GitHub/terraform-provider-tfe
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
2026-05-05T13:49:51.150+0530 [INFO]  backend/local: starting Plan operation


Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # tfe_team_access.admin will be updated in-place
  ~ resource "tfe_team_access" "admin" {
      ~ access       = "admin" -> "custom"
        id           = "tws-TfCuaAi6Q4ZDuHth"
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

──────────────────────────────────────────────────
```
## Acceptance Test

```
sanafaraz@Sanas-MacBook-Pro terraform-provider-tfe % TF_ACC=1 go test -v -run TestAccTFETeamAccess_updateAdminToCustomWithSamePermissions ./internal/provider/ 
=== RUN   TestAccTFETeamAccess_updateAdminToCustomWithSamePermissions
--- PASS: TestAccTFETeamAccess_updateAdminToCustomWithSamePermissions (6.31s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	6.436s
```
