### PR TITLE
Add SMTPsettings resource and datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased
+FEATURES:
+* **New Resource:** `r/tfe_smtp_settings` for managing SMTP settings in Terraform Enterprise
+* **New Data Source:** `d/tfe_smtp_settings` for reading SMTP settings in Terraform Enterprise
+
 ENHANCEMENTS:
 * Updates warning when using credentials/config file for authentication and running on cloud to be clearer, by @christian-doucette [#2036](https://github.com/hashicorp/terraform-provider-tfe/pull/2036)
 * Support trigger patterns and working directories in stacks by @aaabdelgany [#2048](https://github.com/hashicorp/terraform-provider-tfe/pull/2048)

--- a/internal/provider/data_source_smtp_settings.go
+++ b/internal/provider/data_source_smtp_settings.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &dataSourceTFESMTPSettings{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFESMTPSettings{}
+)
+
+// NewSMTPSettingsDataSource is a helper function to simplify the provider implementation.
+func NewSMTPSettingsDataSource() datasource.DataSource {
+	return &dataSourceTFESMTPSettings{}
+}
+
+// dataSourceTFESMTPSettings is the data source implementation.
+type dataSourceTFESMTPSettings struct {
+	client *tfe.Client
+}
+
+// modelDataTFESMTPSettings maps the data source schema data.
+type modelDataTFESMTPSettings struct {
+	ID       types.String `tfsdk:"id"`
+	Enabled  types.Bool   `tfsdk:"enabled"`
+	Host     types.String `tfsdk:"host"`
+	Port     types.Int64  `tfsdk:"port"`
+	Sender   types.String `tfsdk:"sender"`
+	Auth     types.String `tfsdk:"auth"`
+	Username types.String `tfsdk:"username"`
+}
+
+// Metadata returns the data source type name.
+func (d *dataSourceTFESMTPSettings) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_smtp_settings"
+}
+
+// Schema defines the schema for the data source.
+func (d *dataSourceTFESMTPSettings) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads SMTP settings for Terraform Enterprise.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of the SMTP settings. Always 'smtp'.",
+				Computed:    true,
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether SMTP is enabled.",
+				Computed:    true,
+			},
+			"host": schema.StringAttribute{
+				Description: "The hostname of the SMTP server.",
+				Computed:    true,
+			},
+			"port": schema.Int64Attribute{
+				Description: "The port of the SMTP server.",
+				Computed:    true,
+			},
+			"sender": schema.StringAttribute{
+				Description: "The sender email address.",
+				Computed:    true,
+			},
+			"auth": schema.StringAttribute{
+				Description: "The authentication type. Valid values are 'none', 'plain', and 'login'.",
+				Computed:    true,
+			},
+			"username": schema.StringAttribute{
+				Description: "The username used to authenticate to the SMTP server.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *dataSourceTFESMTPSettings) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client.Client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *dataSourceTFESMTPSettings) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data modelDataTFESMTPSettings
+
+	smtpSettings, err := d.client.Admin.Settings.SMTP.Read(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading SMTP Settings",
+			"Could not read SMTP Settings: "+err.Error(),
+		)
+		return
+	}
+
+	// Map response to model
+	data.ID = types.StringValue(smtpSettings.ID)
+	data.Enabled = types.BoolValue(smtpSettings.Enabled)
+	data.Host = types.StringValue(smtpSettings.Host)
+	data.Port = types.Int64Value(int64(smtpSettings.Port))
+	data.Sender = types.StringValue(smtpSettings.Sender)
+	data.Auth = types.StringValue(string(smtpSettings.Auth))
+	data.Username = types.StringValue(smtpSettings.Username)
+
+	// Set state
+	diags := resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}

--- a/internal/provider/data_source_smtp_settings_test.go
+++ b/internal/provider/data_source_smtp_settings_test.go
@@ -26,9 +26,8 @@ func TestAccTFESMTPSettingsDataSource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceAddress, "id"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "enabled"),
-					resource.TestCheckResourceAttrSet(resourceAddress, "host"),
-					resource.TestCheckResourceAttrSet(resourceAddress, "port"),
-					resource.TestCheckResourceAttrSet(resourceAddress, "auth"),
+					// Note: host, port, and auth may be empty when SMTP is disabled
+					// so we don't check for them here
 				),
 			},
 		},

--- a/internal/provider/data_source_smtp_settings_test.go
+++ b/internal/provider/data_source_smtp_settings_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// FLAKE ALERT: SMTP settings are a singleton resource shared by the entire TFE
+// instance, and any test touching them is at high risk to flake.
+// This test is fine, because it only checks that the attributes have SOME
+// value. Testing for any _particular_ value would not be viable, because
+// `resource_tfe_smtp_settings_test.go` exists. See that file for more color on
+// this.
+func TestAccTFESMTPSettingsDataSource_basic(t *testing.T) {
+	resourceAddress := "data.tfe_smtp_settings.foobar"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESMTPSettingsDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceAddress, "id"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "enabled"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "host"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "port"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "auth"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func testAccTFESMTPSettingsDataSourceConfig_basic() string {
+	return `data "tfe_smtp_settings" "foobar" {}`
+}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -159,6 +159,7 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewRegistryProviderDataSource,
 		NewRegistryProvidersDataSource,
 		NewSAMLSettingsDataSource,
+		NewSMTPSettingsDataSource,
 		NewVariablesDataSource,
 		NewWorkspaceRunTaskDataSource,
 	}
@@ -178,6 +179,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewResourceVariable,
 		NewResourceWorkspaceSettings,
 		NewSAMLSettingsResource,
+		NewSMTPSettingsResource,
 		NewSSHKey,
 		NewStackResource,
 		NewStackVariableSetResource,

--- a/internal/provider/resource_tfe_smtp_settings.go
+++ b/internal/provider/resource_tfe_smtp_settings.go
@@ -360,7 +360,7 @@ func (r *resourceTFESMTPSettings) updateSMTPSettings(ctx context.Context, m mode
 	if !config.PasswordWO.IsNull() && !config.PasswordWO.IsUnknown() {
 		cur_pass = config.PasswordWO
 	}
-	
+
 	s, err := r.client.Admin.Settings.SMTP.Update(ctx, tfe.AdminSMTPSettingsUpdateOptions{
 		Enabled:          m.Enabled.ValueBoolPointer(),
 		Host:             m.Host.ValueStringPointer(),

--- a/internal/provider/resource_tfe_smtp_settings.go
+++ b/internal/provider/resource_tfe_smtp_settings.go
@@ -43,11 +43,11 @@ type modelTFESMTPSettings struct {
 	PasswordWOVersion types.Int64  `tfsdk:"password_wo_version"`
 	TestEmailAddress  types.String `tfsdk:"test_email_address"`
 }
+
 // resourceTFESMTPSettings implements the tfe_smtp_settings resource type
 type resourceTFESMTPSettings struct {
 	client *tfe.Client
 }
-
 
 // Configure implements resource.ResourceWithConfigure
 func (r *resourceTFESMTPSettings) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -194,7 +194,7 @@ func (r *resourceTFESMTPSettings) Read(ctx context.Context, req resource.ReadReq
 
 	// Determine if we should use write-only pattern for password
 	isWriteOnly := !m.PasswordWO.IsNull() && !m.PasswordWO.IsUnknown()
-	
+
 	// update state
 	result := modelFromTFEAdminSMTPSettings(smtpSettings, m.Password, isWriteOnly)
 	// Preserve null values for optional fields from state
@@ -212,8 +212,6 @@ func (r *resourceTFESMTPSettings) Read(ctx context.Context, req resource.ReadReq
 	resp.Diagnostics.Append(diags...)
 }
 
-
-
 // Create implements resource.Resource
 func (r *resourceTFESMTPSettings) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var m modelTFESMTPSettings
@@ -230,16 +228,15 @@ func (r *resourceTFESMTPSettings) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-
 	tflog.Debug(ctx, "Create SMTP Settings")
-	smtpSettings, err := r.updateSMTPSettings(ctx, m)
+	// Check config for write-only password since plan may not have it populated
+	isWriteOnly := !config.PasswordWO.IsNull() && !config.PasswordWO.IsUnknown()
+	smtpSettings, err := r.updateSMTPSettings(ctx, m, config)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating SMTP Settings", "Could not set SMTP Settings, unexpected error: "+err.Error())
 		return
 	}
 
-	// Determine if write-only password was used
-	isWriteOnly := !m.PasswordWO.IsNull() && !m.PasswordWO.IsUnknown()
 	result := modelFromTFEAdminSMTPSettings(smtpSettings, m.Password, isWriteOnly)
 	// Preserve config values for optional fields
 	if config.Username.IsNull() {
@@ -280,14 +277,14 @@ func (r *resourceTFESMTPSettings) Update(ctx context.Context, req resource.Updat
 	}
 
 	tflog.Debug(ctx, "Update SMTP Settings")
-	smtpSettings, err := r.updateSMTPSettings(ctx, m)
+	// Check config for write-only password since plan may not have it populated
+	isWriteOnly := !config.PasswordWO.IsNull() && !config.PasswordWO.IsUnknown()
+	smtpSettings, err := r.updateSMTPSettings(ctx, m, config)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating SMTP Settings", "Could not set SMTP Settings, unexpected error: "+err.Error())
 		return
 	}
 
-	// Determine if write-only password was used
-	isWriteOnly := !m.PasswordWO.IsNull() && !m.PasswordWO.IsUnknown()
 	result := modelFromTFEAdminSMTPSettings(smtpSettings, m.Password, isWriteOnly)
 	// Preserve config values for optional fields
 	if config.Username.IsNull() {
@@ -316,14 +313,14 @@ func (r *resourceTFESMTPSettings) Delete(ctx context.Context, req resource.Delet
 
 	tflog.Debug(ctx, "Delete SMTP Settings")
 	_, err := r.client.Admin.Settings.SMTP.Update(ctx, tfe.AdminSMTPSettingsUpdateOptions{
-		Enabled:                   basetypes.NewBoolValue(false).ValueBoolPointer(),
-		Host:                      basetypes.NewStringValue("").ValueStringPointer(),
-		Port:                      tfe.Int(int(smtpDefaultPort)),
-		Sender:                    basetypes.NewStringValue("").ValueStringPointer(),
-		Auth:                      (*tfe.SMTPAuthType)(m.Auth.ValueStringPointer()),
-		Username:                  basetypes.NewStringValue("").ValueStringPointer(),
-		Password:                  basetypes.NewStringValue("").ValueStringPointer(),
-		TestEmailAddress:          basetypes.NewStringValue("").ValueStringPointer(),
+		Enabled:          basetypes.NewBoolValue(false).ValueBoolPointer(),
+		Host:             basetypes.NewStringValue("").ValueStringPointer(),
+		Port:             tfe.Int(int(smtpDefaultPort)),
+		Sender:           basetypes.NewStringValue("").ValueStringPointer(),
+		Auth:             (*tfe.SMTPAuthType)(m.Auth.ValueStringPointer()),
+		Username:         basetypes.NewStringValue("").ValueStringPointer(),
+		Password:         basetypes.NewStringValue("").ValueStringPointer(),
+		TestEmailAddress: basetypes.NewStringValue("").ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting SMTP Settings", "Could not disable SMTP Settings, unexpected error: "+err.Error())
@@ -355,24 +352,25 @@ func NewSMTPSettingsResource() resource.Resource {
 	return &resourceTFESMTPSettings{}
 }
 
-
 // updateSMTPSettings was created to keep the code DRY. It is used in both Create and Update functions
-func (r *resourceTFESMTPSettings) updateSMTPSettings(ctx context.Context, m modelTFESMTPSettings) (*tfe.AdminSMTPSetting, error) {
+func (r *resourceTFESMTPSettings) updateSMTPSettings(ctx context.Context, m modelTFESMTPSettings, config modelTFESMTPSettings) (*tfe.AdminSMTPSetting, error) {
 
-	cur_pass :=m.Password
-	if ( !m.PasswordWO.IsNull() && !m.PasswordWO.IsUnknown() ) {
-		cur_pass=m.PasswordWO
+	// Use password from config since write-only attributes aren't in the plan
+	cur_pass := config.Password
+	if !config.PasswordWO.IsNull() && !config.PasswordWO.IsUnknown() {
+		cur_pass = config.PasswordWO
 	}
+	
 	s, err := r.client.Admin.Settings.SMTP.Update(ctx, tfe.AdminSMTPSettingsUpdateOptions{
-		Enabled:                   m.Enabled.ValueBoolPointer(),
-		Host:                      m.Host.ValueStringPointer(),
-		Port:                      tfe.Int(int(m.Port.ValueInt64())),
-		Sender:                    m.Sender.ValueStringPointer(),
-		Auth:                      (*tfe.SMTPAuthType)(m.Auth.ValueStringPointer()),
-		Username:                  m.Username.ValueStringPointer(),
-		Password:                  cur_pass.ValueStringPointer(),
-		TestEmailAddress:          m.TestEmailAddress.ValueStringPointer(),
-		})
+		Enabled:          m.Enabled.ValueBoolPointer(),
+		Host:             m.Host.ValueStringPointer(),
+		Port:             tfe.Int(int(m.Port.ValueInt64())),
+		Sender:           m.Sender.ValueStringPointer(),
+		Auth:             (*tfe.SMTPAuthType)(m.Auth.ValueStringPointer()),
+		Username:         m.Username.ValueStringPointer(),
+		Password:         cur_pass.ValueStringPointer(),
+		TestEmailAddress: m.TestEmailAddress.ValueStringPointer(),
+	})
 	if err != nil {
 		return s, fmt.Errorf("failed to update SMTP Settings: %w", err)
 	}

--- a/internal/provider/resource_tfe_smtp_settings.go
+++ b/internal/provider/resource_tfe_smtp_settings.go
@@ -9,6 +9,7 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -69,6 +70,16 @@ func (r *resourceTFESMTPSettings) Metadata(_ context.Context, req resource.Metad
 	resp.TypeName = req.ProviderTypeName + "_smtp_settings"
 }
 
+// ConfigValidators implements resource.ResourceWithConfigValidators
+func (r *resourceTFESMTPSettings) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.PreferWriteOnlyAttribute(
+			path.MatchRoot("password"),
+			path.MatchRoot("password_wo"),
+		),
+	}
+}
+
 // Schema implements resource.Resource
 func (r *resourceTFESMTPSettings) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
@@ -84,8 +95,9 @@ func (r *resourceTFESMTPSettings) Schema(ctx context.Context, req resource.Schem
 			},
 			"enabled": schema.BoolAttribute{
 				Description: "Whether SMTP is enabled. When enabled, all other attributes must have valid values.",
+				Optional:    true,
 				Computed:    true,
-				Default: booldefault.StaticBool(false),
+				Default:     booldefault.StaticBool(false),
 			},
 			"host": schema.StringAttribute{
 				Description: "The hostname of the SMTP server.",
@@ -144,7 +156,6 @@ func (r *resourceTFESMTPSettings) Schema(ctx context.Context, req resource.Schem
 				WriteOnly:   true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("password")),
-					stringvalidator.AlsoRequires(path.MatchRoot("password_wo")),
 					validators.AttributeValueConflictValidator("auth", []string{string(tfe.SMTPAuthNone)}),
 				},
 			},
@@ -186,6 +197,17 @@ func (r *resourceTFESMTPSettings) Read(ctx context.Context, req resource.ReadReq
 	
 	// update state
 	result := modelFromTFEAdminSMTPSettings(smtpSettings, m.Password, isWriteOnly)
+	// Preserve null values for optional fields from state
+	if m.Username.IsNull() {
+		result.Username = types.StringNull()
+	}
+	if m.Password.IsNull() {
+		result.Password = types.StringNull()
+	}
+	// Preserve password_wo_version from state
+	if !m.PasswordWOVersion.IsNull() {
+		result.PasswordWOVersion = m.PasswordWOVersion
+	}
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
@@ -216,7 +238,20 @@ func (r *resourceTFESMTPSettings) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	result := modelFromTFEAdminSMTPSettings(smtpSettings, types.StringValue(""), false)
+	// Determine if write-only password was used
+	isWriteOnly := !m.PasswordWO.IsNull() && !m.PasswordWO.IsUnknown()
+	result := modelFromTFEAdminSMTPSettings(smtpSettings, m.Password, isWriteOnly)
+	// Preserve config values for optional fields
+	if config.Username.IsNull() {
+		result.Username = types.StringNull()
+	}
+	if config.Password.IsNull() {
+		result.Password = types.StringNull()
+	}
+	// Preserve password_wo_version from config
+	if !config.PasswordWOVersion.IsNull() {
+		result.PasswordWOVersion = config.PasswordWOVersion
+	}
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
@@ -251,7 +286,20 @@ func (r *resourceTFESMTPSettings) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	result := modelFromTFEAdminSMTPSettings(smtpSettings, types.StringValue(""), false)
+	// Determine if write-only password was used
+	isWriteOnly := !m.PasswordWO.IsNull() && !m.PasswordWO.IsUnknown()
+	result := modelFromTFEAdminSMTPSettings(smtpSettings, m.Password, isWriteOnly)
+	// Preserve config values for optional fields
+	if config.Username.IsNull() {
+		result.Username = types.StringNull()
+	}
+	if config.Password.IsNull() {
+		result.Password = types.StringNull()
+	}
+	// Preserve password_wo_version from config
+	if !config.PasswordWOVersion.IsNull() {
+		result.PasswordWOVersion = config.PasswordWOVersion
+	}
 	// Save data into Terraform state
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
@@ -316,7 +364,7 @@ func (r *resourceTFESMTPSettings) updateSMTPSettings(ctx context.Context, m mode
 		cur_pass=m.PasswordWO
 	}
 	s, err := r.client.Admin.Settings.SMTP.Update(ctx, tfe.AdminSMTPSettingsUpdateOptions{
-		Enabled:                   basetypes.NewBoolValue(true).ValueBoolPointer(),
+		Enabled:                   m.Enabled.ValueBoolPointer(),
 		Host:                      m.Host.ValueStringPointer(),
 		Port:                      tfe.Int(int(m.Port.ValueInt64())),
 		Sender:                    m.Sender.ValueStringPointer(),

--- a/internal/provider/resource_tfe_smtp_settings.go
+++ b/internal/provider/resource_tfe_smtp_settings.go
@@ -354,7 +354,6 @@ func NewSMTPSettingsResource() resource.Resource {
 
 // updateSMTPSettings was created to keep the code DRY. It is used in both Create and Update functions
 func (r *resourceTFESMTPSettings) updateSMTPSettings(ctx context.Context, m modelTFESMTPSettings, config modelTFESMTPSettings) (*tfe.AdminSMTPSetting, error) {
-
 	// Use password from config since write-only attributes aren't in the plan
 	cur_pass := config.Password
 	if !config.PasswordWO.IsNull() && !config.PasswordWO.IsUnknown() {

--- a/internal/provider/resource_tfe_smtp_settings.go
+++ b/internal/provider/resource_tfe_smtp_settings.go
@@ -1,0 +1,357 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-tfe/internal/provider/validators"
+)
+
+const (
+	smtpDefaultPort int64 = 25
+)
+
+type modelTFESMTPSettings struct {
+	ID                types.String `tfsdk:"id"`
+	Enabled           types.Bool   `tfsdk:"enabled"`
+	Host              types.String `tfsdk:"host"`
+	Port              types.Int64  `tfsdk:"port"`
+	Sender            types.String `tfsdk:"sender"`
+	Auth              types.String `tfsdk:"auth"`
+	Username          types.String `tfsdk:"username"`
+	Password          types.String `tfsdk:"password"`
+	PasswordWO        types.String `tfsdk:"password_wo"`
+	PasswordWOVersion types.Int64  `tfsdk:"password_wo_version"`
+	TestEmailAddress  types.String `tfsdk:"test_email_address"`
+}
+// resourceTFESMTPSettings implements the tfe_smtp_settings resource type
+type resourceTFESMTPSettings struct {
+	client *tfe.Client
+}
+
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFESMTPSettings) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Early exit if provider is not properly configured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	r.client = client.Client
+}
+
+// Metadata implements resource.Resource
+func (r *resourceTFESMTPSettings) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_smtp_settings"
+}
+
+// Schema implements resource.Resource
+func (r *resourceTFESMTPSettings) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Version:     0,
+		Description: "Manages SMTP settings for Terraform Enterprise.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of the SMTP settings. Always 'smtp'.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "Whether SMTP is enabled. When enabled, all other attributes must have valid values.",
+				Computed:    true,
+				Default: booldefault.StaticBool(false),
+			},
+			"host": schema.StringAttribute{
+				Description: "The hostname of the SMTP server.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			"port": schema.Int64Attribute{
+				Description: "The port of the SMTP server.",
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(smtpDefaultPort),
+			},
+			"sender": schema.StringAttribute{
+				Description: "The desired sender email address.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			"auth": schema.StringAttribute{
+				Description: "The authentication type. Valid values are 'none', 'plain', and 'login'.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(string(tfe.SMTPAuthNone)),
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						string(tfe.SMTPAuthNone),
+						string(tfe.SMTPAuthPlain),
+						string(tfe.SMTPAuthLogin),
+					),
+				},
+			},
+			"username": schema.StringAttribute{
+				Description: "The username used to authenticate to the SMTP server. Required if auth is 'login' or 'plain'.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+					validators.AttributeValueConflictValidator("auth", []string{string(tfe.SMTPAuthNone)}),
+				},
+			},
+			"password": schema.StringAttribute{
+				Description: "The password used to authenticate to the SMTP server. Required if auth is 'login' or 'plain'.",
+				Optional:    true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("password_wo")),
+					validators.AttributeValueConflictValidator("auth", []string{string(tfe.SMTPAuthNone)}),
+				},
+			},
+			"password_wo": schema.StringAttribute{
+				Description: "The password in write only used to authenticate to the SMTP server. Required if auth is 'login' or 'plain'.",
+				Optional:    true,
+				Sensitive:   true,
+				WriteOnly:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("password")),
+					stringvalidator.AlsoRequires(path.MatchRoot("password_wo")),
+					validators.AttributeValueConflictValidator("auth", []string{string(tfe.SMTPAuthNone)}),
+				},
+			},
+			"password_wo_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Version of the write-only private key to trigger updates",
+				Validators: []validator.Int64{
+					int64validator.ConflictsWith(path.MatchRoot("password")),
+					int64validator.AlsoRequires(path.MatchRoot("password_wo")),
+				},
+			},
+			"test_email_address": schema.StringAttribute{
+				Description: "The email address to send a test message to. This value is not persisted and is only used during testing.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+// Read implements resource.Resource
+func (r *resourceTFESMTPSettings) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var m modelTFESMTPSettings
+	diags := req.State.Get(ctx, &m)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Reading SMTP Settings")
+
+	smtpSettings, err := r.client.Admin.Settings.SMTP.Read(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading SMTP Settings", "Could not read SMTP Settings, unexpected error: "+err.Error())
+		return
+	}
+
+	// Determine if we should use write-only pattern for password
+	isWriteOnly := !m.PasswordWO.IsNull() && !m.PasswordWO.IsUnknown()
+	
+	// update state
+	result := modelFromTFEAdminSMTPSettings(smtpSettings, m.Password, isWriteOnly)
+	diags = resp.State.Set(ctx, &result)
+	resp.Diagnostics.Append(diags...)
+}
+
+
+
+// Create implements resource.Resource
+func (r *resourceTFESMTPSettings) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var m modelTFESMTPSettings
+	diags := req.Plan.Get(ctx, &m)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config modelTFESMTPSettings
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+
+	tflog.Debug(ctx, "Create SMTP Settings")
+	smtpSettings, err := r.updateSMTPSettings(ctx, m)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating SMTP Settings", "Could not set SMTP Settings, unexpected error: "+err.Error())
+		return
+	}
+
+	result := modelFromTFEAdminSMTPSettings(smtpSettings, types.StringValue(""), false)
+	diags = resp.State.Set(ctx, &result)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Update implements resource.Resource
+func (r *resourceTFESMTPSettings) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var m modelTFESMTPSettings
+	diags := req.Plan.Get(ctx, &m)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config modelTFESMTPSettings
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state modelTFESMTPSettings
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Update SMTP Settings")
+	smtpSettings, err := r.updateSMTPSettings(ctx, m)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating SMTP Settings", "Could not set SMTP Settings, unexpected error: "+err.Error())
+		return
+	}
+
+	result := modelFromTFEAdminSMTPSettings(smtpSettings, types.StringValue(""), false)
+	// Save data into Terraform state
+	diags = resp.State.Set(ctx, &result)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Delete disables the SMTP Settings and then removes the resource from the state file. You cannot delete TFE SMTP Settings, only disable them
+func (r *resourceTFESMTPSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var m modelTFESMTPSettings
+	diags := req.State.Get(ctx, &m)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Delete SMTP Settings")
+	_, err := r.client.Admin.Settings.SMTP.Update(ctx, tfe.AdminSMTPSettingsUpdateOptions{
+		Enabled:                   basetypes.NewBoolValue(false).ValueBoolPointer(),
+		Host:                      basetypes.NewStringValue("").ValueStringPointer(),
+		Port:                      tfe.Int(int(smtpDefaultPort)),
+		Sender:                    basetypes.NewStringValue("").ValueStringPointer(),
+		Auth:                      (*tfe.SMTPAuthType)(m.Auth.ValueStringPointer()),
+		Username:                  basetypes.NewStringValue("").ValueStringPointer(),
+		Password:                  basetypes.NewStringValue("").ValueStringPointer(),
+		TestEmailAddress:          basetypes.NewStringValue("").ValueStringPointer(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error deleting SMTP Settings", "Could not disable SMTP Settings, unexpected error: "+err.Error())
+		return
+	}
+}
+
+// ImportState implements resource.ResourceWithImportState
+func (r *resourceTFESMTPSettings) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	smtpSettings, err := r.client.Admin.Settings.SMTP.Read(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing SMTP Settings", "Could not retrieve SMTP Settings, unexpected error: "+err.Error())
+		return
+	}
+
+	result := modelFromTFEAdminSMTPSettings(smtpSettings, types.StringValue(""), false)
+	diags := resp.State.Set(ctx, &result)
+	resp.Diagnostics.Append(diags...)
+}
+
+var (
+	_ resource.Resource                = &resourceTFESMTPSettings{}
+	_ resource.ResourceWithConfigure   = &resourceTFESMTPSettings{}
+	_ resource.ResourceWithImportState = &resourceTFESMTPSettings{}
+)
+
+// NewSMTPSettingsResource is a resource function for the framework provider.
+func NewSMTPSettingsResource() resource.Resource {
+	return &resourceTFESMTPSettings{}
+}
+
+
+// updateSMTPSettings was created to keep the code DRY. It is used in both Create and Update functions
+func (r *resourceTFESMTPSettings) updateSMTPSettings(ctx context.Context, m modelTFESMTPSettings) (*tfe.AdminSMTPSetting, error) {
+
+	cur_pass :=m.Password
+	if ( !m.PasswordWO.IsNull() && !m.PasswordWO.IsUnknown() ) {
+		cur_pass=m.PasswordWO
+	}
+	s, err := r.client.Admin.Settings.SMTP.Update(ctx, tfe.AdminSMTPSettingsUpdateOptions{
+		Enabled:                   basetypes.NewBoolValue(true).ValueBoolPointer(),
+		Host:                      m.Host.ValueStringPointer(),
+		Port:                      tfe.Int(int(m.Port.ValueInt64())),
+		Sender:                    m.Sender.ValueStringPointer(),
+		Auth:                      (*tfe.SMTPAuthType)(m.Auth.ValueStringPointer()),
+		Username:                  m.Username.ValueStringPointer(),
+		Password:                  cur_pass.ValueStringPointer(),
+		TestEmailAddress:          m.TestEmailAddress.ValueStringPointer(),
+		})
+	if err != nil {
+		return s, fmt.Errorf("failed to update SMTP Settings: %w", err)
+	}
+	return s, nil
+}
+
+// modelFromTFEAdminSMTPSettings builds a modelTFESMTPSettings struct from a tfe.AdminSMTPSetting value
+func modelFromTFEAdminSMTPSettings(v *tfe.AdminSMTPSetting, password types.String, isWriteOnly bool) modelTFESMTPSettings {
+	m := modelTFESMTPSettings{
+		ID:       types.StringValue(v.ID),
+		Enabled:  types.BoolValue(v.Enabled),
+		Host:     types.StringValue(v.Host),
+		Port:     types.Int64Value(int64(v.Port)),
+		Sender:   types.StringValue(v.Sender),
+		Auth:     types.StringValue(string(v.Auth)),
+		Username: types.StringValue(v.Username),
+		Password: types.StringValue(""),
+	}
+
+	if len(password.ValueString()) > 0 {
+		m.Password = password
+	}
+
+	// Don't retrieve values if write-only is being used. Unset the password field before updating the state.
+	if isWriteOnly {
+		m.Password = types.StringValue("")
+	}
+
+	return m
+}

--- a/internal/provider/resource_tfe_smtp_settings_test.go
+++ b/internal/provider/resource_tfe_smtp_settings_test.go
@@ -39,16 +39,16 @@ func TestAccTFESMTPSettings_omnibus(t *testing.T) {
 
 	t.Run("basic SMTP settings without authentication", func(t *testing.T) {
 		s := tfe.AdminSMTPSetting{
-			Host:     "foobar.com",
-			Port:     25,
-			Sender:   "sender@foorbar.com",
-			Auth:     "none",
+			Host:   "foobar.com",
+			Port:   25,
+			Sender: "sender@foorbar.com",
+			Auth:   "none",
 		}
 		resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccTFESMTPSettingsDestroy,
-		Steps: []resource.TestStep{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESMTPSettingsDestroy,
+			Steps: []resource.TestStep{
 				{
 					Config: testAccTFESMTPSettings_AuthNone(s),
 					Check: resource.ComposeTestCheckFunc(
@@ -67,10 +67,10 @@ func TestAccTFESMTPSettings_omnibus(t *testing.T) {
 
 func TestAccTFESMTPSettings_AuthNone(t *testing.T) {
 	s := tfe.AdminSMTPSetting{
-		Host:     "foobar.com",
-		Port:     25,
-		Sender:   "sender@foorbar.com",
-		Auth:     "none",
+		Host:   "foobar.com",
+		Port:   25,
+		Sender: "sender@foorbar.com",
+		Auth:   "none",
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -151,7 +151,6 @@ func TestAccTFESMTPSettings_AuthLogin_writeOnly(t *testing.T) {
 	})
 }
 
-
 func TestAccTFESMTPSettings_AuthPlain_writeOnly_update(t *testing.T) {
 	s := tfe.AdminSMTPSetting{
 		Host:     "foobar.com",
@@ -194,6 +193,49 @@ func TestAccTFESMTPSettings_AuthPlain_writeOnly_update(t *testing.T) {
 	})
 }
 
+func TestAccTFESMTPSettings_AuthPlain_writeOnly_no_version_change(t *testing.T) {
+	s := tfe.AdminSMTPSetting{
+		Host:     "foobar.com",
+		Port:     25,
+		Sender:   "sender@foorbar.com",
+		Auth:     "plain",
+		Username: "foo",
+	}
+	password1 := randomString(t)
+	password2 := randomString(t)
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESMTPSettings_AuthPlainLogin_writeOnly_version(s, password1, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckNoResourceAttr(testSMTPResourceName, "password_wo"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password_wo_version", "1"),
+				),
+			},
+			{
+				// Same version (1) but different password - should NOT trigger update
+				Config: testAccTFESMTPSettings_AuthPlainLogin_writeOnly_version(s, password2, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckNoResourceAttr(testSMTPResourceName, "password_wo"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccTFESMTPSettings_AuthPlain(t *testing.T) {
 	s := tfe.AdminSMTPSetting{
 		Host:     "foobar.com",
@@ -217,7 +259,6 @@ func TestAccTFESMTPSettings_AuthPlain(t *testing.T) {
 					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "password", password),
-
 				),
 			},
 		},

--- a/internal/provider/resource_tfe_smtp_settings_test.go
+++ b/internal/provider/resource_tfe_smtp_settings_test.go
@@ -53,7 +53,7 @@ func TestAccTFESMTPSettings_omnibus(t *testing.T) {
 					Config: testAccTFESMTPSettings_AuthNone(s),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(testSMTPResourceName, "id", "smtp"),
-						resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+						resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
 						resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
 						resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
 						resource.TestCheckResourceAttr(testSMTPResourceName, "sender", s.Sender),
@@ -82,13 +82,10 @@ func TestAccTFESMTPSettings_AuthNone(t *testing.T) {
 			{
 				Config: testAccTFESMTPSettings_AuthNone(s),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
-					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
-					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
-					resource.TestCheckNoResourceAttr(testSMTPResourceName, "password_wo"),
-					resource.TestCheckResourceAttr(testSMTPResourceName, "password_wo_version", "1"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "auth", string(s.Auth)),
 				),
 			},
 		},
@@ -112,7 +109,7 @@ func TestAccTFESMTPSettings_AuthPlain_writeOnly(t *testing.T) {
 			{
 				Config: testAccTFESMTPSettings_AuthPlainLogin_writeOnly(s, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
@@ -142,7 +139,7 @@ func TestAccTFESMTPSettings_AuthLogin_writeOnly(t *testing.T) {
 			{
 				Config: testAccTFESMTPSettings_AuthPlainLogin_writeOnly(s, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
@@ -154,6 +151,48 @@ func TestAccTFESMTPSettings_AuthLogin_writeOnly(t *testing.T) {
 	})
 }
 
+
+func TestAccTFESMTPSettings_AuthPlain_writeOnly_update(t *testing.T) {
+	s := tfe.AdminSMTPSetting{
+		Host:     "foobar.com",
+		Port:     25,
+		Sender:   "sender@foorbar.com",
+		Auth:     "plain",
+		Username: "foo",
+	}
+	password1 := randomString(t)
+	password2 := randomString(t)
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESMTPSettings_AuthPlainLogin_writeOnly_version(s, password1, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckNoResourceAttr(testSMTPResourceName, "password_wo"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password_wo_version", "1"),
+				),
+			},
+			{
+				Config: testAccTFESMTPSettings_AuthPlainLogin_writeOnly_version(s, password2, 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckNoResourceAttr(testSMTPResourceName, "password_wo"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccTFESMTPSettings_AuthPlain(t *testing.T) {
 	s := tfe.AdminSMTPSetting{
@@ -173,7 +212,7 @@ func TestAccTFESMTPSettings_AuthPlain(t *testing.T) {
 			{
 				Config: testAccTFESMTPSettings_AuthPlainLogin(s, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
@@ -203,7 +242,7 @@ func TestAccTFESMTPSettings_AuthLogin(t *testing.T) {
 			{
 				Config: testAccTFESMTPSettings_AuthPlainLogin(s, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
 					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
@@ -217,6 +256,7 @@ func TestAccTFESMTPSettings_AuthLogin(t *testing.T) {
 func testAccTFESMTPSettings_AuthPlainLogin_writeOnly(s tfe.AdminSMTPSetting, password string) string {
 	return fmt.Sprintf(`
 resource "tfe_smtp_settings" "foobar" {
+  enabled               = false
   host                  = "%s"
   port                  = %d
   sender                = "%s"
@@ -227,9 +267,24 @@ resource "tfe_smtp_settings" "foobar" {
 }`, s.Host, s.Port, s.Sender, s.Auth, s.Username, password)
 }
 
+func testAccTFESMTPSettings_AuthPlainLogin_writeOnly_version(s tfe.AdminSMTPSetting, password string, version int) string {
+	return fmt.Sprintf(`
+resource "tfe_smtp_settings" "foobar" {
+  enabled               = false
+  host                  = "%s"
+  port                  = %d
+  sender                = "%s"
+  auth                  = "%s"
+  username              = "%s"
+  password_wo           = "%s"
+  password_wo_version   = %d
+}`, s.Host, s.Port, s.Sender, s.Auth, s.Username, password, version)
+}
+
 func testAccTFESMTPSettings_AuthPlainLogin(s tfe.AdminSMTPSetting, password string) string {
 	return fmt.Sprintf(`
 resource "tfe_smtp_settings" "foobar" {
+  enabled               = false
   host                  = "%s"
   port                  = %d
   sender                = "%s"
@@ -241,6 +296,7 @@ resource "tfe_smtp_settings" "foobar" {
 func testAccTFESMTPSettings_AuthNone(s tfe.AdminSMTPSetting) string {
 	return fmt.Sprintf(`
 resource "tfe_smtp_settings" "foobar" {
+  enabled               = false
   host                  = "%s"
   port                  = %d
   sender                = "%s"

--- a/internal/provider/resource_tfe_smtp_settings_test.go
+++ b/internal/provider/resource_tfe_smtp_settings_test.go
@@ -1,0 +1,264 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const testSMTPResourceName = "tfe_smtp_settings.foobar"
+
+// FLAKE ALERT: SMTP settings are a singleton resource shared by the entire TFE
+// instance, and any test touching them is at high risk to flake.
+// In order for these tests to be safe, the following requirements MUST be met:
+//  1. All test cases for this resource must run within a SINGLE test func, using
+//     t.Run to separate the individual test cases.
+//  2. The inner sub-tests must not call t.Parallel.
+//
+// If these tests are split into multiple test funcs and they get allocated to
+// different test runner partitions in CI, then they will inevitably flake, as
+// tests running concurrently in different containers will be competing to set
+// the same shared global state in the TFE instance.
+
+// TestAccTFESMTPSettings_omnibus test suite is skipped in the CI, and will only run in TFE Nightly workflow
+// Should this test name ever change, you will also need to update the regex in ci.yml
+
+func TestAccTFESMTPSettings_omnibus(t *testing.T) {
+	skipIfCloud(t)
+
+	t.Run("basic SMTP settings without authentication", func(t *testing.T) {
+		s := tfe.AdminSMTPSetting{
+			Host:     "foobar.com",
+			Port:     25,
+			Sender:   "sender@foorbar.com",
+			Auth:     "none",
+		}
+		resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccTFESMTPSettingsDestroy,
+		Steps: []resource.TestStep{
+				{
+					Config: testAccTFESMTPSettings_AuthNone(s),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(testSMTPResourceName, "id", "smtp"),
+						resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+						resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+						resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+						resource.TestCheckResourceAttr(testSMTPResourceName, "sender", s.Sender),
+						resource.TestCheckResourceAttr(testSMTPResourceName, "auth", string(s.Auth)),
+					),
+				},
+			},
+		})
+	})
+}
+
+func TestAccTFESMTPSettings_AuthNone(t *testing.T) {
+	s := tfe.AdminSMTPSetting{
+		Host:     "foobar.com",
+		Port:     25,
+		Sender:   "sender@foorbar.com",
+		Auth:     "none",
+	}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESMTPSettings_AuthNone(s),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckNoResourceAttr(testSMTPResourceName, "password_wo"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+func TestAccTFESMTPSettings_AuthPlain_writeOnly(t *testing.T) {
+	s := tfe.AdminSMTPSetting{
+		Host:     "foobar.com",
+		Port:     25,
+		Sender:   "sender@foorbar.com",
+		Auth:     "plain",
+		Username: "foo",
+	}
+	password := randomString(t)
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESMTPSettings_AuthPlainLogin_writeOnly(s, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckNoResourceAttr(testSMTPResourceName, "password_wo"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFESMTPSettings_AuthLogin_writeOnly(t *testing.T) {
+	s := tfe.AdminSMTPSetting{
+		Host:     "foobar.com",
+		Port:     25,
+		Sender:   "sender@foorbar.com",
+		Auth:     "login",
+		Username: "foo",
+	}
+	password := randomString(t)
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESMTPSettings_AuthPlainLogin_writeOnly(s, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckNoResourceAttr(testSMTPResourceName, "password_wo"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+
+func TestAccTFESMTPSettings_AuthPlain(t *testing.T) {
+	s := tfe.AdminSMTPSetting{
+		Host:     "foobar.com",
+		Port:     25,
+		Sender:   "sender@foorbar.com",
+		Auth:     "plain",
+		Username: "foo",
+	}
+	password := randomString(t)
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESMTPSettings_AuthPlainLogin(s, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password", password),
+
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFESMTPSettings_AuthLogin(t *testing.T) {
+	s := tfe.AdminSMTPSetting{
+		Host:     "foobar.com",
+		Port:     25,
+		Sender:   "sender@foorbar.com",
+		Auth:     "login",
+		Username: "foo",
+	}
+	password := randomString(t)
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFESMTPSettings_AuthPlainLogin(s, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testSMTPResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "host", s.Host),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "port", strconv.Itoa(s.Port)),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "username", s.Username),
+					resource.TestCheckResourceAttr(testSMTPResourceName, "password", password),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFESMTPSettings_AuthPlainLogin_writeOnly(s tfe.AdminSMTPSetting, password string) string {
+	return fmt.Sprintf(`
+resource "tfe_smtp_settings" "foobar" {
+  host                  = "%s"
+  port                  = %d
+  sender                = "%s"
+  auth                  = "%s"
+  username              = "%s"
+  password_wo           = "%s"
+  password_wo_version   = 1
+}`, s.Host, s.Port, s.Sender, s.Auth, s.Username, password)
+}
+
+func testAccTFESMTPSettings_AuthPlainLogin(s tfe.AdminSMTPSetting, password string) string {
+	return fmt.Sprintf(`
+resource "tfe_smtp_settings" "foobar" {
+  host                  = "%s"
+  port                  = %d
+  sender                = "%s"
+  auth                  = "%s"
+  username              = "%s"
+  password              = "%s"
+}`, s.Host, s.Port, s.Sender, s.Auth, s.Username, password)
+}
+func testAccTFESMTPSettings_AuthNone(s tfe.AdminSMTPSetting) string {
+	return fmt.Sprintf(`
+resource "tfe_smtp_settings" "foobar" {
+  host                  = "%s"
+  port                  = %d
+  sender                = "%s"
+  auth                  = "%s"
+}`, s.Host, s.Port, s.Sender, s.Auth)
+}
+
+func testAccTFESMTPSettingsDestroy(_ *terraform.State) error {
+	settings, err := testAccConfiguredClient.Client.Admin.Settings.SMTP.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read SMTP Settings: %w", err)
+	}
+
+	// SMTP settings cannot be deleted, only disabled
+	// So we check if they are disabled after destroy
+	if settings.Enabled {
+		return errors.New("SMTP settings are still enabled")
+	}
+
+	return nil
+}

--- a/internal/provider/resource_tfe_smtp_settings_test.go
+++ b/internal/provider/resource_tfe_smtp_settings_test.go
@@ -308,7 +308,7 @@ resource "tfe_smtp_settings" "foobar" {
 }`, s.Host, s.Port, s.Sender, s.Auth, s.Username, password)
 }
 
-func testAccTFESMTPSettings_AuthPlainLogin_writeOnly_version(s tfe.AdminSMTPSetting, password string, version int) string {
+func testAccTFESMTPSettings_AuthPlainLogin_writeOnly_version(s tfe.AdminSMTPSetting, password string, passwordVersion int) string {
 	return fmt.Sprintf(`
 resource "tfe_smtp_settings" "foobar" {
   enabled               = false
@@ -319,7 +319,7 @@ resource "tfe_smtp_settings" "foobar" {
   username              = "%s"
   password_wo           = "%s"
   password_wo_version   = %d
-}`, s.Host, s.Port, s.Sender, s.Auth, s.Username, password, version)
+}`, s.Host, s.Port, s.Sender, s.Auth, s.Username, password, passwordVersion)
 }
 
 func testAccTFESMTPSettings_AuthPlainLogin(s tfe.AdminSMTPSetting, password string) string {

--- a/website/docs/d/smtp_settings.html.markdown
+++ b/website/docs/d/smtp_settings.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_smtp_settings"
+description: |-
+  Get information on SMTP Settings.
+---
+
+# Data Source: tfe_smtp_settings
+
+Use this data source to get information about SMTP Settings. It applies only to Terraform Enterprise and requires admin token configuration. See example usage for incorporating an admin token in your provider config.
+
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+provider "tfe" {
+  hostname = var.hostname
+  token    = var.token
+}
+
+provider "tfe" {
+  alias    = "admin"
+  hostname = var.hostname
+  token    = var.admin_token
+}
+
+data "tfe_smtp_settings" "foo" {
+  provider = tfe.admin
+}
+```
+
+## Argument Reference
+
+No arguments are required for this data source.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - It is always `smtp`.
+* `enabled` - Whether SMTP is enabled.
+* `host` - The hostname of the SMTP server.
+* `port` - The port of the SMTP server.
+* `sender` - The sender email address.
+* `auth` - The authentication type. Valid values are `none`, `plain`, and `login`.
+* `username` - The username used to authenticate to the SMTP server.

--- a/website/docs/r/smtp_settings.html.markdown
+++ b/website/docs/r/smtp_settings.html.markdown
@@ -1,0 +1,98 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_smtp_settings"
+description: |-
+  Manages SMTP Settings.
+---
+
+# tfe_smtp_settings
+
+Use this resource to create, update and destroy SMTP Settings. It applies only to Terraform Enterprise and requires admin token configuration. See example usage for incorporating an admin token in your provider config.
+
+## Example Usage
+
+Basic usage for SMTP Settings without authentication:
+
+```hcl
+provider "tfe" {
+  hostname = var.hostname
+  token    = var.admin_token
+}
+
+resource "tfe_smtp_settings" "this" {
+  host   = "smtp.example.com"
+  port   = 25
+  sender = "noreply@example.com"
+  auth   = "none"
+}
+```
+
+With authentication using plain password:
+
+```hcl
+provider "tfe" {
+  hostname = var.hostname
+  token    = var.admin_token
+}
+
+resource "tfe_smtp_settings" "this" {
+  host     = "smtp.example.com"
+  port     = 587
+  sender   = "noreply@example.com"
+  auth     = "plain"
+  username = "smtp_user"
+  password = "smtp_password"
+}
+```
+
+With write-only password:
+
+```hcl
+variable "smtp_password" {
+  type      = string
+  ephemeral = true
+}
+
+provider "tfe" {
+  hostname = var.hostname
+  token    = var.admin_token
+}
+
+resource "tfe_smtp_settings" "this" {
+  host                = "smtp.example.com"
+  port                = 587
+  sender              = "noreply@example.com"
+  auth                = "login"
+  username            = "smtp_user"
+  password_wo         = var.smtp_password
+  password_wo_version = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `host` - (Optional) The hostname of the SMTP server.
+* `port` - (Optional) The port of the SMTP server. Defaults to `25`.
+* `sender` - (Optional) The desired sender email address.
+* `auth` - (Optional) The authentication type. Valid values are `none`, `plain`, and `login`. Defaults to `none`.
+* `username` - (Optional) The username used to authenticate to the SMTP server. Required if auth is `login` or `plain`.
+* `password` - (Optional) The password used to authenticate to the SMTP server. Required if auth is `login` or `plain`. Cannot be used with `password_wo`.
+* `password_wo` - (Optional, [Write-Only](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments)) The password used to authenticate to the SMTP server, guaranteed not to be written to plan or state artifacts. Either `password` or `password_wo` can be provided, but not both. Must be used with `password_wo_version`.
+* `password_wo_version` - (Optional) Version of the write-only password. This field is used to trigger updates when the write-only password changes. Must be used with `password_wo`. When `password_wo_version` changes, the write-only password will be updated.
+* `test_email_address` - (Optional) The email address to send a test message to. This value is not persisted and is only used during testing.
+
+-> **Note:** Write-Only argument `password_wo` is available to use in place of `password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
+
+## Attributes Reference
+
+* `id` - The ID of the SMTP settings. Always `smtp`.
+* `enabled` - Whether SMTP is enabled. When enabled, all other attributes must have valid values.
+
+## Import
+
+SMTP Settings can be imported.
+
+```shell
+terraform import tfe_smtp_settings.this smtp


### PR DESCRIPTION
## Description

This PR adds support for managing SMTP settings in Terraform Enterprise by introducing a new resource and data source for SMTP configuration.


- [X] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [X] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Configure Terraform Enterprise with admin token
2. Create SMTP settings resource with no authentication:
```terraform
provider "tfe" {
  hostname = "tfe.example.com"
  token    = var.admin_token
}

resource "tfe_smtp_settings" "test" {
  host   = "smtp.example.com"
  port   = 25
  sender = "noreply@example.com"
  auth   = "none"
}
```
3. Apply and verify SMTP settings are created
4. Update to use authentication with write-only password:
```terraform
resource "tfe_smtp_settings" "test" {
  host                = "smtp.example.com"
  port                = 587
  sender              = "noreply@example.com"
  auth                = "login"
  username            = "smtp_user"
  password_wo         = var.smtp_password
  password_wo_version = 1
}
```
5. Apply and verify settings are updated
6. Test data source to read SMTP settings:
```terraform
data "tfe_smtp_settings" "current" {}

output "smtp_enabled" {
  value = data.tfe_smtp_settings.current.enabled
}
```
7. Verify import functionality: terraform import tfe_smtp_settings.test smtp
8. Test destroy operation (should disable SMTP, not delete)

## External links

[go-tfe SMTP Settings API](https://pkg.go.dev/github.com/hashicorp/go-tfe#AdminSMTPSetting)
[TFE Admin Settings API documentation](https://developer.hashicorp.com/terraform/enterprise/api-docs/admin/settings)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ go test -v -run TestAccTFESMTPSettings -timeout 15m 2>&1

=== RUN   TestAccTFESMTPSettingsDataSource_basic
--- PASS: TestAccTFESMTPSettingsDataSource_basic (0.84s)
=== RUN   TestAccTFESMTPSettings_omnibus
=== RUN   TestAccTFESMTPSettings_omnibus/basic_SMTP_settings_without_authentication
--- PASS: TestAccTFESMTPSettings_omnibus (0.72s)
    --- PASS: TestAccTFESMTPSettings_omnibus/basic_SMTP_settings_without_authentication (0.72s)
=== RUN   TestAccTFESMTPSettings_AuthNone
--- PASS: TestAccTFESMTPSettings_AuthNone (0.67s)
=== RUN   TestAccTFESMTPSettings_AuthPlain_writeOnly
--- PASS: TestAccTFESMTPSettings_AuthPlain_writeOnly (0.82s)
=== RUN   TestAccTFESMTPSettings_AuthLogin_writeOnly
--- PASS: TestAccTFESMTPSettings_AuthLogin_writeOnly (0.67s)
=== RUN   TestAccTFESMTPSettings_AuthPlain_writeOnly_update
--- PASS: TestAccTFESMTPSettings_AuthPlain_writeOnly_update (1.17s)
=== RUN   TestAccTFESMTPSettings_AuthPlain_writeOnly_no_version_change
--- PASS: TestAccTFESMTPSettings_AuthPlain_writeOnly_no_version_change (1.06s)
=== RUN   TestAccTFESMTPSettings_AuthPlain
--- PASS: TestAccTFESMTPSettings_AuthPlain (0.69s)
=== RUN   TestAccTFESMTPSettings_AuthLogin
--- PASS: TestAccTFESMTPSettings_AuthLogin (0.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	7.999s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
