### PR TITLE
ci: declare permissions on the 6 remaining workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ on: [workflow_dispatch, push]
 env:
   PKG_NAME: "terraform-provider-tfe"
 
+permissions:
+  contents: read
+
 jobs:
   # Detects the Go toolchain version to use for product builds.
   #

--- a/.github/workflows/call-jira-issue-sync.yml
+++ b/.github/workflows/call-jira-issue-sync.yml
@@ -6,6 +6,12 @@ on:
   issue_comment:
     types: [created]
 
+# Caller for local Jira issue sync. Jira writes use the inherited Jira API
+# token; default GITHUB_TOKEN only needs read.
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   call-workflow:
     uses: ./.github/workflows/jira-issue-sync.yml

--- a/.github/workflows/call-jira-pr-transition.yml
+++ b/.github/workflows/call-jira-pr-transition.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, closed, reopened, converted_to_draft, ready_for_review]
 
+# Caller for local Jira PR transition reusable; Jira writes via the inherited
+# token.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   call-workflow:
     uses: ./.github/workflows/jira-pr-transition.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -5,6 +5,10 @@ on:
       - main
   workflow_dispatch:
 
+# mhausenblas/mkdocs-deploy-gh-pages pushes built docs to gh-pages branch.
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Deploy docs

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -5,6 +5,10 @@ on:
     # Monday-Friday at 7AM UTC (1 hour after infrastructure rebuild)
     - cron: '0 7 * * 1-5'
 
+# TFE provisioning uses TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN; tests just run go.
+permissions:
+  contents: read
+
 jobs:
   instance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` on the six top-level workflows still inheriting org defaults. The two reusables in this repo (`jira-issue-sync.yml` and `jira-pr-transition.yml`) are intentionally **not** edited; per the workflow-permissions convention, adding scopes to reusable callees would intersect with caller grants.

| Workflow | Scope |
|----------|-------|
| `build.yml` | `contents: read` |
| `ci.yml` | `contents: read` |
| `nightly-tfe-test.yml` | `contents: read` (TFE provisioning uses `TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN`) |
| `call-jira-issue-sync.yml` | `contents: read` + `issues: read` |
| `call-jira-pr-transition.yml` | `contents: read` + `pull-requests: read` |
| `mkdocs.yml` | `contents: write` (mhausenblas/mkdocs-deploy-gh-pages pushes to gh-pages) |

YAML validated locally.