### PR TITLE
Adds `provider_type` attribute to specify the saml idp provider type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ provider_tfe_override.tfrc
 site/
 .envrc
 .vscode
+
+# macOS metadata files
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ ENHANCEMENTS:
 * Support trigger patterns and working directories in stacks by @aaabdelgany [#2048](https://github.com/hashicorp/terraform-provider-tfe/pull/2048)
 * Adds `RunPostApplyRunning`,`RunPostApplyCompleted` run status by @jose-kunnel [#2046](https://github.com/hashicorp/terraform-provider-tfe/pull/2046)
 * `r/tfe_policy_set` and `d/tfe_policy_set`: Add `policy_update_patterns` attribute support for policy sets. By @nithishravindra [#2030](https://github.com/hashicorp/terraform-provider-tfe/pull/2030)
-* `r/tfe_saml_settings` and `d/tfe_saml_settings`: Add `provider_type` attribute to specify the SAML identity provider type (`okta`, `entra`, `generic`, `unknown`). By @skj-skj [#2066](https://github.com/hashicorp/terraform-provider-tfe/pull/2066)
+* `r/tfe_saml_settings` and `d/tfe_saml_settings`: Add `provider_type` attribute to specify the SAML identity provider type (`okta`, `entra`, `saml`, `unknown`). By @skj-skj [#2066](https://github.com/hashicorp/terraform-provider-tfe/pull/2066)
 
 BUG FIXES:
 * `r/tfe_team`: Fixed a `Missing Identity After Update` error on resource update by @sebasslash [#2045](https://github.com/hashicorp/terraform-provider-tfe/pull/2045)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ ENHANCEMENTS:
 * Support trigger patterns and working directories in stacks by @aaabdelgany [#2048](https://github.com/hashicorp/terraform-provider-tfe/pull/2048)
 * Adds `RunPostApplyRunning`,`RunPostApplyCompleted` run status by @jose-kunnel [#2046](https://github.com/hashicorp/terraform-provider-tfe/pull/2046)
 * `r/tfe_policy_set` and `d/tfe_policy_set`: Add `policy_update_patterns` attribute support for policy sets. By @nithishravindra [#2030](https://github.com/hashicorp/terraform-provider-tfe/pull/2030)
-* `r/tfe_saml_settings` and `d/tfe_saml_settings`: Add `provider_type` attribute to specify the SAML identity provider type (`okta`, `entra`, `generic`, `unknown`).
+* `r/tfe_saml_settings` and `d/tfe_saml_settings`: Add `provider_type` attribute to specify the SAML identity provider type (`okta`, `entra`, `generic`, `unknown`). By @skj-skj [#2066](https://github.com/hashicorp/terraform-provider-tfe/pull/2066)
 
 BUG FIXES:
 * `r/tfe_team`: Fixed a `Missing Identity After Update` error on resource update by @sebasslash [#2045](https://github.com/hashicorp/terraform-provider-tfe/pull/2045)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 * Support trigger patterns and working directories in stacks by @aaabdelgany [#2048](https://github.com/hashicorp/terraform-provider-tfe/pull/2048)
 * Adds `RunPostApplyRunning`,`RunPostApplyCompleted` run status by @jose-kunnel [#2046](https://github.com/hashicorp/terraform-provider-tfe/pull/2046)
 * `r/tfe_policy_set` and `d/tfe_policy_set`: Add `policy_update_patterns` attribute support for policy sets. By @nithishravindra [#2030](https://github.com/hashicorp/terraform-provider-tfe/pull/2030)
+* `r/tfe_saml_settings` and `d/tfe_saml_settings`: Add `provider_type` attribute to specify the SAML identity provider type (`okta`, `entra`, `generic`, `unknown`).
 
 BUG FIXES:
 * `r/tfe_team`: Fixed a `Missing Identity After Update` error on resource update by @sebasslash [#2045](https://github.com/hashicorp/terraform-provider-tfe/pull/2045)

--- a/internal/provider/data_source_saml_settings.go
+++ b/internal/provider/data_source_saml_settings.go
@@ -52,6 +52,7 @@ type modelDataTFESAMLSettings struct {
 	PrivateKey                types.String `tfsdk:"private_key"`
 	SignatureSigningMethod    types.String `tfsdk:"signature_signing_method"`
 	SignatureDigestMethod     types.String `tfsdk:"signature_digest_method"`
+	ProviderType              types.String `tfsdk:"provider_type"`
 }
 
 // Metadata returns the data source type name.
@@ -127,6 +128,9 @@ func (d *dataSourceTFESAMLSettings) Schema(_ context.Context, _ datasource.Schem
 			"signature_digest_method": schema.StringAttribute{
 				Computed: true,
 			},
+			"provider_type": schema.StringAttribute{
+				Computed: true,
+			},
 		},
 	}
 }
@@ -180,6 +184,7 @@ func (d *dataSourceTFESAMLSettings) Read(ctx context.Context, _ datasource.ReadR
 		PrivateKey:                types.StringValue(s.PrivateKey),
 		SignatureSigningMethod:    types.StringValue(s.SignatureSigningMethod),
 		SignatureDigestMethod:     types.StringValue(s.SignatureDigestMethod),
+		ProviderType:              types.StringValue(string(s.ProviderType)),
 	})
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/data_source_saml_settings_test.go
+++ b/internal/provider/data_source_saml_settings_test.go
@@ -37,6 +37,7 @@ func TestAccTFESAMLSettingsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceAddress, "sso_api_token_session_timeout"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "acs_consumer_url"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "metadata_url"),
+					resource.TestCheckResourceAttrSet(resourceAddress, "provider_type"),
 				),
 			},
 		},

--- a/internal/provider/resource_tfe_saml_settings.go
+++ b/internal/provider/resource_tfe_saml_settings.go
@@ -56,6 +56,7 @@ type modelTFESAMLSettings struct {
 	PrivateKeyWOVersion       types.Int64  `tfsdk:"private_key_wo_version"`
 	SignatureSigningMethod    types.String `tfsdk:"signature_signing_method"`
 	SignatureDigestMethod     types.String `tfsdk:"signature_digest_method"`
+	ProviderType              types.String `tfsdk:"provider_type"`
 }
 
 // resourceTFESAMLSettings implements the tfe_saml_settings resource type
@@ -88,6 +89,7 @@ func modelFromTFEAdminSAMLSettings(v tfe.AdminSAMLSetting, privateKey types.Stri
 		PrivateKeyWOVersion:       privateKeyWOVersion,
 		SignatureSigningMethod:    types.StringValue(v.SignatureSigningMethod),
 		SignatureDigestMethod:     types.StringValue(v.SignatureDigestMethod),
+		ProviderType:              types.StringValue(string(v.ProviderType)),
 	}
 
 	if len(privateKey.String()) > 0 {
@@ -273,6 +275,21 @@ func (r *resourceTFESAMLSettings) Schema(ctx context.Context, req resource.Schem
 					),
 				},
 			},
+			"provider_type": schema.StringAttribute{
+				Description: fmt.Sprintf("The type of identity provider used. Valid values are `%s`, `%s`, `%s`, and `%s`. Defaults to `%s`", string(tfe.SAMLProviderTypeOkta), string(tfe.SAMLProviderTypeEntra), string(tfe.SAMLProviderTypeGeneric), string(tfe.SAMLProviderTypeUnknown), string(tfe.SAMLProviderTypeUnknown)),
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(string(tfe.SAMLProviderTypeUnknown)),
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						string(tfe.SAMLProviderTypeOkta),
+						string(tfe.SAMLProviderTypeEntra),
+						// `tfe.SAMLProviderTypeGeneric` is the string literal "saml", and is shown as `SAML` in the TFE UI.
+						string(tfe.SAMLProviderTypeGeneric),
+						string(tfe.SAMLProviderTypeUnknown),
+					),
+				},
+			},
 		},
 	}
 }
@@ -402,6 +419,7 @@ func (r *resourceTFESAMLSettings) Delete(ctx context.Context, req resource.Delet
 		PrivateKey:                basetypes.NewStringValue("").ValueStringPointer(),
 		SignatureSigningMethod:    basetypes.NewStringValue(samlSignatureMethodSHA256).ValueStringPointer(),
 		SignatureDigestMethod:     basetypes.NewStringValue(samlSignatureMethodSHA256).ValueStringPointer(),
+		ProviderType:              tfe.SAMLProvider(tfe.SAMLProviderTypeUnknown),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting SAML Settings", "Could not disable SAML Settings, unexpected error: "+err.Error())
@@ -482,6 +500,7 @@ func (r *resourceTFESAMLSettings) updateSAMLSettings(ctx context.Context, m mode
 		WantAssertionsSigned:      m.WantAssertionsSigned.ValueBoolPointer(),
 		SignatureSigningMethod:    m.SignatureSigningMethod.ValueStringPointer(),
 		SignatureDigestMethod:     m.SignatureDigestMethod.ValueStringPointer(),
+		ProviderType:              tfe.SAMLProvider(tfe.SAMLProviderType(m.ProviderType.ValueString())),
 	})
 	if err != nil {
 		return s, fmt.Errorf("failed to update SAML Settings: %w", err)

--- a/internal/provider/resource_tfe_saml_settings_test.go
+++ b/internal/provider/resource_tfe_saml_settings_test.go
@@ -69,6 +69,7 @@ func TestAccTFESAMLSettings_writeOnly(t *testing.T) {
 					resource.TestCheckNoResourceAttr(
 						testResourceName, "private_key_wo"),
 					resource.TestCheckResourceAttr(testResourceName, "private_key_wo_version", "1"),
+					resource.TestCheckResourceAttr(testResourceName, "provider_type", string(tfe.SAMLProviderTypeUnknown)),
 				),
 			},
 		},
@@ -96,6 +97,10 @@ func TestAccTFESAMLSettings_writeOnlyValidation(t *testing.T) {
 			{
 				Config:      testAccTFESAMLSettings_privateKeyVersionConflict(),
 				ExpectError: regexp.MustCompile(`Attribute "private_key" cannot be specified when "private_key_wo_version" is\s+specified`),
+			},
+			{
+				Config:      testAccTFESAMLSettings_samlProviderTypeInvalidValues(),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`Attribute provider_type value must be one of: \["%s" "%s" "%s"\s+"%s"\]`, string(tfe.SAMLProviderTypeOkta), string(tfe.SAMLProviderTypeEntra), string(tfe.SAMLProviderTypeGeneric), string(tfe.SAMLProviderTypeUnknown))),
 			},
 		},
 	})
@@ -133,6 +138,7 @@ func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 						resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
 						resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", samlSignatureMethodSHA256),
 						resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", samlSignatureMethodSHA256),
+						resource.TestCheckResourceAttr(testResourceName, "provider_type", string(tfe.SAMLProviderTypeUnknown)),
 					),
 				},
 			},
@@ -157,6 +163,7 @@ func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 			PrivateKey:                "TestPrivateKeyFull",
 			SignatureSigningMethod:    samlSignatureMethodSHA1,
 			SignatureDigestMethod:     samlSignatureMethodSHA256,
+			ProviderType:              tfe.SAMLProviderTypeOkta,
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -183,6 +190,7 @@ func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 						resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
 						resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", s.SignatureSigningMethod),
 						resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", s.SignatureDigestMethod),
+						resource.TestCheckResourceAttr(testResourceName, "provider_type", string(tfe.SAMLProviderTypeOkta)),
 					),
 				},
 			},
@@ -212,6 +220,7 @@ func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 			PrivateKey:                "TestPrivateKeyUpdate",
 			SignatureSigningMethod:    samlSignatureMethodSHA1,
 			SignatureDigestMethod:     samlSignatureMethodSHA256,
+			ProviderType:              tfe.SAMLProviderTypeEntra,
 		}
 
 		resource.Test(t, resource.TestCase{
@@ -239,6 +248,7 @@ func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 						resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
 						resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", samlSignatureMethodSHA256),
 						resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", samlSignatureMethodSHA256),
+						resource.TestCheckResourceAttr(testResourceName, "provider_type", string(tfe.SAMLProviderTypeUnknown)),
 					),
 				},
 				{
@@ -261,6 +271,7 @@ func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 						resource.TestCheckResourceAttrSet(testResourceName, "metadata_url"),
 						resource.TestCheckResourceAttr(testResourceName, "signature_signing_method", updatedSetting.SignatureSigningMethod),
 						resource.TestCheckResourceAttr(testResourceName, "signature_digest_method", updatedSetting.SignatureDigestMethod),
+						resource.TestCheckResourceAttr(testResourceName, "provider_type", string(tfe.SAMLProviderTypeEntra)),
 					),
 				},
 			},
@@ -303,6 +314,10 @@ func TestAccTFESAMLSettings_omnibus(t *testing.T) {
 						}
 						if rs.Attributes["sso_endpoint_url"] != sso {
 							return fmt.Errorf("expected sso_endpoint_url attribute to be equal to %s, received: %s", sso, rs.Attributes["sso_endpoint_url"])
+						}
+
+						if rs.Attributes["provider_type"] != string(tfe.SAMLProviderTypeUnknown) {
+							return fmt.Errorf("expected provider_type attribute to be equal to %s, received: %s", tfe.SAMLProviderTypeUnknown, rs.Attributes["provider_type"])
 						}
 						return nil
 					},
@@ -368,6 +383,9 @@ func testAccTFESAMLSettingsDestroy(_ *terraform.State) error {
 	if s.SSOAPITokenSessionTimeout != int(samlDefaultSSOAPITokenSessionTimeoutSeconds) {
 		return fmt.Errorf("SAML settings SignatureDigestMethod is not `%d`", samlDefaultSSOAPITokenSessionTimeoutSeconds)
 	}
+	if s.ProviderType != tfe.SAMLProviderTypeUnknown {
+		return fmt.Errorf("SAML settings ProviderType is not `%s`", tfe.SAMLProviderTypeUnknown)
+	}
 	return nil
 }
 
@@ -399,7 +417,8 @@ resource "tfe_saml_settings" "foobar" {
   private_key 					= "%s"
   signature_signing_method 		= "%s"
   signature_digest_method 		= "%s"
-}`, s.IDPCert, s.SLOEndpointURL, s.SSOEndpointURL, s.Debug, s.AuthnRequestsSigned, s.WantAssertionsSigned, s.TeamManagementEnabled, s.AttrUsername, s.AttrSiteAdmin, s.AttrGroups, s.SiteAdminRole, s.SSOAPITokenSessionTimeout, s.Certificate, s.PrivateKey, s.SignatureSigningMethod, s.SignatureDigestMethod)
+  provider_type                 = "%s"
+}`, s.IDPCert, s.SLOEndpointURL, s.SSOEndpointURL, s.Debug, s.AuthnRequestsSigned, s.WantAssertionsSigned, s.TeamManagementEnabled, s.AttrUsername, s.AttrSiteAdmin, s.AttrGroups, s.SiteAdminRole, s.SSOAPITokenSessionTimeout, s.Certificate, s.PrivateKey, s.SignatureSigningMethod, s.SignatureDigestMethod, s.ProviderType)
 }
 
 func testAccTFESAMLSettings_writeOnly(s tfe.AdminSAMLSetting) string {
@@ -453,5 +472,15 @@ resource "tfe_saml_settings" "foobar" {
   sso_endpoint_url       = "https://foobar.com/sso"
   private_key            = "some-key"
   private_key_wo_version = 1
+}`
+}
+
+func testAccTFESAMLSettings_samlProviderTypeInvalidValues() string {
+	return `
+resource "tfe_saml_settings" "foobar" {
+  idp_cert         = "testIDPCert"
+  slo_endpoint_url = "https://foobar.com/slo"
+  sso_endpoint_url = "https://foobar.com/sso"
+  provider_type    = "foo"
 }`
 }

--- a/internal/provider/resource_tfe_saml_settings_test.go
+++ b/internal/provider/resource_tfe_saml_settings_test.go
@@ -100,7 +100,7 @@ func TestAccTFESAMLSettings_writeOnlyValidation(t *testing.T) {
 			},
 			{
 				Config:      testAccTFESAMLSettings_samlProviderTypeInvalidValues(),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`Attribute provider_type value must be one of: \["%s" "%s" "%s"\s+"%s"\]`, string(tfe.SAMLProviderTypeOkta), string(tfe.SAMLProviderTypeEntra), string(tfe.SAMLProviderTypeGeneric), string(tfe.SAMLProviderTypeUnknown))),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`Attribute provider_type value must be one of: \[%q %q %q\s+%q\]`, string(tfe.SAMLProviderTypeOkta), string(tfe.SAMLProviderTypeEntra), string(tfe.SAMLProviderTypeGeneric), string(tfe.SAMLProviderTypeUnknown))),
 			},
 		},
 	})

--- a/internal/provider/resource_tfe_saml_settings_test.go
+++ b/internal/provider/resource_tfe_saml_settings_test.go
@@ -100,7 +100,7 @@ func TestAccTFESAMLSettings_writeOnlyValidation(t *testing.T) {
 			},
 			{
 				Config:      testAccTFESAMLSettings_samlProviderTypeInvalidValues(),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`Attribute provider_type value must be one of: \[%q %q %q\s+%q\]`, string(tfe.SAMLProviderTypeOkta), string(tfe.SAMLProviderTypeEntra), string(tfe.SAMLProviderTypeGeneric), string(tfe.SAMLProviderTypeUnknown))),
+				ExpectError: regexp.MustCompile(`(?s)Attribute provider_type value must be one of: \[.*\]`),
 			},
 		},
 	})

--- a/website/docs/d/saml_settings.html.markdown
+++ b/website/docs/d/saml_settings.html.markdown
@@ -61,3 +61,4 @@ The following attributes are exported:
 * `private_key` - The private key used for request and assertion signing.
 * `signature_signing_method` - Signature Signing Method.
 * `signature_digest_method` - Signature Digest Method.
+* `provider_type` - The type of identity provider used. One of `okta`, `entra`, `saml`, or `unknown`.

--- a/website/docs/r/saml_settings.html.markdown
+++ b/website/docs/r/saml_settings.html.markdown
@@ -70,6 +70,7 @@ The following arguments are supported:
 * `private_key_wo_version` - (Optional) Version of the write-only private key. This field is used to trigger updates when the write-only private key changes. Must be used with `private_key_wo`. When `private_key_wo_version` changes, the write-only private key will be updated.
 * `signature_signing_method` - (Optional) Signature Signing Method. Must be either `SHA1` or `SHA256`. Defaults to `SHA256`.
 * `signature_digest_method` - (Optional) Signature Digest Method. Must be either `SHA1` or `SHA256`. Defaults to `SHA256`.
+* `provider_type` - (Optional) The type of identity provider used. Valid values are `okta`, `entra`, `saml`, and `unknown`. Defaults to `unknown`.
 
 -> **Note:** Write-Only argument `private_key_wo` is available to use in place of `private_key`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 


### PR DESCRIPTION
## Description

This pr adds a `provider_type` attribute to `r/tfe_saml_settings` and `d/tfe_saml_settings` to specify the IdP provider (e.g., `okta`, `entra`, generic `saml`, or `unknown`).
It also updates acceptance tests to include coverage for `provider_type`, updates the documentation, and adds a minor changelog entry to ignore `.DS_Store` files to prevent accidental commits.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. I have spinup a TFE v2.0.1 instance and ran the acceptance test against it.

## External links
[JIRA](https://hashicorp.atlassian.net/browse/TF-35678)
[RFC](https://hermes-sharepoint.hashicorp.services/document/01XOO7K4IWFH44KZAPDJC3QXNKIRWEZMBA)

## Output from acceptance tests
1. `TESTARGS="-run TestAccTFESAMLSettings" ENABLE_TFE=1 envchain scim make testacc`
    <img width="966" height="454" alt="Untitled 3" src="https://github.com/user-attachments/assets/00588059-635e-4876-8581-fdc780865aeb" />



<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

we can revert this pr

## Changes to Security Controls

NA
