### PR TITLE
tfe instances need stacks license to enable stack

### DIFF
--- a/internal/provider/resource_tfe_stack_test.go
+++ b/internal/provider/resource_tfe_stack_test.go
@@ -53,6 +53,7 @@ func (notFoundStacks) FetchLatestFromVcs(_ context.Context, _ string) (*tfe.Stac
 }
 
 func TestAccTFEStackResource_basic(t *testing.T) {
+	skipIfEnterprise(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
@@ -90,6 +91,7 @@ func TestAccTFEStackResource_basic(t *testing.T) {
 }
 
 func TestAccTFEStackResource_importByIdentity(t *testing.T) {
+	skipIfEnterprise(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
@@ -164,6 +166,7 @@ resource "tfe_stack" "foobar" {
 }
 
 func TestAccTFEStackResource_withAgentPool(t *testing.T) {
+	skipIfEnterprise(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 
@@ -366,6 +369,7 @@ func runRemovedStackRead(t *testing.T, ctx context.Context, r *resourceTFEStack,
 }
 
 func TestAccTFEStackResource_noVCSRepo(t *testing.T) {
+	skipIfEnterprise(t)
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	orgName := fmt.Sprintf("tst-terraform-%d", rInt)
 


### PR DESCRIPTION
## Description

skip stack test if instance is enterprise since tfe instances need stacks license to enable stack.

## Testing plan

1. Existing test should now pass in both cloud & enterprise instance

## External links



## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

Revert PR

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
