### PR TITLE
[r/tfe_no_code_module] Allow a no-code module's input variable to be free text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES:
 * **New Resource:** `r/tfe_scim_settings` and **New Data Source:** `d/tfe_scim_settings`: Adds resource and data source to manage SCIM settings on Terraform Enterprise. By @skj-skj [#2072](https://github.com/hashicorp/terraform-provider-tfe/pull/2072)
 
+ENHANCEMENTS:
+* `r/tfe_no_code_module`: Allow `variable_options.options` to be empty or omitted [#2074](https://github.com/hashicorp/terraform-provider-tfe/pull/2074)
+
 ## v0.77.0
 
 ENHANCEMENTS:

--- a/internal/provider/resource_tfe_no_code_module.go
+++ b/internal/provider/resource_tfe_no_code_module.go
@@ -79,7 +79,7 @@ func resourceTFENoCodeModule() *schema.Resource {
 							Type:     schema.TypeList,
 							ForceNew: false,
 							Required: true,
-							MinItems: 1,
+							MinItems: 0,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},

--- a/internal/provider/resource_tfe_no_code_module.go
+++ b/internal/provider/resource_tfe_no_code_module.go
@@ -79,7 +79,6 @@ func resourceTFENoCodeModule() *schema.Resource {
 							Type:     schema.TypeList,
 							ForceNew: false,
 							Optional: true,
-							MinItems: 0,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},

--- a/internal/provider/resource_tfe_no_code_module.go
+++ b/internal/provider/resource_tfe_no_code_module.go
@@ -78,7 +78,7 @@ func resourceTFENoCodeModule() *schema.Resource {
 						"options": {
 							Type:     schema.TypeList,
 							ForceNew: false,
-							Required: true,
+							Optional: true,
 							MinItems: 0,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},

--- a/internal/provider/resource_tfe_no_code_module_test.go
+++ b/internal/provider/resource_tfe_no_code_module_test.go
@@ -88,16 +88,118 @@ func TestAccTFENoCodeModule_with_variable_options(t *testing.T) {
 									return fmt.Errorf("Bad 'min_lower' attribute options: %v", nocodeModule.VariableOptions)
 								}
 							}
+						}
 
-							if vo.VariableName == "freetext_string_emptylist" {
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFENoCodeModule_with_variable_options_no_options(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatalf("error getting client %v", err)
+	}
+	org, cleanup := createBusinessOrganization(t, tfeClient)
+	defer cleanup()
+	providers := muxedProvidersWithDefaultOrganization(org.Name)
+	cfg := testAccTFENoCodeModule_with_variable_options_no_options(org.Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: providers,
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						n := "tfe_no_code_module.sensitive"
+						rs, ok := s.RootModule().Resources[n]
+						if !ok || rs.Primary.ID == "" {
+							return fmt.Errorf("Not found: %s", n)
+						}
+
+						opts := &tfe.RegistryNoCodeModuleReadOptions{
+							Include: []tfe.RegistryNoCodeModuleIncludeOpt{tfe.RegistryNoCodeIncludeVariableOptions},
+						}
+						nocodeModule, err := testAccConfiguredClient.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, opts)
+						if err != nil {
+							return fmt.Errorf("unable to read nocodeModule with ID %s", rs.Primary.ID)
+						}
+
+						if !nocodeModule.Enabled {
+							return fmt.Errorf("Bad 'enabled' attribute: %t", nocodeModule.Enabled)
+						}
+
+						if len(nocodeModule.VariableOptions) == 0 {
+							return fmt.Errorf("Bad 'variable_options' attribute: %v", nocodeModule.VariableOptions)
+						}
+
+						for _, vo := range nocodeModule.VariableOptions {
+							if vo.VariableName == "min_lower" {
 								if len(vo.Options) != 0 {
-									return fmt.Errorf("Bad 'freetext_string_emptylist' attribute options: %v", nocodeModule.VariableOptions)
+									return fmt.Errorf("Bad 'min_lower' attribute options: %v", nocodeModule.VariableOptions)
 								}
 							}
+						}
 
-							if vo.VariableName == "freetext_string" {
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFENoCodeModule_with_variable_options_empty_options(t *testing.T) {
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatalf("error getting client %v", err)
+	}
+	org, cleanup := createBusinessOrganization(t, tfeClient)
+	defer cleanup()
+	providers := muxedProvidersWithDefaultOrganization(org.Name)
+	cfg := testAccTFENoCodeModule_with_variable_options_empty_options(org.Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: providers,
+		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						n := "tfe_no_code_module.sensitive"
+						rs, ok := s.RootModule().Resources[n]
+						if !ok || rs.Primary.ID == "" {
+							return fmt.Errorf("Not found: %s", n)
+						}
+
+						opts := &tfe.RegistryNoCodeModuleReadOptions{
+							Include: []tfe.RegistryNoCodeModuleIncludeOpt{tfe.RegistryNoCodeIncludeVariableOptions},
+						}
+						nocodeModule, err := testAccConfiguredClient.Client.RegistryNoCodeModules.Read(ctx, rs.Primary.ID, opts)
+						if err != nil {
+							return fmt.Errorf("unable to read nocodeModule with ID %s", rs.Primary.ID)
+						}
+
+						if !nocodeModule.Enabled {
+							return fmt.Errorf("Bad 'enabled' attribute: %t", nocodeModule.Enabled)
+						}
+
+						if len(nocodeModule.VariableOptions) == 0 {
+							return fmt.Errorf("Bad 'variable_options' attribute: %v", nocodeModule.VariableOptions)
+						}
+
+						for _, vo := range nocodeModule.VariableOptions {
+							if vo.VariableName == "min_lower" {
 								if len(vo.Options) != 0 {
-									return fmt.Errorf("Bad 'freetext_string' attribute options: %v", nocodeModule.VariableOptions)
+									return fmt.Errorf("Bad 'min_lower' attribute options: %v", nocodeModule.VariableOptions)
 								}
 							}
 						}
@@ -473,27 +575,90 @@ func testAccTFENoCodeModule_with_variable_options(org string) string {
 	}
 
 	resource "tfe_no_code_module" "sensitive" {
-	organization    = local.organization_name
-	registry_module = tfe_registry_module.sensitive.id
-	version_pin     = "1.0.0"
+		organization    = local.organization_name
+		registry_module = tfe_registry_module.sensitive.id
+		version_pin     = "1.0.0"
 
-	variable_options {
-			name    = "min_lower"
-			type    = "number"
-			options = [ "1", "2", "3", "4", "5" ]
+		variable_options {
+				name    = "min_lower"
+				type    = "number"
+				options = [ "1", "2", "3", "4", "5" ]
+		}
 	}
-
-	variable_options {
-			name    = "freetext_string_emptylist"
-			type    = "string"
-			options = []
-	}
-
-	variable_options {
-			name    = "freetext_string"
-			type    = "string"
-	}
+`, org, envGithubRegistryModuleIdentifer, envGithubToken)
 }
+
+func testAccTFENoCodeModule_with_variable_options_no_options(org string) string {
+	return fmt.Sprintf(`
+	locals {
+		organization_name = "%s"
+		identifier         = "%s"
+	}
+
+	resource "tfe_oauth_client" "github" {
+		organization     = local.organization_name
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+
+	resource "tfe_registry_module" "sensitive" {
+		vcs_repo {
+			display_identifier = local.identifier
+			identifier         = local.identifier
+			oauth_token_id     = tfe_oauth_client.github.oauth_token_id
+		}
+	}
+
+	resource "tfe_no_code_module" "sensitive" {
+		organization    = local.organization_name
+		registry_module = tfe_registry_module.sensitive.id
+		version_pin     = "1.0.0"
+
+		variable_options {
+				name    = "min_lower"
+				type    = "number"
+				// No options provided. HCP TF will include the variable, and the user must specify its value as free text
+		}
+	}
+`, org, envGithubRegistryModuleIdentifer, envGithubToken)
+}
+
+func testAccTFENoCodeModule_with_variable_options_empty_options(org string) string {
+	return fmt.Sprintf(`
+	locals {
+		organization_name = "%s"
+		identifier         = "%s"
+	}
+
+	resource "tfe_oauth_client" "github" {
+		organization     = local.organization_name
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	}
+
+	resource "tfe_registry_module" "sensitive" {
+		vcs_repo {
+			display_identifier = local.identifier
+			identifier         = local.identifier
+			oauth_token_id     = tfe_oauth_client.github.oauth_token_id
+		}
+	}
+
+	resource "tfe_no_code_module" "sensitive" {
+		organization    = local.organization_name
+		registry_module = tfe_registry_module.sensitive.id
+		version_pin     = "1.0.0"
+
+		variable_options {
+				name    = "min_lower"
+				type    = "number"
+				options = [] // HCP TF treats this as equivalent to this parameter being unset
+		}
+	}
 `, org, envGithubRegistryModuleIdentifer, envGithubToken)
 }
 

--- a/internal/provider/resource_tfe_no_code_module_test.go
+++ b/internal/provider/resource_tfe_no_code_module_test.go
@@ -88,6 +88,18 @@ func TestAccTFENoCodeModule_with_variable_options(t *testing.T) {
 									return fmt.Errorf("Bad 'min_lower' attribute options: %v", nocodeModule.VariableOptions)
 								}
 							}
+
+							if vo.VariableName == "freetext_string_emptylist" {
+								if len(vo.Options) != 0 {
+									return fmt.Errorf("Bad 'freetext_string_emptylist' attribute options: %v", nocodeModule.VariableOptions)
+								}
+							}
+
+							if vo.VariableName == "freetext_string" {
+								if len(vo.Options) != 0 {
+									return fmt.Errorf("Bad 'freetext_string' attribute options: %v", nocodeModule.VariableOptions)
+								}
+							}
 						}
 
 						return nil
@@ -469,6 +481,17 @@ func testAccTFENoCodeModule_with_variable_options(org string) string {
 			name    = "min_lower"
 			type    = "number"
 			options = [ "1", "2", "3", "4", "5" ]
+	}
+
+	variable_options {
+			name    = "freetext_string_emptylist"
+			type    = "string"
+			options = []
+	}
+
+	variable_options {
+			name    = "freetext_string"
+			type    = "string"
 	}
 }
 `, org, envGithubRegistryModuleIdentifer, envGithubToken)

--- a/website/docs/r/no_code_module.html.markdown
+++ b/website/docs/r/no_code_module.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 - `variable_options` - (Optional) A list of variable options to associate with the no code module.
   - `name` - (Required) The name of the variable option.
   - `type` - (Required) The type of the variable option.
-  - `options` - (Required) A list of options for the variable option.
+  - `options` - (Optional) A list of options for the variable option.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Things for me to do still...
* [x] Update tests, which still assume `options = []` is invalid
* [x] Changelog + Docs
* [x] Test what happens if we omit `options` entirely




## Description

We don't seem to document this very well
https://developer.hashicorp.com/terraform/cloud-docs/api-docs/no-code-provisioning#enable-no-code-provisioning-for-a-module but from my own experimentation, adding a variable directly within the UI, without specifying any dropdown options, results in that variable being treated as free text.

If we do that then, as far as Terraform is concerned, this gives us:

```
resource "tfe_no_code_module" "private-nocode-modules" {
  ...

  variable_options {
    ...

    options = []
  }
}
```

The TFE provider assumes this options API paramter is mandatory, and must be a list with at least 1 element, meaning it's not currently possible to enable a free text variable.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

So far, I've done some initial testing with a local build.

I have my modules declared in a locals block, so first, here's my resource definition:

```
resource "tfe_no_code_module" "private-nocode-modules" {
  for_each = local.private_nocode_modules

  registry_module = tfe_registry_module.private-nocode-modules[each.key].id

  dynamic "variable_options" {
    for_each = lookup(each.value, "variable_options", [])

    content {
      name    = variable_options.value["name"]
      type    = variable_options.value["type"]
      options = variable_options.value["options"]
    }
  }

  version_pin = lookup(each.value, "version_pin", [])
}
```

And locals, starting with what's possible in the provider right now:

```
locals {
  private_nocode_modules = {
    "FancyCorp-Demo/terraform-aws-nocode-s3-static-website" : {
      version_pin = "0.7.1"
      variable_options = [
        {
          name    = "region",
          type    = "string",
          options = ["eu-west-1", "eu-west-2"],
        },
        {
          name    = "env",
          type    = "string",
          options = ["dev"],
        },
        {
          name    = "prefix",
          type    = "string",
          options = ["lucytest"],
        },
      ],
    },
  }
}
```

Results in what you would expect, three variables:
<img width="941" height="649" alt="image" src="https://github.com/user-attachments/assets/d849e073-30b9-415a-9a67-00f6ebddc0c5" />

And the new behaviour, now possible with the change in this PR:

```
locals {
  private_nocode_modules = {
    "FancyCorp-Demo/terraform-aws-nocode-s3-static-website" : {
      version_pin = "0.7.1"
      variable_options = [
        {
          name    = "region",
          type    = "string",
          options = ["eu-west-1", "eu-west-2"],
        },
        {
          name    = "env",
          type    = "string",
          options = [],
        },
        {
          name    = "prefix",
          type    = "string",
          options = [],
        },
      ],
    },
  }
}
```

The Terraform Plan:

```
Terraform will perform the following actions:

  # tfe_no_code_module.private-nocode-modules["FancyCorp-Demo/terraform-aws-nocode-s3-static-website"] will be updated in-place
  ~ resource "tfe_no_code_module" "private-nocode-modules" {
        id              = "nocode-ErVniXJmZmYzoZpW"
        # (4 unchanged attributes hidden)

      ~ variable_options {
            name    = "env"
          ~ options = [
              - "dev",
            ]
            # (1 unchanged attribute hidden)
        }
      ~ variable_options {
            name    = "prefix"
          ~ options = [
              - "lucytest",
            ]
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Which now succeeds, and we correctly get variables with no dropdown options

<img width="944" height="573" alt="image" src="https://github.com/user-attachments/assets/1ff3251d-7a1e-4f9b-bfca-d985e76d52f7" />
<img width="795" height="686" alt="image" src="https://github.com/user-attachments/assets/02fa1aec-8c0b-43a2-94d8-d16e199e012e" />





Without this change, Terraform gives you the following error:

```
╷
│ Error: Not enough list items
│
│   with tfe_no_code_module.private-nocode-modules["FancyCorp-Demo/terraform-aws-nocode-s3-static-website"],
│   on registry.tf line 172, in resource "tfe_no_code_module" "private-nocode-modules":
│  172: resource "tfe_no_code_module" "private-nocode-modules" {
│
│ Attribute variable_options.1.options requires 1 item minimum, but config has only 0 declared.
╵
╷
│ Error: Not enough list items
│
│   with tfe_no_code_module.private-nocode-modules["FancyCorp-Demo/terraform-aws-nocode-s3-static-website"],
│   on registry.tf line 172, in resource "tfe_no_code_module" "private-nocode-modules":
│  172: resource "tfe_no_code_module" "private-nocode-modules" {
│
│ Attribute variable_options.2.options requires 1 item minimum, but config has only 0 declared.
╵
```



Something else I need to test, and amend the PR accordingly:
* [x] What happens if we actually do allow `options` to be unset?
(answer: it works too, see below)


## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
 TESTARGS="-run TestAccTFEWorkspace" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspace -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/client     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/logging    (cached) [no tests to run]
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (4.74s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (4.15s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_prefixWildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_prefixWildcard (4.40s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_suffixWildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_suffixWildcard (4.50s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_noMatch
--- PASS: TestAccTFEWorkspaceIDsDataSource_noMatch (5.07s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_substringWildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_substringWildcard (4.89s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_tags
--- PASS: TestAccTFEWorkspaceIDsDataSource_tags (4.10s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_tagBindingFilters
--- PASS: TestAccTFEWorkspaceIDsDataSource_tagBindingFilters (12.37s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_searchByTagAndName
--- PASS: TestAccTFEWorkspaceIDsDataSource_searchByTagAndName (4.09s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_empty
--- PASS: TestAccTFEWorkspaceIDsDataSource_empty (0.31s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_namesEmpty
--- PASS: TestAccTFEWorkspaceIDsDataSource_namesEmpty (4.01s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_excludeTags
--- PASS: TestAccTFEWorkspaceIDsDataSource_excludeTags (4.32s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_sameTagInTagNamesAndExcludeTags
--- PASS: TestAccTFEWorkspaceIDsDataSource_sameTagInTagNamesAndExcludeTags (4.05s)
=== RUN   TestAccTFEWorkspaceRunTaskDataSource_basic
    helper_test.go:247: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTaskDataSource_basic (0.00s)
=== RUN   TestAccTFEWorkspaceDataSource_remoteStateConsumers
--- PASS: TestAccTFEWorkspaceDataSource_remoteStateConsumers (13.64s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
    data_source_workspace_test.go:86: Step 1/1 error: Check failed: Check 27/45 error: data.tfe_workspace.foobar: Attribute 'html_url' expected "https:///app/tst-terraform-6754246863957504738/workspaces/workspace-test-6754246863957504738", got "https://app.terraform.io/app/tst-terraform-6754246863957504738/workspaces/workspace-test-6754246863957504738"
--- FAIL: TestAccTFEWorkspaceDataSource_basic (2.20s)
=== RUN   TestAccTFEWorkspaceDataSource_tagBindings
--- PASS: TestAccTFEWorkspaceDataSource_tagBindings (4.41s)
=== RUN   TestAccTFEWorkspaceDataSourceWithTriggerPatterns
--- PASS: TestAccTFEWorkspaceDataSourceWithTriggerPatterns (2.62s)
=== RUN   TestAccTFEWorkspaceDataSource_readAutoDestroyAt
    data_source_workspace_test.go:248: Step 2/2 error: Check failed: Check 1/2 error: data.tfe_workspace.foobar: Attribute 'auto_destroy_at' expected "2100-01-01T00:00:00Z", got ""
        Check 2/2 error: data.tfe_workspace.foobar: Attribute 'inherits_project_auto_destroy' expected "false", got "true"
--- FAIL: TestAccTFEWorkspaceDataSource_readAutoDestroyAt (6.06s)
=== RUN   TestAccTFEWorkspaceDataSource_readAutoDestroyDuration
    data_source_workspace_test.go:270: Step 2/2 error: Check failed: Check 1/2 error: data.tfe_workspace.foobar: Attribute 'auto_destroy_activity_duration' expected "1d", got ""
        Check 2/2 error: data.tfe_workspace.foobar: Attribute 'inherits_project_auto_destroy' expected "false", got "true"
--- FAIL: TestAccTFEWorkspaceDataSource_readAutoDestroyDuration (6.33s)
=== RUN   TestAccTFEWorkspaceDataSource_readProjectIDDefault
--- PASS: TestAccTFEWorkspaceDataSource_readProjectIDDefault (3.54s)
=== RUN   TestAccTFEWorkspaceDataSource_readProjectIDNonDefault
--- PASS: TestAccTFEWorkspaceDataSource_readProjectIDNonDefault (4.87s)
=== RUN   TestAccTFEWorkspaceDataSource_readHYOKEnabled
    helper_test.go:261: Skipping tests for HYOK. Set 'ENABLE_HYOK' to enable tests.
--- SKIP: TestAccTFEWorkspaceDataSource_readHYOKEnabled (0.00s)
=== RUN   TestAccTFEWorkspacePolicySetExclusion_basic
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspacePolicySetExclusion_basic (0.26s)
=== RUN   TestAccTFEWorkspacePolicySetExclusion_incorrectImportSyntax
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspacePolicySetExclusion_incorrectImportSyntax (0.31s)
=== RUN   TestAccTFEWorkspacePolicySet_basic
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspacePolicySet_basic (0.33s)
=== RUN   TestAccTFEWorkspacePolicySet_incorrectImportSyntax
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspacePolicySet_incorrectImportSyntax (0.32s)
=== RUN   TestAccTFEWorkspaceRunTask_validateSchemaAttributes
--- PASS: TestAccTFEWorkspaceRunTask_validateSchemaAttributes (0.44s)
=== RUN   TestAccTFEWorkspaceRunTask_create_stages_attr
    helper_test.go:247: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTask_create_stages_attr (0.00s)
=== RUN   TestAccTFEWorkspaceRunTask_create_stage_attr
    helper_test.go:247: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTask_create_stage_attr (0.00s)
=== RUN   TestAccTFEWorkspaceRunTask_import
    helper_test.go:247: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTask_import (0.00s)
=== RUN   TestAccTFEWorkspaceRunTask_Read
    helper_test.go:247: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTask_Read (0.00s)
=== RUN   TestAccTFEWorkspaceRun_withApplyOnlyBlock
    helper_test.go:253: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEWorkspaceRun_withApplyOnlyBlock (0.00s)
=== RUN   TestAccTFEWorkspaceRun_withBothApplyAndDestroyBlocks
    helper_test.go:253: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEWorkspaceRun_withBothApplyAndDestroyBlocks (0.00s)
=== RUN   TestAccTFEWorkspaceRun_invalidParams
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceRun_invalidParams (0.33s)
=== RUN   TestAccTFEWorkspaceRun_WhenRunErrors
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceRun_WhenRunErrors (0.31s)
=== RUN   TestAccTFEWorkspaceSettings_basic
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceSettings_basic (0.29s)
=== RUN   TestAccTFEWorkspaceSettings_noArguments
--- PASS: TestAccTFEWorkspaceSettings_noArguments (4.93s)
=== RUN   TestAccTFEWorkspaceSettings_stateSharing
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceSettings_stateSharing (0.28s)
=== RUN   TestAccTFEWorkspaceSettings_overlappingBooleans
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceSettings_overlappingBooleans (0.25s)
=== RUN   TestAccTFEWorkspaceSettings_basicOptions
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceSettings_basicOptions (0.36s)
=== RUN   TestAccTFEWorkspaceSettingsRemoteState
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceSettingsRemoteState (0.25s)
=== RUN   TestAccTFEWorkspaceSettings_import
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceSettings_import (0.26s)
=== RUN   TestAccTFEWorkspaceSettings_importByName
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspaceSettings_importByName (0.44s)
=== RUN   TestAccTFEWorkspaceSettings_basicTags
--- PASS: TestAccTFEWorkspaceSettings_basicTags (15.79s)
=== RUN   TestAccTFEWorkspaceSettings_preservesWorkspaceTagsOnFirstApply
--- PASS: TestAccTFEWorkspaceSettings_preservesWorkspaceTagsOnFirstApply (5.65s)
=== RUN   TestAccTFEWorkspaceSettings_explicitEmptyClearsWorkspaceTags
--- PASS: TestAccTFEWorkspaceSettings_explicitEmptyClearsWorkspaceTags (8.71s)
=== RUN   TestAccTFEWorkspace_basic
    resource_tfe_workspace_test.go:34: Step 1/1 error: Check failed: Check 19/19 error: tfe_workspace.foobar: Attribute 'html_url' expected "https:///app/tst-terraform-1220910903198508662/workspaces/workspace-test", got "https://app.terraform.io/app/tst-terraform-1220910903198508662/workspaces/workspace-test"
--- FAIL: TestAccTFEWorkspace_basic (2.73s)
=== RUN   TestAccTFEWorkspace_defaultOrg
--- PASS: TestAccTFEWorkspace_defaultOrg (3.99s)
=== RUN   TestAccTFEWorkspaceProviderDefaultOrgChanged
--- PASS: TestAccTFEWorkspaceProviderDefaultOrgChanged (5.63s)
=== RUN   TestAccTFEWorkspace_basicReadProjectId
--- PASS: TestAccTFEWorkspace_basicReadProjectId (3.49s)
=== RUN   TestAccTFEWorkspace_customProject
--- PASS: TestAccTFEWorkspace_customProject (3.96s)
=== RUN   TestAccTFEWorkspace_HTMLURL
--- PASS: TestAccTFEWorkspace_HTMLURL (7.04s)
=== RUN   TestAccTFEWorkspace_panic
--- PASS: TestAccTFEWorkspace_panic (3.55s)
=== RUN   TestAccTFEWorkspace_monorepo
--- PASS: TestAccTFEWorkspace_monorepo (3.43s)
=== RUN   TestAccTFEWorkspace_renamed
--- PASS: TestAccTFEWorkspace_renamed (5.61s)
=== RUN   TestAccTFEWorkspace_update
--- PASS: TestAccTFEWorkspace_update (6.45s)
=== RUN   TestAccTFEWorkspace_updateWorkingDirectory
--- PASS: TestAccTFEWorkspace_updateWorkingDirectory (8.90s)
=== RUN   TestAccTFEWorkspace_updateProject
--- PASS: TestAccTFEWorkspace_updateProject (6.67s)
=== RUN   TestAccTFEWorkspace_updateFileTriggers
--- PASS: TestAccTFEWorkspace_updateFileTriggers (6.06s)
=== RUN   TestAccTFEWorkspace_updateTriggerPrefixes
--- PASS: TestAccTFEWorkspace_updateTriggerPrefixes (6.16s)
=== RUN   TestAccTFEWorkspace_overwriteTriggerPatternsWithPrefixes
--- PASS: TestAccTFEWorkspace_overwriteTriggerPatternsWithPrefixes (8.63s)
=== RUN   TestAccTFEWorkspace_permutation_test_suite
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false/and_trigger_prefixes_are_set_and_empty
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false/and_trigger_prefixes_are_populated
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false/and_trigger_patterns_are_set_and_empty
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false/and_trigger_patterns_are_populated
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_trigger_prefixes_are_set_and_empty
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_trigger_prefixes_are_populated
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_trigger_patterns_are_set_and_empty
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_trigger_patterns_are_populated
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_both_trigger_prefixes_and_patterns_are_populated
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_both_trigger_prefixes_and_patterns_are_empty
=== RUN   TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/change_trigger_prefixes_to_trigger_patterns_and_vice-versa
--- PASS: TestAccTFEWorkspace_permutation_test_suite (66.20s)
    --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false (23.34s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false/and_trigger_prefixes_are_set_and_empty (6.09s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false/and_trigger_prefixes_are_populated (6.08s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false/and_trigger_patterns_are_set_and_empty (5.80s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_false/and_trigger_patterns_are_populated (5.37s)
    --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true (42.86s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_trigger_prefixes_are_set_and_empty (5.92s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_trigger_prefixes_are_populated (7.17s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_trigger_patterns_are_set_and_empty (6.03s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_trigger_patterns_are_populated (6.06s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_both_trigger_prefixes_and_patterns_are_populated (0.42s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/and_both_trigger_prefixes_and_patterns_are_empty (0.26s)
        --- PASS: TestAccTFEWorkspace_permutation_test_suite/file_triggers_enabled_is_true/change_trigger_prefixes_to_trigger_patterns_and_vice-versa (17.00s)
=== RUN   TestAccTFEWorkspace_updateTriggerPatterns
--- PASS: TestAccTFEWorkspace_updateTriggerPatterns (11.15s)
=== RUN   TestAccTFEWorkspace_patternsAndPrefixesConflicting
--- PASS: TestAccTFEWorkspace_patternsAndPrefixesConflicting (0.33s)
=== RUN   TestAccTFEWorkspace_tagBindings
--- PASS: TestAccTFEWorkspace_tagBindings (8.20s)
=== RUN   TestAccTFEWorkspace_changeTags
--- PASS: TestAccTFEWorkspace_changeTags (29.12s)
=== RUN   TestAccTFEWorkspace_effectiveTags
    helper_test.go:253: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEWorkspace_effectiveTags (0.00s)
=== RUN   TestAccTFEWorkspace_updateSpeculative
--- PASS: TestAccTFEWorkspace_updateSpeculative (6.21s)
=== RUN   TestAccTFEWorkspace_structuredRunOutputDisabled
--- PASS: TestAccTFEWorkspace_structuredRunOutputDisabled (6.31s)
=== RUN   TestAccTFEWorkspace_updateVCSRepo
    provider_test.go:408: Please set GITHUB_TOKEN to run this test
--- SKIP: TestAccTFEWorkspace_updateVCSRepo (0.00s)
=== RUN   TestAccTFEWorkspace_updateGitHubAppRepo
    provider_test.go:408: Please set GITHUB_TOKEN to run this test
--- SKIP: TestAccTFEWorkspace_updateGitHubAppRepo (0.00s)
=== RUN   TestAccTFEWorkspace_updateVCSRepoTagsRegex
    provider_test.go:408: Please set GITHUB_TOKEN to run this test
--- SKIP: TestAccTFEWorkspace_updateVCSRepoTagsRegex (0.00s)
=== RUN   TestAccTFEWorkspace_updateVCSRepoChangeTagRegexToTriggerPattern
    provider_test.go:408: Please set GITHUB_TOKEN to run this test
--- SKIP: TestAccTFEWorkspace_updateVCSRepoChangeTagRegexToTriggerPattern (0.00s)
=== RUN   TestAccTFEWorkspace_updateRemoveVCSRepoWithTagsRegex
    provider_test.go:408: Please set GITHUB_TOKEN to run this test
--- SKIP: TestAccTFEWorkspace_updateRemoveVCSRepoWithTagsRegex (0.00s)
=== RUN   TestAccTFEWorkspace_sshKey
--- PASS: TestAccTFEWorkspace_sshKey (9.44s)
=== RUN   TestAccTFEWorkspace_import
--- PASS: TestAccTFEWorkspace_import (5.12s)
=== RUN   TestAccTFEWorkspace_importVCSBranch
    provider_test.go:408: Please set GITHUB_TOKEN to run this test
--- SKIP: TestAccTFEWorkspace_importVCSBranch (0.00s)
=== RUN   TestAccTFEWorkspace_importProject
--- PASS: TestAccTFEWorkspace_importProject (4.51s)
=== RUN   TestAccTFEWorkspace_importByIdentity
    resource_tfe_workspace_test.go:1927: Step 1/2 error: Post-apply refresh state check(s) failed:
        tfe_workspace.foobar - "hostname" identity attribute: expected value  for StringExact check, got: app.terraform.io
--- FAIL: TestAccTFEWorkspace_importByIdentity (2.95s)
=== RUN   TestAccTFEWorkspace_operationsAndExecutionModeInteroperability
    admin_helpers_test.go:51: missing API token for admin role provision-licenses
--- FAIL: TestAccTFEWorkspace_operationsAndExecutionModeInteroperability (0.25s)
=== RUN   TestAccTFEWorkspace_globalRemoteState
--- PASS: TestAccTFEWorkspace_globalRemoteState (6.04s)
=== RUN   TestAccTFEWorkspace_alterRemoteStateConsumers
    resource_tfe_workspace_test.go:2072: Step 1/5 error: Check failed: Check 2/2 error: tfe_workspace.foobar: Attribute 'global_remote_state' expected "true", got "false"
--- FAIL: TestAccTFEWorkspace_alterRemoteStateConsumers (2.61s)
=== RUN   TestAccTFEWorkspace_createWithRemoteStateConsumers
--- PASS: TestAccTFEWorkspace_createWithRemoteStateConsumers (5.65s)
=== RUN   TestAccTFEWorkspace_paginatedRemoteStateConsumers
--- PASS: TestAccTFEWorkspace_paginatedRemoteStateConsumers (59.58s)
=== RUN   TestAccTFEWorkspace_delete_forceDeleteSettingDisabled
--- PASS: TestAccTFEWorkspace_delete_forceDeleteSettingDisabled (5.97s)
=== RUN   TestAccTFEWorkspace_delete_forceDeleteSettingEnabled
--- PASS: TestAccTFEWorkspace_delete_forceDeleteSettingEnabled (5.13s)
=== RUN   TestAccTFEWorkspace_basicAssessmentsEnabled
    resource_tfe_workspace_test.go:2670: Step 2/2 error: Check failed: Check 3/3 error: tfe_workspace.foobar: Attribute 'assessments_enabled' expected "true", got "false"
--- FAIL: TestAccTFEWorkspace_basicAssessmentsEnabled (5.36s)
=== RUN   TestAccTFEWorkspace_createWithAutoDestroyAt
    resource_tfe_workspace_test.go:2703: Step 1/1 error: Check failed: Check 2/2 error: tfe_workspace.foobar: Attribute 'auto_destroy_at' expected "2100-01-01T00:00:00Z", got ""
--- FAIL: TestAccTFEWorkspace_createWithAutoDestroyAt (2.72s)
=== RUN   TestAccTFEWorkspace_updateWithAutoDestroyAt
    resource_tfe_workspace_test.go:2722: Step 2/3 error: Check failed: tfe_workspace.foobar: Attribute 'auto_destroy_at' expected "2100-01-01T00:00:00Z", got ""
--- FAIL: TestAccTFEWorkspace_updateWithAutoDestroyAt (4.90s)
=== RUN   TestAccTFEWorkspace_createWithAutoDestroyDuration
    resource_tfe_workspace_test.go:2749: Step 1/1 error: Check failed: Check 2/2 error: tfe_workspace.foobar: Attribute 'auto_destroy_activity_duration' expected "1d", got ""
--- FAIL: TestAccTFEWorkspace_createWithAutoDestroyDuration (2.73s)
=== RUN   TestAccTFEWorkspace_updateWithAutoDestroyDuration
    resource_tfe_workspace_test.go:2768: Step 1/4 error: Check failed: Check 2/2 error: tfe_workspace.foobar: Attribute 'auto_destroy_activity_duration' expected "1d", got ""
--- FAIL: TestAccTFEWorkspace_updateWithAutoDestroyDuration (2.74s)
=== RUN   TestAccTFEWorkspace_validationAutoDestroyDuration
--- PASS: TestAccTFEWorkspace_validationAutoDestroyDuration (0.53s)
=== RUN   TestAccTFEWorkspace_createWithAutoDestroyDurationInProject
    resource_tfe_workspace_test.go:2825: Step 1/1 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to tfe_project.new_project, provider
        "provider[\"registry.terraform.io/hashicorp/tfe\"]" produced an unexpected
        new value: .auto_destroy_activity_duration: was cty.StringVal("1d"), but now
        null.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccTFEWorkspace_createWithAutoDestroyDurationInProject (1.73s)
=== RUN   TestAccTFEWorkspace_updateWithAutoDestroyDurationInProject
    resource_tfe_workspace_test.go:2845: Step 1/3 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to tfe_project.new_project, provider
        "provider[\"registry.terraform.io/hashicorp/tfe\"]" produced an unexpected
        new value: .auto_destroy_activity_duration: was cty.StringVal("1d"), but now
        null.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccTFEWorkspace_updateWithAutoDestroyDurationInProject (1.70s)
=== RUN   TestAccTFEWorkspace_createWithAutoDestroyAtInProject
    resource_tfe_workspace_test.go:2881: Step 1/1 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to tfe_project.new_project, provider
        "provider[\"registry.terraform.io/hashicorp/tfe\"]" produced an unexpected
        new value: .auto_destroy_activity_duration: was cty.StringVal("1d"), but now
        null.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccTFEWorkspace_createWithAutoDestroyAtInProject (1.82s)
=== RUN   TestAccTFEWorkspace_updateWithAutoDestroyAtInProject
    resource_tfe_workspace_test.go:2901: Step 1/2 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to tfe_project.new_project, provider
        "provider[\"registry.terraform.io/hashicorp/tfe\"]" produced an unexpected
        new value: .auto_destroy_activity_duration: was cty.StringVal("1d"), but now
        null.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccTFEWorkspace_updateWithAutoDestroyAtInProject (1.72s)
=== RUN   TestAccTFEWorkspace_createWithSourceURL
--- PASS: TestAccTFEWorkspace_createWithSourceURL (0.32s)
=== RUN   TestAccTFEWorkspace_createWithSourceName
--- PASS: TestAccTFEWorkspace_createWithSourceName (0.27s)
=== RUN   TestAccTFEWorkspace_createWithSourceURLAndName
--- PASS: TestAccTFEWorkspace_createWithSourceURLAndName (3.57s)
=== RUN   TestAccTFEWorkspace_HYOKEnabled
    helper_test.go:261: Skipping tests for HYOK. Set 'ENABLE_HYOK' to enable tests.
--- SKIP: TestAccTFEWorkspace_HYOKEnabled (0.00s)
=== RUN   TestAccTFEWorkspaceVariableSet_basic
--- PASS: TestAccTFEWorkspaceVariableSet_basic (6.46s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-tfe/internal/provider   498.877s
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers   [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers     [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/validators        [no test files]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
FAIL
make: *** [testacc] Error 1
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

I assume standard rollback processes apply here.


## Changes to Security Controls

None
