### PR TITLE
Adds `r/tfe_scim_token` and `d/tfe_scim_token`

### DIFF
--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -47,6 +47,9 @@ inputs:
     description: Accepts regex rules to either include or exclude specific tests from running in either CI or nightly workflows.
     required: false
     default: "."
+  skip:
+    description: Accepts go pattern string to skip specific tests.
+    required: false
   run_tasks_url:
     description: The mock run tasks URL to use for testing.
     required: false
@@ -92,7 +95,7 @@ runs:
         total: ${{ inputs.matrix_total }}
         junit-summary: ./ci-summary-provider.xml
         # When tests are split and run concurrently, lists_tests arg in ci.yml will skip the TestAccTFESAMLSettings_omnibus test suite
-        flags: -skip ${{ inputs.list_tests }}
+        list: ${{ inputs.list_tests }}
     
     - name: Configure Datadog Test Optimization
       uses: datadog/test-visibility-github-action@f4b026bb8b8b53f323960cf86a849a0231ff93b9 # v2.5.0
@@ -127,7 +130,7 @@ runs:
         MOD_TFE: github.com/hashicorp/terraform-provider-tfe/internal/provider
         MOD_VERSION: github.com/hashicorp/terraform-provider-tfe/version
       run: |
-        gotestsum --junitfile summary.xml --format standard-verbose -- $MOD_PROVIDER $MOD_TFE $MOD_VERSION -v -timeout=60m -parallel=2 -run "${{ steps.test_split.outputs.run }}"
+        gotestsum --junitfile summary.xml --format standard-verbose -- $MOD_PROVIDER $MOD_TFE $MOD_VERSION -v -timeout=60m -parallel=2 -run "${{ steps.test_split.outputs.run }}" -skip "${{ inputs.skips}}"
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -92,7 +92,7 @@ runs:
         total: ${{ inputs.matrix_total }}
         junit-summary: ./ci-summary-provider.xml
         # When tests are split and run concurrently, lists_tests arg in ci.yml will skip the TestAccTFESAMLSettings_omnibus test suite
-        list: ${{ inputs.list_tests }}
+        flags: -skip ${{ inputs.list_tests }}
     
     - name: Configure Datadog Test Optimization
       uses: datadog/test-visibility-github-action@f4b026bb8b8b53f323960cf86a849a0231ff93b9 # v2.5.0

--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -130,7 +130,7 @@ runs:
         MOD_TFE: github.com/hashicorp/terraform-provider-tfe/internal/provider
         MOD_VERSION: github.com/hashicorp/terraform-provider-tfe/version
       run: |
-        gotestsum --junitfile summary.xml --format standard-verbose -- $MOD_PROVIDER $MOD_TFE $MOD_VERSION -v -timeout=60m -parallel=2 -run "${{ steps.test_split.outputs.run }}" -skip "${{ inputs.skips}}"
+        gotestsum --junitfile summary.xml --format standard-verbose -- $MOD_PROVIDER $MOD_TFE $MOD_VERSION -v -timeout=60m -parallel=2 -skip "${{ inputs.skip}}" -run "${{ steps.test_split.outputs.run }}"
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -50,6 +50,7 @@ inputs:
   skip:
     description: Regex pattern forwarded to `go test -skip` to exclude specific tests from a run.
     required: false
+    default: "^$"
   run_tasks_url:
     description: The mock run tasks URL to use for testing.
     required: false

--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -48,7 +48,7 @@ inputs:
     required: false
     default: "."
   skip:
-    description: Accepts go pattern string to skip specific tests.
+    description: Regex pattern forwarded to `go test -skip` to exclude specific tests from a run.
     required: false
   run_tasks_url:
     description: The mock run tasks URL to use for testing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           # action.yml uses https://github.com/hashicorp-forge/go-test-split-action/blob/main/action.yml to split acceptance tests
           # which runs against all tests using the list arg
           # list_tests regex is used to skip the TestAccTFESAMLSettings_omnibus and TestAccTFESCIMSettings_omnibus test suites for CI tests only
-          list_tests: "[^(TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus)]"
+          list_tests: "[^(TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus)]"
   tests-combine-summaries:
     name: Combine Test Reports
     if: "!startsWith(github.head_ref, 'changelog/')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           # action.yml uses https://github.com/hashicorp-forge/go-test-split-action/blob/main/action.yml to split acceptance tests
           # which runs against all tests using the list arg
           # list_tests regex is used to skip the TestAccTFESAMLSettings_omnibus and TestAccTFESCIMSettings_omnibus test suites for CI tests only
-          list_tests: "[^(TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus)]"
+          list_tests: "^(TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus)"
   tests-combine-summaries:
     name: Combine Test Reports
     if: "!startsWith(github.head_ref, 'changelog/')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
           # action.yml uses https://github.com/hashicorp-forge/go-test-split-action/blob/main/action.yml to split acceptance tests
           # which runs against all tests using the list arg
           # list_tests regex is used to skip the TestAccTFESAMLSettings_omnibus and TestAccTFESCIMSettings_omnibus test suites for CI tests only
-          list_tests: "^(TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus)"
+          # list_tests: "[^(TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus)]"
+          skip: "TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus"
   tests-combine-summaries:
     name: Combine Test Reports
     if: "!startsWith(github.head_ref, 'changelog/')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,13 @@ jobs:
           admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
           admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
           admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version-maintenance }}
-          # Run terminal cmd 'go help testflag' to learn more about -list flag
+          # Run terminal cmd 'go help testflag' to learn more about -list and -skip flags
           # action.yml uses https://github.com/hashicorp-forge/go-test-split-action/blob/main/action.yml to split acceptance tests
-          # which runs against all tests using the list arg
-          # list_tests regex is used to skip the TestAccTFESAMLSettings_omnibus and TestAccTFESCIMSettings_omnibus test suites for CI tests only
-          # list_tests: "[^(TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus)]"
+          # which runs against all tests using the list arg.
+          # list_tests previously held a negated regex to exclude omnibus suites, but that regex pattern only
+          # worked reliably for a single test name and broke when excluding multiple suites. We now keep
+          # list_tests at its default (".") and use the `skip` input below, which is forwarded to `go test -skip`
+          # to reliably exclude multiple specific test suites from CI runs.
           skip: "TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus"
   tests-combine-summaries:
     name: Combine Test Reports

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -46,15 +46,51 @@ jobs:
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
           enterprise: "1"
+          # Skip SAML/SCIM here; they run serially in the singleton-tests job.
+          skip: "TestAccTFESAML|TestAccTFESCIM"
+
+  singleton-tests:
+    name: SAML and SCIM Tests
+    needs: instance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Runs SAML/SCIM tests serially on one runner; they share singleton TFE state.
+    # The 1-entry matrix exists only so `matrix.index` resolves to a unique value
+    # for the composite action's artifact upload name (junit-test-summary-singletons).
+    strategy:
+      fail-fast: false
+      matrix:
+        index: [ singletons ]
+    steps:
+      - name: Fetch Outputs
+        id: tflocal
+        uses: hashicorp-forge/terraform-cloud-action/outputs@ceddc497db955594f0b0d5f0bee29c41f60d6d33 # v1.1.1
+        with:
+          token: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
+          organization: hashicorp-v2
+          workspace: tflocal-terraform-provider-tfe-nightly
+
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - uses: ./.github/actions/test-provider-tfe
+        with:
+          # Single slice: include every SAML/SCIM test in one serial run.
+          matrix_index: 0
+          matrix_total: 1
+          hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
+          token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
+          testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
+          enterprise: "1"
+          list_tests: "TestAccTFESAML|TestAccTFESCIM"
 
   tests-summarize:
-    needs: [tests]
+    needs: [tests, singleton-tests]
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
       - name: Check tests Status
         run: |
-          if [ "${{ needs.tests.result }}" = "success" ]; then
+          if [ "${{ needs.tests.result }}" = "success" ] && [ "${{ needs.singleton-tests.result }}" = "success" ]; then
             exit 0
           fi
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 * **New Resource:** `r/tfe_scim_settings` and **New Data Source:** `d/tfe_scim_settings`: Adds resource and data source to manage SCIM settings on Terraform Enterprise. By @skj-skj [#2072](https://github.com/hashicorp/terraform-provider-tfe/pull/2072)
+* **New Resource:** `r/tfe_scim_token` and **New Data Source:** `d/tfe_scim_token`: Adds resource and data source to manage SCIM tokens on Terraform Enterprise. By @skj-skj
 
 ## v0.77.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FEATURES:
 * **New Resource:** `r/tfe_scim_settings` and **New Data Source:** `d/tfe_scim_settings`: Adds resource and data source to manage SCIM settings on Terraform Enterprise. By @skj-skj [#2072](https://github.com/hashicorp/terraform-provider-tfe/pull/2072)
-* **New Resource:** `r/tfe_scim_token` and **New Data Source:** `d/tfe_scim_token`: Adds resource and data source to manage SCIM tokens on Terraform Enterprise. By @skj-skj
+* **New Resource:** `r/tfe_scim_token` and **New Data Source:** `d/tfe_scim_token`: Adds resource and data source to manage SCIM tokens on Terraform Enterprise. By @skj-skj [#2076](https://github.com/hashicorp/terraform-provider-tfe/pull/2076)
 
 ## v0.77.0
 

--- a/internal/provider/attribute_helpers.go
+++ b/internal/provider/attribute_helpers.go
@@ -1,15 +1,24 @@
-// Copyright IBM Corp. 2018, 2025
+// Copyright IBM Corp. 2018, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// timeStringOrNull returns t formatted as RFC3339, or null if t is the zero value.
+func timeStringOrNull(t time.Time) types.String {
+	if t.IsZero() {
+		return types.StringNull()
+	}
+	return types.StringValue(t.Format(time.RFC3339))
+}
 
 // AttrGettable is a small enabler for helper functions that need to read one
 // attribute of a Configuration, Plan, or State.

--- a/internal/provider/data_source_scim_token.go
+++ b/internal/provider/data_source_scim_token.go
@@ -1,0 +1,129 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &dataSourceTFESCIMToken{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFESCIMToken{}
+)
+
+// NewSCIMTokenDataSource is a helper function to simplify the provider implementation.
+func NewSCIMTokenDataSource() datasource.DataSource {
+	return &dataSourceTFESCIMToken{}
+}
+
+// dataSourceTFESCIMToken is the data source implementation.
+type dataSourceTFESCIMToken struct {
+	client *tfe.Client
+}
+
+// modelDataTFESCIMToken maps the data source schema data.
+type modelDataTFESCIMToken struct {
+	ID          types.String `tfsdk:"id"`
+	Description types.String `tfsdk:"description"`
+	ExpiredAt   types.String `tfsdk:"expired_at"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+	LastUsedAt  types.String `tfsdk:"last_used_at"`
+}
+
+// Metadata returns the data source type name.
+func (d *dataSourceTFESCIMToken) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scim_token"
+}
+
+// Schema defines the schema for the data source.
+func (d *dataSourceTFESCIMToken) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads a SCIM authentication token by its ID. Requires SCIM to be enabled.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required:    true,
+				Description: "The ID of the SCIM token (starts with `at-`).",
+			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: "The description of the SCIM token.",
+			},
+			"expired_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "The time when the SCIM token expires.",
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "The time when the SCIM token was created.",
+			},
+			"last_used_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "The time when the SCIM token was last used.",
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *dataSourceTFESCIMToken) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+	d.client = client.Client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *dataSourceTFESCIMToken) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data modelDataTFESCIMToken
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scimTokenID := data.ID.ValueString()
+	tflog.Debug(ctx, fmt.Sprintf("Reading SCIM Token %s", scimTokenID))
+
+	scimToken, err := d.client.Admin.Settings.SCIM.Tokens.Read(ctx, scimTokenID)
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("SCIM token %s not found", scimTokenID),
+				fmt.Sprintf("No SCIM token exists with ID %s. Verify the ID is correct and that SCIM is enabled on this Terraform Enterprise instance.", scimTokenID),
+			)
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error reading SCIM token %s", scimTokenID),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &modelDataTFESCIMToken{
+		ID:          types.StringValue(scimToken.ID),
+		Description: types.StringValue(scimToken.Description),
+		ExpiredAt:   timeStringOrNull(scimToken.ExpiredAt),
+		CreatedAt:   timeStringOrNull(scimToken.CreatedAt),
+		LastUsedAt:  timeStringOrNull(scimToken.LastUsedAt),
+	})...)
+}

--- a/internal/provider/data_source_scim_token.go
+++ b/internal/provider/data_source_scim_token.go
@@ -7,10 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -52,7 +55,13 @@ func (d *dataSourceTFESCIMToken) Schema(_ context.Context, _ datasource.SchemaRe
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Required:    true,
-				Description: "The ID of the SCIM token (starts with `at-`).",
+				Description: "The ID of the SCIM token",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^at-`),
+						"must be a valid SCIM token ID starting with 'at-'",
+					),
+				},
 			},
 			"description": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/data_source_scim_token_test.go
+++ b/internal/provider/data_source_scim_token_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -71,6 +72,19 @@ func TestAccTFESCIMTokenDataSource_omnibus(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("invalid id is rejected at validate time", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccTFESCIMTokenDataSourceConfigInvalidID(),
+					ExpectError: regexp.MustCompile("must be a valid SCIM token ID starting with 'at-'"),
+				},
+			},
+		})
+	})
 }
 
 // testAccTFESCIMTokenDataSourceConfig_basic returns a config that enables
@@ -118,4 +132,16 @@ data "tfe_scim_token" "test" {
     depends_on = [tfe_scim_token.test]
 }
 `, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting), description, expiredAt)
+}
+
+// testAccTFESCIMTokenDataSourceConfigInvalidID returns a config with an
+// invalid SCIM token ID format to validate schema-level ID checks.
+func testAccTFESCIMTokenDataSourceConfigInvalidID() string {
+	return fmt.Sprintf(`
+%s
+
+data "tfe_scim_token" "test" {
+	id = "invalid-token-id"
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting))
 }

--- a/internal/provider/data_source_scim_token_test.go
+++ b/internal/provider/data_source_scim_token_test.go
@@ -1,0 +1,121 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccTFESCIMTokenDataSource_omnibus is the single test function for all SCIM
+// token data source acceptance tests.
+//
+// FLAKE ALERT: SCIM settings are a singleton resource shared by the entire TFE
+// instance. Every sub-test here enables SCIM (via an inline tfe_scim_settings
+// block) as a prerequisite. Running all cases inside one function — without
+// calling t.Parallel in any sub-test — prevents concurrent tests from racing
+// over the same singleton state.
+//
+// FLAKE ALERT (dual-singleton): This suite also contends with
+// resource_tfe_saml_settings_test.go for the SAML singleton. Both singletons
+// must be treated as exclusive resources: do not run SCIM and SAML acceptance
+// tests concurrently.
+//
+// Should this test name ever change, you will also need to update the regex in ci.yml.
+func TestAccTFESCIMTokenDataSource_omnibus(t *testing.T) {
+	skipIfCloud(t)
+
+	t.Run("basic read by id", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-ds-" + randomString(t)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESCIMTokenDataSourceConfig_basic(description),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.tfe_scim_token.test", "id"),
+						resource.TestCheckResourceAttr("data.tfe_scim_token.test", "description", description),
+						resource.TestCheckResourceAttrSet("data.tfe_scim_token.test", "expired_at"),
+						resource.TestCheckResourceAttrSet("data.tfe_scim_token.test", "created_at"),
+						resource.TestCheckNoResourceAttr("data.tfe_scim_token.test", "last_used_at"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("read with explicit expired_at", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-ds-exp-" + randomString(t)
+		expiredAt := time.Now().UTC().Add(180 * 24 * time.Hour).Truncate(time.Second).Format(time.RFC3339)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESCIMTokenDataSourceConfig_withExpiredAt(description, expiredAt),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.tfe_scim_token.test", "id"),
+						resource.TestCheckResourceAttr("data.tfe_scim_token.test", "description", description),
+						resource.TestCheckResourceAttr("data.tfe_scim_token.test", "expired_at", expiredAt),
+					),
+				},
+			},
+		})
+	})
+}
+
+// testAccTFESCIMTokenDataSourceConfig_basic returns a config that enables
+// SAML + SCIM, creates a SCIM token, and reads it back via the tfe_scim_token
+// data source using the resource's id.
+func testAccTFESCIMTokenDataSourceConfig_basic(description string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "tfe_scim_settings" "enable_scim" {
+    depends_on = [tfe_saml_settings.enable_saml]
+}
+
+resource "tfe_scim_token" "test" {
+    description = "%s"
+    depends_on  = [tfe_scim_settings.enable_scim]
+}
+
+data "tfe_scim_token" "test" {
+    id         = tfe_scim_token.test.id
+    depends_on = [tfe_scim_token.test]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting), description)
+}
+
+// testAccTFESCIMTokenDataSourceConfig_withExpiredAt returns a config that
+// enables SAML + SCIM, creates a SCIM token with an explicit expiry, and reads
+// it back via the tfe_scim_token data source.
+func testAccTFESCIMTokenDataSourceConfig_withExpiredAt(description, expiredAt string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "tfe_scim_settings" "enable_scim" {
+    depends_on = [tfe_saml_settings.enable_saml]
+}
+
+resource "tfe_scim_token" "test" {
+    description = "%s"
+    expired_at  = "%s"
+    depends_on  = [tfe_scim_settings.enable_scim]
+}
+
+data "tfe_scim_token" "test" {
+    id         = tfe_scim_token.test.id
+    depends_on = [tfe_scim_token.test]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting), description, expiredAt)
+}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -162,6 +162,7 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewVariablesDataSource,
 		NewWorkspaceRunTaskDataSource,
 		NewSCIMSettingsDataSource,
+		NewSCIMTokenDataSource,
 	}
 }
 
@@ -198,6 +199,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewHYOKConfigurationResource,
 		NewProjectPolicySetExclusionResource,
 		NewSCIMSettingsResource,
+		NewSCIMTokenResource,
 	}
 }
 

--- a/internal/provider/resource_tfe_scim_token.go
+++ b/internal/provider/resource_tfe_scim_token.go
@@ -234,7 +234,7 @@ func (r *resourceTFESCIMToken) Create(ctx context.Context, req resource.CreateRe
 		if expiredAt == "" {
 			resp.Diagnostics.AddError(
 				"Invalid expired_at value",
-				`expired_at must be omitted or set to a non-empty iso8601 format timestamp; use null or remove the attribute instead of "".`,
+				`expired_at must be omitted or set to a non-empty RFC3339/iso8601 format timestamp; use null or remove the attribute instead of "".`,
 			)
 			return
 		}
@@ -242,7 +242,7 @@ func (r *resourceTFESCIMToken) Create(ctx context.Context, req resource.CreateRe
 		expiry, err := time.Parse(time.RFC3339, expiredAt)
 		if err != nil {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("%s must be a valid date or time, provided in iso8601 format", expiredAt),
+				fmt.Sprintf("%s must be a valid date or time, provided in RFC3339/iso8601 format", expiredAt),
 				err.Error(),
 			)
 			return

--- a/internal/provider/resource_tfe_scim_token.go
+++ b/internal/provider/resource_tfe_scim_token.go
@@ -230,7 +230,15 @@ func (r *resourceTFESCIMToken) Create(ctx context.Context, req resource.CreateRe
 		Description: plan.Description.ValueStringPointer(),
 	}
 
-	if !plan.ExpiredAt.IsNull() && expiredAt != "" {
+	if !plan.ExpiredAt.IsNull() && !plan.ExpiredAt.IsUnknown() {
+		if expiredAt == "" {
+			resp.Diagnostics.AddError(
+				"Invalid expired_at value",
+				`expired_at must be omitted or set to a non-empty iso8601 format timestamp; use null or remove the attribute instead of "".`,
+			)
+			return
+		}
+
 		expiry, err := time.Parse(time.RFC3339, expiredAt)
 		if err != nil {
 			resp.Diagnostics.AddError(

--- a/internal/provider/resource_tfe_scim_token.go
+++ b/internal/provider/resource_tfe_scim_token.go
@@ -152,7 +152,11 @@ func (r *resourceTFESCIMToken) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					// Order matters: UseStateForUnknown first (keeps re-applies
+					// Modifiers must run in the following order to ensure correct behavior:
+					// 1. UseStateForUnknown – copies prior state so re-applies results in no-ops.
+					// 2. replaceWhenExpiredAtRemoved – forces replace if user removes this attribute.
+					// 3. RequiresReplace – forces replace if the value changes.
+					// 4. WarnIfNullOnCreate – warns about the 365-day default on first create.
 					// no-ops), then the removal check, then RequiresReplace.
 					stringplanmodifier.UseStateForUnknown(),
 					replaceWhenExpiredAtRemoved{},

--- a/internal/provider/resource_tfe_scim_token.go
+++ b/internal/provider/resource_tfe_scim_token.go
@@ -1,0 +1,322 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers"
+)
+
+type modelTFESCIMToken struct {
+	ID          types.String `tfsdk:"id"`
+	Description types.String `tfsdk:"description"`
+	Token       types.String `tfsdk:"token"`
+	ExpiredAt   types.String `tfsdk:"expired_at"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+	LastUsedAt  types.String `tfsdk:"last_used_at"`
+}
+
+// scimTokenExpiredAtUserSetKey records, in private state, whether the user
+// explicitly set expired_at on the last Create. Without this marker we can't
+// tell "user removed expired_at" from "user never set it" at plan time —
+// both look like ConfigValue=null with a non-null Computed state.
+const scimTokenExpiredAtUserSetKey = "expired_at_user_set"
+
+// replaceWhenExpiredAtRemoved forces replacement when the user drops
+// expired_at from config after previously setting it.
+type replaceWhenExpiredAtRemoved struct{}
+
+var _ planmodifier.String = replaceWhenExpiredAtRemoved{}
+
+func (m replaceWhenExpiredAtRemoved) Description(_ context.Context) string {
+	return "Replaces the resource when expired_at is removed from config after being set."
+}
+
+func (m replaceWhenExpiredAtRemoved) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m replaceWhenExpiredAtRemoved) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Skip on create and destroy.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+	// Value changes are handled by the built-in RequiresReplace.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	marker, diags := req.Private.GetKey(ctx, scimTokenExpiredAtUserSetKey)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// No marker -> user never set expired_at; leave the plan alone.
+	if len(marker) == 0 {
+		return
+	}
+
+	// UseStateForUnknown ran earlier in the modifier chain and copied state
+	// into the plan; reset to Unknown so the framework sees a real diff and
+	// honors RequiresReplace.
+	resp.PlanValue = types.StringUnknown()
+	resp.RequiresReplace = true
+}
+
+// resourceTFESCIMToken implements the tfe_scim_token resource type
+type resourceTFESCIMToken struct {
+	client *tfe.Client
+}
+
+// modelFromTFEAdminSCIMToken builds a modelTFESCIMToken struct from a tfe.AdminSCIMToken value
+func modelFromTFEAdminSCIMToken(v tfe.AdminSCIMToken) modelTFESCIMToken {
+	m := modelTFESCIMToken{
+		ID:          types.StringValue(v.ID),
+		Description: types.StringValue(v.Description),
+		Token:       types.StringValue(v.Token),
+		ExpiredAt:   timeStringOrNull(v.ExpiredAt),
+		CreatedAt:   timeStringOrNull(v.CreatedAt),
+		LastUsedAt:  timeStringOrNull(v.LastUsedAt),
+	}
+	return m
+}
+
+var (
+	_ resource.Resource                = &resourceTFESCIMToken{}
+	_ resource.ResourceWithConfigure   = &resourceTFESCIMToken{}
+	_ resource.ResourceWithImportState = &resourceTFESCIMToken{}
+)
+
+// NewSCIMTokenResource is a resource function for the framework provider.
+func NewSCIMTokenResource() resource.Resource {
+	return &resourceTFESCIMToken{}
+}
+
+// Metadata implements resource.Resource
+func (r *resourceTFESCIMToken) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scim_token"
+}
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFESCIMToken) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Early exit if provider is not properly configured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client.Client
+}
+
+func (r *resourceTFESCIMToken) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a resource which manages TFE SCIM tokens. These tokens are used for authentication when using the TFE SCIM API.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of the SCIM token.",
+				Computed:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "The description of the SCIM token.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"token": schema.StringAttribute{
+				Description: "The value of the SCIM token. This is only set on creation and cannot be read afterwards for security purposes.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"expired_at": schema.StringAttribute{
+				Description: "The time when the SCIM token expires.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					// Order matters: UseStateForUnknown first (keeps re-applies
+					// no-ops), then the removal check, then RequiresReplace.
+					stringplanmodifier.UseStateForUnknown(),
+					replaceWhenExpiredAtRemoved{},
+					stringplanmodifier.RequiresReplace(),
+					planmodifiers.WarnIfNullOnCreate(
+						"SCIM token expiration defaults to 365 days when unset.",
+					),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Description: "The time when the SCIM token was created.",
+				Computed:    true,
+			},
+			"last_used_at": schema.StringAttribute{
+				Description: "The time when the SCIM token was last used.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+// Read implements resource.Resource
+func (r *resourceTFESCIMToken) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFESCIMToken
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scimTokenID := state.ID.ValueString()
+
+	var scimToken *tfe.AdminSCIMToken
+	var err error
+
+	tflog.Debug(ctx, "Reading SCIM Token")
+	scimToken, err = r.client.Admin.Settings.SCIM.Tokens.Read(ctx, scimTokenID)
+
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Token ID %s, no longer exists", scimTokenID))
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error reading SCIM Token of ID %s", scimTokenID), "Could not read SCIM Token, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	result := modelTFESCIMToken{
+		ID:          types.StringValue(scimToken.ID),
+		Description: types.StringValue(scimToken.Description),
+		Token:       state.Token, // Token is only returned at creation; preserve existing state value
+		ExpiredAt:   timeStringOrNull(scimToken.ExpiredAt),
+		CreatedAt:   timeStringOrNull(scimToken.CreatedAt),
+		LastUsedAt:  timeStringOrNull(scimToken.LastUsedAt),
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
+}
+
+func (r *resourceTFESCIMToken) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTFESCIMToken
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Creating SCIM Token")
+
+	expiredAt := plan.ExpiredAt.ValueString()
+	options := tfe.AdminSCIMTokenCreateOptions{
+		Description: plan.Description.ValueStringPointer(),
+	}
+
+	if !plan.ExpiredAt.IsNull() && expiredAt != "" {
+		expiry, err := time.Parse(time.RFC3339, expiredAt)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("%s must be a valid date or time, provided in iso8601 format", expiredAt),
+				err.Error(),
+			)
+			return
+		}
+		options.ExpiredAt = &expiry
+	}
+
+	scimToken, err := r.client.Admin.Settings.SCIM.Tokens.CreateWithOptions(ctx, options)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating new SCIM token",
+			err.Error(),
+		)
+		return
+	}
+
+	result := modelFromTFEAdminSCIMToken(*scimToken)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+
+	// Track whether the user set expired_at so the plan modifier can detect
+	// a later removal. Empty bytes clear the key; "1" is an arbitrary
+	// non-empty sentinel (the modifier only checks for length > 0).
+	marker := []byte("")
+	if !plan.ExpiredAt.IsNull() && plan.ExpiredAt.ValueString() != "" {
+		marker = []byte("1")
+	}
+	resp.Diagnostics.Append(resp.Private.SetKey(ctx, scimTokenExpiredAtUserSetKey, marker)...)
+}
+
+func (r *resourceTFESCIMToken) Update(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// This should never be called, based on the schema
+	resp.Diagnostics.AddError("Update not supported.", "Please recreate the resource")
+}
+
+func (r *resourceTFESCIMToken) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFESCIMToken
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scimTokenID := state.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Deleting SCIM Token with ID %s", scimTokenID))
+	err := r.client.Admin.Settings.SCIM.Tokens.Delete(ctx, scimTokenID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error deleting SCIM Token with ID %s", scimTokenID),
+			"Could not delete SCIM Token, unexpected error: "+err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceTFESCIMToken) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if !isTokenID(req.ID) {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier to be a SCIM token ID, got: %s. Please use the format `terraform import tfe_scim_token.<name> <token_id>`.", req.ID),
+		)
+		return
+	}
+
+	scimTokenID := req.ID
+	scimToken, err := r.client.Admin.Settings.SCIM.Tokens.Read(ctx, scimTokenID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error reading SCIM Token with ID %s", scimTokenID),
+			"Could not read SCIM Token, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	// Token is only returned at creation time and is not available via the read endpoint.
+	result := modelTFESCIMToken{
+		ID:          types.StringValue(scimToken.ID),
+		Description: types.StringValue(scimToken.Description),
+		Token:       types.StringNull(),
+		ExpiredAt:   timeStringOrNull(scimToken.ExpiredAt),
+		CreatedAt:   timeStringOrNull(scimToken.CreatedAt),
+		LastUsedAt:  timeStringOrNull(scimToken.LastUsedAt),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}

--- a/internal/provider/resource_tfe_scim_token.go
+++ b/internal/provider/resource_tfe_scim_token.go
@@ -290,6 +290,9 @@ func (r *resourceTFESCIMToken) Delete(ctx context.Context, req resource.DeleteRe
 	tflog.Debug(ctx, fmt.Sprintf("Deleting SCIM Token with ID %s", scimTokenID))
 	err := r.client.Admin.Settings.SCIM.Tokens.Delete(ctx, scimTokenID)
 	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error deleting SCIM Token with ID %s", scimTokenID),
 			"Could not delete SCIM Token, unexpected error: "+err.Error(),

--- a/internal/provider/resource_tfe_scim_token_test.go
+++ b/internal/provider/resource_tfe_scim_token_test.go
@@ -1,0 +1,439 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestAccTFESCIMToken_omnibus is the single test function for all SCIM token
+// acceptance tests.
+//
+// FLAKE ALERT: SCIM settings are a singleton resource shared by the entire TFE
+// instance. Every sub-test here enables SCIM (via an inline tfe_scim_settings
+// block) as a prerequisite. Running all cases inside one function — without
+// calling t.Parallel in any sub-test — prevents concurrent tests from racing
+// over the same singleton state.
+//
+// FLAKE ALERT (dual-singleton): This suite also contends with
+// resource_tfe_saml_settings_test.go for the SAML singleton. Both singletons
+// must be treated as exclusive resources: do not run SCIM and SAML acceptance
+// tests concurrently.
+//
+// Should this test name ever change, you will also need to update the regex in ci.yml.
+func TestAccTFESCIMToken_omnibus(t *testing.T) {
+	skipIfCloud(t)
+
+	t.Run("basic create read delete", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-" + randomString(t)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESCIMToken_basic(description),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "id"),
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "description", description),
+						// token is only returned on create
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "token"),
+						// expired_at defaults to 365 days when not set
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "expired_at"),
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "created_at"),
+					),
+				},
+				// Re-apply must be a no-op.
+				{
+					Config:   testAccTFESCIMToken_basic(description),
+					PlanOnly: true,
+				},
+			},
+		})
+	})
+
+	t.Run("explicit expired_at is preserved across reads", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-exp-" + randomString(t)
+		// stay under the API's 365-day max
+		expiredAt := time.Now().UTC().Add(364 * 24 * time.Hour).Truncate(time.Second).Format(time.RFC3339)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESCIMToken_withExpiredAt(description, expiredAt),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "id"),
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "description", description),
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "token"),
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "expired_at", expiredAt),
+					),
+				},
+				// no perpetual diff
+				{
+					Config:   testAccTFESCIMToken_withExpiredAt(description, expiredAt),
+					PlanOnly: true,
+				},
+			},
+		})
+	})
+
+	t.Run("description change triggers resource replacement", func(t *testing.T) {
+		descriptionA := "tf-acc-test-scim-token-a-" + randomString(t)
+		descriptionB := "tf-acc-test-scim-token-b-" + randomString(t)
+
+		var firstTokenID string
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESCIMToken_basic(descriptionA),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "description", descriptionA),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_scim_token.test"]
+							if !ok {
+								return fmt.Errorf("tfe_scim_token.test not found in state")
+							}
+							firstTokenID = rs.Primary.ID
+							return nil
+						},
+					),
+				},
+				// description change => RequiresReplace, ID must change
+				{
+					Config: testAccTFESCIMToken_basic(descriptionB),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "description", descriptionB),
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "token"),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_scim_token.test"]
+							if !ok {
+								return fmt.Errorf("tfe_scim_token.test not found in state")
+							}
+							if rs.Primary.ID == firstTokenID {
+								return fmt.Errorf("expected resource ID to change after description update (RequiresReplace), but it remained %s", firstTokenID)
+							}
+							return nil
+						},
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("import sets token to null", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-import-" + randomString(t)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				// Create a token to import.
+				{
+					Config: testAccTFESCIMToken_basic(description),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "token"),
+					),
+				},
+				// Import by ID. The Read endpoint never returns the token value, so
+				// ignore it; everything else should round-trip.
+				{
+					ResourceName:            "tfe_scim_token.test",
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"token"},
+				},
+				// token is null post-import; confirm no perpetual diff
+				{
+					Config:   testAccTFESCIMToken_basic(description),
+					PlanOnly: true,
+				},
+			},
+		})
+	})
+
+	t.Run("import with invalid id is rejected", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-badimp-" + randomString(t)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESCIMToken_basic(description),
+				},
+				// IDs must start with "at-"
+				{
+					ResourceName:  "tfe_scim_token.test",
+					ImportState:   true,
+					ImportStateId: "not-a-valid-token-id",
+					ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
+				},
+			},
+		})
+	})
+
+	t.Run("missing description is rejected at validate time", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccTFESCIMToken_missingDescription(),
+					ExpectError: regexp.MustCompile(`(?s)"description" is required|Missing required argument`),
+					PlanOnly:    true,
+				},
+			},
+		})
+	})
+
+	t.Run("invalid expired_at is rejected at create time", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-badexp-" + randomString(t)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccTFESCIMToken_withExpiredAt(description, "not-a-timestamp"),
+					ExpectError: regexp.MustCompile(`must be a valid date or time`),
+				},
+			},
+		})
+	})
+
+	t.Run("expired_at change triggers resource replacement", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-reexp-" + randomString(t)
+		expiredAtA := time.Now().UTC().Add(30 * 24 * time.Hour).Truncate(time.Second).Format(time.RFC3339)
+		expiredAtB := time.Now().UTC().Add(60 * 24 * time.Hour).Truncate(time.Second).Format(time.RFC3339)
+
+		var firstTokenID string
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				// 30-day token
+				{
+					Config: testAccTFESCIMToken_withExpiredAt(description, expiredAtA),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "expired_at", expiredAtA),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_scim_token.test"]
+							if !ok {
+								return fmt.Errorf("tfe_scim_token.test not found in state")
+							}
+							firstTokenID = rs.Primary.ID
+							return nil
+						},
+					),
+				},
+				// bump to 60 days => RequiresReplace, ID must change
+				{
+					Config: testAccTFESCIMToken_withExpiredAt(description, expiredAtB),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "expired_at", expiredAtB),
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "token"),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_scim_token.test"]
+							if !ok {
+								return fmt.Errorf("tfe_scim_token.test not found in state")
+							}
+							if rs.Primary.ID == firstTokenID {
+								return fmt.Errorf("expected resource ID to change after expired_at update (RequiresReplace), but it remained %s", firstTokenID)
+							}
+							return nil
+						},
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("removing expired_at triggers resource replacement", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-rmexp-" + randomString(t)
+		expiredAt := time.Now().UTC().Add(30 * 24 * time.Hour).Truncate(time.Second).Format(time.RFC3339)
+
+		var firstTokenID string
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				// Create with explicit expiry; Create writes a private-state marker.
+				{
+					Config: testAccTFESCIMToken_withExpiredAt(description, expiredAt),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "expired_at", expiredAt),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_scim_token.test"]
+							if !ok {
+								return fmt.Errorf("tfe_scim_token.test not found in state")
+							}
+							firstTokenID = rs.Primary.ID
+							return nil
+						},
+					),
+				},
+				// Drop expired_at: marker + null config => replace.
+				{
+					Config: testAccTFESCIMToken_basic(description),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "expired_at"),
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "token"),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_scim_token.test"]
+							if !ok {
+								return fmt.Errorf("tfe_scim_token.test not found in state")
+							}
+							if rs.Primary.ID == firstTokenID {
+								return fmt.Errorf("expected resource ID to change after removing expired_at (RequiresReplace), but it remained %s", firstTokenID)
+							}
+							return nil
+						},
+					),
+				},
+				// Marker is cleared after the replacement; re-apply must be a no-op.
+				{
+					Config:   testAccTFESCIMToken_basic(description),
+					PlanOnly: true,
+				},
+			},
+		})
+	})
+
+	t.Run("token deleted out-of-band is detected and re-created", func(t *testing.T) {
+		description := "tf-acc-test-scim-token-drift-" + randomString(t)
+
+		var tokenID string
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMTokenDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccTFESCIMToken_basic(description),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "id"),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_scim_token.test"]
+							if !ok {
+								return fmt.Errorf("tfe_scim_token.test not found in state")
+							}
+							tokenID = rs.Primary.ID
+							return nil
+						},
+					),
+				},
+				// Delete out-of-band: Read returns 404, state is cleared, then Create re-establishes.
+				{
+					PreConfig: func() {
+						err := testAccConfiguredClient.Client.Admin.Settings.SCIM.Tokens.Delete(ctx, tokenID)
+						if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
+							t.Fatalf("delete SCIM token out-of-band: %v", err)
+						}
+					},
+					Config: testAccTFESCIMToken_basic(description),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "id"),
+						resource.TestCheckResourceAttr("tfe_scim_token.test", "description", description),
+						resource.TestCheckResourceAttrSet("tfe_scim_token.test", "token"),
+					),
+				},
+			},
+		})
+	})
+}
+
+// testAccTFESCIMTokenDestroy verifies all tfe_scim_token resources have been
+// removed from the backend.
+func testAccTFESCIMTokenDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_scim_token" {
+			continue
+		}
+
+		_, err := testAccConfiguredClient.Client.Admin.Settings.SCIM.Tokens.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("SCIM token %s still exists", rs.Primary.ID)
+		}
+		if !errors.Is(err, tfe.ErrResourceNotFound) {
+			return fmt.Errorf("unexpected error checking SCIM token %s: %w", rs.Primary.ID, err)
+		}
+	}
+	return nil
+}
+
+// testAccTFESCIMToken_basic returns a config with SAML + SCIM enabled and a
+// tfe_scim_token using only the required description.
+func testAccTFESCIMToken_basic(description string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "tfe_scim_settings" "enable_scim" {
+    depends_on = [tfe_saml_settings.enable_saml]
+}
+
+resource "tfe_scim_token" "test" {
+	description = "%s"
+	depends_on  = [tfe_scim_settings.enable_scim]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting), description)
+}
+
+// testAccTFESCIMToken_withExpiredAt returns a config with an explicit
+// expiration timestamp.
+func testAccTFESCIMToken_withExpiredAt(description, expiredAt string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "tfe_scim_settings" "enable_scim" {
+    depends_on = [tfe_saml_settings.enable_saml]
+}
+
+resource "tfe_scim_token" "test" {
+	description = "%s"
+	expired_at  = "%s"
+	depends_on  = [tfe_scim_settings.enable_scim]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting), description, expiredAt)
+}
+
+// testAccTFESCIMToken_missingDescription returns a config that omits the
+// required description attribute, so the framework should reject it at
+// validate/plan time.
+func testAccTFESCIMToken_missingDescription() string {
+	return fmt.Sprintf(`
+%s
+
+resource "tfe_scim_settings" "enable_scim" {
+    depends_on = [tfe_saml_settings.enable_saml]
+}
+
+resource "tfe_scim_token" "test" {
+	depends_on = [tfe_scim_settings.enable_scim]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting))
+}

--- a/website/docs/d/scim_token.html.markdown
+++ b/website/docs/d/scim_token.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_scim_token"
+description: |-
+  Get information on a SCIM authentication token.
+---
+
+# Data Source: tfe_scim_token
+
+Use this data source to get information about a SCIM authentication token by its ID. It applies only to Terraform Enterprise and requires admin token configuration. See example usage for incorporating an admin token in your provider config.
+
+The token value itself is never returned by the read endpoint; only metadata about the token is available.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+provider "tfe" {
+  hostname = var.hostname
+  token    = var.token
+}
+
+provider "tfe" {
+  alias    = "admin"
+  hostname = var.hostname
+  token    = var.admin_token
+}
+
+data "tfe_scim_token" "foo" {
+  provider = tfe.admin
+  id       = "at-XXXXXXXXXXXXXXXX"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) The ID of the SCIM token. Starts with `at-`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `description` - The description of the SCIM token.
+* `expired_at` - The time when the SCIM token expires.
+* `created_at` - The time when the SCIM token was created.
+* `last_used_at` - The time when the SCIM token was last used.

--- a/website/docs/r/scim_token.html.markdown
+++ b/website/docs/r/scim_token.html.markdown
@@ -46,12 +46,16 @@ resource "tfe_scim_token" "this" {
 
 ### With an explicit expiration
 
-`expired_at` accepts an RFC3339 timestamp and must be no more than 365 days in the future:
+`expired_at` accepts an RFC3339 timestamp and must be no more than 365 days in the future. You can use `time_rotating` to generate this dynamically:
 
 ```hcl
+resource "time_rotating" "example" {
+  rotation_days = 30
+}
+
 resource "tfe_scim_token" "this" {
   description = "scim-token-30-day"
-  expired_at  = "2026-12-31T23:59:59Z"
+  expired_at  = time_rotating.example.rotation_rfc3339
   depends_on  = [tfe_scim_settings.this]
 }
 ```

--- a/website/docs/r/scim_token.html.markdown
+++ b/website/docs/r/scim_token.html.markdown
@@ -46,7 +46,7 @@ resource "tfe_scim_token" "this" {
 
 ### With an explicit expiration
 
-`expired_at` accepts an RFC3339 timestamp and must be no more than 365 days in the future. You can use `time_rotating` to generate this dynamically:
+`expired_at` accepts an RFC3339/iso8601 timestamp and must be no more than 365 days in the future. You can use `time_rotating` to generate this dynamically:
 
 ```hcl
 resource "time_rotating" "example" {
@@ -65,7 +65,7 @@ resource "tfe_scim_token" "this" {
 The following arguments are supported:
 
 * `description` - (Required) A human-readable description of the SCIM token. Changing this forces the resource to be replaced.
-* `expired_at` - (Optional) The time when the SCIM token expires, in RFC3339 format. Defaults to 365 days from creation if unset. Changing this — or removing it after it has been set — forces the resource to be replaced.
+* `expired_at` - (Optional) The time when the SCIM token expires, in RFC3339/iso8601 format. Defaults to 365 days from creation if unset. Changing this — or removing it after it has been set — forces the resource to be replaced.
 
 ## Attributes Reference
 

--- a/website/docs/r/scim_token.html.markdown
+++ b/website/docs/r/scim_token.html.markdown
@@ -1,0 +1,81 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_scim_token"
+description: |-
+  Manages SCIM authentication tokens.
+---
+
+# tfe_scim_token
+
+Use this resource to create and manage SCIM authentication tokens. It applies only to Terraform Enterprise and requires admin token configuration. See example usage for incorporating an admin token in your provider config.
+
+SCIM must be enabled before a token can be created. SCIM in turn requires SAML, so the examples below depend on both a `tfe_saml_settings` and a `tfe_scim_settings` resource.
+
+The token value is only returned when the token is first created and cannot be read afterwards. Treat the `token` attribute as a sensitive secret and store it accordingly (for example, in a secrets manager).
+
+~> **Note:** Changing `description` or `expired_at` (including removing `expired_at` after it has been set) will force the resource to be replaced, which generates a new token value and invalidates the previous one.
+
+## Example Usage
+
+### Basic usage
+
+Create a SCIM token with the default expiration (365 days):
+
+```hcl
+provider "tfe" {
+  hostname = var.hostname
+  token    = var.admin_token
+}
+
+resource "tfe_saml_settings" "this" {
+  idp_cert         = "foobarCertificate"
+  slo_endpoint_url = "https://example.com/slo_endpoint_url"
+  sso_endpoint_url = "https://example.com/sso_endpoint_url"
+  provider_type    = "okta"
+}
+
+resource "tfe_scim_settings" "this" {
+  depends_on = [tfe_saml_settings.this]
+}
+
+resource "tfe_scim_token" "this" {
+  description = "scim-token-for-okta"
+  depends_on  = [tfe_scim_settings.this]
+}
+```
+
+### With an explicit expiration
+
+`expired_at` accepts an RFC3339 timestamp and must be no more than 365 days in the future:
+
+```hcl
+resource "tfe_scim_token" "this" {
+  description = "scim-token-30-day"
+  expired_at  = "2026-12-31T23:59:59Z"
+  depends_on  = [tfe_scim_settings.this]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Required) A human-readable description of the SCIM token. Changing this forces the resource to be replaced.
+* `expired_at` - (Optional) The time when the SCIM token expires, in RFC3339 format. Defaults to 365 days from creation if unset. Changing this — or removing it after it has been set — forces the resource to be replaced.
+
+## Attributes Reference
+
+* `id` - The ID of the SCIM token.
+* `token` - The SCIM token value. Only set immediately after creation; this attribute is `null` after an import and cannot be read back from the API afterwards.
+* `created_at` - The time when the SCIM token was created.
+* `last_used_at` - The time when the SCIM token was last used.
+
+## Import
+
+SCIM tokens can be imported by their token ID.
+
+```shell
+terraform import tfe_scim_token.this at-XXXXXXXXXXXXXXXX
+```
+
+The `token` attribute is only returned when the token is first created, so it will be `null` after import.


### PR DESCRIPTION
## Description

This PR Adds `r/tfe_scim_token` and `d/tfe_scim_token` to manage SCIM tokens on Terraform Enterprise. The token value is only returned at creation and cannot be read back. Changing `description` or `expired_at` (including removing it after being set) forces replacement.

Since SCIM tokens share the SCIM settings singleton, all acceptance tests are grouped into a single omnibus test to avoid race conditions.

Additionally, this PR introduces a `skip` input in `.github/actions/test-provider-tfe/action.yml` to allow skipping multiple test cases. The current `list_tests` regex works for single tests, but when multiple tests are included, some required tests may be unintentionally skipped. SCIM-related tests are skipped, as they depend on SCIM being enabled via the singleton SCIM settings, which can otherwise lead to flakiness.

Also updated the `.github/workflows/nightly-tfe-test.yml` file to skip SAML and SCIM tests in the nightly CI for TFE and added a new job `singleton-tests` to ensure that SAML and SCIM tests run sequentially within a single job. This prevents race conditions that could cause tests to fail if SAML and SCIM are executed concurrently.


_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Spin up a TFE instance with SAML + SCIM enabled and run acceptance tests against it.

## External links

[JIRA](https://hashicorp.atlassian.net/browse/TF-35680)
[RFC](https://hermes-sharepoint.hashicorp.services/document/01XOO7K4IWFH44KZAPDJC3QXNKIRWEZMBA)

## Output from acceptance tests

1.  [`Nightly TFE Tests #1166`](https://github.com/hashicorp/terraform-provider-tfe/actions/runs/26439869082) - 🟢 
    <img width="1637" height="647" alt="image" src="https://github.com/user-attachments/assets/2e2eb7f8-2997-449c-a953-06b1709614ad" />


2. `TESTARGS="-run TestAccTFESCIMToken" ENABLE_TFE=1 envchain scim make testacc`
    <img width="964" height="645" alt="image" src="https://github.com/user-attachments/assets/f2a075fb-0ba3-4c47-b33d-088cf39b3890" />


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

we can revert this pr

## Changes to Security Controls

NA
