### PR TITLE
Add `provider_set` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * **New Resource:** `r/tfe_scim_token` and **New Data Source:** `d/tfe_scim_token`: Adds resource and data source to manage SCIM tokens on Terraform Enterprise. By @skj-skj [#2076](https://github.com/hashicorp/terraform-provider-tfe/pull/2076)
 * **New Resource:** `r/tfe_admin_smtp_settings` and **New Data Source:** `d/tfe_admin_smtp_settings`: Adds resource and data source to manage Admin SMTP settings in Terraform Enterprise by @chpag [#2059](https://github.com/hashicorp/terraform-provider-tfe/pull/2059)
 * **New Data Source:** `d/tfe_scim_group`: Adds a data source to retrieve a SCIM group from Terraform Enterprise. By @skj-skj [#2083](https://github.com/hashicorp/terraform-provider-tfe/pull/2083)
+* **New Resource:** `r/tfe_provider_set` for managing shared provider configurations for internal testing. NOTE: This resource is subject to change and has limited support in HCP Terraform. By @mogrogan [#2086](https://github.com/hashicorp/terraform-provider-tfe/pull/2086)
 
 ENHANCEMENTS:
 * `r/tfe_no_code_module`: Allow `variable_options.options` to be empty or omitted [#2074](https://github.com/hashicorp/terraform-provider-tfe/pull/2074)

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -180,6 +180,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewOrganizationRunTaskResource,
 		NewPolicySetParameterResource,
 		NewProjectResource,
+		NewProviderSetResource,
 		NewRegistryGPGKeyResource,
 		NewRegistryProviderResource,
 		NewResourceVariable,

--- a/internal/provider/resource_tfe_project.go
+++ b/internal/provider/resource_tfe_project.go
@@ -40,6 +40,8 @@ type resourceTFEProject struct {
 	config ConfiguredClient
 }
 
+var projectIDRegexp = regexp.MustCompile("^prj-[a-zA-Z0-9]{16}$")
+
 // modelTFEProject maps the resource schema data to a struct.
 type modelTFEProject struct {
 	ID                          types.String `tfsdk:"id"`

--- a/internal/provider/resource_tfe_provider_set.go
+++ b/internal/provider/resource_tfe_provider_set.go
@@ -1,0 +1,531 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	_ resource.Resource               = &resourceTFEProviderSet{}
+	_ resource.ResourceWithConfigure  = &resourceTFEProviderSet{}
+	_ resource.ResourceWithModifyPlan = &resourceTFEProviderSet{}
+)
+
+func NewProviderSetResource() resource.Resource {
+	return &resourceTFEProviderSet{}
+}
+
+type resourceTFEProviderSet struct {
+	config ConfiguredClient
+}
+
+type modelTFEProviderSet struct {
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Description    types.String `tfsdk:"description"`
+	Global         types.Bool   `tfsdk:"global"`
+	Organization   types.String `tfsdk:"organization"`
+	WorkspaceIDs   types.Set    `tfsdk:"workspace_ids"`
+	ProjectIDs     types.Set    `tfsdk:"project_ids"`
+	ProviderSource types.String `tfsdk:"provider_source"`
+	// ProviderConfigHCL is the normal Terraform-managed mode and is persisted in state.
+	ProviderConfigHCL types.String `tfsdk:"provider_config_hcl"`
+	// ProviderConfigHCLWO is the write-only mode for HCL that should not be retained in state.
+	ProviderConfigHCLWO types.String `tfsdk:"provider_config_hcl_wo"`
+	// ProviderConfigHCLWOVersion is the explicit update trigger for write-only HCL.
+	ProviderConfigHCLWOVersion types.Int64 `tfsdk:"provider_config_hcl_wo_version"`
+}
+
+// collectionLengthOptions returns the options for determining the length of
+// collections in the model, treating null and unknown as zero to simplify
+// validation logic.
+func (r modelTFEProviderSet) collectionLengthOptions() basetypes.CollectionLengthOptions {
+	return basetypes.CollectionLengthOptions{
+		UnhandledNullAsZero:    true,
+		UnhandledUnknownAsZero: true,
+	}
+}
+
+// Metadata returns the terraform resource type name.
+func (r *resourceTFEProviderSet) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_provider_set"
+}
+
+// Schema defines the schema for the resource.
+func (r *resourceTFEProviderSet) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages provider sets.",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Description: "The name of the provider set.",
+				Required:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "The ID of the provider set.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"description": schema.StringAttribute{
+				Description: "The description of the provider set.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
+			},
+			"global": schema.BoolAttribute{
+				Description: "Whether the provider set applies globally.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"workspace_ids": schema.SetAttribute{
+				Description: "The workspace IDs attached to the provider set.",
+				ElementType: types.StringType,
+				Optional:    true,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(
+						stringvalidator.RegexMatches(
+							workspaceIDRegexp,
+							"must be a valid workspace ID (ws-<RANDOM STRING>)",
+						),
+					),
+				},
+			},
+			"project_ids": schema.SetAttribute{
+				Description: "The project IDs attached to the provider set.",
+				ElementType: types.StringType,
+				Optional:    true,
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(
+						stringvalidator.RegexMatches(
+							projectIDRegexp,
+							"must be a valid project ID (prj-<RANDOM STRING>)",
+						),
+					),
+				},
+			},
+			"provider_source": schema.StringAttribute{
+				Description: "Source address of the provider, e.g. registry.terraform.io/hashicorp/tfe.",
+				Required:    true,
+				CustomType:  types.StringType,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$`),
+						"must be in the format 'hostname/namespace/type', e.g. 'registry.terraform.io/hashicorp/tfe'",
+					),
+				},
+			},
+			"provider_config_hcl": schema.StringAttribute{
+				Description: "The provider configuration managed by the provider set, expressed as a single HCL provider block",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					// The normal and write-only modes are mutually exclusive because they map to the same backend blob.
+					stringvalidator.ConflictsWith(path.MatchRoot("provider_config_hcl_wo")),
+					stringvalidator.AtLeastOneOf(
+						path.MatchRoot("provider_config_hcl"),
+						path.MatchRoot("provider_config_hcl_wo"),
+					),
+				},
+			},
+			"provider_config_hcl_wo": schema.StringAttribute{
+				Description: "The provider configuration managed by the provider set, expressed as a single HCL provider block in write-only mode.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("provider_config_hcl")),
+					// Write-only values are not stored in state, so a separate version field is required to trigger updates.
+					stringvalidator.AlsoRequires(path.MatchRoot("provider_config_hcl_wo_version")),
+				},
+			},
+			"provider_config_hcl_wo_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Version of the write-only provider configuration to trigger updates.",
+				Validators: []validator.Int64{
+					int64validator.ConflictsWith(path.MatchRoot("provider_config_hcl")),
+					int64validator.AlsoRequires(path.MatchRoot("provider_config_hcl_wo")),
+				},
+			},
+		},
+	}
+}
+
+// modelFromTFEProviderSet builds a modelFromTFEProviderSet struct from a tfe.ProviderSet
+func modelFromTFEProviderSet(
+	ctx context.Context,
+	v tfe.ProviderSet,
+	providerConfigHCLWOVersion types.Int64,
+) (m modelTFEProviderSet, diags diag.Diagnostics) {
+	// Initialize all fields from the provided API struct
+	m = modelTFEProviderSet{
+		ID:             types.StringValue(v.ID),
+		Name:           types.StringValue(v.Name),
+		Description:    types.StringValue(v.Description),
+		Global:         types.BoolValue(v.Global),
+		Organization:   types.StringValue(v.Organization.Name),
+		ProviderSource: types.StringValue(v.ProviderSource),
+		ProjectIDs:     types.SetNull(types.StringType),
+		WorkspaceIDs:   types.SetNull(types.StringType),
+	}
+
+	if !providerConfigHCLWOVersion.IsNull() {
+		m.ProviderConfigHCL = types.StringNull()
+		m.ProviderConfigHCLWOVersion = providerConfigHCLWOVersion
+	} else {
+		m.ProviderConfigHCL = types.StringValue(v.ConfigurationHcl)
+		m.ProviderConfigHCLWOVersion = types.Int64Null()
+	}
+
+	projectIDs := make([]string, len(v.Projects))
+	for i, project := range v.Projects {
+		projectIDs[i] = project.ID
+	}
+
+	var d diag.Diagnostics
+
+	if len(projectIDs) > 0 {
+		m.ProjectIDs, d = types.SetValueFrom(ctx, types.StringType, projectIDs)
+		diags.Append(d...)
+	}
+
+	workspaceIDs := make([]string, len(v.Workspaces))
+	for i, workspace := range v.Workspaces {
+		workspaceIDs[i] = workspace.ID
+	}
+	if len(workspaceIDs) > 0 {
+		m.WorkspaceIDs, d = types.SetValueFrom(ctx, types.StringType, workspaceIDs)
+		diags.Append(d...)
+	}
+	return m, diags
+}
+
+// ModifyPlan is used to enforce that when global is updated from false to
+// true, workspace_ids and project_ids must be empty, since global provider
+// sets cannot have workspaces or projects attached. This is necessary
+// because the API will automatically detach all workspaces and projects when
+// a provider set is updated to global, which would be unexpected and
+// potentially destructive behavior for users if it were allowed to happen
+// implicitly.
+func (r *resourceTFEProviderSet) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	modifyPlanForDefaultOrganizationChange(
+		ctx,
+		r.config.Organization,
+		req.State,
+		req.Config,
+		req.Plan,
+		resp,
+	)
+
+	var plan modelTFEProviderSet
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Global.ValueBool() {
+		return
+	}
+
+	// Validate workspace_ids is not set
+	if plan.WorkspaceIDs.Length(plan.collectionLengthOptions()) > 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("workspace_ids"),
+			"Invalid Attribute Combination",
+			"workspace_ids cannot be set when global is true",
+		)
+	}
+	// Validate project_ids is not set
+	if plan.ProjectIDs.Length(plan.collectionLengthOptions()) > 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("project_ids"),
+			"Invalid Attribute Combination",
+			"project_ids cannot be set when global is true",
+		)
+	}
+}
+
+// Configure is used to provide the resource with the configured API client
+// from the provider.
+func (r *resourceTFEProviderSet) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = client
+}
+
+// tfeWorkspacesFromModel converts the workspace IDs in the model to a slice of
+// tfe.Workspace pointers for API calls.
+func tfeWorkspacesFromModel(m modelTFEProviderSet) []*tfe.Workspace {
+	if m.WorkspaceIDs.IsNull() || m.WorkspaceIDs.IsUnknown() {
+		return []*tfe.Workspace{}
+	}
+	workspaces := make([]*tfe.Workspace, m.WorkspaceIDs.Length(m.collectionLengthOptions()))
+
+	for i, v := range m.WorkspaceIDs.Elements() {
+		workspaces[i] = &tfe.Workspace{ID: v.(types.String).ValueString()}
+	}
+	return workspaces
+}
+
+// tfeProjectsFromModel converts the project IDs in the model to a slice of
+// tfe.Project pointers for API calls.
+func tfeProjectsFromModel(m modelTFEProviderSet) []*tfe.Project {
+	if m.ProjectIDs.IsNull() || m.ProjectIDs.IsUnknown() {
+		return []*tfe.Project{}
+	}
+	projects := make([]*tfe.Project, m.ProjectIDs.Length(m.collectionLengthOptions()))
+
+	for i, v := range m.ProjectIDs.Elements() {
+		projects[i] = &tfe.Project{ID: v.(types.String).ValueString()}
+	}
+	return projects
+}
+
+// Create handles the creation of the resource by making an API call to create a
+// provider set with the specified configuration, and then storing the
+// resulting state. It also handles the logic for the write-only HCL field,
+// ensuring that if it is set, its value is used for the API call instead of
+// the normal HCL field.
+func (r *resourceTFEProviderSet) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTFEProviderSet
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config modelTFEProviderSet
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the organization name from resource or provider config
+	var orgName string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Config, &orgName)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	options := tfe.ProviderSetCreateOptions{
+		Name:             plan.Name.ValueString(),
+		Description:      plan.Description.ValueStringPointer(),
+		ProviderSource:   plan.ProviderSource.ValueString(),
+		Global:           plan.Global.ValueBoolPointer(),
+		Workspaces:       tfeWorkspacesFromModel(plan),
+		Projects:         tfeProjectsFromModel(plan),
+		ConfigurationHcl: plan.ProviderConfigHCL.ValueString(),
+	}
+
+	if !config.ProviderConfigHCLWO.IsNull() {
+		tflog.Debug(
+			ctx,
+			fmt.Sprintf(
+				"Using write-only HCL value for provider set %s",
+				plan.Name.ValueString(),
+			),
+		)
+		options.ConfigurationHcl = config.ProviderConfigHCLWO.ValueString()
+	}
+
+	tflog.Debug(ctx,
+		fmt.Sprintf(
+			"Creating provider set with name: %s, organization: %s",
+			options.Name,
+			orgName,
+		))
+	ps, err := r.config.Client.ProviderSets.Create(ctx, orgName, options)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating provider set",
+			fmt.Sprintf("Couldn't create provider set %s: %s", options.Name, err.Error()),
+		)
+		return
+	}
+
+	result, diags := modelFromTFEProviderSet(ctx, *ps, config.ProviderConfigHCLWOVersion)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// Read handles reading the resource state by making an API call to retrieve the
+// current configuration of the provider set, and then updating the state with
+// the retrieved information. If the provider set no longer exists, it removes
+// the resource from state without error.
+func (r *resourceTFEProviderSet) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFEProviderSet
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	providerSetID := state.ID.ValueString()
+	ps, err := r.config.Client.ProviderSets.Read(ctx, providerSetID)
+	if err != nil {
+		// If it's gone: that's not an error, but we are done.
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(
+				ctx, fmt.Sprintf(
+					"Provider Set %s no longer exists", providerSetID,
+				),
+			)
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError(
+				"Error reading Provider set",
+				fmt.Sprintf("Couldn't read provider set %s: %s", providerSetID, err.Error()),
+			)
+		}
+
+		return
+	}
+
+	// update state
+	result, diags := modelFromTFEProviderSet(ctx, *ps, state.ProviderConfigHCLWOVersion)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// Update handles updating the resource by making an API call to update the
+// provider set with the new configuration specified in the plan, and then
+// updating the state with the resulting configuration. It also handles the
+// logic for the write-only HCL field, ensuring that if it is set in the plan,
+// its value is used for the API call instead of the normal HCL field, and that
+// the version is updated to trigger the update.
+func (r *resourceTFEProviderSet) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan modelTFEProviderSet
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config modelTFEProviderSet
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the organization name from resource or provider config
+	var orgName string
+	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Config, &orgName)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	options := tfe.ProviderSetUpdateOptions{
+		Name:             plan.Name.ValueStringPointer(),
+		Description:      plan.Description.ValueStringPointer(),
+		ProviderSource:   plan.ProviderSource.ValueStringPointer(),
+		Global:           plan.Global.ValueBoolPointer(),
+		Workspaces:       tfeWorkspacesFromModel(plan),
+		Projects:         tfeProjectsFromModel(plan),
+		ConfigurationHcl: plan.ProviderConfigHCL.ValueStringPointer(),
+	}
+
+	if !config.ProviderConfigHCLWO.IsNull() {
+		tflog.Debug(
+			ctx,
+			fmt.Sprintf(
+				"Using write-only HCL value for provider set %s",
+				plan.Name.ValueString(),
+			),
+		)
+		options.ConfigurationHcl = config.ProviderConfigHCLWO.ValueStringPointer()
+	}
+
+	tflog.Debug(ctx,
+		fmt.Sprintf(
+			"Updating provider set %s",
+			plan.ID.String(),
+		))
+	ps, err := r.config.Client.ProviderSets.Update(ctx, plan.ID.ValueString(), options)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating provider set",
+			fmt.Sprintf("Couldn't update provider set %s: %s", plan.ID.String(), err.Error()),
+		)
+		return
+	}
+
+	result, diags := modelFromTFEProviderSet(ctx, *ps, config.ProviderConfigHCLWOVersion)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// Delete handles deleting the resource by making an API call to delete the
+// provider set. If the provider set is already gone, it treats that as a
+// success and removes the resource from state without error.
+func (r *resourceTFEProviderSet) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFEProviderSet
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	providerSetID := state.ID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Delete provider set: %s", providerSetID))
+	err := r.config.Client.ProviderSets.Delete(ctx, providerSetID)
+	// Ignore 404s for delete
+	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
+		resp.Diagnostics.AddError(
+			"Error deleting provider set",
+			fmt.Sprintf("Couldn't delete provider set %s: %s", providerSetID, err.Error()),
+		)
+	}
+	// Resource is implicitly deleted from resp.State if diagnostics have no errors.
+}

--- a/internal/provider/resource_tfe_provider_set_test.go
+++ b/internal/provider/resource_tfe_provider_set_test.go
@@ -1,0 +1,909 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccTFEProviderSet_basic(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSet := &tfe.ProviderSet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "name", "tst-terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "description", "Provider Set description",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl", "provider \"aws\" {\n\tregion = \"us-east-1\"\n}\n",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo_version",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "organization", org.Name,
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "project_ids.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids.#", "1",
+					),
+				),
+			},
+			{
+				Config: testAccTFEProviderSet_no_global_no_relationship(org.Name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "name", "tst-terraform-updated",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "description", "Provider Set description updated",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/google",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl", "provider \"google\" {\n\tregion = \"us-central1\"\n}\n",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo_version",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "organization", org.Name,
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "project_ids",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids",
+					),
+				),
+			},
+			{
+				Config: testAccTFEProviderSet_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "name", "tst-terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "description", "Provider Set description",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl", "provider \"aws\" {\n\tregion = \"us-east-1\"\n}\n",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo_version",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "organization", org.Name,
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "project_ids.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids.#", "1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_update_global_with_relationships(
+	t *testing.T,
+) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSet := &tfe.ProviderSet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_basic(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "project_ids.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids.#", "1",
+					),
+				),
+			},
+			{
+				Config: testAccTFEProviderSet_global(org.Name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"tfe_provider_set.foobar",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "true",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "project_ids",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_global(
+	t *testing.T,
+) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSet := &tfe.ProviderSet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_global(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "true",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "project_ids",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_update_to_global_with_no_relationships(
+	t *testing.T,
+) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSet := &tfe.ProviderSet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_no_global_no_relationship(org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "project_ids",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids",
+					),
+				),
+			},
+			{
+				Config: testAccTFEProviderSet_global(org.Name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"tfe_provider_set.foobar",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "true",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "project_ids",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_minimal(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSet := &tfe.ProviderSet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		// when organization is not specified in the config, the provider should use
+		// the default organization from the provider configuration, so we need to mux
+		// the providers to include that default organization
+		ProtoV6ProviderFactories: muxedProvidersWithDefaultOrganization(org.Name),
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_minimal(nil),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "name", "tst-terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "description", "",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl", "provider \"aws\" {\n\tregion = \"us-east-1\"\n}\n",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo_version",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "organization", org.Name,
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "project_ids.#", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids.#", "0",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_update_org_force_recreation(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orgInitial, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	orgUpdate, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSet := &tfe.ProviderSet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_minimal(&orgInitial.Name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+				),
+			},
+			{
+				Config: testAccTFEProviderSet_minimal(&orgUpdate.Name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"tfe_provider_set.foobar",
+							plancheck.ResourceActionDestroyBeforeCreate,
+						),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_wo(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSet := &tfe.ProviderSet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_wo(org.Name, 1, "us-east-1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "name", "tst-terraform",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "description", "",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl",
+					),
+					resource.TestCheckNoResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo_version", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "organization", org.Name,
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "project_ids.#", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "workspace_ids.#", "0",
+					),
+				),
+			},
+			{
+				// by changing the content of hcl_wo without updating the version, we
+				// expect no changes because the provider should ignore changes to
+				// hcl_wo when version is set
+				Config: testAccTFEProviderSet_wo(org.Name, 1, "us-east-2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccTFEProviderSet_wo(org.Name, 2, "us-east-2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_config_hcl_wo_version", "2",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_validation(t *testing.T) {
+	skipUnlessBeta(t)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEProviderSet_conflict("workspace_ids", "ws-1234123412341234"),
+				ExpectError: regexp.MustCompile("workspace_ids cannot be set when global is true"),
+			},
+			{
+				Config:      testAccTFEProviderSet_conflict("project_ids", "prj-1234123412341234"),
+				ExpectError: regexp.MustCompile("project_ids cannot be set when global is true"),
+			},
+			{
+				Config:      testAccTFEProviderSet_conflict("workspace_ids", "ws-123"),
+				ExpectError: regexp.MustCompile("must be a valid workspace ID"),
+			},
+			{
+				Config:      testAccTFEProviderSet_conflict("project_ids", "prj-123"),
+				ExpectError: regexp.MustCompile("must be a valid project ID"),
+			},
+			{
+				Config:      testAccTFEProviderSet_missing_hcl(),
+				ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_provider_source(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSet := &tfe.ProviderSet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_basic_with_provider_source(org.Name, "hashicorp/aws"),
+				ExpectError: regexp.MustCompile(
+					"Attribute provider_source must be in the format 'hostname/namespace/type'",
+				),
+			},
+			{
+				Config: testAccTFEProviderSet_basic_with_provider_source(org.Name, "registry.terraform.io/hashicorp/aws"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
+					resource.TestCheckResourceAttr(
+						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_Read(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	var providerSetID string
+	resourceName := "tfe_provider_set.foobar"
+	providerSetName := "read-test-" + randomString(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_basic_with_name(org.Name, providerSetName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", providerSetName),
+
+					// we capture the provider set ID from the state so that we can use it in
+					// the next steps to make out-of-band API calls
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("not found: %s", resourceName)
+						}
+						providerSetID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			// Step 2: Manually update the name via the API to test synchronization
+			{
+				PreConfig: func() {
+					// We find the ID from the state and update it directly via go-tfe
+					_, err := tfeClient.ProviderSets.Update(context.Background(), providerSetID, tfe.ProviderSetUpdateOptions{
+						Name: tfe.String(providerSetName + "-updated"),
+					})
+					if err != nil {
+						t.Fatalf("error updating provider set out-of-band: %v", err)
+					}
+				},
+				Config: testAccTFEProviderSet_basic_with_name(org.Name, providerSetName),
+				// Terraform should run Read, see the "-updated" name, and then plan to change it back to providerSetName
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Step 3: Manually delete via the API to test out-of-band deletion
+			{
+				PreConfig: func() {
+					err := tfeClient.ProviderSets.Delete(context.Background(), providerSetID)
+					if err != nil {
+						t.Fatalf("error deleting provider set out-of-band: %v", err)
+					}
+				},
+				Config:             testAccTFEProviderSet_basic_with_name(org.Name, providerSetName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true, // Terraform should see it's gone and plan a "Create"
+			},
+		},
+	})
+}
+
+func testAccCheckTFEProviderSetExists(n string, providerSet *tfe.ProviderSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		ps, err := testAccConfiguredClient.Client.ProviderSets.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if ps.ID != rs.Primary.ID {
+			return fmt.Errorf("ProviderSet not found")
+		}
+
+		*providerSet = *ps
+
+		return nil
+	}
+}
+
+func testAccCheckTFEProviderSetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_provider_set" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := testAccConfiguredClient.Client.ProviderSets.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Provider set %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func TestTFEProviderSetNotImportableInPrepStub(t *testing.T) {
+	if _, ok := any(&resourceTFEProviderSet{}).(fwresource.ResourceWithImportState); ok {
+		t.Fatal("expected provider set prep stub to not support import")
+	}
+}
+
+func TestFrameworkProviderResources_includeProviderSet(t *testing.T) {
+	resources := (&frameworkProvider{}).Resources(context.Background())
+
+	found := false
+	for _, constructor := range resources {
+		if _, ok := constructor().(*resourceTFEProviderSet); ok {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatal("expected framework provider resources to include tfe_provider_set")
+	}
+}
+
+func testAccTFEProviderSet_basic(organization string) string {
+	return fmt.Sprintf(`
+locals {
+    organization_name = "%s"
+}
+
+resource "tfe_workspace" "foo" {
+  name         = "workspace-foo"
+  organization = local.organization_name
+}
+
+resource "tfe_project" "foo" {
+  name         = "project-foo"
+  organization = local.organization_name
+}
+
+resource "tfe_provider_set" "foobar" {
+  name                = "tst-terraform"
+  description         = "Provider Set description"
+  organization        = local.organization_name
+	provider_source     = "registry.terraform.io/hashicorp/aws"
+	global              = false
+	provider_config_hcl = <<-EOT
+provider "aws" {
+	region = "us-east-1"
+}
+EOT
+
+  project_ids =   [ tfe_project.foo.id ]
+  workspace_ids = [ tfe_workspace.foo.id ]
+}`, organization)
+}
+
+func testAccTFEProviderSet_global(organization string) string {
+	return fmt.Sprintf(`
+locals {
+    organization_name = "%s"
+}
+
+resource "tfe_provider_set" "foobar" {
+  name                = "tst-terraform"
+  description         = "Provider Set description"
+  organization        = local.organization_name
+	provider_source     = "registry.terraform.io/hashicorp/aws"
+	global              = true
+	provider_config_hcl = <<-EOT
+provider "aws" {
+	region = "us-east-1"
+}
+EOT
+}`, organization)
+}
+
+func testAccTFEProviderSet_no_global_no_relationship(organization string) string {
+	return fmt.Sprintf(`
+locals {
+    organization_name = "%s"
+}
+
+resource "tfe_workspace" "foo" {
+  name         = "workspace-foo"
+  organization = local.organization_name
+}
+
+resource "tfe_project" "foo" {
+  name         = "project-foo"
+  organization = local.organization_name
+}
+
+resource "tfe_provider_set" "foobar" {
+  name                = "tst-terraform-updated"
+  description         = "Provider Set description updated"
+  organization        = local.organization_name
+	provider_source     = "registry.terraform.io/hashicorp/google"
+	global              = false
+	provider_config_hcl = <<-EOT
+provider "google" {
+	region = "us-central1"
+}
+EOT
+}`, organization)
+}
+
+func testAccTFEProviderSet_minimal(organization *string) string {
+	orgConfig := "// should rely on provider for organization"
+	if organization != nil {
+		orgConfig = fmt.Sprintf("organization        = %q", *organization)
+	}
+	return fmt.Sprintf(`
+resource "tfe_provider_set" "foobar" {
+	%s
+  name                = "tst-terraform"
+	provider_source     = "registry.terraform.io/hashicorp/aws"
+	provider_config_hcl = <<-EOT
+provider "aws" {
+	region = "us-east-1"
+}
+EOT
+}`, orgConfig)
+}
+
+func testAccTFEProviderSet_missing_hcl() string {
+	return `
+resource "tfe_provider_set" "foobar" {
+	organization        = "my-org"
+  name                = "tst-terraform"
+	provider_source     = "registry.terraform.io/hashicorp/aws"
+}`
+}
+
+func testAccTFEProviderSet_wo(organization string, version int64, region string) string {
+	return fmt.Sprintf(`
+locals {
+	organization_name = "%s"
+	version           = %d
+	region            = "%s"
+}
+
+resource "tfe_provider_set" "foobar" {
+  name                           = "tst-terraform"
+	organization                   = local.organization_name
+	provider_source                = "registry.terraform.io/hashicorp/aws"
+	provider_config_hcl_wo_version = local.version
+	provider_config_hcl_wo         = <<-EOT
+provider "aws" {
+	region = local.region
+}
+EOT
+}`, organization, version, region)
+}
+
+func testAccTFEProviderSet_conflict(relationship, id string) string {
+	return fmt.Sprintf(`
+resource "tfe_provider_set" "error" {
+  name            = "conflict-test"
+  organization    = "my-org"
+  provider_source = "registry.terraform.io/hashicorp/aws"
+  global          = true
+	provider_config_hcl = <<-EOT
+provider "aws" {
+	region = "us-east-1"
+}
+EOT
+  %s   = ["%s"] # This should trigger the validation error
+}`, relationship, id)
+}
+
+func testAccTFEProviderSet_basic_with_name(organization, name string) string {
+	return fmt.Sprintf(`
+locals {
+	organization_name = "%s"
+	name              = "%s"
+}
+resource "tfe_provider_set" "foobar" {
+  name                           = local.name
+	organization                   = local.organization_name
+	provider_source                = "registry.terraform.io/hashicorp/aws"
+	provider_config_hcl = <<-EOT
+provider "aws" {
+	region = "us-east-1"
+}
+EOT
+}`, organization, name)
+}
+
+func testAccTFEProviderSet_basic_with_provider_source(organization, providerSource string) string {
+	return fmt.Sprintf(`
+locals {
+	organization_name = "%s"
+	provider_source   = "%s"
+}
+resource "tfe_provider_set" "foobar" {
+  name                           = "provider-source-test"
+	organization                   = local.organization_name
+	provider_source                = local.provider_source
+	provider_config_hcl = <<-EOT
+provider "aws" {
+	region = "us-east-1"
+}
+EOT
+}`, organization, providerSource)
+}

--- a/website/docs/r/provider_set.html.markdown
+++ b/website/docs/r/provider_set.html.markdown
@@ -1,0 +1,94 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_provider_set"
+description: |-
+  Manages provider sets.
+---
+
+# tfe_provider_set
+
+Creates, updates and destroys provider sets.
+
+~> **NOTE:** This resource is currently in beta and isn't generally
+available to all users. It is subject to change or be removed.
+
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_provider_set" "standard" {
+  name            = "example-provider-set"
+  description     = "Reusable provider config for selected workspaces"
+  organization    = "example-org"
+  provider_source = "registry.terraform.io/hashicorp/aws"
+  workspace_ids = [
+    "ws-exampleaaaa11111",
+    "ws-examplebbbb22222",
+  ]
+
+  provider_config_hcl = <<-EOT
+  provider "aws" {
+    region = "us-east-1"
+  }
+  EOT
+}
+```
+
+Write-only configuration:
+
+```hcl
+variable "aws_access_key" {
+  type      = string
+  ephemeral = true
+}
+
+variable "aws_secret_key" {
+  type      = string
+  ephemeral = true
+}
+
+resource "tfe_provider_set" "write_only" {
+  name            = "example-provider-set-write-only"
+  description     = "Reusable provider config with write-only secrets"
+  organization    = "example-org"
+  provider_source = "registry.terraform.io/hashicorp/aws"
+  workspace_ids = [
+    "ws-exampleaaaa1111",
+    "ws-examplebbbb2222",
+  ]
+
+  provider_config_hcl_wo_version = 1
+  provider_config_hcl_wo = <<-EOT
+  provider "aws" {
+    region     = "us-east-1"
+    access_key = var.aws_access_key
+    secret_key = var.aws_secret_key
+  }
+  EOT
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the provider set.
+* `provider_source` - (Required) Source address of the provider, e.g. `registry.terraform.io/hashicorp/tfe`.
+* `description` - (Optional) Description of the provider set.
+* `global` - (Optional) Whether the provider set applies globally. Defaults to `false`.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
+* `workspace_ids` - (Optional) IDs of the workspaces attached to the provider set. Cannot be set if `global` is `true`.
+* `project_ids` - (Optional) IDs of the projects attached to the provider set. Cannot be set if `global` is `true`.
+* `provider_config_hcl` - (Optional) Provider configuration HCL stored in Terraform state.
+* `provider_config_hcl_wo` - (Optional, [Write-Only](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments), Sensitive) Provider configuration HCL that is never stored in state. Cannot be used with `provider_config_hcl`.
+* `provider_config_hcl_wo_version` - (Optional) Version identifier required when `provider_config_hcl_wo` is set to trigger updates.
+
+## Attributes Reference
+
+* `id` - The ID of the provider set.
+
+## Import
+
+Import is not currently supported for the `tfe_provider_set` prep stub.


### PR DESCRIPTION
## Description

This PR introduces the `tfe_provider_set` resource, allowing for the management of shared provider configurations in HCP Terraform and Terraform Enterprise.

### Key Features:
- **New Resource:** `tfe_provider_set` for creating and managing reusable provider configurations.
- **Relationship Management:** Supports attaching provider sets to specific `workspace_ids`, `project_ids`, or applying them globally across an organization.
- **Dual Configuration Modes:**
    - `provider_config_hcl`: Standard HCL configuration stored in the Terraform state.
    - `provider_config_hcl_wo`: Write-only HCL configuration for sensitive credentials, which is never persisted in state (requires `provider_config_hcl_wo_version` to trigger updates).
- **Validation:** Implements plan-time validation via `ModifyPlan` to catch invalid attribute combinations (e.g., setting workspace/project IDs when `global` is enabled).

- [x] Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)
- [x] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/website/docs/r/provider_set.html.markdown)

## Testing plan

1. Create a `tfe_provider_set` with standard configuration and verify successful creation.
2. Attach the provider set to multiple workspaces and projects and verify they are correctly linked.
3. Update the configuration to set `global = true` and verify that it actually fail 
4. Remove the workspaces and projects and make sure it update in place the resource to global
5. Create a provider set with `global = false` and no relationships, then update to `global = true` and verify it updates in-place.
6. Verify write-only HCL workflows using `provider_config_hcl_wo` and its version trigger.

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/provider-sets)

## Output from acceptance tests

```
$ ENABLE_BETA=1 TF_ACC=1 go test -v -count=1  ./internal/provider/ -run ProviderSet
...
=== RUN   TestAccTFEProviderSet_basic
2026/06/05 13:11:49 [DEBUG] Configuring client for host "<redacted>"
--- PASS: TestAccTFEProviderSet_basic (6.03s)
=== RUN   TestAccTFEProviderSet_update_global_with_relationships
--- PASS: TestAccTFEProviderSet_update_global_with_relationships (3.50s)
=== RUN   TestAccTFEProviderSet_global
--- PASS: TestAccTFEProviderSet_global (1.52s)
=== RUN   TestAccTFEProviderSet_update_to_global_with_no_relationships
--- PASS: TestAccTFEProviderSet_update_to_global_with_no_relationships (3.07s)
=== RUN   TestAccTFEProviderSet_minimal
--- PASS: TestAccTFEProviderSet_minimal (1.49s)
=== RUN   TestAccTFEProviderSet_update_org_force_recreation
--- PASS: TestAccTFEProviderSet_update_org_force_recreation (2.96s)
=== RUN   TestAccTFEProviderSet_wo
--- PASS: TestAccTFEProviderSet_wo (2.99s)
=== RUN   TestAccTFEProviderSet_validation
--- PASS: TestAccTFEProviderSet_validation (0.35s)
=== RUN   TestAccTFEProviderSet_provider_source
--- PASS: TestAccTFEProviderSet_provider_source (1.50s)
=== RUN   TestAccTFEProviderSet_Read
--- PASS: TestAccTFEProviderSet_Read (2.15s)
=== RUN   TestTFEProviderSetNotImportableInPrepStub
--- PASS: TestTFEProviderSetNotImportableInPrepStub (0.00s)
=== RUN   TestFrameworkProviderResources_includeProviderSet
--- PASS: TestFrameworkProviderResources_includeProviderSet (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   26.332s
```

## Rollback Plan

This can be safely removed as it's still in internal testing and has not been released. Reverting this PR will remove the `tfe_provider_set` resource type.

## Changes to Security Controls

None.

