### PR TITLE
[TF-35683]Adds SCIM resources to Team Data Source for TFE.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           # worked reliably for a single test name and broke when excluding multiple suites. We now keep
           # list_tests at its default (".") and use the `skip` input below, which is forwarded to `go test -skip`
           # to reliably exclude multiple specific test suites from CI runs.
-          skip: "TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus"
+          skip: "TestAccTFESAMLSettings_omnibus|TestAccTFESCIMSettings_omnibus|TestAccTFESCIMTokenDataSource_omnibus|TestAccTFESCIMToken_omnibus|TestAccTFESCIMTeamDataSource_omnibus"
   tests-combine-summaries:
     name: Combine Test Reports
     if: "!startsWith(github.head_ref, 'changelog/')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 * **New Resource:** `r/tfe_admin_smtp_settings` and **New Data Source:** `d/tfe_admin_smtp_settings`: Adds resource and data source to manage Admin SMTP settings in Terraform Enterprise by @chpag [#2059](https://github.com/hashicorp/terraform-provider-tfe/pull/2059)
 
 ENHANCEMENTS:
-* `d/tfe_team`: Expose SCIM attributes (`scim_linked`, `scim_group_name`, `scim_sync_paused`, `scim_updated_at`) as computed read-only fields. These are only populated when SCIM is enabled on the TFE instance.
+* `d/tfe_team`: Expose SCIM attributes (`scim_linked`, `scim_group_name`, `scim_sync_paused`, `scim_updated_at`) as computed read-only fields. These are only populated when SCIM is enabled on the TFE instance [#2088](https://github.com/hashicorp/terraform-provider-tfe/pull/2088)
 * `r/tfe_no_code_module`: Allow `variable_options.options` to be empty or omitted [#2074](https://github.com/hashicorp/terraform-provider-tfe/pull/2074)
 
 ## v0.77.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * **New Resource:** `r/tfe_admin_smtp_settings` and **New Data Source:** `d/tfe_admin_smtp_settings`: Adds resource and data source to manage Admin SMTP settings in Terraform Enterprise by @chpag [#2059](https://github.com/hashicorp/terraform-provider-tfe/pull/2059)
 
 ENHANCEMENTS:
+* `d/tfe_team`: Expose SCIM attributes (`scim_linked`, `scim_group_name`, `scim_sync_paused`, `scim_updated_at`) as computed read-only fields. These are only populated when SCIM is enabled on the TFE instance.
 * `r/tfe_no_code_module`: Allow `variable_options.options` to be empty or omitted [#2074](https://github.com/hashicorp/terraform-provider-tfe/pull/2074)
 
 ## v0.77.0

--- a/internal/provider/data_source_team.go
+++ b/internal/provider/data_source_team.go
@@ -10,6 +10,7 @@ package provider
 
 import (
 	"fmt"
+	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -30,6 +31,22 @@ func dataSourceTFETeam() *schema.Resource {
 				Optional: true,
 			},
 			"sso_team_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scim_linked": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"scim_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scim_sync_paused": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"scim_updated_at": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -64,9 +81,7 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("could not find team %s/%s", organization, name)
 		}
 
-		d.SetId(tl.Items[0].ID)
-		d.Set("sso_team_id", tl.Items[0].SSOTeamID)
-
+		setTeamResourceData(d, tl.Items[0])
 		return nil
 	default:
 		options := &tfe.TeamListOptions{}
@@ -74,8 +89,7 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 		for {
 			for _, team := range tl.Items {
 				if team.Name == name {
-					d.SetId(team.ID)
-					d.Set("sso_team_id", team.SSOTeamID)
+					setTeamResourceData(d, team)
 					return nil
 				}
 			}
@@ -94,4 +108,24 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return fmt.Errorf("could not find team %s/%s", organization, name)
+}
+
+// setTeamResourceData populates state with the team's attributes. SCIM fields are
+// guarded by nil checks so that older TFE instances do not panic.
+func setTeamResourceData(d *schema.ResourceData, team *tfe.Team) {
+	d.SetId(team.ID)
+	d.Set("sso_team_id", team.SSOTeamID)
+
+	if team.SCIMLinked != nil {
+		d.Set("scim_linked", *team.SCIMLinked)
+	}
+	if team.SCIMGroupName != nil {
+		d.Set("scim_group_name", *team.SCIMGroupName)
+	}
+	if team.SCIMSyncPaused != nil {
+		d.Set("scim_sync_paused", *team.SCIMSyncPaused)
+	}
+	if team.SCIMUpdatedAt != nil {
+		d.Set("scim_updated_at", team.SCIMUpdatedAt.Format(time.RFC3339))
+	}
 }

--- a/internal/provider/data_source_team_test.go
+++ b/internal/provider/data_source_team_test.go
@@ -145,6 +145,10 @@ func TestAccTFESCIMTeamDataSource_omnibus(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttrSet("data.tfe_team.test", "id"),
 						resource.TestCheckResourceAttr("data.tfe_team.test", "name", teamName),
+						resource.TestCheckNoResourceAttr("data.tfe_team.test", "scim_linked"),
+						resource.TestCheckNoResourceAttr("data.tfe_team.test", "scim_group_name"),
+						resource.TestCheckNoResourceAttr("data.tfe_team.test", "scim_sync_paused"),
+						resource.TestCheckNoResourceAttr("data.tfe_team.test", "scim_updated_at"),
 						// Capture the team external ID for use in step 3.
 						func(s *terraform.State) error {
 							rs, ok := s.RootModule().Resources["tfe_team.test"]
@@ -162,6 +166,8 @@ func TestAccTFESCIMTeamDataSource_omnibus(t *testing.T) {
 				{
 					Config: testAccTFETeamDataSourceConfig_scimEnabled(teamName, org.Name),
 					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.tfe_team.test", "id"),
+						resource.TestCheckResourceAttr("data.tfe_team.test", "name", teamName),
 						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_linked", "false"),
 						resource.TestCheckNoResourceAttr("data.tfe_team.test", "scim_group_name"),
 						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_sync_paused", "false"),
@@ -194,6 +200,8 @@ func TestAccTFESCIMTeamDataSource_omnibus(t *testing.T) {
 					},
 					Config: testAccTFETeamDataSourceConfig_scimEnabled(teamName, org.Name),
 					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.tfe_team.test", "id"),
+						resource.TestCheckResourceAttr("data.tfe_team.test", "name", teamName),
 						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_linked", "true"),
 						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_group_name", teamName),
 						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_sync_paused", "false"),

--- a/internal/provider/data_source_team_test.go
+++ b/internal/provider/data_source_team_test.go
@@ -4,12 +4,15 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccTFETeamDataSource_basic(t *testing.T) {
@@ -98,4 +101,133 @@ data "tfe_team" "sso_team" {
   name         = tfe_team.sso_team.name
   organization = tfe_team.sso_team.organization
 }`, rInt, organization, ssoTeamID)
+}
+
+// TestAccTFETeamDataSource_scim validates SCIM attributes on the data source
+// across three stages: no SCIM, SCIM enabled without a group link, and SCIM
+// enabled with a group linked.
+//
+// FLAKE ALERT: SCIM settings are a singleton resource shared by the entire TFE
+// instance. Running all SCIM cases inside one function — without calling
+// t.Parallel in any sub-test — prevents concurrent tests from racing over the
+// same singleton state.
+//
+// Should this test name ever change, you will also need to update the regex in ci.yml.
+func TestAccTFESCIMTeamDataSource_omnibus(t *testing.T) {
+	skipIfCloud(t)
+
+	t.Run("SCIM attributes across full lifecycle", func(t *testing.T) {
+		teamName := "tf-acc-scim-team-" + randomString(t)
+		org := os.Getenv("TFE_ORGANIZATION")
+
+		// teamID is captured from Terraform state after step 1 so that step 3
+		// PreConfig can call linkSCIMGroupToTeam with the correct external ID.
+		var teamID string
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			Steps: []resource.TestStep{
+				// Step 1: No SCIM at all. Verify the data source reads successfully
+				// and does not panic when SCIM fields are absent from the API response.
+				{
+					Config: testAccTFETeamDataSourceConfig_noSCIM(teamName, org),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.tfe_team.test", "id"),
+						resource.TestCheckResourceAttr("data.tfe_team.test", "name", teamName),
+						// Capture the team external ID for use in step 3.
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_team.test"]
+							if !ok {
+								return fmt.Errorf("tfe_team.test not found in state")
+							}
+							teamID = rs.Primary.ID
+							return nil
+						},
+					),
+				},
+				// Step 2: SCIM enabled, team not yet linked to any SCIM group.
+				// The API now returns SCIM fields (scim_enabled? is true), so we
+				// assert their unlinked zero values.
+				{
+					Config: testAccTFETeamDataSourceConfig_scimEnabled(teamName, org),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_linked", "false"),
+						resource.TestCheckNoResourceAttr("data.tfe_team.test", "scim_group_name"),
+						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_sync_paused", "false"),
+						resource.TestCheckNoResourceAttr("data.tfe_team.test", "scim_updated_at"),
+					),
+				},
+				// Step 3: Create a SCIM group out-of-band, link it to the team,
+				// then verify the populated SCIM attributes on the data source.
+				{
+					PreConfig: func() {
+						tokenName := "tf-acc-scim-token-" + randomString(t)
+						token, err := testAccConfiguredClient.Client.Admin.Settings.SCIM.Tokens.Create(
+							context.Background(), tokenName,
+						)
+						if err != nil {
+							t.Fatalf("create SCIM token: %v", err)
+						}
+						t.Cleanup(func() {
+							_ = testAccConfiguredClient.Client.Admin.Settings.SCIM.Tokens.Delete(
+								context.Background(), token.ID)
+						})
+
+						// No explicit group cleanup: disabling SCIM (CheckDestroy) removes all groups.
+						scimGroupID := createSCIMGroup(t, teamName, token.Token)
+						linkSCIMGroupToTeam(t, teamID, scimGroupID)
+					},
+					Config: testAccTFETeamDataSourceConfig_scimEnabled(teamName, org),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_linked", "true"),
+						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_group_name", teamName),
+						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_sync_paused", "false"),
+						resource.TestCheckResourceAttrSet("data.tfe_team.test", "scim_updated_at"),
+					),
+				},
+			},
+		})
+	})
+}
+
+// testAccTFETeamDataSourceConfig_noSCIM returns a config with a team and its
+// data source, with no SCIM resources present.
+func testAccTFETeamDataSourceConfig_noSCIM(teamName, org string) string {
+	return fmt.Sprintf(`
+resource "tfe_team" "test" {
+  name         = "%s"
+  organization = "%s"
+}
+
+data "tfe_team" "test" {
+  name         = tfe_team.test.name
+  organization = tfe_team.test.organization
+  depends_on   = [tfe_team.test]
+}
+`, teamName, org)
+}
+
+// testAccTFETeamDataSourceConfig_scimEnabled returns a config with SAML + SCIM
+// enabled alongside the team and data source. Used for both the "SCIM on, not
+// linked" and "SCIM on, linked" steps so the config is identical between them.
+func testAccTFETeamDataSourceConfig_scimEnabled(teamName, org string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "tfe_scim_settings" "enable_scim" {
+  depends_on = [tfe_saml_settings.enable_saml]
+}
+
+resource "tfe_team" "test" {
+  name         = "%s"
+  organization = "%s"
+}
+
+data "tfe_team" "test" {
+  name         = tfe_team.test.name
+  organization = tfe_team.test.organization
+  depends_on   = [tfe_scim_settings.enable_scim]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting), teamName, org)
 }

--- a/internal/provider/data_source_team_test.go
+++ b/internal/provider/data_source_team_test.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -118,20 +118,30 @@ func TestAccTFESCIMTeamDataSource_omnibus(t *testing.T) {
 
 	t.Run("SCIM attributes across full lifecycle", func(t *testing.T) {
 		teamName := "tf-acc-scim-team-" + randomString(t)
-		org := os.Getenv("TFE_ORGANIZATION")
+
+		client, err := getClientUsingEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		org, orgCleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
+			Name:  tfe.String("tst-" + randomString(t)),
+			Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+		})
+		t.Cleanup(orgCleanup)
 
 		// teamID is captured from Terraform state after step 1 so that step 3
-		// PreConfig can call linkSCIMGroupToTeam with the correct external ID.
+		// PreConfig can call SCIMGroupMappings.Create with the correct external ID.
 		var teamID string
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMSettingsDestroy,
 			Steps: []resource.TestStep{
 				// Step 1: No SCIM at all. Verify the data source reads successfully
 				// and does not panic when SCIM fields are absent from the API response.
 				{
-					Config: testAccTFETeamDataSourceConfig_noSCIM(teamName, org),
+					Config: testAccTFETeamDataSourceConfig_noSCIM(teamName, org.Name),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttrSet("data.tfe_team.test", "id"),
 						resource.TestCheckResourceAttr("data.tfe_team.test", "name", teamName),
@@ -150,7 +160,7 @@ func TestAccTFESCIMTeamDataSource_omnibus(t *testing.T) {
 				// The API now returns SCIM fields (scim_enabled? is true), so we
 				// assert their unlinked zero values.
 				{
-					Config: testAccTFETeamDataSourceConfig_scimEnabled(teamName, org),
+					Config: testAccTFETeamDataSourceConfig_scimEnabled(teamName, org.Name),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_linked", "false"),
 						resource.TestCheckNoResourceAttr("data.tfe_team.test", "scim_group_name"),
@@ -176,9 +186,13 @@ func TestAccTFESCIMTeamDataSource_omnibus(t *testing.T) {
 
 						// No explicit group cleanup: disabling SCIM (CheckDestroy) removes all groups.
 						scimGroupID := createSCIMGroup(t, teamName, token.Token)
-						linkSCIMGroupToTeam(t, teamID, scimGroupID)
+						if err := testAccConfiguredClient.Client.Admin.Settings.SCIM.SCIMGroupMappings.Create(
+							context.Background(), teamID, &tfe.AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroupID},
+						); err != nil {
+							t.Fatalf("link SCIM group to team: %v", err)
+						}
 					},
-					Config: testAccTFETeamDataSourceConfig_scimEnabled(teamName, org),
+					Config: testAccTFETeamDataSourceConfig_scimEnabled(teamName, org.Name),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_linked", "true"),
 						resource.TestCheckResourceAttr("data.tfe_team.test", "scim_group_name", teamName),

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -24,7 +24,7 @@ const RunTasksURLEnvName = "RUN_TASKS_URL"
 const RunTasksHMACKeyEnvName = "RUN_TASKS_HMAC"
 const EnableHYOKEnvName = "ENABLE_HYOK"
 
-const TFEScimGroupAPI = "https://%s/scim/v2/Groups"
+const TFESCIMGroupAPI = "https://%s/scim/v2/Groups"
 
 type testClientOptions struct {
 	defaultOrganization          string
@@ -390,7 +390,7 @@ func createSCIMGroup(t *testing.T, displayName, scimToken string) string {
 		// Re-create the request body each attempt since the reader is consumed.
 		reqBody := bytes.NewReader(body)
 		retryReq, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
-			fmt.Sprintf(TFEScimGroupAPI, hostname), reqBody)
+			fmt.Sprintf(TFESCIMGroupAPI, hostname), reqBody)
 		if err != nil {
 			t.Fatalf("build SCIM group request: %v", err)
 		}
@@ -399,7 +399,7 @@ func createSCIMGroup(t *testing.T, displayName, scimToken string) string {
 
 		resp, err = httpClient.Do(retryReq)
 		if err != nil {
-			t.Fatalf("POST %s: %v", fmt.Sprintf(TFEScimGroupAPI, hostname), err)
+			t.Fatalf("POST %s: %v", fmt.Sprintf(TFESCIMGroupAPI, hostname), err)
 		}
 
 		if resp.StatusCode != http.StatusTooManyRequests {

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -24,6 +24,9 @@ const RunTasksURLEnvName = "RUN_TASKS_URL"
 const RunTasksHMACKeyEnvName = "RUN_TASKS_HMAC"
 const EnableHYOKEnvName = "ENABLE_HYOK"
 
+const TFEScimGroupAPI = "https://%s/scim/v2/Groups"
+const TFEScimLinkAPI = "https://%s/api/v2/admin/teams/%s/scim-group-mapping"
+
 type testClientOptions struct {
 	defaultOrganization          string
 	defaultWorkspaceID           string
@@ -381,7 +384,7 @@ func createSCIMGroup(t *testing.T, displayName, scimToken string) string {
 	}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		fmt.Sprintf("https://%s/scim/v2/Groups", hostname), bytes.NewReader(body))
+		fmt.Sprintf(TFEScimGroupAPI, hostname), bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("build SCIM group request: %v", err)
 	}
@@ -391,7 +394,7 @@ func createSCIMGroup(t *testing.T, displayName, scimToken string) string {
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		t.Fatalf("POST /scim/v2/Groups: %v", err)
+		t.Fatalf("POST %s: %v", fmt.Sprintf(TFEScimGroupAPI, hostname), err)
 	}
 	defer resp.Body.Close()
 
@@ -410,4 +413,47 @@ func createSCIMGroup(t *testing.T, displayName, scimToken string) string {
 		t.Fatal("SCIM group response missing id")
 	}
 	return res.ID
+}
+
+// linkSCIMGroupToTeam links an existing SCIM group to an existing TFE team via the admin SCIM API.
+func linkSCIMGroupToTeam(t *testing.T, teamExternalID, scimGroupID string) {
+	t.Helper()
+
+	hostname := os.Getenv("TFE_HOSTNAME")
+	if hostname == "" {
+		hostname = "app.terraform.io"
+	}
+	token := os.Getenv("TFE_TOKEN")
+
+	body, err := json.Marshal(map[string]any{
+		"data": map[string]any{
+			"attributes": map[string]any{
+				"scim-group-id": scimGroupID,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal link SCIM group request body: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		fmt.Sprintf(TFEScimLinkAPI, hostname, teamExternalID),
+		bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build link SCIM group request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/vnd.api+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", fmt.Sprintf(TFEScimLinkAPI, hostname, teamExternalID), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		errBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("link SCIM group to team: status %d body: %s", resp.StatusCode, errBody)
+	}
 }

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -25,7 +25,6 @@ const RunTasksHMACKeyEnvName = "RUN_TASKS_HMAC"
 const EnableHYOKEnvName = "ENABLE_HYOK"
 
 const TFEScimGroupAPI = "https://%s/scim/v2/Groups"
-const TFEScimLinkAPI = "https://%s/api/v2/admin/teams/%s/scim-group-mapping"
 
 type testClientOptions struct {
 	defaultOrganization          string
@@ -413,47 +412,4 @@ func createSCIMGroup(t *testing.T, displayName, scimToken string) string {
 		t.Fatal("SCIM group response missing id")
 	}
 	return res.ID
-}
-
-// linkSCIMGroupToTeam links an existing SCIM group to an existing TFE team via the admin SCIM API.
-func linkSCIMGroupToTeam(t *testing.T, teamExternalID, scimGroupID string) {
-	t.Helper()
-
-	hostname := os.Getenv("TFE_HOSTNAME")
-	if hostname == "" {
-		hostname = "app.terraform.io"
-	}
-	token := os.Getenv("TFE_TOKEN")
-
-	body, err := json.Marshal(map[string]any{
-		"data": map[string]any{
-			"attributes": map[string]any{
-				"scim-group-id": scimGroupID,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("marshal link SCIM group request body: %v", err)
-	}
-
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		fmt.Sprintf(TFEScimLinkAPI, hostname, teamExternalID),
-		bytes.NewReader(body))
-	if err != nil {
-		t.Fatalf("build link SCIM group request: %v", err)
-	}
-	req.Header.Set("Content-Type", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		t.Fatalf("POST %s: %v", fmt.Sprintf(TFEScimLinkAPI, hostname, teamExternalID), err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusNoContent {
-		errBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("link SCIM group to team: status %d body: %s", resp.StatusCode, errBody)
-	}
 }

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -30,4 +30,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the team.
-* `sso_team_id` - (Optional) The [SSO Team ID](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) of the team, if it has been defined
+* `sso_team_id` - (Optional) The [SSO Team ID](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) of the team, if it has been defined.
+* `scim_linked` - Whether the team is linked to a SCIM group. Only populated when SCIM is enabled on the TFE instance.
+* `scim_group_name` - The display name of the SCIM group linked to this team. Only populated when SCIM is enabled and the team is linked to a SCIM group.
+* `scim_sync_paused` - Whether SCIM membership sync is paused for this team. Only populated when SCIM is enabled and the team is linked to a SCIM group.
+* `scim_updated_at` - The timestamp of the last SCIM reconciliation for this team, in RFC3339 format. Only populated when SCIM is enabled and the team is linked to a SCIM group.

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -31,7 +31,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the team.
 * `sso_team_id` - (Optional) The [SSO Team ID](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) of the team, if it has been defined.
-* `scim_linked` - Whether the team is linked to a SCIM group. Only populated when SCIM is enabled on the TFE instance.
-* `scim_group_name` - The display name of the SCIM group linked to this team. Only populated when SCIM is enabled and the team is linked to a SCIM group.
-* `scim_sync_paused` - Whether SCIM membership sync is paused for this team. Only populated when SCIM is enabled and the team is linked to a SCIM group.
-* `scim_updated_at` - The timestamp of the last SCIM reconciliation for this team, in RFC3339 format. Only populated when SCIM is enabled and the team is linked to a SCIM group.
+* `scim_linked` - Whether the team is linked to a SCIM group. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is either not supported or enabled in the TFE instance.
+* `scim_group_name` - The display name of the SCIM group linked to this team. Only populated when SCIM is enabled and the team is linked to a SCIM group. If not present, SCIM is either not supported or enabled in the TFE instance.
+* `scim_sync_paused` - Whether SCIM membership sync is paused for this team. Only populated when SCIM is enabled and the team is linked to a SCIM group. If not present, SCIM is either not supported or enabled in the TFE instance.
+* `scim_updated_at` - The timestamp of the last SCIM reconciliation for this team, in RFC3339 format. Only populated when SCIM is enabled and the team is linked to a SCIM group. If not present, SCIM is either not supported or enabled in the TFE instance.

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -31,7 +31,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the team.
 * `sso_team_id` - (Optional) The [SSO Team ID](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) of the team, if it has been defined.
-* `scim_linked` - Whether the team is linked to a SCIM group. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is either not supported or enabled in the TFE instance.
-* `scim_group_name` - The display name of the SCIM group linked to this team. Only populated when SCIM is enabled and the team is linked to a SCIM group. If not present, SCIM is either not supported or enabled in the TFE instance.
-* `scim_sync_paused` - Whether SCIM membership sync is paused for this team. Only populated when SCIM is enabled and the team is linked to a SCIM group. If not present, SCIM is either not supported or enabled in the TFE instance.
-* `scim_updated_at` - The timestamp of the last SCIM reconciliation for this team, in RFC3339 format. Only populated when SCIM is enabled and the team is linked to a SCIM group. If not present, SCIM is either not supported or enabled in the TFE instance.
+* `scim_linked` - Whether the team is linked to a SCIM group. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is not supported or not enabled on the TFE instance.
+* `scim_group_name` - The display name of the SCIM group linked to this team. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is not supported or not enabled on the TFE instance, or the team is not linked to a SCIM group.
+* `scim_sync_paused` - Whether SCIM membership sync is paused for this team. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is not supported or not enabled on the TFE instance.
+* `scim_updated_at` - The timestamp of the last SCIM reconciliation for this team, in RFC3339 format. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is not supported or not enabled on the TFE instance, or the team is not linked to a SCIM group.


### PR DESCRIPTION
## Description

Team data source must output SCIM attributes when SCIM is enabled in TFE.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  You can just run the test case `TestAccTFESCIMTeamDataSource_omnibus`
2. Or you can deploy TFE with SAML and SCIM enabled.
3. Create a TFE Team, create a SCIM group using Admin APIs.
4. Configure TFE provider and try to fetch the TFE team with external ID and access the SCIM attributes.

TFE tests - https://github.com/hashicorp/terraform-provider-tfe/actions/runs/27018220194/job/79741292194

## External links

[TF-35683](https://hashicorp.atlassian.net/browse/TF-35683)

## Output from acceptance tests

```
$ TFE_HOSTNAME=<REDACTED> \
TFE_TOKEN=<REDACTED> \
TFE_ORGANIZATION=db-check-test \
ENABLE_TFE=1 \
TF_ACC=1 \
go test ./internal/provider/ -v -run TestAccTFETeamDataSource_scim -timeout 30m 2>&1
=== RUN   TestAccTFETeamDataSource_scim
=== RUN   TestAccTFETeamDataSource_scim/SCIM_attributes_across_full_lifecycle
--- PASS: TestAccTFETeamDataSource_scim (11.83s)
    --- PASS: TestAccTFETeamDataSource_scim/SCIM_attributes_across_full_lifecycle (11.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	12.669s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

Revert the PR.

<img width="781" height="247" alt="image" src="https://github.com/user-attachments/assets/ebd1b96a-dc44-473d-8755-f4ef46158328" />


[TF-35683]: https://hashicorp.atlassian.net/browse/TF-35683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ