### PR TITLE
Adds `r/tfe_scim_group_mapping`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 * **New Resource:** `r/tfe_admin_smtp_settings` and **New Data Source:** `d/tfe_admin_smtp_settings`: Adds resource and data source to manage Admin SMTP settings in Terraform Enterprise by @chpag [#2059](https://github.com/hashicorp/terraform-provider-tfe/pull/2059)
 * **New Data Source:** `d/tfe_scim_group`: Adds a data source to retrieve a SCIM group from Terraform Enterprise. By @skj-skj [#2083](https://github.com/hashicorp/terraform-provider-tfe/pull/2083)
 * **New Resource:** `r/tfe_provider_set` for managing shared provider configurations for internal testing. NOTE: This resource is subject to change and has limited support in HCP Terraform. By @mogrogan [#2086](https://github.com/hashicorp/terraform-provider-tfe/pull/2086)
-* **New Resource:** `r/tfe_scim_group_mapping`: Adds a resource to map a SCIM group to a team on Terraform Enterprise. By @skj-skj
+* **New Resource:** `r/tfe_scim_group_mapping`: Adds a resource to map a SCIM group to a team on Terraform Enterprise. By @skj-skj [#2090](https://github.com/hashicorp/terraform-provider-tfe/pull/2090)
 
 ENHANCEMENTS:
 * `r/tfe_no_code_module`: Allow `variable_options.options` to be empty or omitted [#2074](https://github.com/hashicorp/terraform-provider-tfe/pull/2074)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * **New Resource:** `r/tfe_admin_smtp_settings` and **New Data Source:** `d/tfe_admin_smtp_settings`: Adds resource and data source to manage Admin SMTP settings in Terraform Enterprise by @chpag [#2059](https://github.com/hashicorp/terraform-provider-tfe/pull/2059)
 * **New Data Source:** `d/tfe_scim_group`: Adds a data source to retrieve a SCIM group from Terraform Enterprise. By @skj-skj [#2083](https://github.com/hashicorp/terraform-provider-tfe/pull/2083)
 * **New Resource:** `r/tfe_provider_set` for managing shared provider configurations for internal testing. NOTE: This resource is subject to change and has limited support in HCP Terraform. By @mogrogan [#2086](https://github.com/hashicorp/terraform-provider-tfe/pull/2086)
+* **New Resource:** `r/tfe_scim_group_mapping`: Adds a resource to map a SCIM group to a team on Terraform Enterprise. By @skj-skj
 
 ENHANCEMENTS:
 * `r/tfe_no_code_module`: Allow `variable_options.options` to be empty or omitted [#2074](https://github.com/hashicorp/terraform-provider-tfe/pull/2074)

--- a/internal/provider/data_source_scim_group.go
+++ b/internal/provider/data_source_scim_group.go
@@ -113,7 +113,7 @@ func (d *dataSourceTFESCIMGroup) Read(ctx context.Context, req datasource.ReadRe
 	// matching behavior stays consistent with the SCIM group mapping resource.
 	match, err := findSCIMGroupByName(ctx, d.client, name)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to list SCIM groups", err.Error())
+		resp.Diagnostics.AddError("Error reading SCIM group", err.Error())
 		return
 	}
 

--- a/internal/provider/data_source_scim_group.go
+++ b/internal/provider/data_source_scim_group.go
@@ -105,34 +105,16 @@ func (d *dataSourceTFESCIMGroup) Read(ctx context.Context, req datasource.ReadRe
 	}
 	name := data.Name.ValueString()
 
-	options := &tfe.AdminSCIMGroupListOptions{
-		// ?q= is a fuzzy substring match used here only as a server-side
-		// prefilter; we still narrow to an exact, case-insensitive match below.
-		Query: name,
-	}
-
 	tflog.Debug(ctx, "Listing SCIM groups", map[string]any{
 		"name": name,
 	})
 
-	// Keep the case-insensitive exact match (at most one) and stop
-	// paginating as soon as we find it.
-	var match *tfe.AdminSCIMGroup
-	for {
-		list, err := d.client.Admin.Settings.SCIM.Groups.List(ctx, options)
-		if err != nil {
-			resp.Diagnostics.AddError("Unable to list SCIM groups", err.Error())
-			return
-		}
-
-		if matched := filterExactSCIMGroups(list.Items, name); len(matched) > 0 {
-			match = matched[0]
-			break
-		}
-		if list.Pagination == nil || list.CurrentPage >= list.TotalPages {
-			break
-		}
-		options.PageNumber = list.NextPage
+	// Reuse the shared helper so the pagination and exact, case-insensitive
+	// matching behavior stays consistent with the SCIM group mapping resource.
+	match, err := findSCIMGroupByName(ctx, d.client, name)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to list SCIM groups", err.Error())
+		return
 	}
 
 	if match == nil {

--- a/internal/provider/data_source_scim_group.go
+++ b/internal/provider/data_source_scim_group.go
@@ -113,7 +113,7 @@ func (d *dataSourceTFESCIMGroup) Read(ctx context.Context, req datasource.ReadRe
 	// matching behavior stays consistent with the SCIM group mapping resource.
 	match, err := findSCIMGroupByName(ctx, d.client, name)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to list SCIM groups", err.Error())
+		resp.Diagnostics.AddError("Unable to find SCIM group", err.Error())
 		return
 	}
 

--- a/internal/provider/data_source_scim_group.go
+++ b/internal/provider/data_source_scim_group.go
@@ -113,7 +113,7 @@ func (d *dataSourceTFESCIMGroup) Read(ctx context.Context, req datasource.ReadRe
 	// matching behavior stays consistent with the SCIM group mapping resource.
 	match, err := findSCIMGroupByName(ctx, d.client, name)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to find SCIM group", err.Error())
+		resp.Diagnostics.AddError("Unable to list SCIM groups", err.Error())
 		return
 	}
 

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -206,6 +206,7 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewProjectPolicySetExclusionResource,
 		NewSCIMSettingsResource,
 		NewSCIMTokenResource,
+		NewSCIMGroupMappingResource,
 	}
 }
 

--- a/internal/provider/resource_tfe_scim_group_mapping.go
+++ b/internal/provider/resource_tfe_scim_group_mapping.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -19,6 +18,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	tfe "github.com/hashicorp/go-tfe"
 )
 
 type modelTFESCIMGroupMapping struct {

--- a/internal/provider/resource_tfe_scim_group_mapping.go
+++ b/internal/provider/resource_tfe_scim_group_mapping.go
@@ -1,0 +1,313 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type modelTFESCIMGroupMapping struct {
+	ID          types.String `tfsdk:"id"`
+	TeamID      types.String `tfsdk:"team_id"`
+	SCIMGroupID types.String `tfsdk:"scim_group_id"`
+	Paused      types.Bool   `tfsdk:"paused"`
+}
+
+// resourceTFESCIMGroupMapping implements the tfe_scim_group_mapping resource type.
+type resourceTFESCIMGroupMapping struct {
+	client *tfe.Client
+}
+
+var (
+	_ resource.Resource                = &resourceTFESCIMGroupMapping{}
+	_ resource.ResourceWithConfigure   = &resourceTFESCIMGroupMapping{}
+	_ resource.ResourceWithImportState = &resourceTFESCIMGroupMapping{}
+)
+
+// NewSCIMGroupMappingResource is a resource function for the framework provider.
+func NewSCIMGroupMappingResource() resource.Resource {
+	return &resourceTFESCIMGroupMapping{}
+}
+
+// Metadata implements resource.Resource
+func (r *resourceTFESCIMGroupMapping) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scim_group_mapping"
+}
+
+// Configure implements resource.ResourceWithConfigure
+func (r *resourceTFESCIMGroupMapping) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Early exit if provider is not properly configured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client.Client
+}
+
+// Schema implements resource.Resource
+func (r *resourceTFESCIMGroupMapping) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Maps a SCIM group to a team in Terraform Enterprise. A team can be mapped to at most one SCIM group.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of the SCIM group mapping. Since a team can only be mapped to one SCIM group, this is the same as `team_id`.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"team_id": schema.StringAttribute{
+				Description: "The ID of the team to map the SCIM group to. Changing this forces a new mapping to be created.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"scim_group_id": schema.StringAttribute{
+				Description: "The ID of the SCIM group to map to the team. Changing this forces a new mapping to be created, since the mapping API only supports updating the paused state.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"paused": schema.BoolAttribute{
+				Description: "Whether provisioning for this mapping is paused. Defaults to `false`.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+		},
+	}
+}
+
+// Read implements resource.Resource. The Teams API tells us if the team is
+// SCIM-linked, its paused state and the group's name; we then look up the
+// group's ID by name, since Teams doesn't return it.
+func (r *resourceTFESCIMGroupMapping) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTFESCIMGroupMapping
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	teamID := state.TeamID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading SCIM group mapping for team %s", teamID))
+	team, err := r.client.Teams.Read(ctx, teamID)
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			tflog.Debug(ctx, fmt.Sprintf("Team %s no longer exists; removing SCIM group mapping from state", teamID))
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error reading team %s for SCIM group mapping", teamID),
+			"Could not read team, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	// If the team is no longer SCIM-linked, the mapping was removed out-of-band.
+	if team.SCIMLinked == nil || !*team.SCIMLinked {
+		tflog.Debug(ctx, fmt.Sprintf("Team %s is no longer SCIM-linked; removing mapping from state", teamID))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	groupName := ""
+	if team.SCIMGroupName != nil {
+		groupName = *team.SCIMGroupName
+	}
+
+	scimGroupID, err := r.resolveSCIMGroupID(ctx, groupName)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Error resolving SCIM group for team %s", teamID),
+			err.Error(),
+		)
+		return
+	}
+
+	paused := false
+	if team.SCIMSyncPaused != nil {
+		paused = *team.SCIMSyncPaused
+	}
+
+	result := modelTFESCIMGroupMapping{
+		ID:          types.StringValue(teamID),
+		TeamID:      types.StringValue(teamID),
+		SCIMGroupID: types.StringValue(scimGroupID),
+		Paused:      types.BoolValue(paused),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// Create implements resource.Resource. Create can't set the paused state, so a
+// paused mapping is created then paused in a follow-up update.
+func (r *resourceTFESCIMGroupMapping) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTFESCIMGroupMapping
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	teamID := plan.TeamID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Creating SCIM group mapping for team %s", teamID))
+	err := r.client.Admin.Settings.SCIM.SCIMGroupMappings.Create(ctx, teamID, &tfe.AdminSCIMGroupMappingCreateOptions{
+		SCIMGroupID: plan.SCIMGroupID.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating SCIM group mapping",
+			fmt.Sprintf("Could not create SCIM group mapping for team %s, unexpected error: %s", teamID, err.Error()),
+		)
+		return
+	}
+
+	// Save state now that the mapping exists, so a failed pause below doesn't
+	// orphan it.
+	paused := plan.Paused.ValueBool()
+	result := modelTFESCIMGroupMapping{
+		ID:          types.StringValue(teamID),
+		TeamID:      types.StringValue(teamID),
+		SCIMGroupID: plan.SCIMGroupID,
+		Paused:      types.BoolValue(false),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create always starts unpaused, so pause it now if requested.
+	if paused {
+		tflog.Debug(ctx, fmt.Sprintf("Pausing SCIM group mapping for team %s", teamID))
+		err = r.client.Admin.Settings.SCIM.SCIMGroupMappings.Update(ctx, teamID, &tfe.AdminSCIMGroupMappingUpdateOptions{
+			SCIMSyncPaused: tfe.Bool(true),
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error pausing SCIM group mapping",
+				fmt.Sprintf("The mapping for team %s was created but could not be paused, unexpected error: %s", teamID, err.Error()),
+			)
+			return
+		}
+		result.Paused = types.BoolValue(true)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+	}
+}
+
+// Update implements resource.Resource. Only the paused state can change in
+// place; team_id and scim_group_id changes force a replacement.
+func (r *resourceTFESCIMGroupMapping) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan modelTFESCIMGroupMapping
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	teamID := plan.TeamID.ValueString()
+	paused := plan.Paused.ValueBool()
+
+	tflog.Debug(ctx, fmt.Sprintf("Updating SCIM group mapping for team %s", teamID))
+	err := r.client.Admin.Settings.SCIM.SCIMGroupMappings.Update(ctx, teamID, &tfe.AdminSCIMGroupMappingUpdateOptions{
+		SCIMSyncPaused: tfe.Bool(paused),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating SCIM group mapping",
+			fmt.Sprintf("Could not update SCIM group mapping for team %s, unexpected error: %s", teamID, err.Error()),
+		)
+		return
+	}
+
+	result := modelTFESCIMGroupMapping{
+		ID:          types.StringValue(teamID),
+		TeamID:      types.StringValue(teamID),
+		SCIMGroupID: plan.SCIMGroupID,
+		Paused:      types.BoolValue(paused),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// Delete implements resource.Resource.
+func (r *resourceTFESCIMGroupMapping) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTFESCIMGroupMapping
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	teamID := state.TeamID.ValueString()
+
+	tflog.Debug(ctx, fmt.Sprintf("Deleting SCIM group mapping for team %s", teamID))
+	err := r.client.Admin.Settings.SCIM.SCIMGroupMappings.Delete(ctx, teamID)
+	if err != nil {
+		if errors.Is(err, tfe.ErrResourceNotFound) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error deleting SCIM group mapping",
+			fmt.Sprintf("Could not delete SCIM group mapping for team %s, unexpected error: %s", teamID, err.Error()),
+		)
+		return
+	}
+}
+
+// ImportState implements resource.ResourceWithImportState. The import ID is the
+// team ID; the remaining attributes are populated by the subsequent Read.
+func (r *resourceTFESCIMGroupMapping) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team_id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+}
+
+// resolveSCIMGroupID looks up a SCIM group's ID by name, since the Teams API
+// only gives us the group's name and not its ID.
+func (r *resourceTFESCIMGroupMapping) resolveSCIMGroupID(ctx context.Context, name string) (string, error) {
+	if name == "" {
+		return "", errors.New("team is SCIM-linked but the linked SCIM group name is empty; cannot resolve scim_group_id")
+	}
+
+	group, err := findSCIMGroupByName(ctx, r.client, name)
+	if err != nil {
+		return "", err
+	}
+	if group == nil {
+		return "", fmt.Errorf("no SCIM group found with name %q", name)
+	}
+
+	return group.ID, nil
+}

--- a/internal/provider/resource_tfe_scim_group_mapping.go
+++ b/internal/provider/resource_tfe_scim_group_mapping.go
@@ -298,7 +298,7 @@ func (r *resourceTFESCIMGroupMapping) ImportState(ctx context.Context, req resou
 // only gives us the group's name and not its ID.
 func (r *resourceTFESCIMGroupMapping) resolveSCIMGroupID(ctx context.Context, name string) (string, error) {
 	if name == "" {
-		return "", errors.New("Team is SCIM-linked but the linked SCIM group name is empty; cannot resolve scim_group_id")
+		return "", errors.New("team is SCIM-linked but the linked SCIM group name is empty; cannot resolve scim_group_id")
 	}
 
 	group, err := findSCIMGroupByName(ctx, r.client, name)

--- a/internal/provider/resource_tfe_scim_group_mapping.go
+++ b/internal/provider/resource_tfe_scim_group_mapping.go
@@ -145,12 +145,7 @@ func (r *resourceTFESCIMGroupMapping) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	groupName := ""
-	if team.SCIMGroupName != nil {
-		groupName = *team.SCIMGroupName
-	}
-
-	scimGroupID, err := r.resolveSCIMGroupID(ctx, groupName)
+	scimGroupID, err := r.resolveSCIMGroupID(ctx, *team.SCIMGroupName)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error resolving SCIM group for team %s", teamID),

--- a/internal/provider/resource_tfe_scim_group_mapping.go
+++ b/internal/provider/resource_tfe_scim_group_mapping.go
@@ -183,15 +183,16 @@ func (r *resourceTFESCIMGroupMapping) Create(ctx context.Context, req resource.C
 	}
 
 	teamID := plan.TeamID.ValueString()
+	scimGroupID := plan.SCIMGroupID.ValueString()
 
-	tflog.Debug(ctx, fmt.Sprintf("Creating SCIM group mapping for team %s", teamID))
+	tflog.Debug(ctx, fmt.Sprintf("Creating SCIM group mapping for team %s and SCIM group %s", teamID, scimGroupID))
 	err := r.client.Admin.Settings.SCIM.SCIMGroupMappings.Create(ctx, teamID, &tfe.AdminSCIMGroupMappingCreateOptions{
-		SCIMGroupID: plan.SCIMGroupID.ValueString(),
+		SCIMGroupID: scimGroupID,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating SCIM group mapping",
-			fmt.Sprintf("Could not create SCIM group mapping for team %s, unexpected error: %s", teamID, err.Error()),
+			fmt.Sprintf("Could not create SCIM group mapping for team %s and SCIM group %s, unexpected error: %s", teamID, scimGroupID, err.Error()),
 		)
 		return
 	}

--- a/internal/provider/resource_tfe_scim_group_mapping.go
+++ b/internal/provider/resource_tfe_scim_group_mapping.go
@@ -298,7 +298,7 @@ func (r *resourceTFESCIMGroupMapping) ImportState(ctx context.Context, req resou
 // only gives us the group's name and not its ID.
 func (r *resourceTFESCIMGroupMapping) resolveSCIMGroupID(ctx context.Context, name string) (string, error) {
 	if name == "" {
-		return "", errors.New("team is SCIM-linked but the linked SCIM group name is empty; cannot resolve scim_group_id")
+		return "", errors.New("Team is SCIM-linked but the linked SCIM group name is empty; cannot resolve scim_group_id")
 	}
 
 	group, err := findSCIMGroupByName(ctx, r.client, name)

--- a/internal/provider/resource_tfe_scim_group_mapping.go
+++ b/internal/provider/resource_tfe_scim_group_mapping.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/resource_tfe_scim_group_mapping.go
+++ b/internal/provider/resource_tfe_scim_group_mapping.go
@@ -145,7 +145,7 @@ func (r *resourceTFESCIMGroupMapping) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	scimGroupID, err := r.resolveSCIMGroupID(ctx, *team.SCIMGroupName)
+	scimGroupID, err := r.resolveSCIMGroupID(ctx, team.SCIMGroupName)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error resolving SCIM group for team %s", teamID),
@@ -293,17 +293,17 @@ func (r *resourceTFESCIMGroupMapping) ImportState(ctx context.Context, req resou
 
 // resolveSCIMGroupID looks up a SCIM group's ID by name, since the Teams API
 // only gives us the group's name and not its ID.
-func (r *resourceTFESCIMGroupMapping) resolveSCIMGroupID(ctx context.Context, name string) (string, error) {
-	if name == "" {
+func (r *resourceTFESCIMGroupMapping) resolveSCIMGroupID(ctx context.Context, name *string) (string, error) {
+	if name == nil || *name == "" {
 		return "", errors.New("team is SCIM-linked but the linked SCIM group name is empty; cannot resolve scim_group_id")
 	}
 
-	group, err := findSCIMGroupByName(ctx, r.client, name)
+	group, err := findSCIMGroupByName(ctx, r.client, *name)
 	if err != nil {
 		return "", err
 	}
 	if group == nil {
-		return "", fmt.Errorf("no SCIM group found with name %q", name)
+		return "", fmt.Errorf("no SCIM group found with name %q", *name)
 	}
 
 	return group.ID, nil

--- a/internal/provider/resource_tfe_scim_group_mapping_test.go
+++ b/internal/provider/resource_tfe_scim_group_mapping_test.go
@@ -1,0 +1,552 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestAccTFESCIMGroupMapping_omnibus is the single test function for all SCIM
+// group mapping acceptance tests.
+//
+// FLAKE ALERT: SCIM settings are a singleton resource shared by the entire TFE
+// instance. Every sub-test here enables SCIM (via an inline tfe_scim_settings
+// block) as a prerequisite. Keeping all cases in one function with no
+// t.Parallel call prevents concurrent tests from racing over that singleton.
+//
+// FLAKE ALERT (dual-singleton): This suite also contends with
+// resource_tfe_saml_settings_test.go for the SAML singleton. Both singletons
+// must be treated as exclusive resources: do not run SCIM and SAML acceptance
+// tests concurrently.
+//
+// Keep this test name matching the SCIM acceptance-test prefix used by the
+// skip regex in ci.yml (currently TestAccTFESCIM), or update that regex.
+func TestAccTFESCIMGroupMapping_omnibus(t *testing.T) {
+	skipIfCloud(t)
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("full lifecycle: create, update paused, import", func(t *testing.T) {
+		org, cleanupOrg := createScimGroupMappingOrganization(t, tfeClient)
+		t.Cleanup(cleanupOrg)
+
+		rand := randomString(t)
+		teamName := "tf-acc-scim-map-" + rand
+		tokenDescription := "scim group mapping lifecycle " + rand
+		groupName := "tf-acc-scim-map-group-" + rand
+
+		var scimToken string
+		requireToken := func() {
+			if scimToken == "" {
+				t.Fatal("captured SCIM token value is empty")
+			}
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMGroupMappingDestroy,
+			Steps: []resource.TestStep{
+				// Enable SCIM and grab a token for the SCIM API.
+				{
+					Config: testAccTFESCIMGroupMapping_setup(org.Name, teamName, tokenDescription),
+					Check:  captureSCIMTokenValue("tfe_scim_token.this", &scimToken),
+				},
+				// Create a SCIM group out-of-band, then map it to the team. Its
+				// scim_group_id is resolved from the name by the tfe_scim_group
+				// data source.
+				{
+					PreConfig: func() {
+						requireToken()
+						createSCIMGroup(t, groupName, scimToken)
+					},
+					Config: testAccTFESCIMGroupMapping_basic(org.Name, teamName, tokenDescription, groupName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "team_id",
+							"tfe_team.test", "id",
+						),
+						// scim_group_id matches the ID resolved by the data source.
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+						resource.TestCheckResourceAttr("tfe_scim_group_mapping.test", "paused", "false"),
+						// id mirrors team_id
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "id",
+							"tfe_team.test", "id",
+						),
+					),
+				},
+				// Re-apply must be a no-op.
+				{
+					Config:   testAccTFESCIMGroupMapping_basic(org.Name, teamName, tokenDescription, groupName),
+					PlanOnly: true,
+				},
+				// Pause the mapping (in-place update).
+				{
+					Config: testAccTFESCIMGroupMapping_paused(org.Name, teamName, tokenDescription, groupName, true),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_group_mapping.test", "paused", "true"),
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+					),
+				},
+				// Unpause again (in-place update).
+				{
+					Config: testAccTFESCIMGroupMapping_basic(org.Name, teamName, tokenDescription, groupName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_group_mapping.test", "paused", "false"),
+					),
+				},
+				// Import by team ID; Read resolves scim_group_id by group name.
+				{
+					ResourceName:      "tfe_scim_group_mapping.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+
+	t.Run("out-of-band drift is detected and re-created", func(t *testing.T) {
+		org, cleanupOrg := createScimGroupMappingOrganization(t, tfeClient)
+		t.Cleanup(cleanupOrg)
+
+		rand := randomString(t)
+		teamName := "tf-acc-scim-map-drift-" + rand
+		tokenDescription := "scim group mapping drift " + rand
+		groupName := "tf-acc-scim-map-drift-group-" + rand
+
+		var scimToken string
+		var teamID string
+		requireToken := func() {
+			if scimToken == "" {
+				t.Fatal("captured SCIM token value is empty")
+			}
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMGroupMappingDestroy,
+			Steps: []resource.TestStep{
+				// Enable SCIM and grab a token for the SCIM API.
+				{
+					Config: testAccTFESCIMGroupMapping_setup(org.Name, teamName, tokenDescription),
+					Check:  captureSCIMTokenValue("tfe_scim_token.this", &scimToken),
+				},
+				// Create a SCIM group out-of-band and map it to the team.
+				{
+					PreConfig: func() {
+						requireToken()
+						createSCIMGroup(t, groupName, scimToken)
+					},
+					Config: testAccTFESCIMGroupMapping_basic(org.Name, teamName, tokenDescription, groupName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_scim_group_mapping.test"]
+							if !ok {
+								return fmt.Errorf("tfe_scim_group_mapping.test not found in state")
+							}
+							teamID = rs.Primary.ID
+							return nil
+						},
+					),
+				},
+				// Unlink the mapping out-of-band; Read clears state and the
+				// re-apply re-creates it.
+				{
+					PreConfig: func() {
+						if err := tfeClient.Admin.Settings.SCIM.SCIMGroupMappings.Delete(ctx, teamID); err != nil {
+							t.Fatalf("delete SCIM group mapping out-of-band: %v", err)
+						}
+					},
+					Config: testAccTFESCIMGroupMapping_basic(org.Name, teamName, tokenDescription, groupName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+						resource.TestCheckResourceAttr("tfe_scim_group_mapping.test", "paused", "false"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("team_id change: old team is unlinked, new team is linked", func(t *testing.T) {
+		org, cleanupOrg := createScimGroupMappingOrganization(t, tfeClient)
+		t.Cleanup(cleanupOrg)
+
+		rand := randomString(t)
+		teamAName := "tf-acc-scim-map-team-a-" + rand
+		teamBName := "tf-acc-scim-map-team-b-" + rand
+		tokenDescription := "scim group mapping team swap " + rand
+		groupName := "tf-acc-scim-map-swap-group-" + rand
+
+		var scimToken string
+		var teamAID string
+		requireToken := func() {
+			if scimToken == "" {
+				t.Fatal("captured SCIM token value is empty")
+			}
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMGroupMappingDestroy,
+			Steps: []resource.TestStep{
+				// Enable SCIM and grab a token.
+				{
+					Config: testAccTFESCIMGroupMapping_setupTwoTeams(org.Name, teamAName, teamBName, tokenDescription),
+					Check:  captureSCIMTokenValue("tfe_scim_token.this", &scimToken),
+				},
+				// Create the SCIM group out-of-band and map it to Team A.
+				{
+					PreConfig: func() {
+						requireToken()
+						createSCIMGroup(t, groupName, scimToken)
+					},
+					Config: testAccTFESCIMGroupMapping_twoTeamsMapped(org.Name, teamAName, teamBName, tokenDescription, groupName, "tfe_team.team_a"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "team_id",
+							"tfe_team.team_a", "id",
+						),
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+						// Capture Team A's ID to verify it is unlinked in the next step.
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["tfe_team.team_a"]
+							if !ok {
+								return fmt.Errorf("tfe_team.team_a not found in state")
+							}
+							teamAID = rs.Primary.ID
+							return nil
+						},
+					),
+				},
+				// Re-point the mapping to Team B. The plan should be a replace
+				// (RequiresReplace on team_id); then verify Team B is linked and
+				// Team A is unlinked via the Teams API.
+				{
+					Config: testAccTFESCIMGroupMapping_twoTeamsMapped(org.Name, teamAName, teamBName, tokenDescription, groupName, "tfe_team.team_b"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(
+								"tfe_scim_group_mapping.test",
+								plancheck.ResourceActionDestroyBeforeCreate,
+							),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "team_id",
+							"tfe_team.team_b", "id",
+						),
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+						// Verify Team A is no longer SCIM-linked.
+						func(_ *terraform.State) error {
+							if teamAID == "" {
+								return fmt.Errorf("teamAID was not captured from previous step")
+							}
+							team, err := tfeClient.Teams.Read(ctx, teamAID)
+							if err != nil {
+								return fmt.Errorf("reading team A (%s): %w", teamAID, err)
+							}
+							if team.SCIMLinked != nil && *team.SCIMLinked {
+								return fmt.Errorf("team A (%s) is still SCIM-linked after team_id was changed to team B", teamAID)
+							}
+							return nil
+						},
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("scim_group_id change: mapping is re-created with new SCIM group", func(t *testing.T) {
+		org, cleanupOrg := createScimGroupMappingOrganization(t, tfeClient)
+		t.Cleanup(cleanupOrg)
+
+		rand := randomString(t)
+		teamName := "tf-acc-scim-map-grpswap-" + rand
+		tokenDescription := "scim group mapping group swap " + rand
+		groupName1 := "tf-acc-scim-map-grpswap-1-" + rand
+		groupName2 := "tf-acc-scim-map-grpswap-2-" + rand
+
+		var scimToken string
+		requireToken := func() {
+			if scimToken == "" {
+				t.Fatal("captured SCIM token value is empty")
+			}
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMGroupMappingDestroy,
+			Steps: []resource.TestStep{
+				// Enable SCIM and grab a token.
+				{
+					Config: testAccTFESCIMGroupMapping_setup(org.Name, teamName, tokenDescription),
+					Check:  captureSCIMTokenValue("tfe_scim_token.this", &scimToken),
+				},
+				// Create both SCIM groups up-front and map the team to group 1.
+				{
+					PreConfig: func() {
+						requireToken()
+						createSCIMGroup(t, groupName1, scimToken)
+						createSCIMGroup(t, groupName2, scimToken)
+					},
+					Config: testAccTFESCIMGroupMapping_basic(org.Name, teamName, tokenDescription, groupName1),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+						resource.TestCheckResourceAttr("tfe_scim_group_mapping.test", "paused", "false"),
+					),
+				},
+				// Switch the mapping to group 2. The plan should be a replace
+				// (RequiresReplace on scim_group_id); then verify the mapping
+				// now points at group 2.
+				{
+					Config: testAccTFESCIMGroupMapping_basic(org.Name, teamName, tokenDescription, groupName2),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(
+								"tfe_scim_group_mapping.test",
+								plancheck.ResourceActionDestroyBeforeCreate,
+							),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+						resource.TestCheckResourceAttr("tfe_scim_group_mapping.test", "paused", "false"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("validation: empty config arguments", func(t *testing.T) {
+		lengthErr := regexp.MustCompile(`(?s)Invalid Attribute Value Length|at least 1`)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccTFESCIMGroupMappingNoArgs(),
+					ExpectError: regexp.MustCompile(`(?s)Missing required argument|argument "team_id" is required|argument "scim_group_id" is required`),
+					PlanOnly:    true,
+				},
+				{
+					Config:      testAccTFESCIMGroupMappingEmptyTeamID(),
+					ExpectError: lengthErr,
+					PlanOnly:    true,
+				},
+				{
+					Config:      testAccTFESCIMGroupMappingEmptySCIMGroupID(),
+					ExpectError: lengthErr,
+					PlanOnly:    true,
+				},
+			},
+		})
+	})
+}
+
+// createScimGroupMappingOrganization creates a plain organization for the SCIM
+// group mapping tests. createBusinessOrganization fails on a real TFE instance
+// (its subscription upgrade is unsupported there), so we use createOrganization
+// directly instead.
+func createScimGroupMappingOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
+	return createOrganization(t, client, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+}
+
+// testAccTFESCIMGroupMappingDestroy verifies all tfe_scim_group_mapping
+// resources have been unlinked from their teams.
+func testAccTFESCIMGroupMappingDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_scim_group_mapping" {
+			continue
+		}
+
+		// The id is the team id.
+		team, err := testAccConfiguredClient.Client.Teams.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			// The team being gone means the mapping is gone too.
+			if errors.Is(err, tfe.ErrResourceNotFound) {
+				continue
+			}
+			return fmt.Errorf("unexpected error checking team %s: %w", rs.Primary.ID, err)
+		}
+		if team.SCIMLinked != nil && *team.SCIMLinked {
+			return fmt.Errorf("team %s is still linked to a SCIM group", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+// testAccTFESCIMGroupMapping_setup enables SAML + SCIM, creates a SCIM token,
+// and provisions an organization team that a SCIM group can be mapped to.
+func testAccTFESCIMGroupMapping_setup(orgName, teamName, tokenDescription string) string {
+	return fmt.Sprintf(`
+%s
+
+data "tfe_organization" "org" {
+  name = "%s"
+}
+
+resource "tfe_team" "test" {
+  name         = "%s"
+  organization = data.tfe_organization.org.name
+}
+
+resource "tfe_scim_settings" "enable_scim" {
+  depends_on = [tfe_saml_settings.enable_saml]
+}
+
+resource "tfe_scim_token" "this" {
+  description = "%s"
+  depends_on  = [tfe_scim_settings.enable_scim]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting), orgName, teamName, tokenDescription)
+}
+
+// testAccTFESCIMGroupMapping_basic maps the team to the SCIM group named
+// groupName (which must already exist) with paused set to false.
+func testAccTFESCIMGroupMapping_basic(orgName, teamName, tokenDescription, groupName string) string {
+	return testAccTFESCIMGroupMapping_paused(orgName, teamName, tokenDescription, groupName, false)
+}
+
+// testAccTFESCIMGroupMapping_paused is like the basic config but sets an
+// explicit paused state.
+func testAccTFESCIMGroupMapping_paused(orgName, teamName, tokenDescription, groupName string, paused bool) string {
+	return fmt.Sprintf(`
+%s
+
+data "tfe_scim_group" "test" {
+  name       = "%s"
+  depends_on = [tfe_scim_token.this]
+}
+
+resource "tfe_scim_group_mapping" "test" {
+  team_id       = tfe_team.test.id
+  scim_group_id = data.tfe_scim_group.test.id
+  paused        = %t
+}
+`, testAccTFESCIMGroupMapping_setup(orgName, teamName, tokenDescription), groupName, paused)
+}
+
+// testAccTFESCIMGroupMapping_setupTwoTeams is like testAccTFESCIMGroupMapping_setup
+// but provisions two teams (team_a and team_b) for the team_id-change scenario.
+func testAccTFESCIMGroupMapping_setupTwoTeams(orgName, teamAName, teamBName, tokenDescription string) string {
+	return fmt.Sprintf(`
+%s
+
+data "tfe_organization" "org" {
+  name = "%s"
+}
+
+resource "tfe_team" "team_a" {
+  name         = "%s"
+  organization = data.tfe_organization.org.name
+}
+
+resource "tfe_team" "team_b" {
+  name         = "%s"
+  organization = data.tfe_organization.org.name
+}
+
+resource "tfe_scim_settings" "enable_scim" {
+  depends_on = [tfe_saml_settings.enable_saml]
+}
+
+resource "tfe_scim_token" "this" {
+  description = "%s"
+  depends_on  = [tfe_scim_settings.enable_scim]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting), orgName, teamAName, teamBName, tokenDescription)
+}
+
+// testAccTFESCIMGroupMapping_twoTeamsMapped maps the SCIM group to the team
+// referenced by teamRef (e.g. "tfe_team.team_a"). Both teams come from the
+// embedded setup block, so one helper covers the initial mapping and the
+// team_id swap.
+func testAccTFESCIMGroupMapping_twoTeamsMapped(orgName, teamAName, teamBName, tokenDescription, groupName, teamRef string) string {
+	return fmt.Sprintf(`
+%s
+
+data "tfe_scim_group" "test" {
+  name       = "%s"
+  depends_on = [tfe_scim_token.this]
+}
+
+resource "tfe_scim_group_mapping" "test" {
+  team_id       = %s.id
+  scim_group_id = data.tfe_scim_group.test.id
+}
+`, testAccTFESCIMGroupMapping_setupTwoTeams(orgName, teamAName, teamBName, tokenDescription), groupName, teamRef)
+}
+
+// testAccTFESCIMGroupMappingNoArgs returns a resource block with no arguments,
+// which must fail because both team_id and scim_group_id are required.
+func testAccTFESCIMGroupMappingNoArgs() string {
+	return `resource "tfe_scim_group_mapping" "test" {}`
+}
+
+// testAccTFESCIMGroupMappingEmptyTeamID returns a resource block with an empty
+// team_id, which must fail the LengthAtLeast(1) validator.
+func testAccTFESCIMGroupMappingEmptyTeamID() string {
+	return `
+resource "tfe_scim_group_mapping" "test" {
+  team_id       = ""
+  scim_group_id = "some-group-id"
+}
+`
+}
+
+// testAccTFESCIMGroupMappingEmptySCIMGroupID returns a resource block with an
+// empty scim_group_id, which must fail the LengthAtLeast(1) validator.
+func testAccTFESCIMGroupMappingEmptySCIMGroupID() string {
+	return `
+resource "tfe_scim_group_mapping" "test" {
+  team_id       = "some-team-id"
+  scim_group_id = ""
+}
+`
+}

--- a/internal/provider/resource_tfe_scim_group_mapping_test.go
+++ b/internal/provider/resource_tfe_scim_group_mapping_test.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"testing"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/internal/provider/resource_tfe_scim_group_mapping_test.go
+++ b/internal/provider/resource_tfe_scim_group_mapping_test.go
@@ -9,10 +9,11 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	tfe "github.com/hashicorp/go-tfe"
 )
 
 // TestAccTFESCIMGroupMapping_omnibus is the single test function for all SCIM

--- a/internal/provider/resource_tfe_scim_group_mapping_test.go
+++ b/internal/provider/resource_tfe_scim_group_mapping_test.go
@@ -124,6 +124,58 @@ func TestAccTFESCIMGroupMapping_omnibus(t *testing.T) {
 		})
 	})
 
+	t.Run("create starts paused", func(t *testing.T) {
+		org, cleanupOrg := createScimGroupMappingOrganization(t, tfeClient)
+		t.Cleanup(cleanupOrg)
+
+		rand := randomString(t)
+		teamName := "tf-acc-scim-map-paused-" + rand
+		tokenDescription := "scim group mapping create paused " + rand
+		groupName := "tf-acc-scim-map-paused-group-" + rand
+
+		var scimToken string
+		requireToken := func() {
+			if scimToken == "" {
+				t.Fatal("captured SCIM token value is empty")
+			}
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMGroupMappingDestroy,
+			Steps: []resource.TestStep{
+				// Enable SCIM and grab a token for the SCIM API.
+				{
+					Config: testAccTFESCIMGroupMapping_setup(org.Name, teamName, tokenDescription),
+					Check:  captureSCIMTokenValue("tfe_scim_token.this", &scimToken),
+				},
+				// Create the SCIM group out-of-band, then map it to the team
+				// with paused set to true on creation. Create always starts
+				// unpaused, so the provider pauses it in a follow-up update.
+				{
+					PreConfig: func() {
+						requireToken()
+						createSCIMGroup(t, groupName, scimToken)
+					},
+					Config: testAccTFESCIMGroupMapping_paused(org.Name, teamName, tokenDescription, groupName, true),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_group_mapping.test", "paused", "true"),
+						resource.TestCheckResourceAttrPair(
+							"tfe_scim_group_mapping.test", "scim_group_id",
+							"data.tfe_scim_group.test", "id",
+						),
+					),
+				},
+				// Re-apply must be a no-op.
+				{
+					Config:   testAccTFESCIMGroupMapping_paused(org.Name, teamName, tokenDescription, groupName, true),
+					PlanOnly: true,
+				},
+			},
+		})
+	})
+
 	t.Run("out-of-band drift is detected and re-created", func(t *testing.T) {
 		org, cleanupOrg := createScimGroupMappingOrganization(t, tfeClient)
 		t.Cleanup(cleanupOrg)

--- a/internal/provider/scim_helpers.go
+++ b/internal/provider/scim_helpers.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe"
 )
 
 // filterExactSCIMGroups returns the groups whose name matches the given name,

--- a/internal/provider/scim_helpers.go
+++ b/internal/provider/scim_helpers.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-tfe"
+	tfe "github.com/hashicorp/go-tfe"
 )
 
 // filterExactSCIMGroups returns the groups whose name matches the given name,

--- a/internal/provider/scim_helpers.go
+++ b/internal/provider/scim_helpers.go
@@ -4,6 +4,8 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
@@ -23,4 +25,32 @@ func filterExactSCIMGroups(groups []*tfe.AdminSCIMGroup, name string) []*tfe.Adm
 		}
 	}
 	return matched
+}
+
+// findSCIMGroupByName returns the SCIM group whose name matches exactly
+// (case-insensitive), paging as needed. Returns (nil, nil) if none match, so
+// the caller can craft its own "not found" message. ?q= only prefilters on the
+// server; filterExactSCIMGroups does the real matching.
+func findSCIMGroupByName(ctx context.Context, client *tfe.Client, name string) (*tfe.AdminSCIMGroup, error) {
+	options := &tfe.AdminSCIMGroupListOptions{
+		Query: name,
+	}
+
+	for {
+		list, err := client.Admin.Settings.SCIM.Groups.List(ctx, options)
+		if err != nil {
+			return nil, fmt.Errorf("unable to list SCIM groups: %w", err)
+		}
+
+		if matched := filterExactSCIMGroups(list.Items, name); len(matched) > 0 {
+			return matched[0], nil
+		}
+
+		if list.Pagination == nil || list.CurrentPage >= list.TotalPages {
+			break
+		}
+		options.PageNumber = list.NextPage
+	}
+
+	return nil, nil
 }

--- a/internal/provider/scim_helpers.go
+++ b/internal/provider/scim_helpers.go
@@ -49,6 +49,11 @@ func findSCIMGroupByName(ctx context.Context, client *tfe.Client, name string) (
 		if list.Pagination == nil || list.CurrentPage >= list.TotalPages {
 			break
 		}
+		// Guard against a malformed response (NextPage not advancing past the
+		// current page) that would otherwise re-fetch the same page forever.
+		if list.NextPage <= list.CurrentPage {
+			break
+		}
 		options.PageNumber = list.NextPage
 	}
 

--- a/internal/provider/scim_helpers.go
+++ b/internal/provider/scim_helpers.go
@@ -52,7 +52,7 @@ func findSCIMGroupByName(ctx context.Context, client *tfe.Client, name string) (
 		// Guard against a malformed response (NextPage not advancing past the
 		// current page) that would otherwise re-fetch the same page forever.
 		if list.NextPage <= list.CurrentPage {
-			break
+			return nil, fmt.Errorf("unable to list SCIM groups: pagination did not advance (current_page=%d next_page=%d)", list.CurrentPage, list.NextPage)
 		}
 		options.PageNumber = list.NextPage
 	}

--- a/internal/provider/scim_helpers_test.go
+++ b/internal/provider/scim_helpers_test.go
@@ -275,4 +275,27 @@ func TestFindSCIMGroupByName(t *testing.T) {
 		assert.Contains(t, err.Error(), "bar")
 		assert.Len(t, fake.calls, 2)
 	})
+
+	t.Run("non-advancing pagination errors instead of looping", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					// Pagination claims another page exists but NextPage does
+					// not advance past CurrentPage, which would otherwise
+					// re-fetch the same page forever.
+					Pagination: &tfe.Pagination{CurrentPage: 1, TotalPages: 2, NextPage: 1},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-1", Name: "platform-ops-idp-bar"},
+					},
+				},
+			},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.Error(t, err)
+		assert.Nil(t, group)
+		assert.Contains(t, err.Error(), "pagination did not advance")
+		// Only one request was made; the loop bailed instead of repeating.
+		assert.Len(t, fake.calls, 1)
+	})
 }

--- a/internal/provider/scim_helpers_test.go
+++ b/internal/provider/scim_helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"testing"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/provider/scim_helpers_test.go
+++ b/internal/provider/scim_helpers_test.go
@@ -226,6 +226,25 @@ func TestFindSCIMGroupByName(t *testing.T) {
 		assert.Len(t, fake.calls, 2)
 	})
 
+	t.Run("empty name forwards an empty query and matches nothing named", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					Pagination: &tfe.Pagination{CurrentPage: 1, TotalPages: 1},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-1", Name: "platform-ops-idp"},
+					},
+				},
+			},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), "")
+		require.NoError(t, err)
+		assert.Nil(t, group)
+		require.Len(t, fake.calls, 1)
+		assert.Empty(t, fake.calls[0].Query)
+	})
+
 	t.Run("nil pagination stops after one page", func(t *testing.T) {
 		fake := &fakeSCIMGroups{
 			pages: []*tfe.AdminSCIMGroupList{

--- a/internal/provider/scim_helpers_test.go
+++ b/internal/provider/scim_helpers_test.go
@@ -4,10 +4,13 @@
 package provider
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilterExactSCIMGroups(t *testing.T) {
@@ -51,5 +54,225 @@ func TestFilterExactSCIMGroups(t *testing.T) {
 		matched := filterExactSCIMGroups(groups, "platform-ops-idp-audit-group")
 		assert.Len(t, matched, 1)
 		assert.Equal(t, "sgr-4", matched[0].ID)
+	})
+}
+
+// testSCIMGroupName is the group name searched for throughout the
+// findSCIMGroupByName tests.
+const testSCIMGroupName = "platform-ops-idp"
+
+// fakeSCIMGroups is a stub tfe.AdminSCIMGroups that returns canned pages and
+// records the options passed to each List call so tests can assert on the
+// pagination requests findSCIMGroupByName makes.
+type fakeSCIMGroups struct {
+	pages []*tfe.AdminSCIMGroupList
+	// errs, when set, is consulted by call index: a non-nil errs[i] is
+	// returned on the (i+1)th List call instead of a page. This lets tests
+	// inject a failure on an arbitrary page, not just the first.
+	errs  []error
+	calls []tfe.AdminSCIMGroupListOptions
+}
+
+var _ tfe.AdminSCIMGroups = (*fakeSCIMGroups)(nil)
+
+func (f *fakeSCIMGroups) List(_ context.Context, options *tfe.AdminSCIMGroupListOptions) (*tfe.AdminSCIMGroupList, error) {
+	// findSCIMGroupByName mutates and reuses the same options pointer across
+	// pages, so snapshot it by value before recording.
+	var snapshot tfe.AdminSCIMGroupListOptions
+	if options != nil {
+		snapshot = *options
+	}
+	f.calls = append(f.calls, snapshot)
+
+	idx := len(f.calls) - 1
+	if idx < len(f.errs) && f.errs[idx] != nil {
+		return nil, f.errs[idx]
+	}
+	if idx >= len(f.pages) {
+		return &tfe.AdminSCIMGroupList{Pagination: &tfe.Pagination{}}, nil
+	}
+	return f.pages[idx], nil
+}
+
+// newSCIMGroupsTestClient wires a fake AdminSCIMGroups into the nested client
+// path that findSCIMGroupByName reaches through.
+func newSCIMGroupsTestClient(groups tfe.AdminSCIMGroups) *tfe.Client {
+	return &tfe.Client{
+		Admin: tfe.Admin{
+			Settings: &tfe.AdminSettings{
+				SCIM: &tfe.SCIMResource{
+					Groups: groups,
+				},
+			},
+		},
+	}
+}
+
+func TestFindSCIMGroupByName(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("single page exact match", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					Pagination: &tfe.Pagination{CurrentPage: 1, TotalPages: 1},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-1", Name: "platform-ops-idp"},
+					},
+				},
+			},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.NoError(t, err)
+		require.NotNil(t, group)
+		assert.Equal(t, "sgr-1", group.ID)
+
+		// One request, and the name is forwarded as the server-side prefilter.
+		require.Len(t, fake.calls, 1)
+		assert.Equal(t, testSCIMGroupName, fake.calls[0].Query)
+	})
+
+	t.Run("case-insensitive match", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					Pagination: &tfe.Pagination{CurrentPage: 1, TotalPages: 1},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-9", Name: "Platform-Ops-IDP"},
+					},
+				},
+			},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.NoError(t, err)
+		require.NotNil(t, group)
+		assert.Equal(t, "sgr-9", group.ID)
+	})
+
+	t.Run("paginates until the match is found", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					Pagination: &tfe.Pagination{CurrentPage: 1, TotalPages: 2, NextPage: 2},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-1", Name: "platform-ops-idp-other"},
+					},
+				},
+				{
+					Pagination: &tfe.Pagination{CurrentPage: 2, TotalPages: 2},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-2", Name: "platform-ops-idp"},
+					},
+				},
+			},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.NoError(t, err)
+		require.NotNil(t, group)
+		assert.Equal(t, "sgr-2", group.ID)
+
+		// Two requests; the second one asks for the next page and still carries
+		// the server-side prefilter so it isn't dropped mid-pagination.
+		require.Len(t, fake.calls, 2)
+		assert.Equal(t, 2, fake.calls[1].PageNumber)
+		assert.Equal(t, testSCIMGroupName, fake.calls[1].Query)
+	})
+
+	t.Run("stops paginating once a match is found", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					// Pagination claims more pages exist, but the match is on
+					// this page so no further request should be made.
+					Pagination: &tfe.Pagination{CurrentPage: 1, TotalPages: 5, NextPage: 2},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-1", Name: "platform-ops-idp"},
+					},
+				},
+			},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.NoError(t, err)
+		require.NotNil(t, group)
+		assert.Equal(t, "sgr-1", group.ID)
+		assert.Len(t, fake.calls, 1)
+	})
+
+	t.Run("no match across all pages returns nil", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					Pagination: &tfe.Pagination{CurrentPage: 1, TotalPages: 2, NextPage: 2},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-1", Name: "platform-ops-idp-bar"},
+					},
+				},
+				{
+					Pagination: &tfe.Pagination{CurrentPage: 2, TotalPages: 2},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-2", Name: "platform-ops-idp-baz"},
+					},
+				},
+			},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.NoError(t, err)
+		assert.Nil(t, group)
+		assert.Len(t, fake.calls, 2)
+	})
+
+	t.Run("nil pagination stops after one page", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					Pagination: nil,
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-1", Name: "platform-ops-idp-bar"},
+					},
+				},
+			},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.NoError(t, err)
+		assert.Nil(t, group)
+		assert.Len(t, fake.calls, 1)
+	})
+
+	t.Run("list error is wrapped", func(t *testing.T) {
+		fake := &fakeSCIMGroups{errs: []error{errors.New("foo")}}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.Error(t, err)
+		assert.Nil(t, group)
+		assert.Contains(t, err.Error(), "unable to list SCIM groups")
+		assert.Contains(t, err.Error(), "foo")
+	})
+
+	t.Run("error on a later page is wrapped", func(t *testing.T) {
+		fake := &fakeSCIMGroups{
+			pages: []*tfe.AdminSCIMGroupList{
+				{
+					Pagination: &tfe.Pagination{CurrentPage: 1, TotalPages: 2, NextPage: 2},
+					Items: []*tfe.AdminSCIMGroup{
+						{ID: "sgr-1", Name: "platform-ops-idp-bar"},
+					},
+				},
+			},
+			// First page succeeds, the second fails.
+			errs: []error{nil, errors.New("bar")},
+		}
+
+		group, err := findSCIMGroupByName(ctx, newSCIMGroupsTestClient(fake), testSCIMGroupName)
+		require.Error(t, err)
+		assert.Nil(t, group)
+		assert.Contains(t, err.Error(), "unable to list SCIM groups")
+		assert.Contains(t, err.Error(), "bar")
+		assert.Len(t, fake.calls, 2)
 	})
 }

--- a/internal/provider/scim_helpers_test.go
+++ b/internal/provider/scim_helpers_test.go
@@ -8,9 +8,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	tfe "github.com/hashicorp/go-tfe"
 )
 
 func TestFilterExactSCIMGroups(t *testing.T) {

--- a/website/docs/r/scim_group_mapping.html.markdown
+++ b/website/docs/r/scim_group_mapping.html.markdown
@@ -74,6 +74,13 @@ resource "tfe_scim_group_mapping" "engineering" {
 }
 ```
 
+~> **Note:** Creating a mapping with `paused = true` does not skip the initial
+sync. The mapping API does not support creating a mapping in a paused state, so
+the mapping is created active and then paused in a follow-up request. This means
+an initial sync of the SCIM group's members onto the team runs before the pause
+takes effect, and any changes made to the SCIM group during that brief window may
+be reflected on the team.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -84,7 +91,8 @@ The following arguments are supported:
   Changing this forces a new mapping to be created, since the mapping API only
   supports updating the paused state.
 * `paused` - (Optional) Whether provisioning for this mapping is paused. Defaults
-  to `false`.
+  to `false`. Setting this to `true` on creation does not skip the initial sync,
+  since the mapping is created active and then paused in a follow-up request.
 
 ## Attributes Reference
 

--- a/website/docs/r/scim_group_mapping.html.markdown
+++ b/website/docs/r/scim_group_mapping.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # tfe_scim_group_mapping
 
-Use this resource to map a SCIM group to a team in Terraform Enterprise. When a
+Use this resource to map a team in Terraform Enterprise to a SCIM group. When a
 team is mapped to a SCIM group, its membership is managed by your Identity
 Provider (IdP) through SCIM provisioning. A team can be mapped to at most one
 SCIM group.

--- a/website/docs/r/scim_group_mapping.html.markdown
+++ b/website/docs/r/scim_group_mapping.html.markdown
@@ -23,7 +23,7 @@ mapping can be created.
 The SCIM group you map to must already exist in Terraform Enterprise. Groups are
 created by your IdP after SCIM provisioning is enabled, so this typically follows
 a workflow where SCIM is enabled first, the IdP pushes the group, and then the
-mapping is created. Use the [`tfe_scim_group`](scim_group.html) data source
+mapping is created. Use the [`tfe_scim_group`](../d/scim_group.html) data source
 to look up the group's ID by name:
 
 ```hcl

--- a/website/docs/r/scim_group_mapping.html.markdown
+++ b/website/docs/r/scim_group_mapping.html.markdown
@@ -1,0 +1,100 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_scim_group_mapping"
+description: |-
+  Maps a SCIM group to a team.
+---
+
+# tfe_scim_group_mapping
+
+Use this resource to map a SCIM group to a team in Terraform Enterprise. When a
+team is mapped to a SCIM group, its membership is managed by your Identity
+Provider (IdP) through SCIM provisioning. A team can be mapped to at most one
+SCIM group.
+
+This resource applies only to Terraform Enterprise and requires admin token
+configuration. SCIM (and SAML) must be enabled first; see
+[`tfe_scim_settings`](scim_settings.html) for details. The SCIM group you map to
+must already be provisioned into Terraform Enterprise by your IdP before the
+mapping can be created.
+
+## Example Usage
+
+The SCIM group you map to must already exist in Terraform Enterprise. Groups are
+created by your IdP after SCIM provisioning is enabled, so this typically follows
+a workflow where SCIM is enabled first, the IdP pushes the group, and then the
+mapping is created. Use the [`tfe_scim_group`](scim_group.html) data source
+to look up the group's ID by name:
+
+```hcl
+provider "tfe" {
+  hostname = var.hostname
+  token    = var.admin_token
+}
+
+resource "tfe_saml_settings" "this" {
+  idp_cert         = "foobarCertificate"
+  slo_endpoint_url = "https://example.com/slo_endpoint_url"
+  sso_endpoint_url = "https://example.com/sso_endpoint_url"
+  provider_type    = "okta"
+}
+
+resource "tfe_scim_settings" "this" {
+  depends_on = [tfe_saml_settings.this]
+}
+
+data "tfe_organization" "this" {
+  name = "my-org-name"
+}
+
+resource "tfe_team" "engineering" {
+  name         = "engineering"
+  organization = data.tfe_organization.this.name
+}
+
+# Look up the SCIM group provisioned by your IdP.
+data "tfe_scim_group" "engineering" {
+  name       = "engineering-scim-group"
+  depends_on = [tfe_scim_settings.this]
+}
+
+resource "tfe_scim_group_mapping" "engineering" {
+  team_id       = tfe_team.engineering.id
+  scim_group_id = data.tfe_scim_group.engineering.id
+}
+```
+
+You can pause provisioning for a single mapping without removing it:
+
+```hcl
+resource "tfe_scim_group_mapping" "engineering" {
+  team_id       = tfe_team.engineering.id
+  scim_group_id = data.tfe_scim_group.engineering.id
+  paused        = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `team_id` - (Required) The ID of the team to map the SCIM group to. Changing
+  this forces a new mapping to be created.
+* `scim_group_id` - (Required) The ID of the SCIM group to map to the team.
+  Changing this forces a new mapping to be created, since the mapping API only
+  supports updating the paused state.
+* `paused` - (Optional) Whether provisioning for this mapping is paused. Defaults
+  to `false`.
+
+## Attributes Reference
+
+* `id` - The ID of the SCIM group mapping. Since a team can only be mapped to one
+  SCIM group, this is the same as `team_id`.
+
+## Import
+
+SCIM group mappings can be imported using the team ID.
+
+```shell
+terraform import tfe_scim_group_mapping.engineering team-xxxxxxxxxxxxxxxx
+```


### PR DESCRIPTION
## Description

This PR adds `r/tfe_scim_group_mapping` to map a SCIM group to a team in Terraform Enterprise. A team can be mapped to at most one SCIM group, and its membership is then managed by your IdP through SCIM provisioning.

Changing `team_id` or `scim_group_id` forces a new mapping, since the underlying API only supports updating the `paused` state in place.

Because the Teams API only returns the linked group's *name* (not its ID), `Read` resolves `scim_group_id` by looking the group up by name. This is handled by a new `findSCIMGroupByName` helper, which pages through groups and matches exactly (case-insensitive).

This PR also adds acceptance tests. Since SCIM settings are a shared singleton, the coverage is grouped into a single omnibus test to avoid race conditions.

Docs for `r/tfe_scim_group_mapping` are included as well.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Spin up a TFE instance with SAML + SCIM enabled and run acceptance tests against it.

## External links

[JIRA](https://hashicorp.atlassian.net/browse/TF-35682)
[RFC](https://hermes-sharepoint.hashicorp.services/document/01XOO7K4IWFH44KZAPDJC3QXNKIRWEZMBA)

## Output from acceptance tests

1. `TESTARGS="-run TestAccTFESCIMGroupMapping" ENABLE_TFE=1 envchain scim make testacc`
    <img width="1209" height="441" alt="Untitled" src="https://github.com/user-attachments/assets/06a2191d-6d80-4613-b56c-7fe649dd60f6" />

2. [Nightly TFE Tests #1188](https://github.com/hashicorp/terraform-provider-tfe/actions/runs/27203237365)
    <img width="1658" height="701" alt="Untitled 2" src="https://github.com/user-attachments/assets/2a0be812-9147-4a77-80a6-1c740978ed92" />

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

we can revert this pr

## Changes to Security Controls

NA
