### PR TITLE
add `provider_set` `data_source`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ FEATURES:
 * **New Resource:** `r/tfe_scim_token` and **New Data Source:** `d/tfe_scim_token`: Adds resource and data source to manage SCIM tokens on Terraform Enterprise. By @skj-skj [#2076](https://github.com/hashicorp/terraform-provider-tfe/pull/2076)
 * **New Resource:** `r/tfe_admin_smtp_settings` and **New Data Source:** `d/tfe_admin_smtp_settings`: Adds resource and data source to manage Admin SMTP settings in Terraform Enterprise by @chpag [#2059](https://github.com/hashicorp/terraform-provider-tfe/pull/2059)
 * **New Data Source:** `d/tfe_scim_group`: Adds a data source to retrieve a SCIM group from Terraform Enterprise. By @skj-skj [#2083](https://github.com/hashicorp/terraform-provider-tfe/pull/2083)
-* **New Resource:** `r/tfe_provider_set` for managing shared provider configurations for internal testing. NOTE: This resource is subject to change and has limited support in HCP Terraform. By @mogrogan [#2086](https://github.com/hashicorp/terraform-provider-tfe/pull/2086)
 * **New Resource:** `r/tfe_scim_group_mapping`: Adds a resource to map a SCIM group to a team on Terraform Enterprise. By @skj-skj [#2090](https://github.com/hashicorp/terraform-provider-tfe/pull/2090)
+* **New Resource:** `r/tfe_provider_set` for managing shared provider configurations for internal testing. NOTE: This resource is subject to change and has limited support in HCP Terraform. It is not available to public. By @mogrogan [#2086](https://github.com/hashicorp/terraform-provider-tfe/pull/2086)
+* **New Data Source:** `d/tfe_provider_set` for retrieving shared provider configurations for internal testing. NOTE: This data source is subject to change and has limited support in HCP Terraform. It is not available to public. By @mogrogan [#2091](https://github.com/hashicorp/terraform-provider-tfe/pull/2091)
 
 ENHANCEMENTS:
 * `d/tfe_team`: Expose SCIM attributes (`scim_linked`, `scim_group_name`, `scim_sync_paused`, `scim_updated_at`) as computed read-only fields. These are only populated when SCIM is enabled on the TFE instance [#2088](https://github.com/hashicorp/terraform-provider-tfe/pull/2088)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-slug v1.0.0
-	github.com/hashicorp/go-tfe v1.107.0
+	github.com/hashicorp/go-tfe v1.109.0
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW3o=
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
-github.com/hashicorp/go-tfe v1.107.0 h1:ux6qBTHJ3OmIDnF3qWetDilgdbb4udvw0tp2ZC2oP8I=
-github.com/hashicorp/go-tfe v1.107.0/go.mod h1:d8js2OmMnCq58gEh26mCS81nD8Aj7HmG6IO1b80gM78=
+github.com/hashicorp/go-tfe v1.109.0 h1:zWusjKHkWBdkmgzUc1OizccnlcOiCe/Y0FzOQMQLets=
+github.com/hashicorp/go-tfe v1.109.0/go.mod h1:d8js2OmMnCq58gEh26mCS81nD8Aj7HmG6IO1b80gM78=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/data_source_provider_set.go
+++ b/internal/provider/data_source_provider_set.go
@@ -1,0 +1,198 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceTFEProviderSet{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFEProviderSet{}
+)
+
+// Schema implements datasource.DataSource.
+func (d *dataSourceTFEProviderSet) Schema(
+	ctx context.Context,
+	req datasource.SchemaRequest,
+	resp *datasource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		Description: "This data source can be used to retrieve a provider set.",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Description: "The name of the provider set.",
+				Required:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "The ID of the provider set.",
+				Computed:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "The description of the provider set.",
+				Computed:    true,
+			},
+			"global": schema.BoolAttribute{
+				Description: "Whether the provider set applies globally.",
+				Computed:    true,
+			},
+			"organization": schema.StringAttribute{
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Computed:    true,
+				Optional:    true,
+			},
+			"workspace_ids": schema.SetAttribute{
+				Description: "The workspace IDs attached to the provider set.",
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"project_ids": schema.SetAttribute{
+				Description: "The project IDs attached to the provider set.",
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"provider_source": schema.StringAttribute{
+				Description: "Source address of the provider, e.g. registry.terraform.io/hashicorp/tfe.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+type modelDataSourceTFEProviderSet struct {
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Description    types.String `tfsdk:"description"`
+	Global         types.Bool   `tfsdk:"global"`
+	Organization   types.String `tfsdk:"organization"`
+	WorkspaceIDs   types.Set    `tfsdk:"workspace_ids"`
+	ProjectIDs     types.Set    `tfsdk:"project_ids"`
+	ProviderSource types.String `tfsdk:"provider_source"`
+}
+
+// modelDataSourceFromTFEProviderSet builds a modelDataSourceFromTFEProviderSet struct from a tfe.ProviderSet
+func modelDataSourceFromTFEProviderSet(
+	ctx context.Context,
+	v tfe.ProviderSet,
+) (m modelDataSourceTFEProviderSet, diags diag.Diagnostics) {
+	organization := ""
+	if v.Organization != nil {
+		organization = v.Organization.Name
+	}
+
+	// Initialize all fields from the provided API struct
+	m = modelDataSourceTFEProviderSet{
+		ID:             types.StringValue(v.ID),
+		Name:           types.StringValue(v.Name),
+		Description:    types.StringValue(v.Description),
+		Global:         types.BoolValue(v.Global),
+		Organization:   types.StringValue(organization),
+		ProviderSource: types.StringValue(v.ProviderSource),
+		ProjectIDs:     types.SetNull(types.StringType),
+		WorkspaceIDs:   types.SetNull(types.StringType),
+	}
+
+	projectIDs := make([]string, len(v.Projects))
+	for i, project := range v.Projects {
+		projectIDs[i] = project.ID
+	}
+
+	var d diag.Diagnostics
+
+	if len(projectIDs) > 0 {
+		m.ProjectIDs, d = types.SetValueFrom(ctx, types.StringType, projectIDs)
+		diags.Append(d...)
+	}
+
+	workspaceIDs := make([]string, len(v.Workspaces))
+	for i, workspace := range v.Workspaces {
+		workspaceIDs[i] = workspace.ID
+	}
+	if len(workspaceIDs) > 0 {
+		m.WorkspaceIDs, d = types.SetValueFrom(ctx, types.StringType, workspaceIDs)
+		diags.Append(d...)
+	}
+	return m, diags
+}
+
+type dataSourceTFEProviderSet struct {
+	config ConfiguredClient
+}
+
+// NewProviderSetDataSource is a helper function to simplify the provider implementation.
+func NewProviderSetDataSource() datasource.DataSource {
+	return &dataSourceTFEProviderSet{}
+}
+
+// Configure implements datasource.DataSourceWithConfigure.
+func (d *dataSourceTFEProviderSet) Configure(
+	ctx context.Context,
+	req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse,
+) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+
+		return
+	}
+	d.config = client
+}
+
+// Metadata implements datasource.DataSource.
+func (d *dataSourceTFEProviderSet) Metadata(
+	_ context.Context,
+	req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + "_provider_set"
+}
+
+// Read implements datasource.DataSource.
+func (d *dataSourceTFEProviderSet) Read(
+	ctx context.Context,
+	req datasource.ReadRequest,
+	resp *datasource.ReadResponse,
+) {
+	var config modelDataSourceTFEProviderSet
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var organization string
+	resp.Diagnostics.Append(d.config.dataOrDefaultOrganization(ctx, req.Config, &organization)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Read provider set: %s", config.Name.ValueString()))
+	ps, err := d.config.Client.ProviderSets.ReadByName(ctx, organization, config.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error retrieving provider set", err.Error())
+		return
+	}
+	m, diags := modelDataSourceFromTFEProviderSet(ctx, *ps)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, m)...)
+}

--- a/internal/provider/data_source_provider_set_test.go
+++ b/internal/provider/data_source_provider_set_test.go
@@ -1,0 +1,323 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccTFEProviderSetDataSource_read(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSetName := "tst-provider-set-" + randomString(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSetDataSource_basic_without_data(providerSetName, org.Name),
+			},
+			{
+				Config: testAccTFEProviderSetDataSource_basic_with_data(providerSetName, org.Name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "name", providerSetName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "description", "Provider Set description",
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "organization", org.Name,
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "project_ids.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "workspace_ids.#", "1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSetDataSource_read_uninitialized_provider_set(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSetName := "tst-provider-set-" + randomString(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEProviderSetDataSource_minimal_with_data(providerSetName, &org.Name),
+				ExpectError: regexp.MustCompile("resource not found"),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSetDataSource_read_provider_set_deleted(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSetName := "tst-provider-set-" + randomString(t)
+	providerSetId := "uninitialized"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSetDataSource_minimal_without_data(providerSetName, &org.Name),
+			},
+			{
+				Config: testAccTFEProviderSetDataSource_minimal_with_data(providerSetName, &org.Name),
+				PreConfig: func() {
+					providerSetFromApi, err := tfeClient.ProviderSets.ReadByName(context.Background(), org.Name, providerSetName)
+					if err != nil {
+						panic(err)
+					}
+					providerSetId = providerSetFromApi.ID
+				},
+			},
+			{
+				Config: testAccTFEProviderSetDataSource_minimal_with_data(providerSetName, &org.Name),
+				Check: func(s *terraform.State) error {
+					return resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "id", providerSetId,
+					)(s)
+				},
+			},
+			{
+				PreConfig: func() {
+					err := tfeClient.ProviderSets.Delete(context.Background(), providerSetId)
+					if err != nil {
+						panic(err)
+					}
+				},
+				Config:      testAccTFEProviderSetDataSource_minimal_with_data(providerSetName, &org.Name),
+				ExpectError: regexp.MustCompile("resource not found"),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSetDataSource_read_with_default_organization(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	providerSetName := "tst-provider-set-" + randomString(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		// when organization is not specified in the config, the provider should use
+		// the default organization from the provider configuration, so we need to mux
+		// the providers to include that default organization
+		ProtoV6ProviderFactories: muxedProvidersWithDefaultOrganization(org.Name),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSetDataSource_minimal_without_data(providerSetName, nil),
+			},
+			{
+				Config: testAccTFEProviderSetDataSource_minimal_with_data(providerSetName, nil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "name", providerSetName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "organization", org.Name,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSetDataSource_validation(t *testing.T) {
+	skipUnlessBeta(t)
+
+	providerSetName := "tst-provider-set"
+	organizationName := "tst-organization"
+	invalidOrganization := "invalid/org"
+	invalidName := "invalid/name"
+	emptyString := ""
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEProviderSetDataSource_only_data(&providerSetName, nil),
+				ExpectError: regexp.MustCompile("No organization was specified on the resource or provider"),
+			},
+			{
+				Config:      testAccTFEProviderSetDataSource_only_data(&providerSetName, &invalidOrganization),
+				ExpectError: regexp.MustCompile("invalid value for organization"),
+			},
+			{
+				Config:      testAccTFEProviderSetDataSource_only_data(&providerSetName, &emptyString),
+				ExpectError: regexp.MustCompile("invalid value for organization"),
+			},
+			{
+				Config:      testAccTFEProviderSetDataSource_only_data(nil, &organizationName),
+				ExpectError: regexp.MustCompile("The argument \"name\" is required, but no definition was found"),
+			},
+			{
+				Config:      testAccTFEProviderSetDataSource_only_data(&invalidName, &organizationName),
+				ExpectError: regexp.MustCompile("invalid value for name"),
+			},
+			{
+				Config:      testAccTFEProviderSetDataSource_only_data(&emptyString, &organizationName),
+				ExpectError: regexp.MustCompile("name is required"),
+			},
+		},
+	})
+}
+
+func testAccTFEProviderSetDataSource_basic_without_data(name string, organization string) string {
+	return fmt.Sprintf(`
+locals {
+  name         = %q
+  organization = %q
+}
+
+resource "tfe_workspace" "foo" {
+  name         = "workspace-foo"
+  organization = local.organization
+}
+
+resource "tfe_project" "foo" {
+  name         = "project-foo"
+  organization = local.organization
+}
+
+resource "tfe_provider_set" "foobar" {
+  name                = local.name
+  description         = "Provider Set description"
+  organization        = local.organization
+  provider_source     = "registry.terraform.io/hashicorp/aws"
+  global              = false
+  provider_config_hcl = <<-EOT
+provider "aws" {
+  region = "us-east-1"
+}
+EOT
+
+  project_ids =   [ tfe_project.foo.id ]
+  workspace_ids = [ tfe_workspace.foo.id ]
+}`, name, organization)
+}
+
+func testAccTFEProviderSetDataSource_basic_with_data(name string, organization string) string {
+	return providerSetDataSource_add_data(
+		testAccTFEProviderSetDataSource_basic_without_data(name, organization),
+		&name,
+		&organization,
+	)
+}
+
+func testAccTFEProviderSetDataSource_minimal_without_data(name string, organization *string) string {
+	organizationStr := "// omitted organization since value is nil"
+	if organization != nil {
+		organizationStr = fmt.Sprintf("organization = %q", *organization)
+	}
+
+	return fmt.Sprintf(`
+resource "tfe_provider_set" "foobar" {
+  name                = %q
+  description         = "Provider Set description"
+  %s
+  provider_source     = "registry.terraform.io/hashicorp/aws"
+  global              = false
+  provider_config_hcl = <<-EOT
+provider "aws" {
+  region = "us-east-1"
+}
+EOT
+}`, name, organizationStr)
+}
+
+func testAccTFEProviderSetDataSource_minimal_with_data(name string, organization *string) string {
+	return providerSetDataSource_add_data(
+		testAccTFEProviderSetDataSource_minimal_without_data(name, organization),
+		&name,
+		organization,
+	)
+}
+
+func testAccTFEProviderSetDataSource_only_data(name *string, organization *string) string {
+	return providerSetDataSource_add_data("", name, organization)
+}
+
+func providerSetDataSource_add_data(template string, name, organization *string) string {
+	nameStr := "// omitted name since value is nil"
+	organizationStr := "// omitted organization since value is nil"
+
+	if name != nil {
+		nameStr = fmt.Sprintf("name = %q", *name)
+	}
+	if organization != nil {
+		organizationStr = fmt.Sprintf("organization = %q", *organization)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+data "tfe_provider_set" "foobar" {
+  %s
+  %s
+}
+`, template, nameStr, organizationStr)
+}

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -25,9 +25,11 @@ type frameworkProvider struct {
 }
 
 // Compile-time interface check
-var _ provider.Provider = &frameworkProvider{}
-var _ provider.ProviderWithEphemeralResources = &frameworkProvider{}
-var _ provider.ProviderWithActions = &frameworkProvider{}
+var (
+	_ provider.Provider                       = &frameworkProvider{}
+	_ provider.ProviderWithEphemeralResources = &frameworkProvider{}
+	_ provider.ProviderWithActions            = &frameworkProvider{}
+)
 
 // FrameworkProviderConfig is a helper type for extracting the provider
 // configuration from the provider block.
@@ -114,7 +116,6 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 	}
 
 	providerClient, err := client.GetClient(data.Hostname.ValueString(), data.Token.ValueString(), data.SSLSkipVerify.ValueBool())
-
 	if err != nil {
 		res.Diagnostics.AddError("Failed to initialize HTTP client", err.Error())
 		return
@@ -155,6 +156,7 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewOutputsDataSource,
 		NewProjectDataSource,
 		NewProjectsDataSource,
+		NewProviderSetDataSource,
 		NewRegistryGPGKeyDataSource,
 		NewRegistryGPGKeysDataSource,
 		NewRegistryModuleDataSource,

--- a/website/docs/d/provider_set.html.markdown
+++ b/website/docs/d/provider_set.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_provider_set"
+description: |-
+  Retrieve provider set.
+---
+
+# Data Source: tfe_provider_set
+
+Retrieve a provider set by name.
+
+~> **NOTE:** This data source is currently in beta and isn't generally
+available to all users. It is subject to change or be removed.
+
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+data "tfe_provider_set" "my_provider_set" {
+  name         = "example-provider-set"
+  organization = "example-org"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the provider set.
+* `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
+
+## Attributes Reference
+
+* `id` - The ID of the provider set.
+* `provider_source` -  Source address of the provider, e.g. `registry.terraform.io/hashicorp/tfe`.
+* `description` -  Description of the provider set.
+* `global` -  Whether the provider set applies globally.
+* `workspace_ids` -  IDs of the workspaces attached to the provider set.
+* `project_ids` -  IDs of the projects attached to the provider set.
+


### PR DESCRIPTION
## Description

_Describe why you're making this change._

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

You can simply run this:

```tf
resource "tfe_organization" "example" {
  name  = "example-org"
  email = "foo@email.com"
}

resource "tfe_workspace" "example1" {
  name         = "example-workspace-1"
  organization = tfe_organization.example.name
}

resource "tfe_workspace" "example2" {
  name         = "example-workspace-2"
  organization = tfe_organization.example.name
}

resource "tfe_project" "example" {
  name         = "example-project"
  organization = tfe_organization.example.name
}

resource "tfe_provider_set" "my_provider_set" {
  name         = "example-provider-set"
  description  = "Reusable provider config for selected workspaces"
  organization = tfe_organization.example.name
  global       = false
  workspace_ids = [
    tfe_workspace.example1.id,
    tfe_workspace.example2.id,
  ]
  project_ids = [
    tfe_project.example.id,
  ]

  provider_source     = "registry.terraform.io/hashicorp/aws"
  provider_config_hcl = <<-EOT
  provider "aws" {
    region = "us-east-1"
  }
  EOT
}

data "tfe_provider_set" "example" {
  name         = tfe_provider_set.my_provider_set.name
  organization = tfe_organization.example.name
}

output "provider_set" {
  value = data.tfe_provider_set.example
}

```

Should output something like this:
```
Apply complete! Resources: 0 added, 0 changed, 1 destroyed.

Outputs:

provider_set = {
  "description" = "Reusable provider config for selected workspaces"
  "global" = false
  "id" = "provset-DdqDXg8DT6gDmrhj"
  "name" = "example-provider-set"
  "organization" = "example-org"
  "project_ids" = toset([
    "prj-KSBQX9dmfEdjWioh",
  ])
  "provider_source" = "registry.terraform.io/hashicorp/aws"
  "workspace_ids" = toset([
    "ws-iecy5jMjvbsb7216",
    "ws-kKkycva3UL4fRPTk",
  ])
}
```

## External links

- [#2086](https://github.com/hashicorp/terraform-provider-tfe/pull/2086)
- [go-tfe #1355](https://github.com/hashicorp/go-tfe/pull/1355)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
TF_ACC=1 ENABLE_BETA=1 go test -v ./internal/provider/ -run TestAccTFEProviderSetDataSource
=== RUN   TestAccTFEProviderSetDataSource_read
--- PASS: TestAccTFEProviderSetDataSource_read (3.97s)
=== RUN   TestAccTFEProviderSetDataSource_read_unitialized_provider_set
--- PASS: TestAccTFEProviderSetDataSource_read_unitialized_provider_set (0.62s)
=== RUN   TestAccTFEProviderSetDataSource_read_provider_set_deleted
--- PASS: TestAccTFEProviderSetDataSource_read_provider_set_deleted (2.93s)
=== RUN   TestAccTFEProviderSetDataSource_read_with_default_organization
--- PASS: TestAccTFEProviderSetDataSource_read_with_default_organization (1.87s)
=== RUN   TestAccTFEProviderSetDataSource_validation
--- PASS: TestAccTFEProviderSetDataSource_validation (0.33s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   10.326s
...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
