### PR TITLE
TF-38110-migrate-data-source-ip-ranges-to-plugin-framework

### DIFF
--- a/internal/provider/data_source_ip_ranges.go
+++ b/internal/provider/data_source_ip_ranges.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -77,7 +78,7 @@ func (d *dataSourceTFEIPRanges) Schema(ctx context.Context, req datasource.Schem
 		Description: "This data source can be used to retrieve a list of HCP Terraform's IP ranges.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Description: "Static identifier for HCP IP ranges.",
+				Description: "Static identifier for HCP Terraform's IP ranges data source.",
 				Computed:    true,
 			},
 			"api": schema.ListAttribute{
@@ -112,6 +113,7 @@ func (d *dataSourceTFEIPRanges) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
+	tflog.Debug(ctx, "Requesting IP Ranges")
 	ipRanges, err := d.config.Client.Meta.IPRanges.Read(ctx, "")
 	if err != nil {
 		resp.Diagnostics.AddError("Error retrieving IP Ranges", err.Error())

--- a/internal/provider/data_source_ip_ranges.go
+++ b/internal/provider/data_source_ip_ranges.go
@@ -29,15 +29,17 @@ type dataSourceTFEIPRanges struct {
 
 // model TFEIPRages maps the data source schema data to a struct.
 type modelTFEIPRanges struct {
-	API           types.List `tfsdk:"api"`
-	Notifications types.List `tfsdk:"notifications"`
-	Sentinel      types.List `tfsdk:"sentinel"`
-	VCS           types.List `tfsdk:"vcs"`
+	ID            types.String `tfsdk:"id"`
+	API           types.List   `tfsdk:"api"`
+	Notifications types.List   `tfsdk:"notifications"`
+	Sentinel      types.List   `tfsdk:"sentinel"`
+	VCS           types.List   `tfsdk:"vcs"`
 }
 
 // modelFromTFEIPRanges builds a modelTFEIPRanges struct from a tfe.IPRanges value.
 func modelFromTFEIPRanges(i *tfe.IPRange) (modelTFEIPRanges, diag.Diagnostics) {
 	model := modelTFEIPRanges{
+		ID:            types.StringValue("ip_ranges"),
 		API:           types.ListNull(types.StringType),
 		Notifications: types.ListNull(types.StringType),
 		Sentinel:      types.ListNull(types.StringType),
@@ -74,6 +76,10 @@ func (d *dataSourceTFEIPRanges) Schema(ctx context.Context, req datasource.Schem
 	resp.Schema = schema.Schema{
 		Description: "This data source can be used to retrieve a list of HCP Terraform's IP ranges.",
 		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Static identifier for HCP IP ranges.",
+				Computed:    true,
+			},
 			"api": schema.ListAttribute{
 				ElementType: types.StringType,
 				Description: "The list of IP ranges in CIDR notation used for connections from user site to HCP Terraform APIs.",
@@ -99,9 +105,9 @@ func (d *dataSourceTFEIPRanges) Schema(ctx context.Context, req datasource.Schem
 }
 
 func (d *dataSourceTFEIPRanges) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var config modelTFEIPRanges
+	var data modelTFEIPRanges
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -130,7 +136,7 @@ func (d *dataSourceTFEIPRanges) Configure(ctx context.Context, req datasource.Co
 	client, ok := req.ProviderData.(ConfiguredClient)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected resource Configure type",
+			"Unexpected Data Source Configure type",
 			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
 		)
 	}

--- a/internal/provider/data_source_ip_ranges.go
+++ b/internal/provider/data_source_ip_ranges.go
@@ -40,7 +40,7 @@ type modelTFEIPRanges struct {
 // modelFromTFEIPRanges builds a modelTFEIPRanges struct from a tfe.IPRanges value.
 func modelFromTFEIPRanges(i *tfe.IPRange) (modelTFEIPRanges, diag.Diagnostics) {
 	model := modelTFEIPRanges{
-		ID:            types.StringValue("ip_ranges"),
+		ID:            types.StringValue("ip-ranges"),
 		API:           types.ListNull(types.StringType),
 		Notifications: types.ListNull(types.StringType),
 		Sentinel:      types.ListNull(types.StringType),

--- a/internal/provider/data_source_ip_ranges.go
+++ b/internal/provider/data_source_ip_ranges.go
@@ -1,63 +1,138 @@
-// Copyright IBM Corp. 2018, 2025
+// Copyright IBM Corp. 2018, 2026
 // SPDX-License-Identifier: MPL-2.0
-
-// NOTE: This is a legacy resource and should be migrated to the Plugin
-// Framework if substantial modifications are planned. See
-// docs/new-resources.md if planning to use this code as boilerplate for
-// a new resource.
 
 package provider
 
 import (
+	"context"
 	"fmt"
-	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func dataSourceTFEIPRanges() *schema.Resource {
-	return &schema.Resource{
-		Read: dataSourceTFEIPRangesRead,
+var (
+	_ datasource.DataSource              = &dataSourceTFEIPRanges{}
+	_ datasource.DataSourceWithConfigure = &dataSourceTFEIPRanges{}
+)
 
-		Schema: map[string]*schema.Schema{
-			"api": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+func NewIPRangesDataSource() datasource.DataSource {
+	return &dataSourceTFEIPRanges{}
+}
+
+type dataSourceTFEIPRanges struct {
+	config ConfiguredClient
+}
+
+// model TFEIPRages maps the data source schema data to a struct.
+type modelTFEIPRanges struct {
+	API           types.List `tfsdk:"api"`
+	Notifications types.List `tfsdk:"notifications"`
+	Sentinel      types.List `tfsdk:"sentinel"`
+	VCS           types.List `tfsdk:"vcs"`
+}
+
+// modelFromTFEIPRanges builds a modelTFEIPRanges struct from a tfe.IPRanges value.
+func modelFromTFEIPRanges(i *tfe.IPRange) (modelTFEIPRanges, diag.Diagnostics) {
+	model := modelTFEIPRanges{
+		API:           types.ListNull(types.StringType),
+		Notifications: types.ListNull(types.StringType),
+		Sentinel:      types.ListNull(types.StringType),
+		VCS:           types.ListNull(types.StringType),
+	}
+
+	var diags diag.Diagnostics
+
+	// Since calls are low-stakes computationally, these are not short circuited so all errors are visible
+	api, err := types.ListValueFrom(ctx, types.StringType, i.API)
+	diags.Append(err...)
+	model.API = api
+
+	n, err := types.ListValueFrom(ctx, types.StringType, i.Notifications)
+	diags.Append(err...)
+	model.Notifications = n
+
+	s, err := types.ListValueFrom(ctx, types.StringType, i.Sentinel)
+	diags.Append(err...)
+	model.Sentinel = s
+
+	v, err := types.ListValueFrom(ctx, types.StringType, i.VCS)
+	diags.Append(err...)
+	model.VCS = v
+
+	return model, diags
+}
+
+func (d *dataSourceTFEIPRanges) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ip_ranges"
+}
+
+func (d *dataSourceTFEIPRanges) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source can be used to retrieve a list of HCP Terraform's IP ranges.",
+		Attributes: map[string]schema.Attribute{
+			"api": schema.ListAttribute{
+				ElementType: types.StringType,
+				Description: "The list of IP ranges in CIDR notation used for connections from user site to HCP Terraform APIs.",
+				Computed:    true,
 			},
-			"notifications": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+			"notifications": schema.ListAttribute{
+				ElementType: types.StringType,
+				Description: "The list of IP ranges in CIDR notation used for notifications.",
+				Computed:    true,
 			},
-			"sentinel": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+			"sentinel": schema.ListAttribute{
+				ElementType: types.StringType,
+				Description: "The list of IP ranges in CIDR notation used for outbound requests from Sentinel policies. Applicable for Policy Checks mode only.",
+				Computed:    true,
 			},
-			"vcs": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+			"vcs": schema.ListAttribute{
+				ElementType: types.StringType,
+				Description: "The list of IP ranges in CIDR notation used for connecting to VCS providers.",
+				Computed:    true,
 			},
 		},
 	}
 }
 
-func dataSourceTFEIPRangesRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(ConfiguredClient)
+func (d *dataSourceTFEIPRanges) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config modelTFEIPRanges
 
-	log.Printf("[DEBUG] Reading IP Ranges")
-	ipRanges, err := config.Client.Meta.IPRanges.Read(ctx, "")
-	if err != nil {
-		return fmt.Errorf("Error retrieving IP ranges: %w", err)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	d.SetId("ip-ranges")
-	d.Set("api", ipRanges.API)
-	d.Set("notifications", ipRanges.Notifications)
-	d.Set("sentinel", ipRanges.Sentinel)
-	d.Set("vcs", ipRanges.VCS)
+	ipRanges, err := d.config.Client.Meta.IPRanges.Read(ctx, "")
+	if err != nil {
+		resp.Diagnostics.AddError("Error retrieving IP Ranges", err.Error())
+		return
+	}
 
-	return nil
+	result, diags := modelFromTFEIPRanges(ipRanges)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+// When we need configuration data from or about the provider e.g. via login, we need Configure
+func (d *dataSourceTFEIPRanges) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Early exit if provider is unconfigured (i.e. we're only validating config or something)
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource Configure type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+	}
+	d.config = client
 }

--- a/internal/provider/data_source_ip_ranges.go
+++ b/internal/provider/data_source_ip_ranges.go
@@ -38,7 +38,7 @@ type modelTFEIPRanges struct {
 }
 
 // modelFromTFEIPRanges builds a modelTFEIPRanges struct from a tfe.IPRanges value.
-func modelFromTFEIPRanges(i *tfe.IPRange) (modelTFEIPRanges, diag.Diagnostics) {
+func modelFromTFEIPRanges(ctx context.Context, i *tfe.IPRange) (modelTFEIPRanges, diag.Diagnostics) {
 	model := modelTFEIPRanges{
 		ID:            types.StringValue("ip-ranges"),
 		API:           types.ListNull(types.StringType),
@@ -120,7 +120,7 @@ func (d *dataSourceTFEIPRanges) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	result, diags := modelFromTFEIPRanges(ipRanges)
+	result, diags := modelFromTFEIPRanges(ctx, ipRanges)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return

--- a/internal/provider/data_source_ip_ranges_test.go
+++ b/internal/provider/data_source_ip_ranges_test.go
@@ -22,6 +22,7 @@ func TestAccTFEIPRangesDataSource_basic(t *testing.T) {
 				Config: testAccTFEIPRangesDataSourceConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.tfe_ip_ranges.ips", "id"),
+					resource.TestCheckResourceAttr("data.tfe_ip_ranges.ips", "id", "ip-ranges"),
 					resource.TestCheckResourceAttrSet("data.tfe_ip_ranges.ips", "api.0"),
 					resource.TestMatchResourceAttr("data.tfe_ip_ranges.ips", "api.0", ipRegex),
 					resource.TestCheckResourceAttrSet("data.tfe_ip_ranges.ips", "notifications.0"),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -109,7 +109,6 @@ func Provider() *schema.Provider {
 			"tfe_organizations":           dataSourceTFEOrganizations(),
 			"tfe_organization":            dataSourceTFEOrganization(),
 			"tfe_agent_pool":              dataSourceTFEAgentPool(),
-			"tfe_ip_ranges":               dataSourceTFEIPRanges(),
 			"tfe_oauth_client":            dataSourceTFEOAuthClient(),
 			"tfe_organization_membership": dataSourceTFEOrganizationMembership(),
 			"tfe_organization_tags":       dataSourceTFEOrganizationTags(),

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -148,6 +148,7 @@ func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource
 		NewCurrentUserDataSource,
 		NewHYOKCustomerKeyVersionDataSource,
 		NewHYOKEncryptedDataKeyDataSource,
+		NewIPRangesDataSource,
 		NewNoCodeModuleDataSource,
 		NewOrgMaxTokenTTLPolicyDataSource,
 		NewOrganizationAuditConfigurationDataSource,


### PR DESCRIPTION
## Description

Migrate data_source_ip_ranges to tf plugin framework

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Should have no changes to behaviour; read ip ranges using the data source. 

## Output from acceptance tests

```
$ TF_ACC=1 go test ./internal/provider/... --run="TFEIPRanges" -v
=== RUN   TestAccTFEIPRangesDataSource_basic
--- PASS: TestAccTFEIPRangesDataSource_basic (1.69s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   2.190s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

Revert PR and make a release. 

## Changes to Security Controls

N/A.
