### PR TITLE
feat: TF-35808: Added BETA support for tag scoping on policy sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+FEATURES:
+* **New Resource:** `r/tfe_tag_policy_set` and `r/tfe_tag_policy_set_exclusion`: Adds resources to manage tag-based inclusion and exclusion on policy sets. **NOTE:** This feature is currently in beta and is not available to all users. By @anubhav-goel [#2093](https://github.com/hashicorp/terraform-provider-tfe/pull/2093)
+
+
 ## v0.78.0
 
 FEATURES:

--- a/internal/provider/provider_next.go
+++ b/internal/provider/provider_next.go
@@ -206,6 +206,8 @@ func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Res
 		NewAzureOIDCConfigurationResource,
 		NewVaultOIDCConfigurationResource,
 		NewHYOKConfigurationResource,
+		NewTagPolicySetResource,
+		NewTagPolicySetExclusionResource,
 		NewProjectPolicySetExclusionResource,
 		NewSCIMSettingsResource,
 		NewSCIMTokenResource,

--- a/internal/provider/resource_tfe_tag_policy_set.go
+++ b/internal/provider/resource_tfe_tag_policy_set.go
@@ -1,0 +1,319 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &resourceTFETagPolicySet{}
+	_ resource.ResourceWithConfigure   = &resourceTFETagPolicySet{}
+	_ resource.ResourceWithImportState = &resourceTFETagPolicySet{}
+)
+
+type resourceTFETagPolicySet struct {
+	config ConfiguredClient
+}
+
+func NewTagPolicySetResource() resource.Resource {
+	return &resourceTFETagPolicySet{}
+}
+
+// ptrValueOrNil returns the dereferenced string or "<nil>" for display purposes.
+func ptrValueOrNil(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}
+
+type modelTagPolicySet struct {
+	ID          types.String `tfsdk:"id"`
+	PolicySetID types.String `tfsdk:"policy_set_id"`
+	Key         types.String `tfsdk:"key"`
+	Value       types.String `tfsdk:"value"`
+}
+
+func (r *resourceTFETagPolicySet) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = client
+}
+
+// Metadata implements [resource.Resource].
+func (r *resourceTFETagPolicySet) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_tag_policy_set"
+}
+
+// Schema implements [resource.Resource].
+func (r *resourceTFETagPolicySet) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a resource which manages tag inclusions on a policy set.",
+		Version:     0,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The composite ID of the tag inclusion, in the format <POLICY_SET_ID>/<TAG_KEY> or <POLICY_SET_ID>/<TAG_KEY>/<TAG_VALUE>.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"policy_set_id": schema.StringAttribute{
+				Description: "The ID of the policy set to add the tag inclusion to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^polset-[a-zA-Z0-9]{16}$`),
+						"must be a valid policy set ID (e.g. polset-<RANDOM_STRING>)",
+					),
+				},
+			},
+			"key": schema.StringAttribute{
+				Description: "The tag key for the tag inclusion.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"value": schema.StringAttribute{
+				Description: "The tag value for the tag inclusion. If not set, this becomes a key-only tag and only matches workspaces that also have a key-only tag with the given key.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+		},
+	}
+}
+
+// Create implements [resource.Resource].
+func (r *resourceTFETagPolicySet) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTagPolicySet
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policySetID := plan.PolicySetID.ValueString()
+	key := plan.Key.ValueString()
+	valuePtr := plan.Value.ValueStringPointer()
+
+	tflog.Debug(ctx, fmt.Sprintf("Adding tag inclusion (key=%s, value=%s) to policy set %s", key, ptrValueOrNil(valuePtr), policySetID))
+	err := r.config.Client.PolicySets.AddTagSelectors(ctx, policySetID, tfe.PolicySetAddTagSelectorsOptions{
+		TagSelectors: []*tfe.PolicySetTagSelector{
+			{Key: key, Value: valuePtr, IsExclude: false},
+		},
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Adding Tag Inclusion to Policy Set",
+			fmt.Sprintf("An error was encountered when adding tag inclusion (key=%q, value=%q) to policy set %q: %s", key, ptrValueOrNil(valuePtr), policySetID, err),
+		)
+		return
+	}
+
+	if valuePtr != nil {
+		plan.ID = types.StringValue(fmt.Sprintf("%s/%s/%s", policySetID, key, *valuePtr))
+	} else {
+		plan.ID = types.StringValue(fmt.Sprintf("%s/%s", policySetID, key))
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Creation of tag inclusion (key=%s, value=%s) for policy set %s is complete", key, ptrValueOrNil(valuePtr), policySetID))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Read implements [resource.Resource].
+func (r *resourceTFETagPolicySet) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTagPolicySet
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policySetID := state.PolicySetID.ValueString()
+	key := state.Key.ValueString()
+	valuePtr := state.Value.ValueStringPointer()
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading tag inclusion (key=%s, value=%s) from policy set %s", key, ptrValueOrNil(valuePtr), policySetID))
+	policySet, err := r.config.Client.PolicySets.Read(ctx, policySetID)
+	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Policy Set",
+			fmt.Sprintf("An error was encountered when reading policy set %q: %s", policySetID, err),
+		)
+		return
+	}
+
+	for _, ts := range policySet.TagSelectors {
+		if ts.Key == key && !ts.IsExclude && r.tagValueMatches(ts.Value, state.Value) {
+			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+			return
+		}
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Tag inclusion (key=%s, value=%s) not found in policy set %s. Removing from state.", key, ptrValueOrNil(valuePtr), policySetID))
+	resp.State.RemoveResource(ctx)
+}
+
+// Update implements [resource.Resource].
+func (r *resourceTFETagPolicySet) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// This method is a no-op but required by the framework
+	var plan modelTagPolicySet
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete implements [resource.Resource].
+func (r *resourceTFETagPolicySet) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTagPolicySet
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policySetID := state.PolicySetID.ValueString()
+	key := state.Key.ValueString()
+	valuePtr := state.Value.ValueStringPointer()
+
+	tflog.Debug(ctx, fmt.Sprintf("Removing tag inclusion (key=%s, value=%s) from policy set (%s)", key, ptrValueOrNil(valuePtr), policySetID))
+	err := r.config.Client.PolicySets.RemoveTagSelectors(ctx, policySetID, tfe.PolicySetRemoveTagSelectorsOptions{
+		TagSelectors: []*tfe.PolicySetTagSelector{
+			{Key: key, Value: valuePtr, IsExclude: false},
+		},
+	})
+
+	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Removing Tag Inclusion from Policy Set",
+			fmt.Sprintf("An error was encountered when removing tag inclusion (key=%q, value=%q) from policy set %q: %s", key, ptrValueOrNil(valuePtr), policySetID, err),
+		)
+		return
+	}
+}
+
+// ImportState implements [resource.ResourceWithImportState].
+func (r *resourceTFETagPolicySet) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splitID := strings.SplitN(req.ID, "/", 3)
+	if len(splitID) < 2 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID Format",
+			fmt.Sprintf("The import ID must be in the format <POLICY_SET_ID>/<TAG_KEY> or <POLICY_SET_ID>/<TAG_KEY>/<TAG_VALUE>. Got: %q", req.ID),
+		)
+		return
+	}
+
+	policySetID := splitID[0]
+	tagKey := splitID[1]
+
+	matched, _ := regexp.MatchString(`^polset-[a-zA-Z0-9]{16}$`, policySetID)
+	if !matched {
+		resp.Diagnostics.AddError(
+			"Invalid Policy Set ID",
+			fmt.Sprintf("The policy set ID %q is not valid. Expected format: polset-<16 alphanumeric chars>.", policySetID),
+		)
+		return
+	}
+
+	var tagValue *string
+	if len(splitID) == 3 {
+		v := splitID[2]
+		tagValue = &v
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Importing tag inclusion (key=%s, value=%s) for policy set %s", tagKey, ptrValueOrNil(tagValue), policySetID))
+
+	policySet, err := r.config.Client.PolicySets.Read(ctx, policySetID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Policy Set",
+			fmt.Sprintf("An error was encountered when reading policy set %q: %s", policySetID, err),
+		)
+		return
+	}
+
+	for _, ts := range policySet.TagSelectors {
+		if ts.Key != tagKey || ts.IsExclude {
+			continue
+		}
+		if !r.tagValueMatches(ts.Value, types.StringPointerValue(tagValue)) {
+			continue
+		}
+
+		var id string
+		if ts.Value != nil {
+			id = fmt.Sprintf("%s/%s/%s", policySetID, tagKey, *ts.Value)
+		} else {
+			id = fmt.Sprintf("%s/%s", policySetID, tagKey)
+		}
+
+		state := modelTagPolicySet{
+			ID:          types.StringValue(id),
+			PolicySetID: types.StringValue(policySetID),
+			Key:         types.StringValue(tagKey),
+			Value:       types.StringPointerValue(ts.Value),
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+		return
+	}
+
+	resp.Diagnostics.AddError(
+		"Tag Inclusion Not Found",
+		fmt.Sprintf("Tag inclusion (key=%q, value=%q) not found in policy set %q.", tagKey, ptrValueOrNil(tagValue), policySetID),
+	)
+}
+
+// tagValueMatches returns true when the tag value from the API
+// matches the value stored in state. A null stateValue means the tag has no
+// value (key-only), which corresponds to a nil API value.
+func (r *resourceTFETagPolicySet) tagValueMatches(tsValue *string, stateValue types.String) bool {
+	if stateValue.IsNull() {
+		return tsValue == nil
+	}
+	return tsValue != nil && *tsValue == stateValue.ValueString()
+}

--- a/internal/provider/resource_tfe_tag_policy_set_exclusion.go
+++ b/internal/provider/resource_tfe_tag_policy_set_exclusion.go
@@ -1,0 +1,311 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &resourceTFETagPolicySetExclusion{}
+	_ resource.ResourceWithConfigure   = &resourceTFETagPolicySetExclusion{}
+	_ resource.ResourceWithImportState = &resourceTFETagPolicySetExclusion{}
+)
+
+type resourceTFETagPolicySetExclusion struct {
+	config ConfiguredClient
+}
+
+func NewTagPolicySetExclusionResource() resource.Resource {
+	return &resourceTFETagPolicySetExclusion{}
+}
+
+type modelTagPolicySetExclusion struct {
+	ID          types.String `tfsdk:"id"`
+	PolicySetID types.String `tfsdk:"policy_set_id"`
+	Key         types.String `tfsdk:"key"`
+	Value       types.String `tfsdk:"value"`
+}
+
+func (r *resourceTFETagPolicySetExclusion) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(ConfiguredClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected tfe.ConfiguredClient, got %T. This is a bug in the tfe provider, so please report it on GitHub.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = client
+}
+
+// Metadata implements [resource.Resource].
+func (r *resourceTFETagPolicySetExclusion) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_tag_policy_set_exclusion"
+}
+
+// Schema implements [resource.Resource].
+func (r *resourceTFETagPolicySetExclusion) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a resource which manages tag exclusions on a policy set.",
+		Version:     0,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The composite ID of the tag exclusion, in the format <POLICY_SET_ID>/<TAG_KEY> or <POLICY_SET_ID>/<TAG_KEY>/<TAG_VALUE>.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"policy_set_id": schema.StringAttribute{
+				Description: "The ID of the policy set to add the tag exclusion to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^polset-[a-zA-Z0-9]{16}$`),
+						"must be a valid policy set ID (e.g. polset-<RANDOM_STRING>)",
+					),
+				},
+			},
+			"key": schema.StringAttribute{
+				Description: "The tag key for the exclusion.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"value": schema.StringAttribute{
+				Description: "The tag value for the tag exclusion. If not set, this becomes a key-only tag and only matches workspaces that also have a key-only tag with the given key.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+		},
+	}
+}
+
+// Create implements [resource.Resource].
+func (r *resourceTFETagPolicySetExclusion) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan modelTagPolicySetExclusion
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policySetID := plan.PolicySetID.ValueString()
+	key := plan.Key.ValueString()
+	valuePtr := plan.Value.ValueStringPointer()
+
+	tflog.Debug(ctx, fmt.Sprintf("Adding tag exclusion (key=%s, value=%s) to policy set %s", key, ptrValueOrNil(valuePtr), policySetID))
+	err := r.config.Client.PolicySets.AddTagSelectors(ctx, policySetID, tfe.PolicySetAddTagSelectorsOptions{
+		TagSelectors: []*tfe.PolicySetTagSelector{
+			{Key: key, Value: valuePtr, IsExclude: true},
+		},
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Adding Tag Exclusion to Policy Set",
+			fmt.Sprintf("An error was encountered when adding tag exclusion (key=%q, value=%q) to policy set %q: %s", key, ptrValueOrNil(valuePtr), policySetID, err),
+		)
+		return
+	}
+
+	if valuePtr != nil {
+		plan.ID = types.StringValue(fmt.Sprintf("%s/%s/%s", policySetID, key, *valuePtr))
+	} else {
+		plan.ID = types.StringValue(fmt.Sprintf("%s/%s", policySetID, key))
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Creation of tag exclusion (key=%s, value=%s) for policy set %s is complete", key, ptrValueOrNil(valuePtr), policySetID))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Read implements [resource.Resource].
+func (r *resourceTFETagPolicySetExclusion) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state modelTagPolicySetExclusion
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policySetID := state.PolicySetID.ValueString()
+	key := state.Key.ValueString()
+	valuePtr := state.Value.ValueStringPointer()
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading tag exclusion (key=%s, value=%s) from policy set %s", key, ptrValueOrNil(valuePtr), policySetID))
+	policySet, err := r.config.Client.PolicySets.Read(ctx, policySetID)
+	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Policy Set",
+			fmt.Sprintf("An error was encountered when reading policy set %q: %s", policySetID, err),
+		)
+		return
+	}
+
+	for _, ts := range policySet.TagSelectors {
+		if ts.Key == key && ts.IsExclude && r.tagValueMatches(ts.Value, state.Value) {
+			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+			return
+		}
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Tag exclusion (key=%s, value=%s) not found in policy set %s. Removing from state.", key, ptrValueOrNil(valuePtr), policySetID))
+	resp.State.RemoveResource(ctx)
+}
+
+// Update implements [resource.Resource].
+func (r *resourceTFETagPolicySetExclusion) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// This method is a no-op but required by the framework
+	var plan modelTagPolicySetExclusion
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete implements [resource.Resource].
+func (r *resourceTFETagPolicySetExclusion) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state modelTagPolicySetExclusion
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	policySetID := state.PolicySetID.ValueString()
+	key := state.Key.ValueString()
+	valuePtr := state.Value.ValueStringPointer()
+
+	tflog.Debug(ctx, fmt.Sprintf("Removing tag exclusion (key=%s, value=%s) from policy set (%s)", key, ptrValueOrNil(valuePtr), policySetID))
+	err := r.config.Client.PolicySets.RemoveTagSelectors(ctx, policySetID, tfe.PolicySetRemoveTagSelectorsOptions{
+		TagSelectors: []*tfe.PolicySetTagSelector{
+			{Key: key, Value: valuePtr, IsExclude: true},
+		},
+	})
+
+	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Removing Tag Exclusion from Policy Set",
+			fmt.Sprintf("An error was encountered when removing tag exclusion (key=%q, value=%q) from policy set %q: %s", key, ptrValueOrNil(valuePtr), policySetID, err),
+		)
+		return
+	}
+}
+
+// ImportState implements [resource.ResourceWithImportState].
+func (r *resourceTFETagPolicySetExclusion) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	splitID := strings.SplitN(req.ID, "/", 3)
+	if len(splitID) < 2 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID Format",
+			fmt.Sprintf("The import ID must be in the format <POLICY_SET_ID>/<TAG_KEY> or <POLICY_SET_ID>/<TAG_KEY>/<TAG_VALUE>. Got: %q", req.ID),
+		)
+		return
+	}
+
+	policySetID := splitID[0]
+	tagKey := splitID[1]
+
+	matched, _ := regexp.MatchString(`^polset-[a-zA-Z0-9]{16}$`, policySetID)
+	if !matched {
+		resp.Diagnostics.AddError(
+			"Invalid Policy Set ID",
+			fmt.Sprintf("The policy set ID %q is not valid. Expected format: polset-<16 alphanumeric chars>.", policySetID),
+		)
+		return
+	}
+
+	var tagValue *string
+	if len(splitID) == 3 {
+		v := splitID[2]
+		tagValue = &v
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Importing tag exclusion (key=%s, value=%s) for policy set %s", tagKey, ptrValueOrNil(tagValue), policySetID))
+
+	policySet, err := r.config.Client.PolicySets.Read(ctx, policySetID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Policy Set",
+			fmt.Sprintf("An error was encountered when reading policy set %q: %s", policySetID, err),
+		)
+		return
+	}
+
+	for _, ts := range policySet.TagSelectors {
+		if ts.Key != tagKey || !ts.IsExclude {
+			continue
+		}
+		if !r.tagValueMatches(ts.Value, types.StringPointerValue(tagValue)) {
+			continue
+		}
+
+		var id string
+		if ts.Value != nil {
+			id = fmt.Sprintf("%s/%s/%s", policySetID, tagKey, *ts.Value)
+		} else {
+			id = fmt.Sprintf("%s/%s", policySetID, tagKey)
+		}
+
+		state := modelTagPolicySetExclusion{
+			ID:          types.StringValue(id),
+			PolicySetID: types.StringValue(policySetID),
+			Key:         types.StringValue(tagKey),
+			Value:       types.StringPointerValue(ts.Value),
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+		return
+	}
+
+	resp.Diagnostics.AddError(
+		"Tag Exclusion Not Found",
+		fmt.Sprintf("Tag exclusion (key=%q, value=%q) not found in policy set %q.", tagKey, ptrValueOrNil(tagValue), policySetID),
+	)
+}
+
+// tagValueMatches returns true when the tag value from the API
+// matches the value stored in state. A null stateValue means the tag has no
+// value (key-only), which corresponds to a nil API value.
+func (r *resourceTFETagPolicySetExclusion) tagValueMatches(tsValue *string, stateValue types.String) bool {
+	if stateValue.IsNull() {
+		return tsValue == nil
+	}
+	return tsValue != nil && *tsValue == stateValue.ValueString()
+}

--- a/internal/provider/resource_tfe_tag_policy_set_exclusion_test.go
+++ b/internal/provider/resource_tfe_tag_policy_set_exclusion_test.go
@@ -1,0 +1,256 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccTFETagPolicySetExclusion_keyValueTag(t *testing.T) {
+	skipUnlessBeta(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{Name: tfe.String("tst-" + randomString(t)), Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t)))})
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETagPolicySetExclusionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETagPolicySetExclusion_keyValueTag(org.Name, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETagPolicySetExclusionExists("tfe_tag_policy_set_exclusion.test"),
+					resource.TestCheckResourceAttr("tfe_tag_policy_set_exclusion.test", "key", "env"),
+					resource.TestCheckResourceAttr("tfe_tag_policy_set_exclusion.test", "value", "staging"),
+					resource.TestCheckResourceAttrSet("tfe_tag_policy_set_exclusion.test", "policy_set_id"),
+				),
+			},
+			{
+				ResourceName: "tfe_tag_policy_set_exclusion.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["tfe_tag_policy_set_exclusion.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("%s/env/staging", rs.Primary.Attributes["policy_set_id"]), nil
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFETagPolicySetExclusion_keyOnlyTag(t *testing.T) {
+	skipUnlessBeta(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{Name: tfe.String("tst-" + randomString(t)), Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t)))})
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETagPolicySetExclusionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETagPolicySetExclusion_keyOnlyTag(org.Name, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETagPolicySetExclusionExists("tfe_tag_policy_set_exclusion.test"),
+					resource.TestCheckResourceAttr("tfe_tag_policy_set_exclusion.test", "key", "team"),
+					resource.TestCheckNoResourceAttr("tfe_tag_policy_set_exclusion.test", "value"),
+					resource.TestCheckResourceAttrSet("tfe_tag_policy_set_exclusion.test", "policy_set_id"),
+				),
+			},
+			{
+				ResourceName: "tfe_tag_policy_set_exclusion.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["tfe_tag_policy_set_exclusion.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("%s/team", rs.Primary.Attributes["policy_set_id"]), nil
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFETagPolicySetExclusion_incorrectImportSyntax(t *testing.T) {
+	skipUnlessBeta(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{Name: tfe.String("tst-" + randomString(t)), Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t)))})
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETagPolicySetExclusion_keyValueTag(org.Name, rInt),
+			},
+			{
+				ResourceName:  "tfe_tag_policy_set_exclusion.test",
+				ImportState:   true,
+				ImportStateId: "not-a-polset/env/staging",
+				ExpectError:   regexp.MustCompile(`Invalid Policy Set ID`),
+			},
+		},
+	})
+}
+
+func testAccCheckTFETagPolicySetExclusionExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		id := rs.Primary.ID
+		if id == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		policySetID := rs.Primary.Attributes["policy_set_id"]
+		if policySetID == "" {
+			return fmt.Errorf("no policy set id set")
+		}
+
+		key := rs.Primary.Attributes["key"]
+		if key == "" {
+			return fmt.Errorf("no tag key set")
+		}
+
+		value := rs.Primary.Attributes["value"]
+
+		policySet, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, policySetID)
+		if err != nil {
+			return fmt.Errorf("error reading policy set %s: %w", policySetID, err)
+		}
+
+		for _, ts := range policySet.TagSelectors {
+			if ts.Key == key && ts.IsExclude {
+				if value == "" && ts.Value == nil {
+					return nil
+				}
+				if ts.Value != nil && *ts.Value == value {
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("tag exclusion (key=%s, value=%s) not found in policy set (%s)", key, value, policySetID)
+	}
+}
+
+func testAccCheckTFETagPolicySetExclusionDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_tag_policy_set_exclusion" {
+			continue
+		}
+
+		policySetID := rs.Primary.Attributes["policy_set_id"]
+		key := rs.Primary.Attributes["key"]
+		value := rs.Primary.Attributes["value"]
+
+		policySet, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, policySetID)
+		if err != nil {
+			// Policy set itself was destroyed, so tag exclusion is definitely gone
+			continue
+		}
+
+		for _, ts := range policySet.TagSelectors {
+			if ts.Key == key && ts.IsExclude {
+				if value == "" && ts.Value == nil {
+					return fmt.Errorf("tag exclusion (key=%s) still exists in policy set %s", key, policySetID)
+				}
+				if ts.Value != nil && *ts.Value == value {
+					return fmt.Errorf("tag exclusion (key=%s, value=%s) still exists in policy set %s", key, value, policySetID)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccTFETagPolicySetExclusion_keyValueTag(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_workspace" "test" {
+		name         = "tst-workspace-%d"
+		organization = "%s"
+		tags = {
+			env = "staging"
+		}
+	}
+
+	resource "tfe_policy_set" "test" {
+		name         = "tst-policy-set-%d"
+		description  = "Policy Set"
+		organization = "%s"
+		global       = true
+	}
+
+	resource "tfe_tag_policy_set_exclusion" "test" {
+		policy_set_id = tfe_policy_set.test.id
+		key           = "env"
+		value         = "staging"
+	}`,
+		rInt, orgName, rInt, orgName)
+}
+
+func testAccTFETagPolicySetExclusion_keyOnlyTag(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_workspace" "test" {
+		name         = "tst-workspace-%d"
+		organization = "%s"
+		tags = {
+			team = ""
+		}
+	}
+
+	resource "tfe_policy_set" "test" {
+		name         = "tst-policy-set-%d"
+		description  = "Policy Set"
+		organization = "%s"
+		global       = true
+	}
+
+	resource "tfe_tag_policy_set_exclusion" "test" {
+		policy_set_id = tfe_policy_set.test.id
+		key           = "team"
+	}`,
+		rInt, orgName, rInt, orgName)
+}

--- a/internal/provider/resource_tfe_tag_policy_set_test.go
+++ b/internal/provider/resource_tfe_tag_policy_set_test.go
@@ -1,0 +1,242 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccTFETagPolicySet_keyValueTag(t *testing.T) {
+	skipUnlessBeta(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{Name: tfe.String("tst-" + randomString(t)), Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t)))})
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETagPolicySetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETagPolicySet_keyValueTag(org.Name, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETagPolicySetExists("tfe_tag_policy_set.test"),
+					resource.TestCheckResourceAttr("tfe_tag_policy_set.test", "key", "env"),
+					resource.TestCheckResourceAttr("tfe_tag_policy_set.test", "value", "prod"),
+					resource.TestCheckResourceAttrSet("tfe_tag_policy_set.test", "policy_set_id"),
+				),
+			},
+			{
+				ResourceName: "tfe_tag_policy_set.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["tfe_tag_policy_set.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("%s/env/prod", rs.Primary.Attributes["policy_set_id"]), nil
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFETagPolicySet_keyOnlyTag(t *testing.T) {
+	skipUnlessBeta(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{Name: tfe.String("tst-" + randomString(t)), Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t)))})
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFETagPolicySetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETagPolicySet_keyOnlyTag(org.Name, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETagPolicySetExists("tfe_tag_policy_set.test"),
+					resource.TestCheckResourceAttr("tfe_tag_policy_set.test", "key", "team"),
+					resource.TestCheckNoResourceAttr("tfe_tag_policy_set.test", "value"),
+					resource.TestCheckResourceAttrSet("tfe_tag_policy_set.test", "policy_set_id"),
+				),
+			},
+			{
+				ResourceName: "tfe_tag_policy_set.test",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["tfe_tag_policy_set.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("%s/team", rs.Primary.Attributes["policy_set_id"]), nil
+				},
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFETagPolicySet_incorrectImportSyntax(t *testing.T) {
+	skipUnlessBeta(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{Name: tfe.String("tst-" + randomString(t)), Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t)))})
+	t.Cleanup(orgCleanup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETagPolicySet_keyValueTag(org.Name, rInt),
+			},
+			{
+				ResourceName:  "tfe_tag_policy_set.test",
+				ImportState:   true,
+				ImportStateId: "not-a-polset/env/prod",
+				ExpectError:   regexp.MustCompile(`Invalid Policy Set ID`),
+			},
+		},
+	})
+}
+
+func testAccCheckTFETagPolicySetExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		policySetID := rs.Primary.Attributes["policy_set_id"]
+		key := rs.Primary.Attributes["key"]
+		value := rs.Primary.Attributes["value"]
+
+		policySet, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, policySetID)
+		if err != nil {
+			return fmt.Errorf("error reading policy set %s: %w", policySetID, err)
+		}
+		for _, ts := range policySet.TagSelectors {
+			if ts.Key == key && !ts.IsExclude {
+				if value == "" && ts.Value == nil {
+					return nil
+				}
+				if ts.Value != nil && *ts.Value == value {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("tag inclusion (key=%s, value=%s) not found in policy set %s", key, value, policySetID)
+	}
+}
+
+func testAccCheckTFETagPolicySetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_tag_policy_set" {
+			continue
+		}
+
+		policySetID := rs.Primary.Attributes["policy_set_id"]
+		key := rs.Primary.Attributes["key"]
+		value := rs.Primary.Attributes["value"]
+
+		policySet, err := testAccConfiguredClient.Client.PolicySets.Read(ctx, policySetID)
+		if err != nil {
+			// Policy set itself was destroyed, so tag is definitely gone
+			continue
+		}
+
+		for _, ts := range policySet.TagSelectors {
+			if ts.Key == key && !ts.IsExclude {
+				if value == "" && ts.Value == nil {
+					return fmt.Errorf("tag inclusion (key=%s) still exists in policy set %s", key, policySetID)
+				}
+				if ts.Value != nil && *ts.Value == value {
+					return fmt.Errorf("tag inclusion (key=%s, value=%s) still exists in policy set %s", key, value, policySetID)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccTFETagPolicySet_keyValueTag(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_workspace" "test" {
+		name         = "tst-workspace-%d"
+		organization = "%s"
+		tags = {
+			env = "prod"
+		}
+	}
+
+	resource "tfe_policy_set" "test" {
+		name         = "tst-policy-set-%d"
+		description  = "Policy Set"
+		organization = "%s"
+	}
+
+	resource "tfe_tag_policy_set" "test" {
+		policy_set_id = tfe_policy_set.test.id
+		key           = "env"
+		value         = "prod"
+	}`,
+		rInt, orgName, rInt, orgName)
+}
+
+func testAccTFETagPolicySet_keyOnlyTag(orgName string, rInt int) string {
+	return fmt.Sprintf(`
+	resource "tfe_workspace" "test" {
+		name         = "tst-workspace-%d"
+		organization = "%s"
+		tags = {
+			team = ""
+		}
+	}
+
+	resource "tfe_policy_set" "test" {
+		name         = "tst-policy-set-%d"
+		description  = "Policy Set"
+		organization = "%s"
+	}
+
+	resource "tfe_tag_policy_set" "test" {
+		policy_set_id = tfe_policy_set.test.id
+		key           = "team"
+	}`,
+		rInt, orgName, rInt, orgName)
+}

--- a/website/docs/r/project_policy_set.html.markdown
+++ b/website/docs/r/project_policy_set.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 Adds and removes policy sets from a project
 
+~> **NOTE:** Tag-based scoping and explicit workspace/project associations are mutually exclusive on a policy set. To switch between them, first remove the existing association (`terraform apply`), then add the new one (`terraform apply`). Attempting both in a single apply may fail.
+
 ## Example Usage
 
 Basic usage:

--- a/website/docs/r/project_policy_set_exclusion.html.markdown
+++ b/website/docs/r/project_policy_set_exclusion.html.markdown
@@ -11,6 +11,8 @@ Adds and removes project exclusions from a policy set.
 
 -> **Note:** `tfe_policy_set` has an argument `global` that should be `true` to use this resource.
 
+~> **NOTE:** Tag-based scoping and explicit workspace/project associations are mutually exclusive on a policy set. To switch between them, first remove the existing association (`terraform apply`), then add the new one (`terraform apply`). Attempting both in a single apply may fail.
+
 ## Example Usage
 
 Basic usage:

--- a/website/docs/r/tag_policy_set.html.markdown
+++ b/website/docs/r/tag_policy_set.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_tag_policy_set"
+description: |-
+  Add a tag-based inclusion to a policy set
+---
+
+# tfe_tag_policy_set
+
+Adds and removes tag-based inclusions on a policy set. Tag inclusions scope policy set enforcement to workspaces that carry a matching tag. If a tag value is not provided, this becomes a key-only tag and only matches workspaces that also have a key-only tag with the given key.
+
+~> **NOTE:** This feature is currently in beta and is not available to all users.
+
+~> **NOTE:** Tag-based scoping and explicit workspace/project associations are mutually exclusive on a policy set. To switch between them, first remove the existing association (`terraform apply`), then add the new one (`terraform apply`). Attempting both in a single apply may fail.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_organization" "test" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_policy_set" "test" {
+  name         = "my-policy-set"
+  description  = "Some description."
+  organization = tfe_organization.test.name
+}
+
+resource "tfe_tag_policy_set" "test" {
+  policy_set_id = tfe_policy_set.test.id
+  key           = "env"
+  value         = "prod"
+}
+```
+
+Key-only tag (no value):
+
+```hcl
+resource "tfe_tag_policy_set" "env_any" {
+  policy_set_id = tfe_policy_set.test.id
+  key           = "env"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_set_id` - (Required) ID of the policy set.
+* `key` - (Required) The tag key to match.
+* `value` - (Optional) The tag value to match. If omitted, this becomes a key-only tag and only matches workspaces that also have a key-only tag with the given key.
+
+## Import
+
+Tag policy set inclusions can be imported; use `<POLICY_SET_ID>/<TAG_KEY>/<TAG_VALUE>` for key+value tags, or `<POLICY_SET_ID>/<TAG_KEY>` for key-only tags. For example:
+
+```shell
+terraform import tfe_tag_policy_set.test 'polset-abc123/env/prod'
+```

--- a/website/docs/r/tag_policy_set_exclusion.html.markdown
+++ b/website/docs/r/tag_policy_set_exclusion.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_tag_policy_set_exclusion"
+description: |-
+  Add a tag-based exclusion to a policy set
+---
+
+# tfe_tag_policy_set_exclusion
+
+Adds and removes tag-based exclusions on a policy set. Tag exclusions exempt workspaces that carry a matching tag from policy set enforcement. If a tag value is not provided, this becomes a key-only tag and only matches workspaces that also have a key-only tag with the given key.
+
+~> **Note:** `tfe_policy_set` has an argument `global` that should be `true` to use this resource.
+
+~> **NOTE:** This feature is currently in beta and is not available to all users.
+
+~> **NOTE:** Tag-based scoping and explicit workspace/project associations are mutually exclusive on a policy set. To switch between them, first remove the existing association (`terraform apply`), then add the new one (`terraform apply`). Attempting both in a single apply may fail.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_organization" "test" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_policy_set" "test" {
+  name         = "my-policy-set"
+  description  = "Some description."
+  organization = tfe_organization.test.name
+  global       = true
+}
+
+resource "tfe_tag_policy_set_exclusion" "test" {
+  policy_set_id = tfe_policy_set.test.id
+  key           = "env"
+  value         = "staging"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_set_id` - (Required) ID of the policy set.
+* `key` - (Required) The tag key to match for exclusion.
+* `value` - (Optional) The tag value to match. If omitted, this becomes a key-only tag and only matches workspaces that also have a key-only tag with the given key.
+
+## Import
+
+Tag policy set exclusions can be imported; use `<POLICY_SET_ID>/<TAG_KEY>/<TAG_VALUE>` for key+value tags, or `<POLICY_SET_ID>/<TAG_KEY>` for key-only tags. For example:
+
+```shell
+terraform import tfe_tag_policy_set_exclusion.test 'polset-abc123/env/staging'
+```

--- a/website/docs/r/workspace_policy_set.html.markdown
+++ b/website/docs/r/workspace_policy_set.html.markdown
@@ -11,6 +11,8 @@ Adds and removes policy sets from a workspace
 
 -> **Note:** `tfe_policy_set` has an argument `workspace_ids` that should not be used alongside this resource. They attempt to manage the same attachments.
 
+~> **NOTE:** Tag-based scoping and explicit workspace/project associations are mutually exclusive on a policy set. To switch between them, first remove the existing association (`terraform apply`), then add the new one (`terraform apply`). Attempting both in a single apply may fail.
+
 ## Example Usage
 
 Basic usage:

--- a/website/docs/r/workspace_policy_set_exclusion.html.markdown
+++ b/website/docs/r/workspace_policy_set_exclusion.html.markdown
@@ -11,6 +11,8 @@ Adds and removes policy sets from an excluded workspace
 
 -> **Note:** `tfe_policy_set` has an argument `workspace_ids` that should not be used alongside this resource. They attempt to manage the same attachments.
 
+~> **NOTE:** Tag-based scoping and explicit workspace/project associations are mutually exclusive on a policy set. To switch between them, first remove the existing association (`terraform apply`), then add the new one (`terraform apply`). Attempting both in a single apply may fail.
+
 ## Example Usage
 
 Basic usage:


### PR DESCRIPTION
## Description

Adds two new Plugin Framework resources for managing tag-based policy set scoping:
- tfe_tag_policy_set - Manages tag-based inclusions on a policy set. Scopes policy set enforcement to workspaces carrying a matching tag.
- tfe_tag_policy_set_exclusion - Manages tag-based exclusions on a policy set. Exempts workspaces carrying a matching tag from policy set enforcement.

Both resources support key+value tags (e.g. env=prod) and key-only tags (omit value to match only workspaces with a key-only tag).

This feature is currently in beta and is not available to all users.

## Testing plan

1.  Run acceptance tests.
2. Manual testing with example config:
```
resource "tfe_tag_policy_set" "env_prod" {
  policy_set_id = tfe_policy_set.non_global.id
  key           = "env"
  value         = "prod"
}

resource "tfe_tag_policy_set_exclusion" "exclude_dev" {
  policy_set_id = tfe_policy_set.global.id
  key           = "env"
  value         = "dev"
}
```
3. Import testing:
```
terraform state rm tfe_tag_policy_set.env_prod
terraform import tfe_tag_policy_set.env_prod '<POLICY_SET_ID>/env/prod'
terraform plan  # Should show "No changes"
```

## External links

- [go-tfe v1.108.0](https://github.com/hashicorp/go-tfe/pull/1345) - Adds AddTagSelectors, RemoveTagSelectors, and TagSelectors on policy sets

## Output from acceptance tests

```
export TFE_HOSTNAME="anubhavgoel.ngrok.app"                    
export TFE_TOKEN="<TOKEN>"
export ENABLE_BETA=1
export TF_ACC=1
go test -count=1 -v -run 'TestAccTFETagPolicySet_|TestAccTFETagPolicySetExclusion_' ./internal/provider/

=== RUN   TestAccTFETagPolicySetExclusion_keyValueTag
2026/06/10 17:10:00 [DEBUG] Configuring client for host "anubhavgoel.ngrok.app"
2026/06/10 17:10:00 [WARN] Unable to read CLI config or credentials file /Users/anubhav.goel/.terraformrc: open /Users/anubhav.goel/.terraformrc: no such file or directory
2026/06/10 17:10:00 [DEBUG] Service discovery for anubhavgoel.ngrok.app at https://anubhavgoel.ngrok.app/.well-known/terraform.json
--- PASS: TestAccTFETagPolicySetExclusion_keyValueTag (3.99s)
=== RUN   TestAccTFETagPolicySetExclusion_keyOnlyTag
--- PASS: TestAccTFETagPolicySetExclusion_keyOnlyTag (2.63s)
=== RUN   TestAccTFETagPolicySetExclusion_incorrectImportSyntax
--- PASS: TestAccTFETagPolicySetExclusion_incorrectImportSyntax (2.02s)
=== RUN   TestAccTFETagPolicySet_keyValueTag
--- PASS: TestAccTFETagPolicySet_keyValueTag (2.70s)
=== RUN   TestAccTFETagPolicySet_keyOnlyTag
--- PASS: TestAccTFETagPolicySet_keyOnlyTag (2.64s)
=== RUN   TestAccTFETagPolicySet_incorrectImportSyntax
--- PASS: TestAccTFETagPolicySet_incorrectImportSyntax (2.07s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   16.698s
...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan
Revert PR and make a release.

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

