### PR TITLE
chore: fix CI by not referencing sunset trial entitlement

### DIFF
--- a/internal/provider/data_source_organization_audit_configuration_test.go
+++ b/internal/provider/data_source_organization_audit_configuration_test.go
@@ -46,7 +46,7 @@ func TestAccTFEOrganizationAuditConfigurationDataSource_disallowed(t *testing.T)
 		t.Fatal(err)
 	}
 
-	org, orgCleanup := createTrialOrganization(t, tfeClient)
+	org, orgCleanup := createFreeOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -95,13 +95,13 @@ func createStandardOrganization(t *testing.T, client *tfe.Client) (*tfe.Organiza
 	return org, orgCleanup
 }
 
-func createTrialOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
+func createFreeOrganization(t *testing.T, client *tfe.Client) (*tfe.Organization, func()) {
 	org, orgCleanup := createOrganization(t, client, tfe.OrganizationCreateOptions{
 		Name:  tfe.String("tst-" + randomString(t)),
 		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
 	})
 
-	newSubscriptionUpdater(org).WithTrialPlan().Update(t)
+	newSubscriptionUpdater(org).WithFreePlan().Update(t)
 
 	return org, orgCleanup
 }

--- a/internal/provider/resource_tfe_organization_run_task_global_settings_test.go
+++ b/internal/provider/resource_tfe_organization_run_task_global_settings_test.go
@@ -96,7 +96,7 @@ func TestAccTFEOrganizationRunTaskGlobalSettings_createUnsupported(t *testing.T)
 		t.Fatal(err)
 	}
 
-	org, orgCleanup := createTrialOrganization(t, tfeClient)
+	org, orgCleanup := createFreeOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
 	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()

--- a/internal/provider/subscription_updater_test.go
+++ b/internal/provider/subscription_updater_test.go
@@ -100,8 +100,8 @@ func (b *organizationSubscriptionUpdater) WithPremiumPlan() *organizationSubscri
 	return b
 }
 
-func (b *organizationSubscriptionUpdater) WithTrialPlan() *organizationSubscriptionUpdater {
-	b.planName = "Trial"
+func (b *organizationSubscriptionUpdater) WithFreePlan() *organizationSubscriptionUpdater {
+	b.planName = "Free"
 	ceiling := 1
 	b.updateOpts.RunsCeiling = &ceiling
 	return b


### PR DESCRIPTION
## Description

-switch to using a free account rather than trial for the tests (trial is sunset so updating to trial was throwing an error)

The cases of the tests using a trial account was for testing what happens when not entitled to certain features, so a free account still works for these assertions

## Testing plan

This is just an update to tests, so no testing plan needed


## Rollback Plan

Revert the PR 
