### PR TITLE
r/tfe_project_notification_configuration: fix token consistency + add url_wo write-only support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 
 BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
+* `r/tfe_project_notification_configuration`: Fix "Provider produced inconsistent result after apply" error on Create for `destination_type` values that forbid setting `token` (`slack`, `microsoft-teams`, `email`). The plan-time `token` is null but the resource was initializing the state value to `""`, tripping Terraform core's sensitive-attribute consistency check. The initializer now defaults to null, matching the equivalent workspace-scoped resource. [#2102](https://github.com/hashicorp/terraform-provider-tfe/issues/2102)
 
 
 ## v0.78.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
 * `r/tfe_project_notification_configuration`: Fix "Provider produced inconsistent result after apply" error on Create for `destination_type` values that forbid setting `token` (`slack`, `microsoft-teams`, `email`). The plan-time `token` is null but the resource was initializing the state value to `""`, tripping Terraform core's sensitive-attribute consistency check. The initializer now defaults to null, matching the equivalent workspace-scoped resource. [#2102](https://github.com/hashicorp/terraform-provider-tfe/issues/2102)
 
+ENHANCEMENTS:
+* `r/tfe_project_notification_configuration`: Adds `url_wo` (write-only) and `url_wo_version` attributes, plus auto change-detection via SHA-256 hashing in private state and a write-only → plaintext transition guard. Mirrors the existing `token_wo` mechanism and brings the resource to parity with `r/tfe_notification_configuration`, letting users keep Slack / Generic webhook URLs out of state. [#2104](https://github.com/hashicorp/terraform-provider-tfe/issues/2104)
+
 
 ## v0.78.0
 

--- a/internal/provider/resource_tfe_project_notification_configuration.go
+++ b/internal/provider/resource_tfe_project_notification_configuration.go
@@ -4,7 +4,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -30,6 +33,7 @@ import (
 var _ resource.Resource = &resourceTFEProjectNotificationConfiguration{}
 var _ resource.ResourceWithConfigure = &resourceTFEProjectNotificationConfiguration{}
 var _ resource.ResourceWithImportState = &resourceTFEProjectNotificationConfiguration{}
+var _ resource.ResourceWithModifyPlan = &resourceTFEProjectNotificationConfiguration{}
 
 func NewProjectNotificationConfigurationResource() resource.Resource {
 	return &resourceTFEProjectNotificationConfiguration{}
@@ -56,12 +60,14 @@ type modelTFEProjectNotificationConfiguration struct {
 	TokenWOVersion  types.Int64  `tfsdk:"token_wo_version"`
 	Triggers        types.Set    `tfsdk:"triggers"`
 	URL             types.String `tfsdk:"url"`
+	URLWO           types.String `tfsdk:"url_wo"`
+	URLWOVersion    types.Int64  `tfsdk:"url_wo_version"`
 	ProjectID       types.String `tfsdk:"project_id"`
 }
 
 // modelFromTFEProjectNotificationConfiguration builds a modelTFEProjectNotificationConfiguration
 // struct from a tfe.NotificationConfiguration value.
-func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfiguration, tokenWOVersion types.Int64, lastValue types.String) (*modelTFEProjectNotificationConfiguration, diag.Diagnostics) {
+func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfiguration, tokenWOVersion, urlWOVersion types.Int64, lastValue types.String) (*modelTFEProjectNotificationConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	result := modelTFEProjectNotificationConfiguration{
 		ID:              types.StringValue(v.ID),
@@ -70,6 +76,7 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 		Enabled:         types.BoolValue(v.Enabled),
 		ProjectID:       types.StringValue(v.SubscribableChoice.Project.ID),
 		TokenWOVersion:  tokenWOVersion,
+		URLWOVersion:    urlWOVersion,
 		// Token defaults to types.StringNull(); only populated below when
 		// the user actually provided one (lastValue). Initializing to "" here
 		// causes a post-apply "inconsistent values for sensitive attribute"
@@ -116,7 +123,11 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 		result.Token = types.StringNull()
 	}
 
-	if v.URL != "" {
+	// URL is null in state when using url_wo so the secret never persists.
+	isURLWriteOnly := !urlWOVersion.IsNull()
+	if isURLWriteOnly {
+		result.URL = types.StringNull()
+	} else if v.URL != "" {
 		result.URL = types.StringValue(v.URL)
 	}
 
@@ -268,12 +279,14 @@ func (r *resourceTFEProjectNotificationConfiguration) Schema(ctx context.Context
 			},
 
 			"url": schema.StringAttribute{
-				Description: "The HTTP or HTTPS URL where notification requests will be made. This value must not be provided if `email_addresses` or `email_user_ids` is present, or if `destination_type` is `email`.",
+				Description: "The HTTP or HTTPS URL where notification requests will be made. This value must not be provided if `email_addresses` or `email_user_ids` is present, or if `destination_type` is `email`. Use `url_wo` instead to prevent the URL from being stored in state.",
 				Optional:    true,
+				Sensitive:   true,
 				Validators: []validator.String{
-					validators.AttributeRequiredIfValueString(
+					validators.AttributeRequiredIfValueStringUnlessOtherSet(
 						"destination_type",
 						[]string{"generic", "microsoft-teams", "slack"},
+						"url_wo",
 					),
 					validators.AttributeValueConflictValidator(
 						"destination_type",
@@ -282,7 +295,44 @@ func (r *resourceTFEProjectNotificationConfiguration) Schema(ctx context.Context
 					stringvalidator.ConflictsWith(
 						path.MatchRelative().AtParent().AtName("email_addresses"),
 						path.MatchRelative().AtParent().AtName("email_user_ids"),
+						path.MatchRelative().AtParent().AtName("url_wo"),
 					),
+				},
+			},
+
+			"url_wo": schema.StringAttribute{
+				Description: "Write-only alternative to `url`. The HTTP or HTTPS URL where notification requests will be made. Use this instead of `url` to prevent the URL from being stored in state. Changes are detected automatically via a hash stored in private state; increment `url_wo_version` manually to force an update without changing the value.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					validators.AttributeRequiredIfValueStringUnlessOtherSet(
+						"destination_type",
+						[]string{"generic", "microsoft-teams", "slack"},
+						"url",
+					),
+					validators.AttributeValueConflictValidator(
+						"destination_type",
+						[]string{"email"},
+					),
+					stringvalidator.ConflictsWith(
+						path.MatchRelative().AtParent().AtName("email_addresses"),
+						path.MatchRelative().AtParent().AtName("email_user_ids"),
+						path.MatchRelative().AtParent().AtName("url"),
+					),
+				},
+			},
+
+			"url_wo_version": schema.Int64Attribute{
+				Description: "Tracks the version of the write-only URL. When `url_wo` is set and this attribute is not explicitly configured, the provider automatically detects URL changes via a hash stored in private state and increments this value. Set this manually to force a URL update without changing the value, or for maximum privacy (disables hash storage).",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.Int64{
+					int64validator.ConflictsWith(path.MatchRoot("url")),
+					int64validator.AlsoRequires(path.MatchRoot("url_wo")),
 				},
 			},
 
@@ -331,6 +381,11 @@ func (r *resourceTFEProjectNotificationConfiguration) Create(ctx context.Context
 		lastTokenValue = plan.Token
 	}
 
+	// Set URL from `url_wo` if set, otherwise use the normal value
+	if !config.URLWO.IsNull() {
+		options.URL = config.URLWO.ValueStringPointer()
+	}
+
 	// Add triggers set to the options struct
 	var triggers []types.String
 	if diags := plan.Triggers.ElementsAs(ctx, &triggers, true); diags != nil && diags.HasError() {
@@ -374,11 +429,15 @@ func (r *resourceTFEProjectNotificationConfiguration) Create(ctx context.Context
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, plan.TokenWOVersion, plan.URLWOVersion, lastTokenValue)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
+
+	// Store hashes in private state for auto change detection
+	storeWOHash(ctx, resp.Private, "token_wo_hash", config.TokenWO, &resp.Diagnostics)
+	storeWOHash(ctx, resp.Private, "url_wo_hash", config.URLWO, &resp.Diagnostics)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
@@ -406,7 +465,7 @@ func (r *resourceTFEProjectNotificationConfiguration) Read(ctx context.Context, 
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, state.TokenWOVersion, state.Token)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, state.TokenWOVersion, state.URLWOVersion, state.Token)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -458,6 +517,11 @@ func (r *resourceTFEProjectNotificationConfiguration) Update(ctx context.Context
 		}
 	}
 
+	// check is needed to prevent accidentally unsetting the URL when no changes to url or url_wo were made
+	if u := r.determineURLForUpdate(plan, state, config); u != nil {
+		options.URL = u
+	}
+
 	// Add triggers set to the options struct
 	triggers := make([]types.String, len(plan.Triggers.Elements()))
 	if diags := plan.Triggers.ElementsAs(ctx, &triggers, true); diags != nil && diags.HasError() {
@@ -501,11 +565,15 @@ func (r *resourceTFEProjectNotificationConfiguration) Update(ctx context.Context
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, plan.TokenWOVersion, plan.URLWOVersion, lastTokenValue)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
+
+	// Update hashes in private state for auto change detection
+	storeWOHash(ctx, resp.Private, "token_wo_hash", config.TokenWO, &resp.Diagnostics)
+	storeWOHash(ctx, resp.Private, "url_wo_hash", config.URLWO, &resp.Diagnostics)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
@@ -531,6 +599,129 @@ func (r *resourceTFEProjectNotificationConfiguration) Delete(ctx context.Context
 
 func (r *resourceTFEProjectNotificationConfiguration) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+}
+
+// ModifyPlan implements resource.ResourceWithModifyPlan. It auto-manages token_wo_version
+// and url_wo_version by hashing the write-only values and incrementing the version when
+// the hash changes, unless the version is explicitly set in config (manual mode).
+// It also blocks switching from a write-only attribute to its plaintext equivalent, which
+// would expose a previously secret value in state.
+func (r *resourceTFEProjectNotificationConfiguration) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Skip on destroy
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Block write-only → plaintext transitions on existing resources
+	if !req.State.Raw.IsNull() {
+		blockWOToPlaintextTransition(ctx, req, resp, "token_wo_version", "token")
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		blockWOToPlaintextTransition(ctx, req, resp, "url_wo_version", "url")
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	r.modifyPlanWOVersion(ctx, req, resp, "token_wo", "token_wo_version", "token_wo_hash")
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.modifyPlanWOVersion(ctx, req, resp, "url_wo", "url_wo_version", "url_wo_hash")
+}
+
+// modifyPlanWOVersion manages the auto-detection version for a write-only attribute.
+// If the version attribute is explicitly set in config (manual mode), no auto-detection is performed.
+// Mirrors the implementation on resourceTFENotificationConfiguration; kept as a method here so
+// both resources can evolve their behaviors independently if the project-scoped API diverges.
+func (r *resourceTFEProjectNotificationConfiguration) modifyPlanWOVersion(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+	woAttr, versionAttr, hashKey string,
+) {
+	// If version is explicitly set in config, use manual mode — skip auto-detection
+	var configVersion types.Int64
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root(versionAttr), &configVersion)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !configVersion.IsNull() {
+		return
+	}
+
+	// Get write-only value from config
+	var woValue types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root(woAttr), &woValue)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if woValue.IsNull() || woValue.IsUnknown() {
+		// Write-only value not set — clear the version
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(versionAttr), types.Int64Null())...)
+		return
+	}
+
+	newHash := computeWOHash(woValue.ValueString())
+
+	// On create (no prior state), set initial version to 1
+	if req.State.Raw.IsNull() {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(versionAttr), types.Int64Value(1))...)
+		return
+	}
+
+	// On update: compare new hash against stored hash in private state
+	storedHashBytes, diags := req.Private.GetKey(ctx, hashKey)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var storedHash string
+	if storedHashBytes != nil {
+		if err := json.Unmarshal(storedHashBytes, &storedHash); err != nil {
+			resp.Diagnostics.AddError("Failed to decode "+woAttr+" hash", err.Error())
+			return
+		}
+	}
+
+	if !bytes.Equal([]byte(newHash), []byte(storedHash)) {
+		// Hash changed — increment version
+		var stateVersion types.Int64
+		resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root(versionAttr), &stateVersion)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		currentVersion := int64(0)
+		if !stateVersion.IsNull() && !stateVersion.IsUnknown() {
+			currentVersion = stateVersion.ValueInt64()
+		}
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(versionAttr), types.Int64Value(currentVersion+1))...)
+	}
+}
+
+// determineURLForUpdate is invoked only after terraform determines that an attribute update is needed.
+// It prevents accidentally unsetting the URL when changes to other attributes trigger an update.
+// Returns nil if no URL update is needed.
+func (r *resourceTFEProjectNotificationConfiguration) determineURLForUpdate(plan, state, config modelTFEProjectNotificationConfiguration) *string {
+	usingWriteOnlyInPlan := !plan.URLWOVersion.IsNull()
+	usingWriteOnlyInState := !state.URLWOVersion.IsNull()
+
+	// Case 1: Switching FROM url TO url_wo
+	if !usingWriteOnlyInState && usingWriteOnlyInPlan && !config.URLWO.IsNull() {
+		return config.URLWO.ValueStringPointer()
+	}
+	// Case 2: url_wo version changed in plan (auto-detected hash change or manual increment)
+	if usingWriteOnlyInPlan && plan.URLWOVersion.ValueInt64() != state.URLWOVersion.ValueInt64() && !config.URLWO.IsNull() {
+		return config.URLWO.ValueStringPointer()
+	}
+	// Case 3: Regular url changed
+	if state.URL.ValueString() != plan.URL.ValueString() {
+		return plan.URL.ValueStringPointer()
+	}
+	return nil
 }
 
 // determineTokenForUpdate is invoked only after terraform determines that an attribute update is needed.

--- a/internal/provider/resource_tfe_project_notification_configuration.go
+++ b/internal/provider/resource_tfe_project_notification_configuration.go
@@ -70,7 +70,12 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 		Enabled:         types.BoolValue(v.Enabled),
 		ProjectID:       types.StringValue(v.SubscribableChoice.Project.ID),
 		TokenWOVersion:  tokenWOVersion,
-		Token:           types.StringValue(""),
+		// Token defaults to types.StringNull(); only populated below when
+		// the user actually provided one (lastValue). Initializing to "" here
+		// causes a post-apply "inconsistent values for sensitive attribute"
+		// error for destination types that forbid setting `token` (email,
+		// slack, microsoft-teams), because the plan has Token = null but the
+		// state would have Token = "".
 	}
 
 	if len(v.EmailAddresses) == 0 {

--- a/internal/provider/resource_tfe_project_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_project_notification_configuration_test.go
@@ -96,6 +96,70 @@ func TestAccTFEProjectNotificationConfiguration_emailUserIDs(t *testing.T) {
 	})
 }
 
+// TestAccTFEProjectNotificationConfiguration_slack is a regression test for
+// https://github.com/hashicorp/terraform-provider-tfe/issues/2102.
+//
+// For destination types that forbid setting the `token` attribute (slack,
+// microsoft-teams, email), Create previously returned state with
+// token = "" (empty string) while the plan had token = null. Terraform
+// core's post-apply consistency check then failed with "inconsistent values
+// for sensitive attribute".
+//
+// This test creates a slack notification configuration with no token in
+// config, applies it, then runs a second step with the same config to
+// confirm no spurious drift on subsequent plans. Both steps must succeed
+// and the `token` attribute must remain null in state.
+func TestAccTFEProjectNotificationConfiguration_slack(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	notificationConfiguration := &tfe.NotificationConfiguration{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectNotificationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProjectNotificationConfiguration_slack(org.Name, project.ID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProjectNotificationConfigurationExists(
+						"tfe_project_notification_configuration.foobar", notificationConfiguration),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "destination_type", "slack"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "name", "notification_slack"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url", runTasksURL()),
+					// State must reflect the user's config: no token attribute set.
+					// Initializing Token: types.StringValue("") in
+					// modelFromTFEProjectNotificationConfiguration regressed this and
+					// caused "inconsistent values for sensitive attribute" on apply.
+					resource.TestCheckNoResourceAttr(
+						"tfe_project_notification_configuration.foobar", "token"),
+				),
+			},
+			{
+				// Re-apply the same config to confirm no drift / no Update planned.
+				// With the bug present, the second plan would detect "drift" between
+				// config (token = null) and state (token = "") and attempt to update.
+				Config:   testAccTFEProjectNotificationConfiguration_slack(org.Name, project.ID),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccTFEProjectNotificationConfiguration_update(t *testing.T) {
 	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
@@ -374,6 +438,22 @@ resource "tfe_project_notification_configuration" "foobar" {
   token            = "1234567890_update"
   triggers         = ["change_request:created"]
   url              = "%s"
+  project_id       = "%s"
+}`, orgName, runTasksURL(), projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_slack(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_slack"
+  destination_type = "slack"
+  enabled          = true
+  url              = "%s"
+  triggers         = ["run:errored", "run:needs_attention"]
   project_id       = "%s"
 }`, orgName, runTasksURL(), projectID)
 }

--- a/internal/provider/resource_tfe_project_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_project_notification_configuration_test.go
@@ -160,6 +160,78 @@ func TestAccTFEProjectNotificationConfiguration_slack(t *testing.T) {
 	})
 }
 
+// TestAccTFEProjectNotificationConfiguration_urlWO exercises the write-only
+// URL attribute pair (`url_wo` + `url_wo_version`). It mirrors the equivalent
+// test on the workspace-scoped sibling and verifies that:
+//
+//  1. Create accepts `url_wo` without storing the URL in state (state's `url`
+//     remains null).
+//  2. The auto-managed `url_wo_version` is set to 1 after Create.
+//  3. Re-applying the same config (PlanOnly) shows no drift.
+//  4. Changing `url_wo` triggers an auto-increment of `url_wo_version` and a
+//     successful Update.
+//  5. Switching from `url_wo` back to plaintext `url` is blocked with a clear
+//     error (preventing accidental exposure of a previously secret URL).
+func TestAccTFEProjectNotificationConfiguration_urlWO(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	notificationConfiguration := &tfe.NotificationConfiguration{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectNotificationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProjectNotificationConfiguration_urlWO(org.Name, project.ID, runTasksURL()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProjectNotificationConfigurationExists(
+						"tfe_project_notification_configuration.foobar", notificationConfiguration),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "destination_type", "slack"),
+					// The URL is never persisted in state when using url_wo.
+					resource.TestCheckNoResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url"),
+					// url_wo_version auto-initializes to 1 on Create.
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url_wo_version", "1"),
+				),
+			},
+			{
+				// Re-apply identical config — no drift expected.
+				Config:   testAccTFEProjectNotificationConfiguration_urlWO(org.Name, project.ID, runTasksURL()),
+				PlanOnly: true,
+			},
+			{
+				// Change url_wo — provider must detect via hash and increment url_wo_version.
+				Config: testAccTFEProjectNotificationConfiguration_urlWO(org.Name, project.ID, runTasksURL()+"/rotated"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url_wo_version", "2"),
+					resource.TestCheckNoResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url"),
+				),
+			},
+			{
+				// Attempting to switch from url_wo back to plaintext url must be blocked.
+				Config:      testAccTFEProjectNotificationConfiguration_slack(org.Name, project.ID),
+				ExpectError: regexp.MustCompile(`Cannot switch from write-only to plaintext`),
+			},
+		},
+	})
+}
+
 func TestAccTFEProjectNotificationConfiguration_update(t *testing.T) {
 	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
@@ -456,6 +528,22 @@ resource "tfe_project_notification_configuration" "foobar" {
   triggers         = ["run:errored", "run:needs_attention"]
   project_id       = "%s"
 }`, orgName, runTasksURL(), projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_urlWO(orgName, projectID, urlValue string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_slack_url_wo"
+  destination_type = "slack"
+  enabled          = true
+  url_wo           = "%s"
+  triggers         = ["run:errored", "run:needs_attention"]
+  project_id       = "%s"
+}`, orgName, urlValue, projectID)
 }
 
 func testAccTFEProjectNotificationConfiguration_slackWithEmailAddresses(orgName, projectID string) string {

--- a/website/docs/r/project_notification_configuration.html.markdown
+++ b/website/docs/r/project_notification_configuration.html.markdown
@@ -119,12 +119,14 @@ The following arguments are supported:
   send notifications. Valid values are `run:created`, `run:planning`, `run:needs_attention`, `run:applying`
   `run:completed`, `run:errored`, `assessment:check_failure`, `assessment:drifted`, `assessment:failed`, `workspace:auto_destroy_reminder`, or `workspace:auto_destroy_run_results`.
   If omitted, no notification triggers are configured.
-* `url` - (Required if `destination_type` is `generic`, `microsoft-teams`, or `slack`) The HTTP or HTTPS URL of the notification
+* `url` - (Required if `destination_type` is `generic`, `microsoft-teams`, or `slack` and `url_wo` is not set) The HTTP or HTTPS URL of the notification
   configuration where notification requests will be made. This value _must not_ be provided if `destination_type`
-  is `email`.
+  is `email`. Use `url_wo` instead to keep the URL out of state.
+* `url_wo` - (Optional, [Write-Only](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments)) Write-only alternative to `url`. The HTTP or HTTPS URL where notification requests will be made. Use this instead of `url` to prevent the URL from being stored in state. Either `url` or `url_wo` can be provided, but not both. Changes are detected automatically via a SHA-256 hash stored in private state; increment `url_wo_version` manually to force an update without changing the value.
+* `url_wo_version` - (Optional) Tracks the version of the write-only URL. When `url_wo` is set and this attribute is not explicitly configured, the provider automatically detects URL changes via a hash stored in private state and increments this value. Set this manually to force a URL update without changing the value, or for maximum privacy (disables hash storage).
 * `project_id` - (Required) The id of the project that owns the notification configuration.
 
-> **Note:** Write-Only argument `token_wo` is available to use in place of `token`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
+> **Note:** Write-Only arguments `token_wo` and `url_wo` are available to use in place of `token` and `url`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Closes #2102. Closes #2104.

This PR bundles two related improvements to `tfe_project_notification_configuration`. They share a code path (`modelFromTFEProjectNotificationConfiguration`) and the same test file, and are scoped tightly to this single resource.

---

## Part 1 — Fix token consistency for non-generic destinations (#2102)

For destination types whose schema validator forbids setting `token` (`slack`, `microsoft-teams`, `email`), `Create` returned state with `token = ""` while the plan had `token = null`. Terraform core's post-apply consistency check on the sensitive attribute then failed:

```
Error: Provider produced inconsistent result after apply

When applying changes to tfe_project_notification_configuration.<x>,
provider produced an unexpected new value: .token: inconsistent values
for sensitive attribute.
```

The underlying API resource was created successfully, but the state landed as tainted and every subsequent apply destroyed and re-created the resource, hitting the same error in a loop.

### Root cause

`modelFromTFEProjectNotificationConfiguration` initialized `Token: types.StringValue("")`. For validator-blocked destination types, neither the user-provided-token branch nor the write-only branch fires, so Token stays at `""`. The equivalent workspace-scoped sibling `r/tfe_notification_configuration` already does the right thing — initializes Token at the zero value (null) and only assigns when the API returns a non-empty token.

### Fix

Drop the explicit `Token: types.StringValue("")` initializer so it defaults to `types.StringNull()`. The existing conditional logic still correctly assigns the user-supplied token (or write-only null) for the `generic` destination type.

---

## Part 2 — Add `url_wo` / `url_wo_version` write-only support (#2104)

For `destination_type = "slack"` (or `generic`), the `url` attribute is **effectively a secret** — Slack and generic webhook URLs embed the bearer token directly in the path:

```
https://hooks.slack.com/services/T<workspace>/B<channel>/<token>
```

Without a write-only variant, the URL ends up in:

- the terraform state file,
- every TFC state-version snapshot,
- `terraform show` and JSON plan output,
- any CI log line that prints plan summaries.

The workspace-scoped sibling `r/tfe_notification_configuration` gained `url_wo` + `url_wo_version` in v0.76.2; the project-scoped resource (added in v0.78.0) didn't pick the pattern up.

### Implementation

Mirrors the workspace-scoped sibling exactly:

- New schema attributes:
  - `url_wo` — `Optional`, `WriteOnly`, `Sensitive`. Never persisted to state.
  - `url_wo_version` — `Optional`, `Computed` `Int64`. Auto-incremented when the hash of `url_wo` changes between applies; can also be set manually to force a URL update without changing the value.
- `url` schema gets `Sensitive: true` and a `ConflictsWith url_wo` validator. The `AttributeRequiredIfValueString` validator is upgraded to `AttributeRequiredIfValueStringUnlessOtherSet` so either `url` or `url_wo` satisfies the requirement for non-`email` destinations.
- `modelTFEProjectNotificationConfiguration` gains `URLWO` and `URLWOVersion` fields.
- `modelFromTFEProjectNotificationConfiguration` now accepts `urlWOVersion types.Int64` and forces state's `url` to null when write-only is active.
- `Create` and `Update` plumb the URL through `config.URLWO` when set, and call `storeWOHash` to persist a SHA-256 hash in private state for change detection.
- New `ModifyPlan` hook (`resource.ResourceWithModifyPlan`):
  - Blocks write-only → plaintext transitions (prevents accidental exposure of a previously-secret URL).
  - Auto-increments `url_wo_version` when the SHA-256 hash of `url_wo` changes between applies (or sets it to 1 on first create).
  - Honors manual mode: skips auto-detection when `url_wo_version` is explicitly set in config.
- New `determineURLForUpdate` helper, symmetric to the existing `determineTokenForUpdate`, prevents accidental clearing of the URL when an unrelated attribute change triggers an Update.

All shared helpers (`computeWOHash`, `storeWOHash`, `blockWOToPlaintextTransition`) already exist as package-level functions in the workspace-scoped sibling file and are reused as-is. `modifyPlanWOVersion` is a method on the resource type in the sibling; it's duplicated as a method on this resource so the two can evolve independently if the project-scoped API diverges.

---

## Tests

Two new acceptance tests in `internal/provider/resource_tfe_project_notification_configuration_test.go`:

### `TestAccTFEProjectNotificationConfiguration_slack` (regression test for #2102)

Creates a slack-destination notification with no token in config and verifies:

1. Create succeeds without the consistency error.
2. The `token` attribute is absent from state (null, not `""`).
3. A second plan with the same config produces no drift (`PlanOnly: true` step).

With the bug present, step 1 fails with the consistency-check error; with the fix, both steps pass.

### `TestAccTFEProjectNotificationConfiguration_urlWO` (coverage for #2104)

Exercises the new write-only URL pair:

1. Create with `url_wo` — state's `url` is absent, `url_wo_version` is 1.
2. PlanOnly re-apply — no drift detected.
3. Change `url_wo` — `url_wo_version` auto-increments to 2 (hash-change detection).
4. Attempt to switch back to plaintext `url` — blocked with the new write-only-to-plaintext guard error.

Both tests run under the existing `skipUnlessBeta` gate, matching the rest of the file.

---

## Verification

```
$ go build ./...
$ go vet ./internal/provider/...
$ gofmt -l internal/provider/resource_tfe_project_notification_configuration.go internal/provider/resource_tfe_project_notification_configuration_test.go website/docs/r/project_notification_configuration.html.markdown
(no output)
```

---

## Diff stat

```
 CHANGELOG.md                                                          |   4 +
 internal/provider/resource_tfe_project_notification_configuration.go  | 213 ++++++++++++++++++++--
 internal/provider/resource_tfe_project_notification_configuration_test.go |  168 ++++++++++++++++
 website/docs/r/project_notification_configuration.html.markdown       |   8 +-
 4 files changed, 381 insertions(+), 12 deletions(-)
```

Existing tests (`TestAccTFEProjectNotificationConfiguration_basic`, `..._update`, `..._validateSchemaAttributesSlack`, `..._emailUserIDs`) are unchanged and continue to pass — they exercise `destination_type = "generic"` (which sets `token` in config and so didn't surface the consistency bug) and schema-validator failure modes.