### PR TITLE
Fix Documentation admin_smtp_settings where enabled attribute was missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
 
 BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
-* r/tfe_admin_smtp_settngs: fixed documentation Example and Attribute list to add missing enabled field. By @cpag [#2107](https://github.com/hashicorp/terraform-provider-tfe/pull/2107)
+* `r/tfe_admin_smtp_settngs`: fixed documentation Example and Attribute list to add missing enabled field. By @cpag [#2107](https://github.com/hashicorp/terraform-provider-tfe/pull/2107)
 
 
 ## v0.78.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
 
 BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
-* r/tfe_workspace: fixed documentation Example and Attribute list to add missing enabled field. By @cpag [#2107](https://github.com/hashicorp/terraform-provider-tfe/pull/2107)
+* r/tfe_admin_smtp_settngs: fixed documentation Example and Attribute list to add missing enabled field. By @cpag [#2107](https://github.com/hashicorp/terraform-provider-tfe/pull/2107)
 
 
 ## v0.78.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
 
 BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
-* r/tfe_workspace: fixed documentation Example and Attribute list to add missing enabled field
+* r/tfe_workspace: fixed documentation Example and Attribute list to add missing enabled field. By @cpag [#2107](https://github.com/hashicorp/terraform-provider-tfe/pull/2107)
 
 
 ## v0.78.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 
 BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
+* r/tfe_workspace: fixed documentation Example and Attribute list to add missing enabled field
 
 
 ## v0.78.0

--- a/website/docs/r/admin_smtp_settings.html.markdown
+++ b/website/docs/r/admin_smtp_settings.html.markdown
@@ -20,10 +20,11 @@ provider "tfe" {
 }
 
 resource "tfe_admin_smtp_settings" "this" {
-  host   = "smtp.example.com"
-  port   = 25
-  sender = "noreply@example.com"
-  auth   = "none"
+  enabled = true
+  host    = "smtp.example.com"
+  port    = 25
+  sender  = "noreply@example.com"
+  auth    = "none"
 }
 ```
 
@@ -36,6 +37,7 @@ provider "tfe" {
 }
 
 resource "tfe_admin_smtp_settings" "this" {
+  enabled  = true
   host     = "smtp.example.com"
   port     = 587
   sender   = "noreply@example.com"
@@ -59,6 +61,7 @@ provider "tfe" {
 }
 
 resource "tfe_admin_smtp_settings" "this" {
+  enabled             = true
   host                = "smtp.example.com"
   port                = 587
   sender              = "noreply@example.com"
@@ -73,6 +76,7 @@ resource "tfe_admin_smtp_settings" "this" {
 
 The following arguments are supported:
 
+* `enabled` - (Optional) Whether SMTP is enabled. When enabled, all other attributes must have valid values. Defaults to `false`
 * `host` - (Optional) The hostname of the SMTP server.
 * `port` - (Optional) The port of the SMTP server. Defaults to `25`.
 * `sender` - (Optional) The desired sender email address.


### PR DESCRIPTION
Add the enabled field which was missing in the examples and list of atributes

## Description

Fix Documentation for tfe_admin_smtp-settings  with missing `enabled` attributes in both examples and list of attributes

_Remember to:_

- [X] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [X] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

Only documentation change

## External links

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
