### PR TITLE
Compile the TFE provider for linux s390x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
       # Verify expected Artifacts list for a workflow run.
       matrix:
         goos: [freebsd, windows, linux, darwin]
-        goarch: ["386", "amd64", "arm", "arm64"]
+        goarch: ["386", "amd64", "arm", "arm64", "s390x"]
         exclude:
           - goos: freebsd
             goarch: arm64
@@ -137,6 +137,15 @@ jobs:
             goarch: 386
           - goos: darwin
             goarch: arm
+          # Only compile on s390x for Linux
+          - goos: openbsd
+            goarch: s390x
+          - goos: darwin
+            goarch: s390x
+          - goos: freebsd
+            goarch: s390x
+          - goos: windows
+            goarch: s390x
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,22 +129,19 @@ jobs:
         exclude:
           - goos: freebsd
             goarch: arm64
+          - goos: freebsd
+            goarch: s390x
           - goos: windows
             goarch: arm64
           - goos: windows
             goarch: arm
+          - goos: windows
+            goarch: s390x
           - goos: darwin
             goarch: 386
           - goos: darwin
             goarch: arm
-          # Only compile on s390x for Linux
-          - goos: openbsd
-            goarch: s390x
           - goos: darwin
-            goarch: s390x
-          - goos: freebsd
-            goarch: s390x
-          - goos: windows
             goarch: s390x
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/.release/terraform-provider-tfe-artifacts.hcl
+++ b/.release/terraform-provider-tfe-artifacts.hcl
@@ -14,6 +14,7 @@ artifacts {
     "terraform-provider-tfe_${version}_linux_amd64.zip",
     "terraform-provider-tfe_${version}_linux_arm.zip",
     "terraform-provider-tfe_${version}_linux_arm64.zip",
+    "terraform-provider-tfe_${version}_linux_s390x.zip",
     "terraform-provider-tfe_${version}_windows_386.zip",
     "terraform-provider-tfe_${version}_windows_amd64.zip",
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 * **New Resource:** `r/tfe_tag_policy_set` and `r/tfe_tag_policy_set_exclusion`: Adds resources to manage tag-based inclusion and exclusion on policy sets. **NOTE:** This feature is currently in beta and is not available to all users. By @anubhav-goel [#2093](https://github.com/hashicorp/terraform-provider-tfe/pull/2093)
 * `r/tfe_tag_policy_set` and `r/tfe_tag_policy_set_exclusion`: Removed beta notices. ([#669](https://github.com/hashicorp/terraform-provider-tfe/pull/669))
+* Adds support for s390x Linux builds of the TFE terraform provider. By @JenGoldstrich [#2117](https://github.com/hashicorp/terraform-provider-tfe/pull/2117)
 
 BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)


### PR DESCRIPTION
## Description

Adds support running the Terraform TFE provider from an s390x runner.

Nearly identical to https://github.com/hashicorp/terraform-provider-aws/pull/48272

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

It's just a new compiled platform!

