### PR TITLE
[TF-38714] Align URL Sensitivity Across Notification Configuration Subscribable Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
 
 ENHANCEMENTS:
-* `r/tfe_project_notification_configuration` and `r/tfe_team_notification_configuration`: Update url attribute to be sensitive, by @kadenluang [#XXXX](https://github.com/hashicorp/terraform-provider-tfe/pull/XXXX)
+* `r/tfe_project_notification_configuration` and `r/tfe_team_notification_configuration`: update url attributes to be sensitive, by @kadenluang [#2120](https://github.com/hashicorp/terraform-provider-tfe/pull/2120)
 
 
 ## v0.78.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ FEATURES:
 BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
 
+ENHANCEMENTS:
+* `r/tfe_project_notification_configuration` and `r/tfe_team_notification_configuration`: Update url attribute to be sensitive, by @kadenluang [#XXXX](https://github.com/hashicorp/terraform-provider-tfe/pull/XXXX)
+
 
 ## v0.78.0
 

--- a/internal/provider/resource_tfe_project_notification_configuration.go
+++ b/internal/provider/resource_tfe_project_notification_configuration.go
@@ -265,6 +265,7 @@ func (r *resourceTFEProjectNotificationConfiguration) Schema(ctx context.Context
 			"url": schema.StringAttribute{
 				Description: "The HTTP or HTTPS URL where notification requests will be made. This value must not be provided if `email_addresses` or `email_user_ids` is present, or if `destination_type` is `email`.",
 				Optional:    true,
+				Sensitive:   true,
 				Validators: []validator.String{
 					validators.AttributeRequiredIfValueString(
 						"destination_type",

--- a/internal/provider/resource_tfe_team_notification_configuration.go
+++ b/internal/provider/resource_tfe_team_notification_configuration.go
@@ -245,6 +245,7 @@ func (r *resourceTFETeamNotificationConfiguration) Schema(ctx context.Context, r
 			"url": schema.StringAttribute{
 				Description: "The HTTP or HTTPS URL where notification requests will be made. This value must not be provided if `email_addresses` or `email_user_ids` is present, or if `destination_type` is `email`.",
 				Optional:    true,
+				Sensitive:   true,
 				Validators: []validator.String{
 					validators.AttributeRequiredIfValueString(
 						"destination_type",


### PR DESCRIPTION
## Description

In tfe_project_notification_configuration and tfe_team_notification_configuration, the url argument is now marked as sensitive so that the values are masked.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan
1. **Build & format:** Ran `make fmt` and `go build ./...`
2. **Tests:** Ran `make test` and confirmed success

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._
- [Jira](https://hashicorp.atlassian.net/browse/TF-38714)