### PR TITLE
TF-38379-backfill-of-imports-into-docgen

### DIFF
--- a/examples/resources/tfe_admin_smtp_settings/import.sh
+++ b/examples/resources/tfe_admin_smtp_settings/import.sh
@@ -1,0 +1,2 @@
+# via the fixed ID 'smtp'
+terraform import tfe_admin_smtp_settings.this smtp

--- a/examples/resources/tfe_agent_pool/import-by-identity.tf
+++ b/examples/resources/tfe_agent_pool/import-by-identity.tf
@@ -1,0 +1,7 @@
+import {
+  to = tfe_agent_pool.test
+  identity = {
+    id       = "apool-12345678"
+    hostname = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_agent_pool/import.sh
+++ b/examples/resources/tfe_agent_pool/import.sh
@@ -1,0 +1,5 @@
+# via <AGENT POOL ID>
+terraform import tfe_agent_pool.test apool-rW0KoLSlnuNb5adB
+
+# via <ORGANIZATION NAME>/<AGENT POOL NAME>
+terraform import tfe_agent_pool.test my-org-name/my-agent-pool-name

--- a/examples/resources/tfe_agent_pool_allowed_projects/import.sh
+++ b/examples/resources/tfe_agent_pool_allowed_projects/import.sh
@@ -1,0 +1,2 @@
+# via <AGENT POOL ID>
+terraform import tfe_agent_pool_allowed_projects.foobar apool-rW0KoLSlnuNb5adB

--- a/examples/resources/tfe_agent_pool_allowed_workspaces/import.sh
+++ b/examples/resources/tfe_agent_pool_allowed_workspaces/import.sh
@@ -1,0 +1,2 @@
+# via <AGENT POOL ID>
+terraform import tfe_agent_pool_allowed_workspaces.foobar apool-rW0KoLSlnuNb5adB

--- a/examples/resources/tfe_agent_pool_excluded_workspaces/import.sh
+++ b/examples/resources/tfe_agent_pool_excluded_workspaces/import.sh
@@ -1,0 +1,2 @@
+# via <AGENT POOL ID>
+terraform import tfe_agent_pool_excluded_workspaces.foobar apool-rW0KoLSlnuNb5adB

--- a/examples/resources/tfe_audit_trail_token/import.sh
+++ b/examples/resources/tfe_audit_trail_token/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>
+terraform import tfe_audit_trail_token.test my-org-name

--- a/examples/resources/tfe_aws_oidc_configuration/import.sh
+++ b/examples/resources/tfe_aws_oidc_configuration/import.sh
@@ -1,0 +1,2 @@
+# via <AWS OIDC ID>
+terraform import tfe_aws_oidc_configuration.example awsoidc-DXmy3B2emVHysnbq

--- a/examples/resources/tfe_azure_oidc_configuration/import.sh
+++ b/examples/resources/tfe_azure_oidc_configuration/import.sh
@@ -1,0 +1,2 @@
+# via <AZURE OIDC ID>
+terraform import tfe_azure_oidc_configuration.example azoidc-8DCgwEV2GbMcQjk8

--- a/examples/resources/tfe_data_retention_policy/import.sh
+++ b/examples/resources/tfe_data_retention_policy/import.sh
@@ -1,0 +1,5 @@
+# via <ORGANIZATION>/<WORKSPACE NAME>
+terraform import tfe_data_retention_policy.foobar my-org-name/my-workspace-name
+
+# via <ORGANIZATION>
+terraform import tfe_data_retention_policy.bar my-org-name

--- a/examples/resources/tfe_gcp_oidc_configuration/import.sh
+++ b/examples/resources/tfe_gcp_oidc_configuration/import.sh
@@ -1,0 +1,2 @@
+# via <GCP OIDC ID>
+terraform import tfe_gcp_oidc_configuration.example gcpoidc-PuXEeRoSaK3ENGj9

--- a/examples/resources/tfe_hyok_configuration/import.sh
+++ b/examples/resources/tfe_hyok_configuration/import.sh
@@ -1,0 +1,2 @@
+# via <HYOK ID>
+terraform import tfe_hyok_configuration.gcp_example hyokc-XqYizSPQmeiG1aHJ

--- a/examples/resources/tfe_no_code_module/import.sh
+++ b/examples/resources/tfe_no_code_module/import.sh
@@ -1,0 +1,2 @@
+# via <NO CODE MODULE ID> 
+terraform import tfe_no_code_module.test nocode-qV9JnKRkmtMa4zcA

--- a/examples/resources/tfe_notification_configuration/import.sh
+++ b/examples/resources/tfe_notification_configuration/import.sh
@@ -1,0 +1,2 @@
+# via <NOTIFICATION CONFIGURATION ID>
+terraform import tfe_notification_configuration.test nc-qV9JnKRkmtMa4zcA

--- a/examples/resources/tfe_opa_version/import.sh
+++ b/examples/resources/tfe_opa_version/import.sh
@@ -1,0 +1,5 @@
+# via <OPA VERSION ID>
+terraform import tfe_opa_version.test tool-L4oe7rNwn7J4E5Yr
+
+# via <OPA VERSION NUMBER>
+terraform import tfe_opa_version.test 0.58.0

--- a/examples/resources/tfe_org_max_token_ttl_policy/import.sh
+++ b/examples/resources/tfe_org_max_token_ttl_policy/import.sh
@@ -1,0 +1,3 @@
+# After import, the provider will convert the API's millisecond values to human-readable duration strings. If you prefer a different format of those strings, update your Terraform configuration accordingly. 
+# via <ORGANIZATION NAME>
+terraform import tfe_org_max_token_ttl_policy.example my-organization

--- a/examples/resources/tfe_organization/import.sh
+++ b/examples/resources/tfe_organization/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>
+terraform import tfe_organization.test my-org-name

--- a/examples/resources/tfe_organization_default_settings/import.sh
+++ b/examples/resources/tfe_organization_default_settings/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>
+terraform import tfe_organization_default_settings.test my-org-name

--- a/examples/resources/tfe_organization_membership/import-by-identity.tf
+++ b/examples/resources/tfe_organization_membership/import-by-identity.tf
@@ -1,0 +1,7 @@
+import {
+  to = tfe_organization_membership.test
+  identity = {
+    id       = "ou-12345678"
+    hostname = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_organization_membership/import.sh
+++ b/examples/resources/tfe_organization_membership/import.sh
@@ -1,0 +1,5 @@
+# via <ORGANIZATION>/<USER EMAIL>
+terraform import tfe_organization_membership.test my-org-name/user@example.com
+
+# via <ORGANIZATION MEMBERSHIP ID>
+terraform import tfe_organization_membership.test ou-wAs3zYmWAhYK7peR

--- a/examples/resources/tfe_organization_run_task/import.sh
+++ b/examples/resources/tfe_organization_run_task/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>/<TASK NAME>
+terraform import tfe_organization_run_task.test my-org-name/task-name

--- a/examples/resources/tfe_organization_run_task_global_settings/import.sh
+++ b/examples/resources/tfe_organization_run_task_global_settings/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>/<TASK NAME>
+terraform import tfe_organization_run_task_global_settings.test my-org-name/task-name

--- a/examples/resources/tfe_organization_token/import.sh
+++ b/examples/resources/tfe_organization_token/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>
+terraform import tfe_organization_token.test my-org-name

--- a/examples/resources/tfe_policy/import-by-identity.tf
+++ b/examples/resources/tfe_policy/import-by-identity.tf
@@ -1,0 +1,8 @@
+import {
+  to = tfe_policy.test
+  identity = {
+    id           = "pol-wAs3zYmWAhYK7peR"
+    organization = "my-org-name"
+    hostname     = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_policy/import.sh
+++ b/examples/resources/tfe_policy/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>/<POLICY ID>
+terraform import tfe_policy.test my-org-name/pol-wAs3zYmWAhYK7peR

--- a/examples/resources/tfe_policy_set/import-by-identity.tf
+++ b/examples/resources/tfe_policy_set/import-by-identity.tf
@@ -1,0 +1,7 @@
+import {
+  to = tfe_policy_set.test
+  identity = {
+    id       = "polset-12345678"
+    hostname = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_policy_set/import.sh
+++ b/examples/resources/tfe_policy_set/import.sh
@@ -1,0 +1,2 @@
+# via <POLICY SET ID>
+terraform import tfe_policy_set.test polset-wAs3zYmWAhYK7peR

--- a/examples/resources/tfe_policy_set_parameter/import.sh
+++ b/examples/resources/tfe_policy_set_parameter/import.sh
@@ -1,0 +1,2 @@
+# via <POLICY SET ID>/<PARAMETER ID>
+terraform import tfe_policy_set_parameter.test polset-wAs3zYmWAhYK7peR/var-5rTwnSaRPogw6apb

--- a/examples/resources/tfe_project/import-by-identity.tf
+++ b/examples/resources/tfe_project/import-by-identity.tf
@@ -1,0 +1,7 @@
+import {
+  to = tfe_project.test
+  identity = {
+    id       = "prj-12345678"
+    hostname = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_project/import.sh
+++ b/examples/resources/tfe_project/import.sh
@@ -1,0 +1,2 @@
+# via <PROJECT ID>
+terraform import tfe_project.test prj-niVoeESBXT8ZREhr

--- a/examples/resources/tfe_project_notification_configuration/import.sh
+++ b/examples/resources/tfe_project_notification_configuration/import.sh
@@ -1,0 +1,2 @@
+# via <NOTIFICATION CONFIGURATION ID>
+terraform import tfe_project_notification_configuration.test nc-qV9JnKRkmtMa4zcA

--- a/examples/resources/tfe_project_oauth_client/import.sh
+++ b/examples/resources/tfe_project_oauth_client/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION>/<PROJECT ID>/<OAUTH CLIENT NAME>
+terraform import tfe_project_oauth_client.test 'my-org-name/project/oauth-client-name'

--- a/examples/resources/tfe_project_policy_set/import.sh
+++ b/examples/resources/tfe_project_policy_set/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION>/<PROJECT ID>/<POLICY SET NAME>
+terraform import tfe_project_policy_set.test 'my-org-name/project/policy-set-name'

--- a/examples/resources/tfe_project_policy_set_exclusion/import.sh
+++ b/examples/resources/tfe_project_policy_set_exclusion/import.sh
@@ -1,0 +1,2 @@
+# via <PROJECT ID>/<POLICY SET ID>
+terraform import tfe_project_policy_set_exclusion.test 'prj-123456789/polset-123456789'

--- a/examples/resources/tfe_project_settings/import.sh
+++ b/examples/resources/tfe_project_settings/import.sh
@@ -1,0 +1,2 @@
+# via <PROJECT ID>
+terraform import tfe_project_settings.my_project_settings prj-F1NpdVBuCF3xc5R

--- a/examples/resources/tfe_project_variable_set/import.sh
+++ b/examples/resources/tfe_project_variable_set/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION>/<PROJECT ID>/<VARIABLE SET NAME>
+terraform import tfe_project_variable_set.test 'my-org-name/prj-F1NpdVBuCF3xc5Rp/Test Varset'

--- a/examples/resources/tfe_registry_gpg_key/import.sh
+++ b/examples/resources/tfe_registry_gpg_key/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>/<KEY ID>
+terraform import tfe_registry_gpg_key.example my-org-name/34365D9472D7468F

--- a/examples/resources/tfe_registry_module/import-by-identity.tf
+++ b/examples/resources/tfe_registry_module/import-by-identity.tf
@@ -1,0 +1,12 @@
+import {
+  to = tfe_registry_module.test
+  identity = {
+    id              = "mod-qV9JnKRkmtMa4zcA"
+    organization    = "my-org-name"
+    registry_name   = "private"
+    namespace       = "my-org-name"
+    name            = "vpc"
+    module_provider = "aws"
+    hostname        = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_registry_module/import.sh
+++ b/examples/resources/tfe_registry_module/import.sh
@@ -1,0 +1,5 @@
+# via <ORGANIZATION>/<REGISTRY NAME>/<NAMESPACE>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>
+terraform import tfe_registry_module.test my-org-name/public/namespace/name/provider/mod-qV9JnKRkmtMa4zcA
+
+# **Deprecated** via <ORGANIZATION NAME>/<REGISTRY MODULE NAME>/<REGISTRY MODULE PROVIDER>/<REGISTRY MODULE ID>
+terraform import tfe_registry_module.test my-org-name/name/provider/mod-qV9JnKRkmtMa4zcA

--- a/examples/resources/tfe_registry_provider/import-by-identity.tf
+++ b/examples/resources/tfe_registry_provider/import-by-identity.tf
@@ -1,0 +1,11 @@
+import {
+  to = tfe_registry_provider.test
+  identity = {
+    id            = "prov-kwt1cBiX2SdDz38w"
+    organization  = "my-org-name"
+    registry_name = "private"
+    namespace     = "my-org-name"
+    name          = "aws"
+    hostname      = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_registry_provider/import.sh
+++ b/examples/resources/tfe_registry_provider/import.sh
@@ -1,0 +1,6 @@
+# via <ORGANIZATION>/<REGISTRY NAME>/<NAMESPACE>/<PROVIDER NAME>
+# For a private provider:
+terraform import tfe_registry_provider.example my-org-name/private/my-org-name/my-provider
+
+# For a public provider:
+terraform import tfe_registry_provider.example my-org-name/public/hashicorp/aws

--- a/examples/resources/tfe_run_trigger/import.sh
+++ b/examples/resources/tfe_run_trigger/import.sh
@@ -1,0 +1,2 @@
+# via <RUN TRIGGER ID>
+terraform import tfe_run_trigger.test rt-qV9JnKRkmtMa4zcA

--- a/examples/resources/tfe_saml_settings/import.sh
+++ b/examples/resources/tfe_saml_settings/import.sh
@@ -1,0 +1,2 @@
+# via the fixed ID 'saml'
+terraform import tfe_saml_settings.this saml

--- a/examples/resources/tfe_scim_group_mapping/import.sh
+++ b/examples/resources/tfe_scim_group_mapping/import.sh
@@ -1,0 +1,2 @@
+# via <TEAM ID>
+terraform import tfe_scim_group_mapping.engineering team-xxxxxxxxxxxxxxxx

--- a/examples/resources/tfe_scim_settings/import.sh
+++ b/examples/resources/tfe_scim_settings/import.sh
@@ -1,0 +1,2 @@
+# via the fixed ID 'scim'
+terraform import tfe_scim_settings.this scim

--- a/examples/resources/tfe_scim_token/import.sh
+++ b/examples/resources/tfe_scim_token/import.sh
@@ -1,0 +1,3 @@
+# Note: the token attribute is only returned when the token is first created, so it will be null after import
+# via <TOKEN ID>
+terraform import tfe_scim_token.this at-XXXXXXXXXXXXXXXX

--- a/examples/resources/tfe_sentinel_policy/import.sh
+++ b/examples/resources/tfe_sentinel_policy/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>/<POLICY ID>
+terraform import tfe_sentinel_policy.test my-org-name/pol-wAs3zYmWAhYK7peR

--- a/examples/resources/tfe_sentinel_version/import.sh
+++ b/examples/resources/tfe_sentinel_version/import.sh
@@ -1,0 +1,5 @@
+# via <SENTINEL VERSION ID>
+terraform import tfe_sentinel_version.test tool-L4oe7rNwn7J4E5Yr
+
+# via <SENTINEL VERSION NUMBER>
+terraform import tfe_sentinel_version.test 0.24.0

--- a/examples/resources/tfe_stack/import-by-identity.tf
+++ b/examples/resources/tfe_stack/import-by-identity.tf
@@ -1,0 +1,7 @@
+import {
+  to = tfe_stack.test
+  identity = {
+    id       = "st-W6k9K23oSXRHGpj3"
+    hostname = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_stack/import.sh
+++ b/examples/resources/tfe_stack/import.sh
@@ -1,0 +1,3 @@
+# via <STACK ID>
+# Note: the stack ID can be found on the stack's settings tab in the UI
+terraform import tfe_stack.test-stack st-9cs9Vf6Z49Zzrk1t

--- a/examples/resources/tfe_stack_variable_set/import.sh
+++ b/examples/resources/tfe_stack_variable_set/import.sh
@@ -1,0 +1,2 @@
+# via <STACK ID>/<VARSET ID>
+terraform import tfe_stack_variable_set.test st-abcdefgh/varset-ijklmnop

--- a/examples/resources/tfe_tag_policy_set/import.sh
+++ b/examples/resources/tfe_tag_policy_set/import.sh
@@ -1,0 +1,5 @@
+# For key and value tags, via <POLICY SET ID>/<TAG KEY>/<TAG VALUE>
+terraform import tfe_tag_policy_set.test 'polset-abc123/env/prod'
+
+# For key-only tags, via <POLICY SET ID>/<TAG KEY>
+terraform import tfe_tag_policy_set.test 'polset-abc123/key-only'

--- a/examples/resources/tfe_tag_policy_set_exclusion/import.sh
+++ b/examples/resources/tfe_tag_policy_set_exclusion/import.sh
@@ -1,0 +1,5 @@
+# For key and value tags, via <POLICY SET ID>/<TAG KEY>/<TAG VALUE>
+terraform import tfe_tag_policy_set_exclusion.test 'polset-abc123/env/staging'
+
+# For key-only tags, via <POLICY SET ID>/<TAG KEY>
+terraform import tfe_tag_policy_set_exclusion.test 'polset-abc123/key-only'

--- a/examples/resources/tfe_team/import-by-identity.tf
+++ b/examples/resources/tfe_team/import-by-identity.tf
@@ -1,0 +1,8 @@
+import {
+  to = tfe_team.test
+  identity = {
+    id           = "team-uomQZysH9ou42ZYY"
+    organization = "my-org-name"
+    hostname     = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_team/import.sh
+++ b/examples/resources/tfe_team/import.sh
@@ -1,0 +1,5 @@
+# via <ORGANIZATION NAME>/<TEAM ID>
+terraform import tfe_team.test my-org-name/team-uomQZysH9ou42ZYY
+
+# via <ORGANIZATION NAME>/<TEAM NAME>
+terraform import tfe_team.test my-org-name/my-team-name

--- a/examples/resources/tfe_team_access/import.sh
+++ b/examples/resources/tfe_team_access/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION NAME>/<WORKSPACE NAME>/<TEAM ACCESS ID>
+terraform import tfe_team_access.test my-org-name/my-workspace-name/tws-8S5wnRbRpogw6apb

--- a/examples/resources/tfe_team_member/import-by-identity.tf
+++ b/examples/resources/tfe_team_member/import-by-identity.tf
@@ -1,0 +1,7 @@
+import {
+  to = tfe_team_member.test
+  identity = {
+    id       = "team-6p5jTwJQXwqZBncC/my_user_name"
+    hostname = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_team_member/import.sh
+++ b/examples/resources/tfe_team_member/import.sh
@@ -1,0 +1,2 @@
+# via <TEAM ID>/<USERNAME>
+terraform import tfe_team_member.test team-47qC3LmA47piVan7/sander

--- a/examples/resources/tfe_team_members/import.sh
+++ b/examples/resources/tfe_team_members/import.sh
@@ -1,0 +1,2 @@
+# via <TEAM ID>
+terraform import tfe_team_members.test team-47qC3LmA47piVan7

--- a/examples/resources/tfe_team_notification_configuration/import.sh
+++ b/examples/resources/tfe_team_notification_configuration/import.sh
@@ -1,0 +1,2 @@
+# via <NOTIFICATION CONFIGURATION ID>
+terraform import tfe_team_notification_configuration.test nc-qV9JnKRkmtMa4zcA

--- a/examples/resources/tfe_team_organization_member/import.sh
+++ b/examples/resources/tfe_team_organization_member/import.sh
@@ -1,0 +1,5 @@
+# via <TEAM ID>/<ORGANIZATION MEMBERSHIP ID>
+terraform import tfe_team_organization_member.test team-47qC3LmA47piVan7/ou-2342390sdf0jj
+
+# via <ORGANIZATION NAME>/<USER EMAIL>/<TEAM NAME>
+terraform import tfe_team_organization_member.test my-org-name/user@company.com/my-team-name

--- a/examples/resources/tfe_team_organization_members/import.sh
+++ b/examples/resources/tfe_team_organization_members/import.sh
@@ -1,0 +1,2 @@
+# via <TEAM ID>
+terraform import tfe_team_organization_members.test team-47qC3LmA47piVan7

--- a/examples/resources/tfe_team_project_access/import.sh
+++ b/examples/resources/tfe_team_project_access/import.sh
@@ -1,0 +1,2 @@
+# via <TEAM ACCESS ID>
+terraform import tfe_team_project_access.admin tprj-2pmtXpZa4YzVMTPi

--- a/examples/resources/tfe_team_token/import.sh
+++ b/examples/resources/tfe_team_token/import.sh
@@ -1,0 +1,5 @@
+# via <TOKEN ID>
+terraform import tfe_team_token.test at-47qC3LmA47piVan7
+
+# via <TEAM ID>
+terraform import tfe_team_token.test team-47qC3LmA47piVan7

--- a/examples/resources/tfe_terraform_version/import.sh
+++ b/examples/resources/tfe_terraform_version/import.sh
@@ -1,0 +1,5 @@
+# via <TERRAFORM VERSION ID>
+terraform import tfe_terraform_version.test tool-L4oe7rNwn7J4E5Yr
+
+# via <TERRAFORM VERSION NUMBER>
+terraform import tfe_terraform_version.test 1.1.2

--- a/examples/resources/tfe_variable/import-by-identity.tf
+++ b/examples/resources/tfe_variable/import-by-identity.tf
@@ -1,0 +1,17 @@
+import {
+  to = tfe_variable.foo
+  identity = {
+    id              = "var-5rTwnSaRPogw6apb"
+    configurable_id = "ws-66fE3LmF42piTaN2"
+    hostname        = "app.terraform.io"
+  }
+}
+
+import {
+  to = tfe_variable.bar
+  identity = {
+    id              = "var-5rTwnSaRPogw6apb"
+    configurable_id = "varset-47qC3LmA47piVan7"
+    hostname        = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_variable/import.sh
+++ b/examples/resources/tfe_variable/import.sh
@@ -1,0 +1,5 @@
+# via <ORGANIZATION NAME>/<WORKSPACE NAME>/<VARIABLE ID>
+terraform import tfe_variable.test my-org-name/my-workspace-name/var-5rTwnSaRPogw6apb
+
+# via <ORGANIZATION NAME>/<VARIABLE SET ID>/<VARIABLE ID>
+terraform import tfe_variable.test my-org-name/varset-47qC3LmA47piVan7/var-5rTwnSaRPogw6apb

--- a/examples/resources/tfe_variable_set/import-by-identity.tf
+++ b/examples/resources/tfe_variable_set/import-by-identity.tf
@@ -1,0 +1,7 @@
+import {
+  to = tfe_variable_set.test
+  identity = {
+    id       = "varset-kjkN545LH2Sfercv"
+    hostname = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_variable_set/import.sh
+++ b/examples/resources/tfe_variable_set/import.sh
@@ -1,0 +1,2 @@
+# via <VARIABLE SET ID>
+terraform import tfe_variable_set.test varset-5rTwnSaRPogw6apb

--- a/examples/resources/tfe_vault_oidc_configuration/import.sh
+++ b/examples/resources/tfe_vault_oidc_configuration/import.sh
@@ -1,0 +1,2 @@
+# via <VAULT OIDC ID>
+terraform import tfe_vault_oidc_configuration.example voidc-AV61VxigiRvkkvPd

--- a/examples/resources/tfe_workspace/import-by-identity.tf
+++ b/examples/resources/tfe_workspace/import-by-identity.tf
@@ -1,0 +1,7 @@
+import {
+  to = tfe_workspace.test
+  identity = {
+    id       = "ws-CH5in3chf8RJjrVd"
+    hostname = "app.terraform.io"
+  }
+}

--- a/examples/resources/tfe_workspace/import.sh
+++ b/examples/resources/tfe_workspace/import.sh
@@ -1,0 +1,5 @@
+# via <WORKSPACE ID>
+terraform import tfe_workspace.test ws-CH5in3chf8RJjrVd
+
+# via <ORGANIZATION NAME>/<WORKSPACE NAME>
+terraform import tfe_workspace.test my-org-name/my-wkspace-name

--- a/examples/resources/tfe_workspace_policy_set/import.sh
+++ b/examples/resources/tfe_workspace_policy_set/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION>/<WORKSPACE NAME>/<POLICY SET NAME>
+terraform import tfe_workspace_policy_set.test 'my-org-name/workspace/policy-set-name'

--- a/examples/resources/tfe_workspace_policy_set_exclusion/import.sh
+++ b/examples/resources/tfe_workspace_policy_set_exclusion/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION>/<WORKSPACE NAME>/<POLICY SET NAME>
+terraform import tfe_workspace_policy_set_exclusion.test 'my-org-name/workspace/policy-set-name'

--- a/examples/resources/tfe_workspace_run_task/import.sh
+++ b/examples/resources/tfe_workspace_run_task/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION>/<WORKSPACE NAME>/<TASK NAME>
+terraform import tfe_workspace_run_task.test my-org-name/workspace/task-name

--- a/examples/resources/tfe_workspace_settings/import.sh
+++ b/examples/resources/tfe_workspace_settings/import.sh
@@ -1,0 +1,5 @@
+# via <WORKSPACE ID>
+terraform import tfe_workspace_settings.test ws-CH5in3chf8RJjrVd
+
+# via <ORGANIZATION NAME>/<WORKSPACE NAME>
+terraform import tfe_workspace_settings.test my-org-name/my-wkspace-name

--- a/examples/resources/tfe_workspace_variable_set/import.sh
+++ b/examples/resources/tfe_workspace_variable_set/import.sh
@@ -1,0 +1,2 @@
+# via <ORGANIZATION>/<WORKSPACE NAME>/<VARIABLE SET NAME>
+terraform import tfe_workspace_variable_set.test 'my-org-name/workspace/My Variable Set'

--- a/website/docs/r/admin_smtp_settings.html.markdown
+++ b/website/docs/r/admin_smtp_settings.html.markdown
@@ -96,3 +96,4 @@ SMTP Settings can be imported.
 
 ```shell
 terraform import tfe_admin_smtp_settings.this smtp
+```

--- a/website/docs/r/project_policy_set_exclusion.html.markdown
+++ b/website/docs/r/project_policy_set_exclusion.html.markdown
@@ -58,3 +58,4 @@ Excluded Project Policy Sets can be imported; use `<PROJECT ID>/<POLICY SET ID>`
 
 ```shell
 terraform import tfe_project_policy_set_exclusion.test 'prj-123456789/polset-123456789`
+```


### PR DESCRIPTION
## Description

Adding examples for HCL and CLI imports appropriate for tfplugindocs as a backfill from the website documentation. 
Minor corrections to website documentation. 

## Testing plan

Run `tfplugindocs generate` and note the imports are included. Compare against website docs for information contained. 
Reviewing the changes to `project_policy_set_exclusion` and `admin_smtp_settings` as present in the website docs. 

## External links

[tfplugindocs reference](https://github.com/hashicorp/terraform-plugin-docs)

## Rollback Plan

Reverting the PR is sufficient. 

## Changes to Security Controls

N/A
