### PR TITLE
Small fix on failure of nocode module update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 
 BUG FIXES:
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
+* Fixed  a provider bug where a failed no-code module update could reference an uninitialized module ID [#2122](https://github.com/hashicorp/terraform-provider-tfe/pull/2122)
 
 ENHANCEMENTS:
 * `r/tfe_project_notification_configuration` and `r/tfe_team_notification_configuration`: update url attributes to be sensitive, by @kadenluang [#2120](https://github.com/hashicorp/terraform-provider-tfe/pull/2120)

--- a/internal/provider/resource_tfe_no_code_module.go
+++ b/internal/provider/resource_tfe_no_code_module.go
@@ -129,7 +129,6 @@ func resourceTFENoCodeModuleCreate(ctx context.Context, d *schema.ResourceData, 
 
 	log.Printf("[DEBUG] Create no-code module for registry module %s", options.RegistryModule.ID)
 	noCodeModule, err := config.Client.RegistryNoCodeModules.Create(ctx, orgName, options)
-
 	if err != nil {
 		return diag.Errorf("Error creating no-code module for registry module %s: %s", options.RegistryModule.ID, err)
 	}
@@ -214,9 +213,8 @@ func resourceTFENoCodeModuleUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 		return nil
 	})
-
 	if err != nil {
-		return diag.Errorf("Error while waiting for no-code module %s to be updated: %s", noCodeModule.ID, err)
+		return diag.Errorf("Error while waiting for no-code module %s to be updated: %s", d.Id(), err)
 	}
 
 	d.SetId(noCodeModule.ID)

--- a/internal/provider/resource_tfe_no_code_module_test.go
+++ b/internal/provider/resource_tfe_no_code_module_test.go
@@ -30,11 +30,14 @@ func TestAccTFENoCodeModule_basic(t *testing.T) {
 				Config: testAccTFENoCodeModule_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENoCodeModuleExists(
-						"tfe_no_code_module.foobar", nocodeModule),
+						"tfe_no_code_module.foobar", nocodeModule,
+					),
 					resource.TestCheckResourceAttr(
-						"tfe_no_code_module.foobar", "enabled", "true"),
+						"tfe_no_code_module.foobar", "enabled", "true",
+					),
 					resource.TestCheckResourceAttr(
-						"tfe_no_code_module.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
+						"tfe_no_code_module.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt),
+					),
 				),
 			},
 		},
@@ -275,18 +278,22 @@ func TestAccTFENoCodeModule_update(t *testing.T) {
 				Config: testAccTFENoCodeModule_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENoCodeModuleExists(
-						"tfe_no_code_module.foobar", nocodeModule),
+						"tfe_no_code_module.foobar", nocodeModule,
+					),
 					resource.TestCheckResourceAttr(
-						"tfe_no_code_module.foobar", "enabled", "true"),
+						"tfe_no_code_module.foobar", "enabled", "true",
+					),
 				),
 			},
 			{
 				Config: testAccTFENoCodeModule_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENoCodeModuleExists(
-						"tfe_no_code_module.foobar", nocodeModule),
+						"tfe_no_code_module.foobar", nocodeModule,
+					),
 					resource.TestCheckResourceAttr(
-						"tfe_no_code_module.foobar", "enabled", "true"),
+						"tfe_no_code_module.foobar", "enabled", "true",
+					),
 				),
 			},
 		},
@@ -296,53 +303,71 @@ func TestAccTFENoCodeModule_update(t *testing.T) {
 func TestAccTFENoCodeModule_update_variable_options(t *testing.T) {
 	skipUnlessBeta(t)
 	nocodeModule := &tfe.RegistryNoCodeModule{}
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	regionOptions := `"us-east-1", "us-west-1", "eu-west-2"`
-	updatedRegionOptions := `"eu-east-1", "eu-west-1", "us-west-2"`
+	initialOptions := `"1", "2", "3"`
+	updatedOptions := `"4", "5", "6"`
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatalf("error getting client %v", err)
+	}
+
+	org, cleanup := createBusinessOrganization(t, tfeClient)
+	defer cleanup()
+
+	providers := muxedProvidersWithDefaultOrganization(org.Name)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccMuxedProviders,
+		ProtoV6ProviderFactories: providers,
 		CheckDestroy:             testAccCheckTFENoCodeModuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFENoCodeModule_with_options(rInt, regionOptions),
+				Config: testAccTFENoCodeModule_with_options(initialOptions),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENoCodeModuleExists(
-						"tfe_no_code_module.foobar", nocodeModule),
+						"tfe_no_code_module.foobar", nocodeModule,
+					),
 					resource.TestCheckResourceAttr(
-						"tfe_no_code_module.foobar", "enabled", "true"),
+						"tfe_no_code_module.foobar", "enabled", "true",
+					),
 					func(s *terraform.State) error {
 						if len(nocodeModule.VariableOptions) == 0 {
 							return fmt.Errorf("Bad 'variable_options' attribute: %v", nocodeModule.VariableOptions)
 						}
-
+						hasVariable := false
 						for _, vo := range nocodeModule.VariableOptions {
-							if vo.VariableName == "region" {
-								assert.ElementsMatch(t, []string{"us-east-1", "us-west-1", "eu-west-2"}, vo.Options)
+							if vo.VariableName == "min_lower" {
+								hasVariable = true
+								assert.ElementsMatch(t, []string{"1", "2", "3"}, vo.Options)
 							}
 						}
+						assert.True(t, hasVariable, "Expected variable 'min_lower' not found in variable_options")
 						return nil
 					},
 				),
 			},
 			{
-				Config: testAccTFENoCodeModule_with_options(rInt, updatedRegionOptions),
+				Config: testAccTFENoCodeModule_with_options(updatedOptions),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENoCodeModuleExists(
-						"tfe_no_code_module.foobar", nocodeModule),
+						"tfe_no_code_module.foobar", nocodeModule,
+					),
 					resource.TestCheckResourceAttr(
-						"tfe_no_code_module.foobar", "enabled", "true"),
+						"tfe_no_code_module.foobar", "enabled", "true",
+					),
 					func(s *terraform.State) error {
 						if len(nocodeModule.VariableOptions) == 0 {
 							return fmt.Errorf("Bad 'variable_options' attribute: %v", nocodeModule.VariableOptions)
 						}
 
+						hasVariable := false
 						for _, vo := range nocodeModule.VariableOptions {
-							if vo.VariableName == "region" {
-								assert.ElementsMatch(t, []string{"eu-east-1", "eu-west-1", "us-west-2"}, vo.Options)
+							if vo.VariableName == "min_lower" {
+								hasVariable = true
+								assert.ElementsMatch(t, []string{"4", "5", "6"}, vo.Options)
 							}
 						}
+						assert.True(t, hasVariable, "Expected variable 'min_lower' not found in variable_options")
 						return nil
 					},
 				),
@@ -365,18 +390,22 @@ func TestAccTFENoCodeModule_delete(t *testing.T) {
 				Config: testAccTFENoCodeModule_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENoCodeModuleExists(
-						"tfe_no_code_module.foobar", nocodeModule),
+						"tfe_no_code_module.foobar", nocodeModule,
+					),
 					resource.TestCheckResourceAttr(
-						"tfe_no_code_module.foobar", "enabled", "true"),
+						"tfe_no_code_module.foobar", "enabled", "true",
+					),
 				),
 			},
 			{
 				Config: testAccTFENoCodeModule_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFENoCodeModuleExists(
-						"tfe_no_code_module.foobar", nocodeModule),
+						"tfe_no_code_module.foobar", nocodeModule,
+					),
 					resource.TestCheckResourceAttr(
-						"tfe_no_code_module.foobar", "enabled", "true"),
+						"tfe_no_code_module.foobar", "enabled", "true",
+					),
 				),
 			},
 		},
@@ -395,7 +424,8 @@ func TestAccTFENoCodeModule_import(t *testing.T) {
 			{
 				Config: testAccTFENoCodeModule_basic(rInt),
 				Check: testAccCheckTFENoCodeModuleExists(
-					"tfe_no_code_module.foobar", nocodeModule),
+					"tfe_no_code_module.foobar", nocodeModule,
+				),
 			},
 
 			{
@@ -419,13 +449,13 @@ resource "tfe_organization" "foobar" {
 	name  = "tst-terraform-%d"
 	email = "admin@company.com"
 }
-	
+
 resource "tfe_registry_module" "foobar" {
 	organization    = tfe_organization.foobar.id
 	module_provider = "my_provider"
 	name            = "test_module"
 }
-	
+
 resource "tfe_no_code_module" "foobar" {
 	organization = tfe_organization.foobar.id
 	registry_module = tfe_registry_module.foobar.id
@@ -452,36 +482,41 @@ resource "tfe_no_code_module" "foobar" {
 `, rInt)
 }
 
-func testAccTFENoCodeModule_with_options(rInt int, regionOpts string) string {
+func testAccTFENoCodeModule_with_options(opts string) string {
 	return fmt.Sprintf(`
-resource "tfe_organization" "foobar" {
-name  = "tst-terraform-%d"
-email = "admin@company.com"
+
+locals {
+	options            = [%s]
+	github_token       = %q
+	identifier         = %q
 }
 
-resource "tfe_registry_module" "foobar" {
-	organization    = tfe_organization.foobar.id
-	module_provider = "my_provider"
-	name            = "test_module"
+resource "tfe_registry_module" "sensitive" {
+	vcs_repo {
+		display_identifier = local.identifier
+		identifier         = local.identifier
+		oauth_token_id     = tfe_oauth_client.github.oauth_token_id
+	}
+}
+
+resource "tfe_oauth_client" "github" {
+	api_url          = "https://api.github.com"
+	http_url         = "https://github.com"
+	oauth_token      = local.github_token
+	service_provider = "github"
 }
 
 resource "tfe_no_code_module" "foobar" {
-	organization = tfe_organization.foobar.id
-	registry_module = tfe_registry_module.foobar.id
+	registry_module = tfe_registry_module.sensitive.id
+	version_pin = "1.0.0"
 
 	variable_options {
-		name    = "ami"
-		type    = "string"
-		options = [ "ami-0", "ami-1", "ami-2" ]
-	}
-
-	variable_options {
-		name    = "region"
-		type    = "string"
-		options = [%s]
+		name    = "min_lower"
+		type    = "number"
+		options = local.options
 	}
 }
-`, rInt, regionOpts)
+`, opts, envGithubToken, envGithubRegistryModuleIdentifer)
 }
 
 func testAccCheckTFENoCodeModuleDestroy(s *terraform.State) error {
@@ -529,7 +564,8 @@ func testAccCheckTFENoCodeModuleExists(n string, nocodeModule *tfe.RegistryNoCod
 }
 
 func testAccCheckTFENoCodeModuleVariableOptions(
-	nocodeModule *tfe.RegistryNoCodeModule) resource.TestCheckFunc {
+	nocodeModule *tfe.RegistryNoCodeModule,
+) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if !nocodeModule.Enabled {
 			return fmt.Errorf("Bad 'enabled' attribute: %t", nocodeModule.Enabled)
@@ -580,9 +616,9 @@ func testAccTFENoCodeModule_with_variable_options(org string) string {
 		version_pin     = "1.0.0"
 
 		variable_options {
-				name    = "min_lower"
-				type    = "number"
-				options = [ "1", "2", "3", "4", "5" ]
+			name    = "min_lower"
+			type    = "number"
+			options = [ "1", "2", "3", "4", "5" ]
 		}
 	}
 `, org, envGithubRegistryModuleIdentifer, envGithubToken)
@@ -617,9 +653,9 @@ func testAccTFENoCodeModule_with_variable_options_no_options(org string) string 
 		version_pin     = "1.0.0"
 
 		variable_options {
-				name    = "min_lower"
-				type    = "number"
-				// No options provided. HCP TF will include the variable, and the user must specify its value as free text
+			name    = "min_lower"
+			type    = "number"
+			// No options provided. HCP TF will include the variable, and the user must specify its value as free text
 		}
 	}
 `, org, envGithubRegistryModuleIdentifer, envGithubToken)
@@ -654,9 +690,9 @@ func testAccTFENoCodeModule_with_variable_options_empty_options(org string) stri
 		version_pin     = "1.0.0"
 
 		variable_options {
-				name    = "min_lower"
-				type    = "number"
-				options = [] // HCP TF treats this as equivalent to this parameter being unset
+			name    = "min_lower"
+			type    = "number"
+			options = [] // HCP TF treats this as equivalent to this parameter being unset
 		}
 	}
 `, org, envGithubRegistryModuleIdentifer, envGithubToken)


### PR DESCRIPTION
## Description

This PR fixes broken tfe_no_code_module acceptance tests and a related update error path. The test coverage was updated to use a more reliable no-code module setup, with stronger assertions around variable options updates and fixtures that match the GitHub-backed registry module flow. It also fixes a provider bug where a failed no-code module update could reference an uninitialized module ID, so update errors now reliably use the resource ID instead.

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] ~_Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_~

## Testing plan

This one is going to be hard to test as this PR was related to an `atlas` bug that was fixed.

for the test you ca run something like this:

```sh
GITHUB_TOKEN=$TFE_GITHUB_TOKEN \
      ENABLE_TFE=1 \
      TF_ACC=1 \
      ENABLE_BETA=1 \
      go test -v ./internal/provider/ -run TestAccTFENoCodeModule
```

But you would need to setup a bunch of stuff like a valid github repo terraform module

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/xxxx)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
GITHUB_TOKEN=$TFE_GITHUB_TOKEN \
      ENABLE_TFE=1 \
      TF_ACC=1 \
      ENABLE_BETA=1 \
      go test -v ./internal/provider/ -run TestAccTFENoCodeModule
=== RUN   TestAccTFENoCodeModuleDataSource_public
--- PASS: TestAccTFENoCodeModuleDataSource_public (4.89s)
=== RUN   TestAccTFENoCodeModule_basic
--- PASS: TestAccTFENoCodeModule_basic (3.15s)
=== RUN   TestAccTFENoCodeModule_with_variable_options
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
--- PASS: TestAccTFENoCodeModule_with_variable_options (18.81s)
=== RUN   TestAccTFENoCodeModule_with_variable_options_no_options
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
--- PASS: TestAccTFENoCodeModule_with_variable_options_no_options (18.59s)
=== RUN   TestAccTFENoCodeModule_with_variable_options_empty_options
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
--- PASS: TestAccTFENoCodeModule_with_variable_options_empty_options (18.34s)
=== RUN   TestAccTFENoCodeModule_with_version_pin
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
--- PASS: TestAccTFENoCodeModule_with_version_pin (13.61s)
=== RUN   TestAccTFENoCodeModule_update
--- PASS: TestAccTFENoCodeModule_update (4.69s)
=== RUN   TestAccTFENoCodeModule_update_variable_options
    subscription_updater_test.go:113: Skipping subscription upgrade: enterprise mode enabled (TFE orgs have full entitlements by default)
--- PASS: TestAccTFENoCodeModule_update_variable_options (19.98s)
=== RUN   TestAccTFENoCodeModule_delete
--- PASS: TestAccTFENoCodeModule_delete (4.35s)
=== RUN   TestAccTFENoCodeModule_import
--- PASS: TestAccTFENoCodeModule_import (3.57s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   110.780s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
