### PR TITLE
Tf 38917 backfill of descriptions into component schemas for data sources ephemerals and actions

### DIFF
--- a/internal/provider/action_query_run.go
+++ b/internal/provider/action_query_run.go
@@ -64,7 +64,7 @@ func (a *actionTFEQueryRun) Schema(ctx context.Context, req action.SchemaRequest
 				Required:    true,
 			},
 			"configuration_version_id": schema.StringAttribute{
-				Description: "specific Configuration Version ID to use for the query run (e.g., \"cv-ntv3HbhJqvFzamy7\"). Exactly one of configuration_version_id or wait_for_latest_configuration must be provided.",
+				Description: "A specific Configuration Version ID to use for the query run (e.g., \"cv-ntv3HbhJqvFzamy7\"). Exactly one of configuration_version_id or wait_for_latest_configuration must be provided.",
 				Optional:    true,
 			},
 			"variables": schema.MapAttribute{

--- a/internal/provider/action_query_run.go
+++ b/internal/provider/action_query_run.go
@@ -57,19 +57,24 @@ func (a *actionTFEQueryRun) Metadata(ctx context.Context, req action.MetadataReq
 
 func (a *actionTFEQueryRun) Schema(ctx context.Context, req action.SchemaRequest, resp *action.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: "Creates a query run in an HCP Terraform or Terraform Enterprise workspace.",
 		Attributes: map[string]schema.Attribute{
 			"workspace_id": schema.StringAttribute{
-				Required: true,
+				Description: "The ID of the workspace where the query run will be executed.",
+				Required:    true,
 			},
 			"configuration_version_id": schema.StringAttribute{
-				Optional: true,
+				Description: "specific Configuration Version ID to use for the query run (e.g., \"cv-ntv3HbhJqvFzamy7\"). Exactly one of configuration_version_id or wait_for_latest_configuration must be provided.",
+				Optional:    true,
 			},
 			"variables": schema.MapAttribute{
+				Description: "A map of key-value string pairs representing variables to pass directly into the query run.",
 				ElementType: types.StringType,
 				Optional:    true,
 			},
 			"wait_for_latest_configuration": schema.BoolAttribute{
-				Optional: true,
+				Description: "A boolean flag that, when set to true, tells the action to wait for and use the latest configuration version available in the workspace. Exactly one of wait_for_latest_configuration or configuration_version_id must be provided.",
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_admin_smtp_settings.go
+++ b/internal/provider/data_source_admin_smtp_settings.go
@@ -48,7 +48,7 @@ func (d *dataSourceTFEAdminSMTPSettings) Metadata(_ context.Context, req datasou
 // Schema defines the schema for the data source.
 func (d *dataSourceTFEAdminSMTPSettings) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Reads SMTP settings for Terraform Enterprise.",
+		Description: "Reads SMTP settings for Terraform Enterprise. Only applies to Terraform Enterprise and requires admin token configuration.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The ID of the SMTP settings. Always 'smtp'.",

--- a/internal/provider/data_source_agent_pool.go
+++ b/internal/provider/data_source_agent_pool.go
@@ -14,40 +14,54 @@ import (
 
 func dataSourceTFEAgentPool() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information about an agent pool.",
+
 		Read: dataSourceTFEAgentPoolRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The agent pool ID.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "Name of the agent pool.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"organization_scoped": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether or not the agent pool can be used by all workspaces in the organization.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"allowed_workspace_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "The set of workspace IDs that have permission to use the agent pool.",
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"allowed_project_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "The set of project IDs that have permission to use the agent pool.",
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"excluded_workspace_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "The set of workspace IDs that are excluded from the scope of the agent pool.",
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}

--- a/internal/provider/data_source_current_user.go
+++ b/internal/provider/data_source_current_user.go
@@ -39,7 +39,7 @@ func (d *dataSourceCurrentUser) Metadata(_ context.Context, req datasource.Metad
 
 func (d *dataSourceCurrentUser) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Get the current user associated with the API token.",
+		MarkdownDescription: "Get the current user associated with the API token. When authenticated with a team or organization token, HCP Terraform returns a synthetic service user rather than a real user account, so attributes like `email` and `username` will not reflect a real person.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/provider/data_source_github_app_installation.go
+++ b/internal/provider/data_source_github_app_installation.go
@@ -18,20 +18,24 @@ import (
 
 func dataSourceTFEGHAInstallation() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceGHAInstallationRead,
+		Description: "Gets information about the Github App installation.",
+		Read:        dataSourceGHAInstallationRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The internal ID of the Github Installation. This is different from the `installation_id`",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"installation_id": {
+				Description:  "ID of the Github Installation. The installation ID can be found in the URL slug when visiting the installation's configuration page, e.g `https://github.com/settings/installations/12345678`.",
 				Type:         schema.TypeInt,
 				Optional:     true,
 				AtLeastOneOf: []string{"name", "installation_id"},
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the Github user or organization account that installed the app.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_hyok_customer_key_version.go
+++ b/internal/provider/data_source_hyok_customer_key_version.go
@@ -57,7 +57,7 @@ func (d *dataSourceHYOKCustomerKeyVersion) Metadata(ctx context.Context, req dat
 
 func (d *dataSourceHYOKCustomerKeyVersion) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "This data source can be used to retrieve a HYOK customer key version.",
+		Description: "This data source can be used to retrieve a Hold Your Own Keys (HYOK) customer key version.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The ID of the HYOK customer key version.",

--- a/internal/provider/data_source_hyok_customer_key_version.go
+++ b/internal/provider/data_source_hyok_customer_key_version.go
@@ -76,7 +76,7 @@ func (d *dataSourceHYOKCustomerKeyVersion) Schema(ctx context.Context, req datas
 				Computed:    true,
 			},
 			"workspaces_secured": schema.Int64Attribute{
-				Description: "The number workspaces secured by this customer key version.",
+				Description: "The number of workspaces secured by this customer key version.",
 				Computed:    true,
 			},
 			"created_at": schema.StringAttribute{

--- a/internal/provider/data_source_hyok_encrypted_data_key.go
+++ b/internal/provider/data_source_hyok_encrypted_data_key.go
@@ -55,7 +55,7 @@ func (d *dataSourceHYOKEncryptedDataKey) Metadata(ctx context.Context, req datas
 
 func (d *dataSourceHYOKEncryptedDataKey) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "This data source can be used to retrieve a HYOK customer key version.",
+		Description: "This data source can be used to retrieve a Hold Your Own Keys (HYOK) encrypted data key.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The ID of the HYOK encrypted data key.",

--- a/internal/provider/data_source_ip_ranges.go
+++ b/internal/provider/data_source_ip_ranges.go
@@ -75,7 +75,7 @@ func (d *dataSourceTFEIPRanges) Metadata(_ context.Context, req datasource.Metad
 
 func (d *dataSourceTFEIPRanges) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "This data source can be used to retrieve a list of HCP Terraform's IP ranges.",
+		MarkdownDescription: "This data source can be used to retrieve a list of HCP Terraform's IP ranges. For more information about these IP ranges, view our [documentation about HCP Terraform IP Ranges](https://developer.hashicorp.com/terraform/cloud-docs/architectural-details/ip-ranges).",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Static identifier for HCP Terraform's IP ranges data source.",

--- a/internal/provider/data_source_no_code_module.go
+++ b/internal/provider/data_source_no_code_module.go
@@ -71,7 +71,7 @@ func (d *dataSourceTFENoCodeModule) Schema(_ context.Context, _ datasource.Schem
 				Computed:    true,
 			},
 			"enabled": schema.BoolAttribute{
-				Description: "Indiate if this no-code module is currently enabled.",
+				Description: "Indicate if this no-code module is currently enabled.",
 				Computed:    true,
 			},
 		},

--- a/internal/provider/data_source_no_code_module.go
+++ b/internal/provider/data_source_no_code_module.go
@@ -48,7 +48,7 @@ func (d *dataSourceTFENoCodeModule) Metadata(_ context.Context, req datasource.M
 // Schema defines the schema for the data source.
 func (d *dataSourceTFENoCodeModule) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "This data source can be used to retrieve a public or private no-code module.",
+		Description: "This data source can be used to retrieve a public or private existing no-code module.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "ID of the no-code module.",

--- a/internal/provider/data_source_oauth_client.go
+++ b/internal/provider/data_source_oauth_client.go
@@ -20,23 +20,28 @@ import (
 
 func dataSourceTFEOAuthClient() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceTFEOAuthClientRead,
+		Description: "Gets information about an OAuth client.",
+		Read:        dataSourceTFEOAuthClientRead,
 		Schema: map[string]*schema.Schema{
 			"oauth_client_id": {
+				Description:  "ID of the OAuth client.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				AtLeastOneOf: []string{"oauth_client_id", "name", "service_provider"},
 			},
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "The name of the organization in which to search.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 			"name": {
+				Description:  "Name of the OAuth client.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"organization"},
 			},
 			"service_provider": {
+				Description:  "The API identifier of the OAuth service provider. If set, must be one of: `ado_server`, `ado_services`, `bitbucket_data_center`,  `bitbucket_hosted`, `bitbucket_server`(deprecated), `github`, `github_enterprise`, `gitlab_hosted`, `gitlab_community_edition`, or `gitlab_enterprise_edition`.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"organization"},
@@ -58,37 +63,45 @@ func dataSourceTFEOAuthClient() *schema.Resource {
 				)),
 			},
 			"service_provider_display_name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The display name of the OAuth service provider.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"api_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The client's API URL.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"callback_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "OAuth callback URL to provide to the OAuth service provider.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The date and time this OAuth client was created in RFC3339 format.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"http_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The client's HTTP URL.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"oauth_token_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The ID of the OAuth token associated with the OAuth client.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"organization_scoped": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether or not the agent pool can be used by all workspaces and projects in the organization.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 			"project_ids": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
+				Description: "IDs of the projects that use the oauth client.",
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_organization.go
+++ b/internal/provider/data_source_organization.go
@@ -18,76 +18,93 @@ import (
 
 func dataSourceTFEOrganization() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information about an organization.",
+
 		Read: dataSourceTFEOrganizationRead,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"external_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "An identifier for the organization.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"collaborator_auth_policy": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "Authentication policy (`password` or `two_factor_mandatory`). Defaults to `password`.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"cost_estimation_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a HCP Terraform organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"default_project_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "ID of the organization's default project. All workspaces created without specifying a project ID are created in this project.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"email": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "Admin email address.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"owners_team_saml_role_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The name of the \"owners\" team.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"two_factor_conformant": {
+				// TODO: needs description not present on website
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
 
 			"send_passing_statuses_for_untriggered_speculative_plans": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to true. In Terraform Enterprise, this setting has no effect and cannot be changed but is also available in Site Administration.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"aggregated_commit_status_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether or not to enable Aggregated Status Checks. This can be useful for monorepo repositories with multiple workspaces receiving status checks for events such as a pull request.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"assessments_enforced": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "(Available only in HCP Terraform) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"speculative_plan_management_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether or not to enable Speculative Plan Management. If true, pending VCS-triggered speculative plans from outdated commits will be cancelled if a newer commit is pushed to the same branch.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"enforce_hyok": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "(Available only in HCP Terraform) Whether HYOK is enforced for all new workspaces in the organization.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
+
 			"max_ttl_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether maximum token TTL policies are enabled for the organization.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_organization.go
+++ b/internal/provider/data_source_organization.go
@@ -84,7 +84,7 @@ func dataSourceTFEOrganization() *schema.Resource {
 			},
 
 			"assessments_enforced": {
-				Description: "(Available only in HCP Terraform) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.",
+				Description: "(Available only in HCP Terraform) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set their own preferences.",
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_organization.go
+++ b/internal/provider/data_source_organization.go
@@ -66,9 +66,9 @@ func dataSourceTFEOrganization() *schema.Resource {
 			},
 
 			"two_factor_conformant": {
-				// TODO: needs description not present on website
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether or not to require two factor authentication for this organization.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"send_passing_statuses_for_untriggered_speculative_plans": {

--- a/internal/provider/data_source_organization_audit_configuration.go
+++ b/internal/provider/data_source_organization_audit_configuration.go
@@ -58,6 +58,7 @@ func (d *dataSourceOrganizationAuditConfiguration) Metadata(_ context.Context, r
 
 func (d *dataSourceOrganizationAuditConfiguration) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: "Gets information about the audit configuration for a given organization. Note that this data source requires using the provider with HCP Terraform.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/provider/data_source_organization_members.go
+++ b/internal/provider/data_source_organization_members.go
@@ -14,45 +14,60 @@ import (
 
 func dataSourceTFEOrganizationMembers() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information about members of an organization.",
+
 		Read: dataSourceTFEOrganizationMembersRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"members": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Description: "A list of active members of the organization.",
+				Type:        schema.TypeList,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"user_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The ID of the user.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"organization_membership_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The ID of the organization membership.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 					},
 				},
 			},
 
 			"members_waiting": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Description: "A list of members with pending invite to organization.",
+				Type:        schema.TypeList,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"user_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The ID of the user.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"organization_membership_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The ID of the organization membership.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/data_source_organization_membership.go
+++ b/internal/provider/data_source_organization_membership.go
@@ -50,7 +50,7 @@ func dataSourceTFEOrganizationMembership() *schema.Resource {
 			},
 
 			"user_id": {
-				Description: "The ID of the use associated with the organization membership.",
+				Description: "The ID of the user associated with the organization membership.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_organization_membership.go
+++ b/internal/provider/data_source_organization_membership.go
@@ -19,31 +19,44 @@ import (
 
 func dataSourceTFEOrganizationMembership() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information about an organization membership. Requires using the provider with HCP Terraform or an instance of Terraform Enterprise at least as recent as v202004-1. Note that if a user updates their email address, configurations using the email address should be updated manually.",
+
 		Read: dataSourceTFEOrganizationMembershipRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The organization membership ID.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"email": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Email of the user.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"username": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Description: "The username of the user. Although both are option, at least one of `email` and `username` is required.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
 			},
 
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"user_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The ID of the use associated with the organization membership.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"organization_membership_id": {
+				Description:  "ID belonging to the organization membership.",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,

--- a/internal/provider/data_source_organization_run_task.go
+++ b/internal/provider/data_source_organization_run_task.go
@@ -64,29 +64,36 @@ func (d *dataSourceOrganizationRunTask) Metadata(_ context.Context, req datasour
 
 func (d *dataSourceOrganizationRunTask) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: "Gets information on an [Organization Run task](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks#creating-a-run-task).",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
-				Description: "Service-generated identifier for the task",
+				Description: "Service-generated identifier for the task.",
 			},
 			"name": schema.StringAttribute{
-				Required: true,
+				Description: "Name of the Run task.",
+				Required:    true,
 			},
 			"organization": schema.StringAttribute{
-				Optional: true,
+				Description: "Name of the organization.",
+				Optional:    true,
 			},
 			"url": schema.StringAttribute{
-				Optional: true,
+				Description: "URL to send a task payload.",
+				Optional:    true,
 			},
 			"category": schema.StringAttribute{
-				Optional: true,
+				Description: "The type of task.",
+				Optional:    true,
 			},
 			"enabled": schema.BoolAttribute{
-				Optional: true,
+				Description: "Whether the task will be run.",
+				Optional:    true,
 			},
 			"description": schema.StringAttribute{
-				Optional: true,
+				Description: "A short description of the task.",
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_organization_run_task_global_settings.go
+++ b/internal/provider/data_source_organization_run_task_global_settings.go
@@ -39,7 +39,7 @@ func (d *dataSourceOrganizationRunTaskGlobalSettings) Schema(_ context.Context, 
 				Optional:    true,
 			},
 			"enforcement_level": schema.StringAttribute{
-				Description: "The enforcement level of the global task. Valid values are `advisory` and `mandatory`",
+				Description: "The enforcement level of the global task. Valid values are `advisory` and `mandatory`.",
 				Optional:    true,
 			},
 			"id": schema.StringAttribute{

--- a/internal/provider/data_source_organization_run_task_global_settings.go
+++ b/internal/provider/data_source_organization_run_task_global_settings.go
@@ -31,26 +31,28 @@ func (d *dataSourceOrganizationRunTaskGlobalSettings) Metadata(_ context.Context
 
 func (d *dataSourceOrganizationRunTaskGlobalSettings) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		MarkdownDescription: "[Run tasks](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks) allow HCP Terraform to interact with external systems at specific points in the HCP Terraform run lifecycle. Run tasks are reusable configurations that you can attach to any workspace in an organization. <br><br> The tfe_organization_run_task_global_settings resource creates, updates and destroys the [global settings](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks#global-run-tasks) for an [Organization Run task](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks#creating-a-run-task). Your organization must have the `global-run-task` [entitlement](https://developer.hashicorp.com/terraform/cloud-docs/api-docs#feature-entitlements) to use global run tasks.",
+
 		Attributes: map[string]schema.Attribute{
 			"enabled": schema.BoolAttribute{
-				Description: "Whether the run task will be applied globally",
+				Description: "Whether the run task will be applied globally.",
 				Optional:    true,
 			},
 			"enforcement_level": schema.StringAttribute{
-				Description: "The enforcement level of the global task.",
+				Description: "The enforcement level of the global task. Valid values are `advisory` and `mandatory`",
 				Optional:    true,
 			},
 			"id": schema.StringAttribute{
 				Computed:    true,
-				Description: "Service-generated identifier for the task settings",
+				Description: "Service-generated identifier for the task settings.",
 			},
 			"stages": schema.ListAttribute{
 				ElementType: types.StringType,
-				Description: "Which stages the task will run in.",
+				Description: "Which stages the task will run in. Valid values are one or more of `pre_plan`, `post_plan`, `pre_apply` and `post_apply`.",
 				Optional:    true,
 			},
 			"task_id": schema.StringAttribute{
-				Description: "The id of the run task.",
+				Description: "The id of the Run task with the global settings.",
 				Required:    true,
 			},
 		},

--- a/internal/provider/data_source_organization_tags.go
+++ b/internal/provider/data_source_organization_tags.go
@@ -17,31 +17,38 @@ import (
 
 func dataSourceTFEOrganizationTags() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information about the workspace tags for a given organization.",
+
 		Read: dataSourceTFEOrganizationTagsRead,
 
 		Schema: map[string]*schema.Schema{
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 			"tags": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Description: "A list of workspace tags within the organization.",
+				Type:        schema.TypeList,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The name of the workspace tag.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The ID of the workspace tag.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"workspace_count": {
-							Type:     schema.TypeInt,
-							Computed: true,
+							Description: "The number of workspaces the tag is associated with.",
+							Type:        schema.TypeInt,
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/data_source_organizations.go
+++ b/internal/provider/data_source_organizations.go
@@ -18,24 +18,29 @@ import (
 
 func dataSourceTFEOrganizations() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets a list of organizations and a map of their IDs.",
+
 		Read: dataSourceTFEOrganizationList,
 
 		Schema: map[string]*schema.Schema{
 			"names": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "A list of names of every organization.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"ids": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Description: "A map of organization names and their IDs.",
+				Type:        schema.TypeMap,
+				Computed:    true,
 			},
 
 			"admin": {
-				Type:     schema.TypeBool,
-				Default:  false,
-				Optional: true,
+				Description: "This field is for Terraform Enterprise only. It is a boolean field that determines the list of organizations that should be retrieved. If it is true, then it will retrieve all the organizations for the entire installation. If it is false, then it will retrieve the organizations available as per permissions of the API Token.",
+				Type:        schema.TypeBool,
+				Default:     false,
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_outputs.go
+++ b/internal/provider/data_source_outputs.go
@@ -54,7 +54,7 @@ func modelFromOutputs(v *tfe.Workspace, sensitiveOutputs types.Dynamic, nonSensi
 
 func (d *outputsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "This data source can be used to retrieve a workspace's state outputs.",
+		Description: "This data source can be used to retrieve a workspace's state outputs. Note that the `values` attribute is preemptively marked [sensitive](https://developer.hashicorp.com/terraform/language/values/outputs#sensitive-suppressing-values-in-cli-output) and is only populated after a run completes on the associated workspace. Use the `nonsensitive_values` attribute to access the subset of the outputs that are known to be non-sensitive.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: `System-generated unique identifier for the resource.`,
@@ -74,7 +74,7 @@ func (d *outputsDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				Sensitive:   true,
 			},
 			"nonsensitive_values": schema.DynamicAttribute{
-				Description: `Non-sensitive values of the workspace outputs.`,
+				Description: `Non-sensitive values of the workspace outputs, this is a subset of all output values.`,
 				Computed:    true,
 			},
 		},

--- a/internal/provider/data_source_policy_set.go
+++ b/internal/provider/data_source_policy_set.go
@@ -144,7 +144,7 @@ func dataSourceTFEPolicySet() *schema.Resource {
 			},
 
 			"project_ids": {
-				Description: "IDs of the policies attached to the policy set.",
+				Description: "IDs of the projects attached to the policy set.",
 				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Computed:    true,

--- a/internal/provider/data_source_policy_set.go
+++ b/internal/provider/data_source_policy_set.go
@@ -18,93 +18,107 @@ import (
 
 func dataSourceTFEPolicySet() *schema.Resource {
 	return &schema.Resource{
+		Description: "Retrieves a policy set defined in a specified organization.",
+
 		Read: dataSourceTFEPolicySetRead,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "Name of the policy set.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "Description of the policy set.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"global": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether or not the policy set applies to all workspaces in the organization.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"kind": {
-				Description: "The policy-as-code framework for the policy. Valid values are sentinel and opa",
+				Description: "The policy-as-code framework for the policy. Valid values are `sentinel` and `opa`.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
 
 			"overridable": {
-				Description: "Whether users can override this policy when it fails during a run. Only valid for OPA policies",
+				Description: "Whether users can override this policy when it fails during a run. Only valid for OPA policies.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
 
 			"agent_enabled": {
-				Description: "Whether the policy set is executed in the HCP Terraform agent. True by default for OPA policies",
+				Description: "Whether the policy set is executed in the HCP Terraform agent. True by default for OPA policies.",
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
 
 			"policy_tool_version": {
-				Description: "The policy tool version to run the policy evaluation against",
+				Description: "The policy tool version to run the policy evaluation against. For `opa` policy sets, `latest` will not be a valid input.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 
 			"policies_path": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The sub-path within the attached VCS repository when using `vcs_repo`.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"policy_update_patterns": {
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
+				Description: "Glob patterns specifying which file changes trigger policy set updates. Patterns are relative to the repository root, and a maximum of 100 patterns can be returned. This attribute is only valid when the policy set specifies a VCS repository.",
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
 			},
 
 			"policy_ids": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
+				Description: "IDs of the policies attached to the policy set.",
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
 			},
 
 			"vcs_repo": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Description: "Settings for the workspace's VCS repository.",
+				Type:        schema.TypeList,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"identifier": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "A reference to your VCS repository in the format `<vcs organization>/<repository>` where `<vcs organization>` and `<repository>` refer to the organization and repository in your VCS provider.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"branch": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The repository branch that Terraform will execute from.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"ingress_submodules": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Indicates whether submodules should be fetched when cloning the VCS repository.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"oauth_token_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "OAuth token ID of the configured VCS connection.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"github_app_installation_id": {
@@ -116,21 +130,24 @@ func dataSourceTFEPolicySet() *schema.Resource {
 			},
 
 			"workspace_ids": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
+				Description: "IDs of the workspaces that use the policy set.",
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
 			},
 
 			"excluded_workspace_ids": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
+				Description: "IDs of the workspaces that do not use the policy set.",
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
 			},
 
 			"project_ids": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
+				Description: "IDs of the policies attached to the policy set.",
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_projects.go
+++ b/internal/provider/data_source_projects.go
@@ -69,7 +69,8 @@ func (d *dataSourceTFEProjects) Schema(_ context.Context, _ datasource.SchemaReq
 		Description: "This data source can be used to retrieve all projects in an organization.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: "Name of the organization for use as an ID.",
+				Computed:    true,
 			},
 			"organization": schema.StringAttribute{
 				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",

--- a/internal/provider/data_source_provider_set.go
+++ b/internal/provider/data_source_provider_set.go
@@ -27,7 +27,7 @@ func (d *dataSourceTFEProviderSet) Schema(
 	resp *datasource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		Description: "This data source can be used to retrieve a provider set.",
+		Description: "This data source can be used to retrieve a provider set. Note that this data source is currently in beta and isn't generally available to all users. It is subject to change or be removed.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
 				Description: "The name of the provider set.",

--- a/internal/provider/data_source_registry_gpg_key.go
+++ b/internal/provider/data_source_registry_gpg_key.go
@@ -40,7 +40,8 @@ func (d *dataSourceTFERegistryGPGKey) Schema(_ context.Context, _ datasource.Sch
 		Description: "This data source can be used to retrieve a private registry GPG key.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Required: true,
+				Description: "ID of the GPG key.",
+				Required:    true,
 			},
 			"organization": schema.StringAttribute{
 				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",

--- a/internal/provider/data_source_registry_gpg_keys.go
+++ b/internal/provider/data_source_registry_gpg_keys.go
@@ -49,7 +49,8 @@ func (d *dataSourceTFERegistryGPGKeys) Schema(_ context.Context, _ datasource.Sc
 		Description: "This data source can be used to retrieve all private registry GPG keys of an organization.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: "Name of the organization for use as an ID.",
+				Computed:    true,
 			},
 			"organization": schema.StringAttribute{
 				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",

--- a/internal/provider/data_source_registry_module.go
+++ b/internal/provider/data_source_registry_module.go
@@ -262,7 +262,8 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"tests_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Indicates whether tests are enabled for a module.",
+							Computed:    true,
 						},
 					},
 				},
@@ -276,10 +277,12 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 							Computed:    true,
 						},
 						"status": schema.StringAttribute{
-							Computed: true,
+							Description: "Status of the module at specific version.",
+							Computed:    true,
 						},
 						"error": schema.StringAttribute{
-							Computed: true,
+							Description: "Error message reported by module at specific version.",
+							Computed:    true,
 						},
 					},
 				},
@@ -287,23 +290,29 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 			"vcs_repo": schema.ListNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
+						// TODO: many attributes lack descriptions on the website
 						"branch": schema.StringAttribute{
-							Computed: true,
+							Description: "The git branch used for publishing when using branch-based publishing for the registry module. When a `branch` is set, `tags` will be returned as `false`.",
+							Computed:    true,
 						},
 						"display_identifier": schema.StringAttribute{
-							Computed: true,
+							Description: "The display identifier for your VCS repository. For most VCS providers outside of BitBucket Cloud and Azure DevOps, this will match the `identifier` string.",
+							Computed:    true,
 						},
 						"identifier": schema.StringAttribute{
-							Computed: true,
+							Description: "A reference to your VCS repository in the format `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization (or project key, for Bitbucket Data Center) and repository in your VCS provider. The format for Azure DevOps is `<ado organization>/<ado project>/_git/<ado repository>`.",
+							Computed:    true,
 						},
 						"ingress_submodules": schema.BoolAttribute{
 							Computed: true,
 						},
 						"oauth_token_id": schema.StringAttribute{
-							Computed: true,
+							Description: "Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.",
+							Computed:    true,
 						},
 						"github_app_installation_id": schema.StringAttribute{
-							Computed: true,
+							Description: "The installation id of the Github App. This conflicts with `oauth_token_id` and can only be used if `oauth_token_id` is not used.",
+							Computed:    true,
 						},
 						"repository_http_url": schema.StringAttribute{
 							Computed: true,
@@ -312,13 +321,16 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 							Computed: true,
 						},
 						"source_directory": schema.StringAttribute{
-							Computed: true,
+							Description: "The path to the module configuration files within the VCS repository. This feature is currently in beta and is not available to all users.",
+							Computed:    true,
 						},
 						"tag_prefix": schema.StringAttribute{
-							Computed: true,
+							Description: "The prefix to filter repository Git tags when using the tag-based publishing type in a repository that contains code for multiple modules. Without a prefix, HCP Terraform and Terraform Enterprise publish new versions for all modules with valid Git tags that use semantic versioning. This feature is currently in beta and is not available to all users.",
+							Computed:    true,
 						},
 						"tags": schema.BoolAttribute{
-							Computed: true,
+							Description: "Specifies whether tag based publishing is enabled for the registry module. When `tags` is set to `true`, the `branch` must be set to an empty value.",
+							Computed:    true,
 						},
 						"tags_regex": schema.StringAttribute{
 							Computed: true,

--- a/internal/provider/data_source_registry_module.go
+++ b/internal/provider/data_source_registry_module.go
@@ -259,6 +259,7 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 				},
 			},
 			"test_config": schema.ListNestedBlock{
+				Description: "Test configuration indicating module testing setup.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"tests_enabled": schema.BoolAttribute{
@@ -288,6 +289,7 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 				},
 			},
 			"vcs_repo": schema.ListNestedBlock{
+				Description: "Settings for the registry module's VCS repository.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"branch": schema.StringAttribute{

--- a/internal/provider/data_source_registry_module.go
+++ b/internal/provider/data_source_registry_module.go
@@ -290,7 +290,6 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 			"vcs_repo": schema.ListNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
-						// TODO: many attributes lack descriptions on the website
 						"branch": schema.StringAttribute{
 							Description: "The git branch used for publishing when using branch-based publishing for the registry module. When a `branch` is set, `tags` will be returned as `false`.",
 							Computed:    true,
@@ -304,7 +303,8 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 							Computed:    true,
 						},
 						"ingress_submodules": schema.BoolAttribute{
-							Computed: true,
+							Description: "Indicates whether submodules should be fetched when cloning the VCS repository.",
+							Computed:    true,
 						},
 						"oauth_token_id": schema.StringAttribute{
 							Description: "Token ID of the VCS Connection (OAuth Connection Token) to use. This conflicts with `github_app_installation_id` and can only be used if `github_app_installation_id` is not used.",
@@ -315,10 +315,12 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 							Computed:    true,
 						},
 						"repository_http_url": schema.StringAttribute{
-							Computed: true,
+							Description: "The browsable HTTPS URL of the VCS repository.",
+							Computed:    true,
 						},
 						"service_provider": schema.StringAttribute{
-							Computed: true,
+							Description: "The VCS service provider type. Valid values include `github`, `github_enterprise`, `gitlab_hosted`, `gitlab_community_edition`, `gitlab_enterprise_edition`, `bitbucket_hosted`, `bitbucket_data_center`, `bitbucket_server`, `ado_server`, `ado_services`.",
+							Computed:    true,
 						},
 						"source_directory": schema.StringAttribute{
 							Description: "The path to the module configuration files within the VCS repository. This feature is currently in beta and is not available to all users.",
@@ -333,10 +335,12 @@ func (d *dataSourceTFERegistryModule) Schema(_ context.Context, _ datasource.Sch
 							Computed:    true,
 						},
 						"tags_regex": schema.StringAttribute{
-							Computed: true,
+							Description: "Read-only echo of any tags regex stored on the VCS repository.",
+							Computed:    true,
 						},
 						"webhook_url": schema.StringAttribute{
-							Computed: true,
+							Description: "The inbound webhook URL registered with the VCS provider. This is the HCP Terraform or Terraform Enterprise endpoint that the VCS provider calls on push or pull-request events.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/data_source_registry_provider.go
+++ b/internal/provider/data_source_registry_provider.go
@@ -64,7 +64,7 @@ func (d *dataSourceTFERegistryProvider) Schema(_ context.Context, _ datasource.S
 				},
 			},
 			"namespace": schema.StringAttribute{
-				Description: "The namespace of the provider. For private providers this is the same as the oraganization.",
+				Description: "The namespace of the provider. For private providers this is the same as the organization.",
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_registry_providers.go
+++ b/internal/provider/data_source_registry_providers.go
@@ -53,7 +53,8 @@ func (d *dataSourceTFERegistryProviders) Schema(_ context.Context, _ datasource.
 		Description: "This data source can be used to retrieve public and private providers from the private registry of an organization.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: "Name of the organization.",
+				Computed:    true,
 			},
 			"organization": schema.StringAttribute{
 				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",

--- a/internal/provider/data_source_saml_settings.go
+++ b/internal/provider/data_source_saml_settings.go
@@ -69,7 +69,7 @@ func (d *dataSourceTFESAMLSettings) Schema(_ context.Context, _ datasource.Schem
 				Computed:    true,
 			},
 			"enabled": schema.BoolAttribute{
-				Description: "Whetther SAML single sign-on is enabled.",
+				Description: "Whether SAML single sign-on is enabled.",
 				Computed:    true,
 			},
 			"debug": schema.BoolAttribute{
@@ -89,7 +89,7 @@ func (d *dataSourceTFESAMLSettings) Schema(_ context.Context, _ datasource.Schem
 				Computed:    true,
 			},
 			"idp_cert": schema.StringAttribute{
-				Description: "EM encoded X.509 Certificate as provided by the IdP configuration.",
+				Description: "PEM encoded X.509 Certificate as provided by the IdP configuration.",
 				Computed:    true,
 			},
 			"old_idp_cert": schema.StringAttribute{

--- a/internal/provider/data_source_saml_settings.go
+++ b/internal/provider/data_source_saml_settings.go
@@ -65,71 +65,93 @@ func (d *dataSourceTFESAMLSettings) Schema(_ context.Context, _ datasource.Schem
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: "ID of the SAML settings. It is always `saml`.",
+				Computed:    true,
 			},
 			"enabled": schema.BoolAttribute{
-				Computed: true,
+				Description: "Whetther SAML single sign-on is enabled.",
+				Computed:    true,
 			},
 			"debug": schema.BoolAttribute{
-				Computed: true,
+				Description: "Whether debug mode is enabled, which means that the SAMLResponse XML will be displayed on the login page.",
+				Computed:    true,
 			},
 			"team_management_enabled": schema.BoolAttribute{
-				Computed: true,
+				Description: "Whether Terraform Enterprise is set to manage team membership.",
+				Computed:    true,
 			},
 			"authn_requests_signed": schema.BoolAttribute{
-				Computed: true,
+				Description: "Whether `<samlp:AuthnRequest>` messages are signed.",
+				Computed:    true,
 			},
 			"want_assertions_signed": schema.BoolAttribute{
-				Computed: true,
+				Description: "Whether `<saml:Assertion>` elements are signed.",
+				Computed:    true,
 			},
 			"idp_cert": schema.StringAttribute{
-				Computed: true,
+				Description: "EM encoded X.509 Certificate as provided by the IdP configuration.",
+				Computed:    true,
 			},
 			"old_idp_cert": schema.StringAttribute{
-				Computed: true,
+				Description: "Previous version of the PEM encoded X.509 Certificate as provided by the IdP configuration.",
+				Computed:    true,
 			},
 			"slo_endpoint_url": schema.StringAttribute{
-				Computed: true,
+				Description: "Single Log Out URL.",
+				Computed:    true,
 			},
 			"sso_endpoint_url": schema.StringAttribute{
-				Computed: true,
+				Description: "Single Sign On URL.",
+				Computed:    true,
 			},
 			"attr_username": schema.StringAttribute{
-				Computed: true,
+				Description: "Name of the SAML attribute that determines the user's username.",
+				Computed:    true,
 			},
 			"attr_groups": schema.StringAttribute{
-				Computed: true,
+				Description: "Name of the SAML attribute that determines team membership.",
+				Computed:    true,
 			},
 			"attr_site_admin": schema.StringAttribute{
-				Computed: true,
+				Description: "Site admin access role.",
+				Computed:    true,
 			},
 			"site_admin_role": schema.StringAttribute{
-				Computed: true,
+				Description: "Site admin access role.",
+				Computed:    true,
 			},
 			"sso_api_token_session_timeout": schema.Int64Attribute{
-				Computed: true,
+				Description: "Single Sign On session timeout in seconds.",
+				Computed:    true,
 			},
 			"acs_consumer_url": schema.StringAttribute{
-				Computed: true,
+				Description: "ACS Consumer (Recipient) URL.",
+				Computed:    true,
 			},
 			"metadata_url": schema.StringAttribute{
-				Computed: true,
+				Description: "Metadata (Audience) URL.",
+				Computed:    true,
 			},
 			"certificate": schema.StringAttribute{
-				Computed: true,
+				Description: "Request and assertion signing certificate.",
+				Computed:    true,
 			},
 			"private_key": schema.StringAttribute{
-				Computed:  true,
-				Sensitive: true,
+				Description: "The private key used for request and assertion signing.",
+				Computed:    true,
+				Sensitive:   true,
 			},
 			"signature_signing_method": schema.StringAttribute{
-				Computed: true,
+				Description: "Signature Signing Method.",
+				Computed:    true,
 			},
 			"signature_digest_method": schema.StringAttribute{
-				Computed: true,
+				Description: "Signature Digest Method.",
+				Computed:    true,
 			},
 			"provider_type": schema.StringAttribute{
-				Computed: true,
+				Description: "The type of identity provider used. One of `okta`, `entra`, `saml`, or `unknown`.",
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_scim_settings.go
+++ b/internal/provider/data_source_scim_settings.go
@@ -62,7 +62,7 @@ func (d *dataSourceTFESCIMSettings) Schema(_ context.Context, _ datasource.Schem
 			},
 			"site_admin_group_scim_id": schema.StringAttribute{
 				Computed:    true,
-				Description: "The SCIM ID of the group whose members are granted site admin privileges.",
+				Description: "The SCIM ID of the group whose members are granted site admin privileges. Empty when no group is linked.",
 			},
 			"site_admin_group_display_name": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/data_source_scim_token.go
+++ b/internal/provider/data_source_scim_token.go
@@ -55,7 +55,7 @@ func (d *dataSourceTFESCIMToken) Schema(_ context.Context, _ datasource.SchemaRe
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Required:    true,
-				Description: "The ID of the SCIM token",
+				Description: "The ID of the SCIM token.",
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^at-`),

--- a/internal/provider/data_source_slug.go
+++ b/internal/provider/data_source_slug.go
@@ -22,12 +22,15 @@ import (
 
 func dataSourceTFESlug() *schema.Resource {
 	return &schema.Resource{
+		Description: "Manages files.",
+
 		Read: dataSourceTFESlugRead,
 
 		Schema: map[string]*schema.Schema{
 			"source_path": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "The path to the directory where the files are located.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_ssh_key.go
+++ b/internal/provider/data_source_ssh_key.go
@@ -17,17 +17,27 @@ import (
 
 func dataSourceTFESSHKey() *schema.Resource {
 	return &schema.Resource{
+		Description: "Get information on an SSH key.",
+
 		Read: dataSourceTFESSHKeyRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the SSH key.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "Name of the SSH key.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_team.go
+++ b/internal/provider/data_source_team.go
@@ -18,37 +18,52 @@ import (
 
 func dataSourceTFETeam() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information on a team.",
+
 		Read: dataSourceTFETeamRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the team.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "Name of the team.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 			"sso_team_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The [SSO Team ID](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) of the team, if it has been defined.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"scim_linked": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether the team is linked to a SCIM group. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is not supported or not enabled on the TFE instance.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 			"scim_group_name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The display name of the SCIM group linked to this team. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is not supported or not enabled on the TFE instance, or the team is not linked to a SCIM group.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"scim_sync_paused": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether SCIM membership sync is paused for this team. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is not supported or not enabled on the TFE instance.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 			"scim_updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The timestamp of the last SCIM reconciliation for this team, in RFC3339 format. Only populated when SCIM is enabled on the TFE instance. If not present, SCIM is not supported or not enabled on the TFE instance, or the team is not linked to a SCIM group.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_team_access.go
+++ b/internal/provider/data_source_team_access.go
@@ -17,65 +17,84 @@ import (
 
 func dataSourceTFETeamAccess() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information on team permissions on a workspace.",
+
 		Read: dataSourceTFETeamAccessRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The team access ID",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"access": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The type of access granted to the team on the workspace.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"permissions": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Description: "The custom permissions granted to the team on the workspace.",
+				Type:        schema.TypeList,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"runs": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to runs. Valid values are `read`, `plan`, or `apply`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"variables": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to variables. Valid values are `none`, `read`, or `write`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"state_versions": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to state versions. Valid values are `none`, `read-outputs`, `read`, or `write`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"sentinel_mocks": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to Sentinel mocks. Valid values are `none` or `read`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"workspace_locking": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Whether the team can manually lock or unlock the workspace.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"run_tasks": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Whether the team can manage workspace run tasks.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"policy_overrides": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "This permission allows a team to override soft-mandatory policy evaluations, provided that team has been granted the org level 'delegate policy overrides' permission.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 					},
 				},
 			},
 
 			"team_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "ID of the team.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"workspace_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "ID of the workspace.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_team_access.go
+++ b/internal/provider/data_source_team_access.go
@@ -23,7 +23,7 @@ func dataSourceTFETeamAccess() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Description: "The team access ID",
+				Description: "The team access ID.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_team_project_access.go
+++ b/internal/provider/data_source_team_project_access.go
@@ -19,7 +19,7 @@ import (
 
 func dataSourceTFETeamProjectAccess() *schema.Resource {
 	return &schema.Resource{
-		Description: "Getes information on team permissions on a project.",
+		Description: "Gets information on team permissions on a project.",
 
 		ReadContext: dataSourceTFETeamProjectAccessRead,
 

--- a/internal/provider/data_source_team_project_access.go
+++ b/internal/provider/data_source_team_project_access.go
@@ -19,100 +19,126 @@ import (
 
 func dataSourceTFETeamProjectAccess() *schema.Resource {
 	return &schema.Resource{
+		Description: "Getes information on team permissions on a project.",
+
 		ReadContext: dataSourceTFETeamProjectAccessRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The team project access ID.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"access": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The type of access granted to the team on the project.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"team_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "ID of the team.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"project_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "ID of the project.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"project_access": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Description: "The permissions granted to the team on the project itself.",
+				Type:        schema.TypeList,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"settings": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to the project's settings. Valid values are `read`, `update`, or `delete`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"teams": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to the project's teams. Valid values are `none`, `read`, or `manage`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"variable_sets": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to the project's variable sets. Valid values are `none`, `read`, or `write`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 					},
 				},
 			},
 
 			"workspace_access": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Description: "The permissions granted to the team across all workspaces in the project.",
+				Type:        schema.TypeList,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"create": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Whether the team can create workspaces in the project.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"locking": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Whether the team can manually lock or unlock workspaces in the project.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"move": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Whether the team can move workspaces into and out of the project.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"delete": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Whether the team can delete workspaces in the project.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"run_tasks": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Whether the team can manage run tasks in the project's workspaces.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"policy_overrides": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "This permission allows a team to override soft-mandatory policy evaluations, provided that team has been granted the org level 'delegate policy overrides' permission.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"runs": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to runs. Valid values are `read`, `plan`, or `apply`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"sentinel_mocks": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to Sentinel mocks. Valid values are `none` or `read`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"state_versions": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to state versions. Valid values are `none`, `read-outputs`, `read`, or `write`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"variables": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The permission granted to variables. Valid values are `none`, `read`, or `write`.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/data_source_teams.go
+++ b/internal/provider/data_source_teams.go
@@ -17,23 +17,34 @@ import (
 
 func dataSourceTFETeams() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information on teams.",
+
 		Read: dataSourceTFETeamsRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"names": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "A list of team names in an organization.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"ids": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Description: "A map of team names in an organization and their IDs.",
+				Type:        schema.TypeMap,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_variable_set.go
+++ b/internal/provider/data_source_variable_set.go
@@ -18,66 +18,84 @@ import (
 
 func dataSourceTFEVariableSet() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information on organization variable sets.",
+
 		Read: dataSourceTFEVariableSetRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the variable.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "Name of the variable set.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "Description of the variable set.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"global": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether the variable set applies to all workspaces in the organization.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"priority": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether the variables in this set are able to be over-written.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"workspace_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "IDs of the workspaces that use the variable set.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"variable_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "IDs of the variables attached to the variable set.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"project_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "IDs of the projects that use the variable set.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"stack_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "IDs of the stacks that use the variable set.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"parent_project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Description: "ID of the project that owns the variable set.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_variables.go
+++ b/internal/provider/data_source_variables.go
@@ -179,104 +179,104 @@ func (d *dataSourceTFEVariables) Schema(_ context.Context, _ datasource.SchemaRe
 			},
 
 			"env": schema.ListNestedAttribute{
-					Description: "List containing environment variables configured on the workspace.",
-					Computed:    true,
-					NestedObject: schema.NestedAttributeObject{
-						Attributes: map[string]schema.Attribute{
-							"id": schema.StringAttribute{
-								Description: "The variable ID.",
-								Computed:    true,
-							},
-							"name": schema.StringAttribute{
-								Description: "The variable Key name.",
-								Computed:    true,
-							},
-							"value": schema.StringAttribute{
-								Description: "The variable value. If the variable is sensitive this value will be empty.",
-								Computed:    true,
-							},
-							"category": schema.StringAttribute{
-								Description: "The category of he variable. Valid values are `terraform` or `env`.",
-								Computed:    true,
-							},
-							"hcl": schema.BoolAttribute{
-								Description: "Whether the variable is HCL formatted.",
-								Computed:    true,
-							},
-							"sensitive": schema.BoolAttribute{
-								Description: "Whether the variable's value is sensitive and hidden.",
-								Computed:    true,
-							},
+				Description: "List containing environment variables configured on the workspace.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "The variable ID.",
+							Computed:    true,
 						},
-					},
-				},
-	
-				"terraform": schema.ListNestedAttribute{
-					Description: "List containing environment variables configured on the workspace.",
-					Computed:    true,
-					NestedObject: schema.NestedAttributeObject{
-						Attributes: map[string]schema.Attribute{
-							"id": schema.StringAttribute{
-								Description: "The variable ID.",
-								Computed:    true,
-							},
-							"name": schema.StringAttribute{
-								Description: "The variable Key name.",
-								Computed:    true,
-							},
-							"value": schema.StringAttribute{
-								Description: "The variable value. If the variable is sensitive this value will be empty.",
-								Computed:    true,
-							},
-							"category": schema.StringAttribute{
-								Description: "The category of he variable. Valid values are `terraform` or `env`.",
-								Computed:    true,
-							},
-							"hcl": schema.BoolAttribute{
-								Description: "Whether the variable is HCL formatted.",
-								Computed:    true,
-							},
-							"sensitive": schema.BoolAttribute{
-								Description: "Whether the variable's value is sensitive and hidden.",
-								Computed:    true,
-							},
+						"name": schema.StringAttribute{
+							Description: "The variable Key name.",
+							Computed:    true,
 						},
-					},
-				},
-	
-				"variables": schema.ListNestedAttribute{
-					Description: "List containing environment variables configured on the workspace.",
-					Computed:    true,
-					NestedObject: schema.NestedAttributeObject{
-						Attributes: map[string]schema.Attribute{
-							"id": schema.StringAttribute{
-								Description: "The variable ID.",
-								Computed:    true,
-							},
-							"name": schema.StringAttribute{
-								Description: "The variable Key name.",
-								Computed:    true,
-							},
-							"value": schema.StringAttribute{
-								Description: "The variable value. If the variable is sensitive this value will be empty.",
-								Computed:    true,
-							},
-							"category": schema.StringAttribute{
-								Description: "The category of he variable. Valid values are `terraform` or `env`.",
-								Computed:    true,
-							},
-							"hcl": schema.BoolAttribute{
-								Description: "Whether the variable is HCL formatted.",
-								Computed:    true,
-							},
-							"sensitive": schema.BoolAttribute{
-								Description: "Whether the variable's value is sensitive and hidden.",
-								Computed:    true,
-							},
+						"value": schema.StringAttribute{
+							Description: "The variable value. If the variable is sensitive this value will be empty.",
+							Computed:    true,
+						},
+						"category": schema.StringAttribute{
+							Description: "The category of he variable. Valid values are `terraform` or `env`.",
+							Computed:    true,
+						},
+						"hcl": schema.BoolAttribute{
+							Description: "Whether the variable is HCL formatted.",
+							Computed:    true,
+						},
+						"sensitive": schema.BoolAttribute{
+							Description: "Whether the variable's value is sensitive and hidden.",
+							Computed:    true,
 						},
 					},
 				},
 			},
+
+			"terraform": schema.ListNestedAttribute{
+				Description: "List containing environment variables configured on the workspace.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "The variable ID.",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "The variable Key name.",
+							Computed:    true,
+						},
+						"value": schema.StringAttribute{
+							Description: "The variable value. If the variable is sensitive this value will be empty.",
+							Computed:    true,
+						},
+						"category": schema.StringAttribute{
+							Description: "The category of he variable. Valid values are `terraform` or `env`.",
+							Computed:    true,
+						},
+						"hcl": schema.BoolAttribute{
+							Description: "Whether the variable is HCL formatted.",
+							Computed:    true,
+						},
+						"sensitive": schema.BoolAttribute{
+							Description: "Whether the variable's value is sensitive and hidden.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+
+			"variables": schema.ListNestedAttribute{
+				Description: "List containing environment variables configured on the workspace.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "The variable ID.",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "The variable Key name.",
+							Computed:    true,
+						},
+						"value": schema.StringAttribute{
+							Description: "The variable value. If the variable is sensitive this value will be empty.",
+							Computed:    true,
+						},
+						"category": schema.StringAttribute{
+							Description: "The category of he variable. Valid values are `terraform` or `env`.",
+							Computed:    true,
+						},
+						"hcl": schema.BoolAttribute{
+							Description: "Whether the variable is HCL formatted.",
+							Computed:    true,
+						},
+						"sensitive": schema.BoolAttribute{
+							Description: "Whether the variable's value is sensitive and hidden.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/internal/provider/data_source_variables.go
+++ b/internal/provider/data_source_variables.go
@@ -212,7 +212,7 @@ func (d *dataSourceTFEVariables) Schema(_ context.Context, _ datasource.SchemaRe
 			},
 
 			"terraform": schema.ListNestedAttribute{
-				Description: "List containing environment variables configured on the workspace.",
+				Description: "List containing terraform variables configured on the workspace.",
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -245,7 +245,7 @@ func (d *dataSourceTFEVariables) Schema(_ context.Context, _ datasource.SchemaRe
 			},
 
 			"variables": schema.ListNestedAttribute{
-				Description: "List containing environment variables configured on the workspace.",
+				Description: "List containing terraform and environment variables configured on the workspace.",
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/data_source_variables.go
+++ b/internal/provider/data_source_variables.go
@@ -196,7 +196,7 @@ func (d *dataSourceTFEVariables) Schema(_ context.Context, _ datasource.SchemaRe
 							Computed:    true,
 						},
 						"category": schema.StringAttribute{
-							Description: "The category of he variable. Valid values are `terraform` or `env`.",
+							Description: "The category of the variable. Valid values are `terraform` or `env`.",
 							Computed:    true,
 						},
 						"hcl": schema.BoolAttribute{
@@ -229,7 +229,7 @@ func (d *dataSourceTFEVariables) Schema(_ context.Context, _ datasource.SchemaRe
 							Computed:    true,
 						},
 						"category": schema.StringAttribute{
-							Description: "The category of he variable. Valid values are `terraform` or `env`.",
+							Description: "The category of the variable. Valid values are `terraform` or `env`.",
 							Computed:    true,
 						},
 						"hcl": schema.BoolAttribute{
@@ -262,7 +262,7 @@ func (d *dataSourceTFEVariables) Schema(_ context.Context, _ datasource.SchemaRe
 							Computed:    true,
 						},
 						"category": schema.StringAttribute{
-							Description: "The category of he variable. Valid values are `terraform` or `env`.",
+							Description: "The category of the variable. Valid values are `terraform` or `env`.",
 							Computed:    true,
 						},
 						"hcl": schema.BoolAttribute{

--- a/internal/provider/data_source_variables.go
+++ b/internal/provider/data_source_variables.go
@@ -161,34 +161,41 @@ func (d *dataSourceTFEVariables) Schema(_ context.Context, _ datasource.SchemaRe
 		Description: "This data source can be used to retrieve all variables in a workspace or variable set.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
+				Description: "Static identifier for the variables group in the workspace.",
+				Computed:    true,
 			},
 
 			"workspace_id": schema.StringAttribute{
-				Optional: true,
+				Description: "ID of the workspace.",
+				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("variable_set_id")),
 				},
 			},
 
 			"variable_set_id": schema.StringAttribute{
-				Optional: true,
+				Description: "ID of the variable set. One of this or `workspace_id` is required.",
+				Optional:    true,
 			},
 
 			"env": schema.ListAttribute{
+				Description: "List containing environment variables configured on the workspace.",
 				Computed:    true,
 				ElementType: variableType,
 			},
 
 			"terraform": schema.ListAttribute{
+				Description: "List containing terraform variables configured on the workspace.",
 				Computed:    true,
 				ElementType: variableType,
 			},
 
 			"variables": schema.ListAttribute{
+				Description: "List containing all terraform and environment variables configured on the workspace.",
 				Computed:    true,
 				ElementType: variableType,
 			},
+			// TODO the content of each block is not explicitly listed in the current schema
 		},
 	}
 }

--- a/internal/provider/data_source_variables.go
+++ b/internal/provider/data_source_variables.go
@@ -178,25 +178,105 @@ func (d *dataSourceTFEVariables) Schema(_ context.Context, _ datasource.SchemaRe
 				Optional:    true,
 			},
 
-			"env": schema.ListAttribute{
-				Description: "List containing environment variables configured on the workspace.",
-				Computed:    true,
-				ElementType: variableType,
+			"env": schema.ListNestedAttribute{
+					Description: "List containing environment variables configured on the workspace.",
+					Computed:    true,
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								Description: "The variable ID.",
+								Computed:    true,
+							},
+							"name": schema.StringAttribute{
+								Description: "The variable Key name.",
+								Computed:    true,
+							},
+							"value": schema.StringAttribute{
+								Description: "The variable value. If the variable is sensitive this value will be empty.",
+								Computed:    true,
+							},
+							"category": schema.StringAttribute{
+								Description: "The category of he variable. Valid values are `terraform` or `env`.",
+								Computed:    true,
+							},
+							"hcl": schema.BoolAttribute{
+								Description: "Whether the variable is HCL formatted.",
+								Computed:    true,
+							},
+							"sensitive": schema.BoolAttribute{
+								Description: "Whether the variable's value is sensitive and hidden.",
+								Computed:    true,
+							},
+						},
+					},
+				},
+	
+				"terraform": schema.ListNestedAttribute{
+					Description: "List containing environment variables configured on the workspace.",
+					Computed:    true,
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								Description: "The variable ID.",
+								Computed:    true,
+							},
+							"name": schema.StringAttribute{
+								Description: "The variable Key name.",
+								Computed:    true,
+							},
+							"value": schema.StringAttribute{
+								Description: "The variable value. If the variable is sensitive this value will be empty.",
+								Computed:    true,
+							},
+							"category": schema.StringAttribute{
+								Description: "The category of he variable. Valid values are `terraform` or `env`.",
+								Computed:    true,
+							},
+							"hcl": schema.BoolAttribute{
+								Description: "Whether the variable is HCL formatted.",
+								Computed:    true,
+							},
+							"sensitive": schema.BoolAttribute{
+								Description: "Whether the variable's value is sensitive and hidden.",
+								Computed:    true,
+							},
+						},
+					},
+				},
+	
+				"variables": schema.ListNestedAttribute{
+					Description: "List containing environment variables configured on the workspace.",
+					Computed:    true,
+					NestedObject: schema.NestedAttributeObject{
+						Attributes: map[string]schema.Attribute{
+							"id": schema.StringAttribute{
+								Description: "The variable ID.",
+								Computed:    true,
+							},
+							"name": schema.StringAttribute{
+								Description: "The variable Key name.",
+								Computed:    true,
+							},
+							"value": schema.StringAttribute{
+								Description: "The variable value. If the variable is sensitive this value will be empty.",
+								Computed:    true,
+							},
+							"category": schema.StringAttribute{
+								Description: "The category of he variable. Valid values are `terraform` or `env`.",
+								Computed:    true,
+							},
+							"hcl": schema.BoolAttribute{
+								Description: "Whether the variable is HCL formatted.",
+								Computed:    true,
+							},
+							"sensitive": schema.BoolAttribute{
+								Description: "Whether the variable's value is sensitive and hidden.",
+								Computed:    true,
+							},
+						},
+					},
+				},
 			},
-
-			"terraform": schema.ListAttribute{
-				Description: "List containing terraform variables configured on the workspace.",
-				Computed:    true,
-				ElementType: variableType,
-			},
-
-			"variables": schema.ListAttribute{
-				Description: "List containing all terraform and environment variables configured on the workspace.",
-				Computed:    true,
-				ElementType: variableType,
-			},
-			// TODO the content of each block is not explicitly listed in the current schema
-		},
 	}
 }
 

--- a/internal/provider/data_source_workspace.go
+++ b/internal/provider/data_source_workspace.go
@@ -22,208 +22,255 @@ import (
 
 func dataSourceTFEWorkspace() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information about a workspace. Note that using `global_remote_state` or `remote_state_consumer_ids` requires using the provider with HCP Terraform or an instance of Terraform Enterprise at least as recent as v202104-1.",
+
 		Read: dataSourceTFEWorkspaceRead,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The workspace ID.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "Name of the workspace.",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "Name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "Description of the workspace.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"allow_destroy_plan": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether destroy plans can be queued on the workspace.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"auto_apply": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether to automatically apply changes when a Terraform plan is successful.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"auto_apply_run_trigger": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether the workspace will automatically apply changes for runs that were created by run triggers from another workspace.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"auto_destroy_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "Future date/time string at which point all resources in a workspace will be scheduled to be deleted.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"auto_destroy_activity_duration": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "A duration string representing time after workspace activity when an auto-destroy run will be triggered.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"inherits_project_auto_destroy": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether this workspace inherits project auto destroy settings.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"file_triggers_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"global_remote_state": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument). Cannot be true if `project_remote_state` is true.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"project_remote_state": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whether the workspace should allow all workspaces in the project to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument). Cannot be true if `global_remote_state` is true.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"remote_state_consumer_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` or `project_remote_state` is set to `true`.",
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"assessments_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Available only in HCP Terraform) Indicates whether health assessments such as drift detection are enabled for the workspace.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"operations": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether the workspace is using remote execution mode. Set to `false` to switch execution mode to local. `true` by default.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"policy_check_failures": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Description: "The number of policy check failures from the latest run.",
+				Type:        schema.TypeInt,
+				Computed:    true,
 			},
 
 			"project_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "ID of the workspace's project.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"queue_all_runs": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether the workspace will automatically perform runs in response to webhooks immediately after its creation. If `false`, an initial run must be manually queued to enable future automatic runs.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"resource_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Description: "The number of resources managed by the workspace.",
+				Type:        schema.TypeInt,
+				Computed:    true,
 			},
 
 			"run_failures": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Description: "The number of run failures on the workspace.",
+				Type:        schema.TypeInt,
+				Computed:    true,
 			},
 
 			"runs_count": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Description: "The number of runs on the workspace.",
+				Type:        schema.TypeInt,
+				Computed:    true,
 			},
 
 			"source_name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The name of the workspace creation source, if set.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"source_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The URL of the workspace creation source, if set.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"speculative_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether this workspace allows speculative plans.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"ssh_key_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The ID of an SSH key assigned to the workspace.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"structured_run_output_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether runs in this workspace use the enhanced apply UI.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"effective_tags": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "A map of key-value tags associated with the workspace, including any inherited tags from the parent project.",
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"tag_names": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "The names of tags added to this workspace.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"terraform_version": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The version (or version constraint) of Terraform used for this workspace.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"trigger_prefixes": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "List of trigger prefixes that describe the paths HCP Terraform monitors for changes, in addition to the working directory. Trigger prefixes are always appended to the root directory of the repository.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"trigger_patterns": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "List of [glob patterns](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/vcs#glob-patterns-for-automatic-run-triggering) that describe the files HCP Terraform monitors for changes. Trigger patterns are always appended to the root directory of the repository.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"working_directory": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "A relative path that Terraform will execute within.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"execution_mode": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "Indicates the [execution mode](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings#execution-mode) of the workspace. **Note:** This value might be derived from an organization-level default or set on the workspace itself; see the [`tfe_workspace_settings` resource](tfe_workspace_settings) for details.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"vcs_repo": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Description: "Settings for the workspace's VCS repository.",
+				Type:        schema.TypeList,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"identifier": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "A reference to your VCS repository in the format `<vcs organization>/<repository>` where `<vcs organization>` and `<repository>` refer to the organization and repository in your VCS provider.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"branch": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "The repository branch that Terraform will execute from.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"ingress_submodules": {
-							Type:     schema.TypeBool,
-							Computed: true,
+							Description: "Indicates whether submodules should be fetched when cloning the VCS repository.",
+							Type:        schema.TypeBool,
+							Computed:    true,
 						},
 
 						"oauth_token_id": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "OAuth token ID of the configured VCS connection.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"tags_regex": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Description: "A regular expression used to trigger a Workspace run for matching Git tags.",
+							Type:        schema.TypeString,
+							Computed:    true,
 						},
 
 						"github_app_installation_id": {
@@ -234,64 +281,76 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				},
 			},
 			"html_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The URL to the browsable HTML overview of the workspace.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 			"hyok_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Whther HYOK is enbabled for the workspace.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 			"locked": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Description: "Indicates whether the workspace is locked.",
+				Type:        schema.TypeBool,
+				Computed:    true,
 			},
 
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The time when the workspace was created.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "the time when the workspace was last updated.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"environment": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The environment of the workspace.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"apply_duration_average": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Description: "The average duration of applies for this workspace.",
+				Type:        schema.TypeInt,
+				Computed:    true,
 			},
 
 			"plan_duration_average": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Description: "The average duration of plans for this workspace.",
+				Type:        schema.TypeInt,
+				Computed:    true,
 			},
 
 			"source": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The source of the workspace.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 
 			"setting_overwrites": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeBool},
+				Description: "Settings that are overwritten for this workspace.", // TODO list contents of the setting overwrites block, may require schema changes
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeBool},
 			},
 
 			"permissions": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeBool},
+				Description: "The permissions for the current user on this workspace.", // TODO list contents of the permissions block, may require schema changes
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeBool},
 			},
 
 			"actions": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeBool},
+				Description: "Actions that can be performed on this workspace", // TODO list contents of the actions block, may require schema changes
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeBool},
 			},
 		},
 	}

--- a/internal/provider/data_source_workspace.go
+++ b/internal/provider/data_source_workspace.go
@@ -333,21 +333,21 @@ func dataSourceTFEWorkspace() *schema.Resource {
 			},
 
 			"setting_overwrites": {
-				Description: "Settings that are overwritten for this workspace.", // TODO list contents of the setting overwrites block, may require schema changes
+				Description: "Settings that are overwritten for this workspace. Contains: `is-destroyable` - Whether the workspace can be destroyed.", // On migration, ideally reformat into non-inline descriptions
 				Type:        schema.TypeMap,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeBool},
 			},
 
 			"permissions": {
-				Description: "The permissions for the current user on this workspace.", // TODO list contents of the permissions block, may require schema changes
+				Description: "The permissions for the current user on this workspace. Contains: `can-update` - Can update the workspace. `can-destroy` - Can destroy the workspace. `can-queue-run` - Can queue runs. `can-queue-apply` - Can queue apply. `can-queue-destroy` - Can queue destroy. `can-lock` - Can lock the workspace. `can-unlock` - Can unlock the workspace. `can-force-unlock` - Can force unlock the workspace. `can-read-settings` - Can read workspace settings. `can-update-variable` - Can update variables. `can-manage-run-tasks` - Can manage run tasks. `can-force-delete` - Can force delete the workspace.", // On migration, ideally reformat into non-inline descriptions
 				Type:        schema.TypeMap,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeBool},
 			},
 
 			"actions": {
-				Description: "Actions that can be performed on this workspace", // TODO list contents of the actions block, may require schema changes
+				Description: "Actions that can be performed on this workspace. Contains: `execution-mode` - Whether execution mode is overwritten at the workspace level. `agent-pool` - Whether agent pool is overwritten at the workspace level.", // On migration, ideally reformat into non-inline descriptions
 				Type:        schema.TypeMap,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeBool},

--- a/internal/provider/data_source_workspace.go
+++ b/internal/provider/data_source_workspace.go
@@ -113,7 +113,7 @@ func dataSourceTFEWorkspace() *schema.Resource {
 			},
 
 			"assessments_enabled": {
-				Description: "Available only in HCP Terraform) Indicates whether health assessments such as drift detection are enabled for the workspace.",
+				Description: "(Available only in HCP Terraform) Indicates whether health assessments such as drift detection are enabled for the workspace.",
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
@@ -286,7 +286,7 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Computed:    true,
 			},
 			"hyok_enabled": {
-				Description: "Whther HYOK is enbabled for the workspace.",
+				Description: "Whether HYOK is enbabled for the workspace.",
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
@@ -303,7 +303,7 @@ func dataSourceTFEWorkspace() *schema.Resource {
 			},
 
 			"updated_at": {
-				Description: "the time when the workspace was last updated.",
+				Description: "The time when the workspace was last updated.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_workspace.go
+++ b/internal/provider/data_source_workspace.go
@@ -286,7 +286,7 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Computed:    true,
 			},
 			"hyok_enabled": {
-				Description: "Whether HYOK is enbabled for the workspace.",
+				Description: "Whether HYOK is enabled for the workspace.",
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_workspace_ids.go
+++ b/internal/provider/data_source_workspace_ids.go
@@ -19,10 +19,13 @@ import (
 
 func dataSourceTFEWorkspaceIDs() *schema.Resource {
 	return &schema.Resource{
+		Description: "Gets information on workspace IDs.",
+
 		Read: dataSourceTFEWorkspaceIDsRead,
 
 		Schema: map[string]*schema.Schema{
 			"names": {
+				Description:  "A list of workspace names to search for. Names that don't match a valid workspace will be omitted from the results, but are not an error. To select _all_ workspaces for an organization, provide a list with a single asterisk, like `[\"*\"]`. The asterisk also supports partial matching on prefix and/or suffix, like `[*-prod]`, `[test-*]`, `[*dev*]`.",
 				Type:         schema.TypeList,
 				Elem:         &schema.Schema{Type: schema.TypeString},
 				Optional:     true,
@@ -30,51 +33,59 @@ func dataSourceTFEWorkspaceIDs() *schema.Resource {
 			},
 
 			"tag_names": {
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
+				Description: "A set of key-value tag filters to search for workspaces. At least one of this or `names` must be present.",
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
 			},
 
 			"exclude_tags": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
+				Description: "Deprecated. A list of tag names to exclude when searching.",
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
 			},
 
 			"tag_filters": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MinItems: 1,
-				MaxItems: 1,
+				Description: "Deprecated. A list of tag names to search for.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MinItems:    1,
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"include": {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Description: "A map of key-value tags the workspaces must contain. Each tag included here will be combined using a logical AND when filtering results.",
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
 						"exclude": {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Description: "A map of key-value tags to exclude workspaces from the returned list. To exclude all workspaces containing a specific key, use `\"*\"` as the value.",
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
 			},
 
 			"organization": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "The name of the organization.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 
 			"ids": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Description: "A map of workspace names and their opaque, immutable IDs, which look like `ws-<RANDOM STRING>`.",
+				Type:        schema.TypeMap,
+				Computed:    true,
 			},
 
 			"full_names": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Description: "A map of workspace names and their full names, which look like `<ORGANIZATION>/<WORKSPACE>`.",
+				Type:        schema.TypeMap,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/data_source_workspace_run_task.go
+++ b/internal/provider/data_source_workspace_run_task.go
@@ -32,6 +32,7 @@ func (d *dataSourceWorkspaceRunTask) Metadata(_ context.Context, req datasource.
 
 func (d *dataSourceWorkspaceRunTask) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: "Gets information about a [Workspace Run task](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks#associating-run-tasks-with-a-workspace).",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Service-generated identifier for the task",
@@ -50,7 +51,7 @@ func (d *dataSourceWorkspaceRunTask) Schema(_ context.Context, _ datasource.Sche
 				Computed:    true,
 			},
 			"stage": schema.StringAttribute{
-				DeprecationMessage: "stage is deprecated, please use stages instead",
+				DeprecationMessage: "stage is deprecated, please use `stages` instead",
 				Description:        "Which stage the task will run in.",
 				Computed:           true,
 			},

--- a/internal/provider/data_source_workspace_run_task.go
+++ b/internal/provider/data_source_workspace_run_task.go
@@ -35,7 +35,7 @@ func (d *dataSourceWorkspaceRunTask) Schema(_ context.Context, _ datasource.Sche
 		Description: "Gets information about a [Workspace Run task](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks#associating-run-tasks-with-a-workspace).",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Description: "Service-generated identifier for the task",
+				Description: "Service-generated identifier for the task.",
 				Computed:    true,
 			},
 			"workspace_id": schema.StringAttribute{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -216,5 +216,5 @@ var descriptions = map[string]string{
 		"the token which can be set as credentials in the CLI config file.",
 	"ssl_skip_verify": "Whether or not to skip certificate verifications.",
 	"organization": "The organization to apply to a resource if one is not defined on\n" +
-		"the resource itself",
+		"the resource itself.",
 }

--- a/website/docs/d/github_app_installation.html.markdown
+++ b/website/docs/d/github_app_installation.html.markdown
@@ -2,7 +2,7 @@
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_github_app_installation"
 description: |-
-Get information on the Github App Installation.
+  Get information on the Github App Installation.
 ---
 
 # Data Source: tfe_github_app_installation

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -28,7 +28,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `email` - Admin email address.
 * `external_id` - An identifier for the organization.
-* `assessments_enforced` - (Available only in HCP Terraform) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set thier own preferences.
+* `assessments_enforced` - (Available only in HCP Terraform) Whether to force health assessments (drift detection) on all eligible workspaces or allow workspaces to set their own preferences.
 * `collaborator_auth_policy` - Authentication policy (`password` or `two_factor_mandatory`). Defaults to `password`.
 * `cost_estimation_enabled` - Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to true. In a HCP Terraform organization which does not have Teams & Governance features, this value is always false and cannot be changed. In Terraform Enterprise, Cost Estimation must also be enabled in Site Administration.
 * `enforce_hyok` - (Available only in HCP Terraform) Whether HYOK is enforced for all new workspaces in the organization.

--- a/website/docs/d/organization_tags.html.markdown
+++ b/website/docs/d/organization_tags.html.markdown
@@ -33,4 +33,4 @@ The `tag` block contains:
 
 * `name` - The name of the workspace tag
 * `id` - The ID of the workspace tag
-* `workspace_count` - The number of workspaces the tag is associate with
+* `workspace_count` - The number of workspaces the tag is associated with

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -2,7 +2,7 @@
 layout: "tfe"
 page_title: "Terraform Enterprise: tfe_project"
 description: |-
-Get information on a Project.
+  Get information on a Project.
 ---
 
 # Data Source: tfe_project

--- a/website/docs/d/saml_settings.html.markdown
+++ b/website/docs/d/saml_settings.html.markdown
@@ -57,7 +57,6 @@ The following attributes are exported:
 * `acs_consumer_url` - ACS Consumer (Recipient) URL.
 * `metadata_url` - Metadata (Audience) URL.
 * `certificate` - Request and assertion signing certificate.
-* `certificate` - Request and assertion signing certificate.
 * `private_key` - The private key used for request and assertion signing.
 * `signature_signing_method` - Signature Signing Method.
 * `signature_digest_method` - Signature Digest Method.

--- a/website/docs/d/variables.html.markdown
+++ b/website/docs/d/variables.html.markdown
@@ -42,7 +42,7 @@ data "tfe_variables" "test" {
 One of following arguments are required:
 
 * `workspace_id` - ID of the workspace.
-* `variable_set_id` - ID of the workspace.
+* `variable_set_id` - ID of the variable set.
 
 ## Attributes Reference
 

--- a/website/docs/d/workspace_run_task.html.markdown
+++ b/website/docs/d/workspace_run_task.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 [Run tasks](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks) allow HCP Terraform to interact with external systems at specific points in the HCP Terraform run lifecycle. Run tasks are reusable configurations that you can attach to any workspace in an organization.
 
-Use this data source to get information about a [Workspace Run tasks](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks#associating-run-tasks-with-a-workspace).
+Use this data source to get information about a [Workspace Run task](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks#associating-run-tasks-with-a-workspace).
 
 ## Example Usage
 


### PR DESCRIPTION
## Description

Both sdk/v2 and plugin-framework versions of data-sources, ephemeral-resources, and actions have the capacity to hold description information which might be used in documentation generation or in other uses. Although copies of the information usually exist in `website/docs`, they have often not been backfilled into the source files themselves. This PR performs that backfill. 

We should not consider the backfill process complete for three categories of work: 

1. Items with nested attributes - these do have the information backfilled, but require migration to provider-framework for tools like [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs) to capture them. 
2. Items with mandatory, unused "id" fields - these are discussed later in this PR. Performing the backfill here could be misleading. 
3. Items with mapped attributes - these require migration to plugin-framework in order to provide the opportunity to associate sub-attribute descriptions with the sub-attribute. Instead, this information has been backfilled into their parent attribute, but this solution ought to be considered temporary. 

## Testing plan

Regarding the beneficial output

1. Generate a copy of the provider schema. One method can be seen [here](https://gist.github.com/gbaker-ibm/f74fc2a9d48491893b4abfc71a7ae3d3)
5. Identify that all non-resources now have descriptions associated with their components and the attributes under those components. For resources which have nested subcomponents, identify instead that the information is simply available in the source for later use. 
A functional tool for doing so exists [here](https://gist.github.com/gbaker-ibm/9b3532894df61ab1cd72027f4ba0553f). 
For the failing items, note that their "id" is the only attribute missing a description, that they are using sdk/v2 instead of plugin-framework, and that their id is not used in the go source code. We note that sdk/v2 will generate an "id" field even if none is intended to exist. (`oauth_client, organization, organization_tags, organizations, policy_set, slug, workspace_ids`). 

Regarding non-negative changes

1.  Run existing acceptance tests against DataSource(s)
2. Run existing acceptance test against the action `query_run`

## Output from acceptance tests

### For the data sources: 

Note that some tests failed. We submit that most of these do not result from changes made by this branch, considering that the testing states match. 

Attached as a file is the test output for the main branch without this repo with the same arguments: 
[test_results_base.txt](https://github.com/user-attachments/files/29707654/test_results_base.txt)


Below is the run for this repo. 

```
TFE_ADMIN_PROVISION_LICENSES_TOKEN=$TFE_TOKEN TF_ACC=1 go test ./internal/provider/... --run="DataSource" -v

=== RUN   TestAccTFEAdminSMTPSettingsDataSource_basic
    helper_test.go:237: Skipping test for a feature unavailable in HCP Terraform. Set 'ENABLE_TFE=1' to run.
--- SKIP: TestAccTFEAdminSMTPSettingsDataSource_basic (0.00s)
=== RUN   TestAccTFEAgentPoolDataSource_basic
2026/07/13 09:50:39 [DEBUG] Configuring client for host "app.staging.terraform.io"
2026/07/13 09:50:39 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEAgentPoolDataSource_basic (0.82s)
=== RUN   TestAccTFEAgentPoolDataSource_allowed_workspaces
2026/07/13 09:50:40 [DEBUG] Configuring client for host "app.staging.terraform.io"
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEAgentPoolDataSource_allowed_workspaces (0.50s)
=== RUN   TestAccTFEAgentPoolDataSource_allowed_projects
2026/07/13 09:50:40 [DEBUG] Configuring client for host "app.staging.terraform.io"
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEAgentPoolDataSource_allowed_projects (0.56s)
=== RUN   TestAccTFEAgentPoolDataSource_excluded_workspaces
2026/07/13 09:50:41 [DEBUG] Configuring client for host "app.staging.terraform.io"
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEAgentPoolDataSource_excluded_workspaces (0.57s)
=== RUN   TestAccCurrentUserDataSource_basic
--- PASS: TestAccCurrentUserDataSource_basic (1.62s)
=== RUN   TestAccTFEGHAInstallationDataSource_findByName
    data_source_github_app_installation_test.go:16: Please set GITHUB_APP_INSTALLATION_NAME to run this test
--- SKIP: TestAccTFEGHAInstallationDataSource_findByName (0.00s)
=== RUN   TestAccTFEHYOKCustomerKeyVersionDataSource_basic
    helper_test.go:263: Skipping tests for HYOK. Set 'ENABLE_HYOK' to enable tests.
--- SKIP: TestAccTFEHYOKCustomerKeyVersionDataSource_basic (0.00s)
=== RUN   TestAccTFEHYOKEncryptedDataKeyDataSource_basic
    helper_test.go:263: Skipping tests for HYOK. Set 'ENABLE_HYOK' to enable tests.
--- SKIP: TestAccTFEHYOKEncryptedDataKeyDataSource_basic (0.00s)
=== RUN   TestAccTFEIPRangesDataSource_basic
--- PASS: TestAccTFEIPRangesDataSource_basic (1.66s)
=== RUN   TestAccTFENoCodeModuleDataSource_public
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFENoCodeModuleDataSource_public (0.00s)
=== RUN   TestAccTFEOAuthClientDataSource_basic
--- PASS: TestAccTFEOAuthClientDataSource_basic (4.33s)
=== RUN   TestAccTFEOAuthClientDataSource_findByID
--- PASS: TestAccTFEOAuthClientDataSource_findByID (3.79s)
=== RUN   TestAccTFEOAuthClientDataSource_findByName
--- PASS: TestAccTFEOAuthClientDataSource_findByName (3.86s)
=== RUN   TestAccTFEOAuthClientDataSource_findByServiceProvider
--- PASS: TestAccTFEOAuthClientDataSource_findByServiceProvider (3.80s)
=== RUN   TestAccTFEOAuthClientDataSource_missingParameters
--- PASS: TestAccTFEOAuthClientDataSource_missingParameters (0.50s)
=== RUN   TestAccTFEOAuthClientDataSource_missingOrgWithName
--- PASS: TestAccTFEOAuthClientDataSource_missingOrgWithName (0.44s)
=== RUN   TestAccTFEOAuthClientDataSource_missingOrgWithServiceProvider
--- PASS: TestAccTFEOAuthClientDataSource_missingOrgWithServiceProvider (0.46s)
=== RUN   TestAccTFEOAuthClientDataSource_sameName
--- PASS: TestAccTFEOAuthClientDataSource_sameName (2.51s)
=== RUN   TestAccTFEOAuthClientDataSource_noName
--- PASS: TestAccTFEOAuthClientDataSource_noName (2.58s)
=== RUN   TestAccTFEOAuthClientDataSource_sameServiceProvider
--- PASS: TestAccTFEOAuthClientDataSource_sameServiceProvider (2.80s)
=== RUN   TestAccTFEOrganizationAuditConfigurationDataSource_basic
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEOrganizationAuditConfigurationDataSource_basic (0.00s)
=== RUN   TestAccTFEOrganizationAuditConfigurationDataSource_disallowed
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEOrganizationAuditConfigurationDataSource_disallowed (0.00s)
=== RUN   TestAccTFEOrganizationMembersDataSource_basic
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEOrganizationMembersDataSource_basic (0.58s)
=== RUN   TestAccTFEOrganizationMembershipDataSource_basic
--- PASS: TestAccTFEOrganizationMembershipDataSource_basic (7.24s)
=== RUN   TestAccTFEOrganizationMembershipDataSource_findByName
    data_source_organization_membership_test.go:67: Please set TFE_USER1 to run this test
--- SKIP: TestAccTFEOrganizationMembershipDataSource_findByName (0.00s)
=== RUN   TestAccTFEOrganizationMembershipDataSource_missingParams
--- PASS: TestAccTFEOrganizationMembershipDataSource_missingParams (0.48s)
=== RUN   TestAccTFEOrganizationRunTaskDataSource_basic
    helper_test.go:249: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEOrganizationRunTaskDataSource_basic (0.00s)
=== RUN   TestAccTFEOrganizationTagsDataSource_basic
--- PASS: TestAccTFEOrganizationTagsDataSource_basic (3.51s)
=== RUN   TestAccTFEOrganizationDataSource_basic
--- PASS: TestAccTFEOrganizationDataSource_basic (3.30s)
=== RUN   TestAccTFEOrganizationDataSource_defaultProject
--- PASS: TestAccTFEOrganizationDataSource_defaultProject (3.43s)
=== RUN   TestAccTFEOrganizationDataSource_defaultOrganization
--- PASS: TestAccTFEOrganizationDataSource_defaultOrganization (2.37s)
=== RUN   TestAccTFEOrganizationDataSource_readEnforceHYOK
    helper_test.go:263: Skipping tests for HYOK. Set 'ENABLE_HYOK' to enable tests.
--- SKIP: TestAccTFEOrganizationDataSource_readEnforceHYOK (0.00s)
=== RUN   TestAccTFEOrganizationDataSource_maxTTLEnabled
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEOrganizationDataSource_maxTTLEnabled (0.00s)
=== RUN   TestAccTFEOrganizationsDataSource_basic
--- PASS: TestAccTFEOrganizationsDataSource_basic (145.75s)
=== RUN   TestAccTFEPolicySetDataSource_basic
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEPolicySetDataSource_basic (0.60s)
=== RUN   TestAccTFEPolicySetDataSource_pinnedPolicyRuntimeVersion
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEPolicySetDataSource_pinnedPolicyRuntimeVersion (0.72s)
=== RUN   TestAccTFEPolicySetDataSourceOPA_basic
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEPolicySetDataSourceOPA_basic (0.56s)
=== RUN   TestAccTFEPolicySetDataSource_vcs
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEPolicySetDataSource_vcs (0.56s)
=== RUN   TestAccTFEPolicySetDataSource_notFound
--- PASS: TestAccTFEPolicySetDataSource_notFound (1.71s)
=== RUN   TestAccTFEProjectDataSource_basic
--- PASS: TestAccTFEProjectDataSource_basic (5.55s)
=== RUN   TestAccTFEProjectDataSource_tagBindings
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProjectDataSource_tagBindings (0.00s)
=== RUN   TestAccTFEProjectDataSource_caseInsensitive
--- PASS: TestAccTFEProjectDataSource_caseInsensitive (5.12s)
=== RUN   TestAccTFEProjectDataSource_basicWithAutoDestroy
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEProjectDataSource_basicWithAutoDestroy (0.54s)
=== RUN   TestAccTFEProjectsDataSource_basic
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEProjectsDataSource_basic (0.68s)
=== RUN   TestAccTFEProjectsDataSource_basicNoProjects
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFEProjectsDataSource_basicNoProjects (0.82s)
=== RUN   TestAccTFEProviderSetDataSource_read
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_read (0.00s)
=== RUN   TestAccTFEProviderSetDataSource_read_uninitialized_provider_set
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_read_uninitialized_provider_set (0.00s)
=== RUN   TestAccTFEProviderSetDataSource_read_provider_set_deleted
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_read_provider_set_deleted (0.00s)
=== RUN   TestAccTFEProviderSetDataSource_read_with_default_organization
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_read_with_default_organization (0.00s)
=== RUN   TestAccTFEProviderSetDataSource_validation
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_validation (0.00s)
=== RUN   TestAccTFERegistryGPGKeyDataSource_basic
--- PASS: TestAccTFERegistryGPGKeyDataSource_basic (2.97s)
=== RUN   TestAccTFERegistryGPGKeysDataSource_basic
--- PASS: TestAccTFERegistryGPGKeysDataSource_basic (3.13s)
=== RUN   TestAccTFERegistryGPGKeysDataSource_basicNoKeys
--- PASS: TestAccTFERegistryGPGKeysDataSource_basicNoKeys (2.77s)
=== RUN   TestAccTFERegistryModuleDataSource_basicPrivate
    data_source_registry_module_test.go:28: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating registry module from repository : identifier is required
        
          with tfe_registry_module.foobar,
          on terraform_plugin_test.tf line 26, in resource "tfe_registry_module" "foobar":
          26: resource "tfe_registry_module" "foobar" {
        
--- FAIL: TestAccTFERegistryModuleDataSource_basicPrivate (2.41s)
=== RUN   TestAccTFERegistryModuleDataSource_basicNoCodePublic
    data_source_registry_module_test.go:75: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating no-code module for registry module mod-CWdNiJVVtTmCrrER: unprocessable content
        
        Validation failed: Provided version pin is not equal to latest or provided string does not represent an existing version of the module.
        
          with tfe_no_code_module.foobar,
          on terraform_plugin_test.tf line 26, in resource "tfe_no_code_module" "foobar":
          26:  resource "tfe_no_code_module" "foobar" {
        
--- FAIL: TestAccTFERegistryModuleDataSource_basicNoCodePublic (4.34s)
=== RUN   TestAccTFERegistryModuleDataSource_basicNoCodePrivate
    data_source_registry_module_test.go:112: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating registry module from repository : identifier is required
        
          with tfe_registry_module.foobar,
          on terraform_plugin_test.tf line 25, in resource "tfe_registry_module" "foobar":
          25: resource "tfe_registry_module" "foobar" {
        
--- FAIL: TestAccTFERegistryModuleDataSource_basicNoCodePrivate (2.26s)
=== RUN   TestAccTFERegistryProviderDataSource_public
--- PASS: TestAccTFERegistryProviderDataSource_public (3.01s)
=== RUN   TestAccTFERegistryProviderDataSource_private
--- PASS: TestAccTFERegistryProviderDataSource_private (3.25s)
=== RUN   TestAccTFERegistryProvidersDataSource_all
--- PASS: TestAccTFERegistryProvidersDataSource_all (3.30s)
=== RUN   TestAccTFERegistryProvidersDataSource_public
--- PASS: TestAccTFERegistryProvidersDataSource_public (3.53s)
=== RUN   TestAccTFERegistryProvidersDataSource_private
--- PASS: TestAccTFERegistryProvidersDataSource_private (3.20s)
=== RUN   TestAccTFERegistryProvidersDataSource_filtered
--- PASS: TestAccTFERegistryProvidersDataSource_filtered (3.26s)
=== RUN   TestAccTFESAMLSettingsDataSource_basic
    data_source_saml_settings_test.go:20: Step 1/1 error: Error running pre-apply plan: exit status 1
        
        Error: Unable to read SAML settings
        
          with data.tfe_saml_settings.foobar,
          on terraform_plugin_test.tf line 11, in data "tfe_saml_settings" "foobar":
          11: data "tfe_saml_settings" "foobar" {}
        
        resource not found
--- FAIL: TestAccTFESAMLSettingsDataSource_basic (0.59s)
=== RUN   TestAccTFESCIMGroupDataSource_omnibus
    helper_test.go:237: Skipping test for a feature unavailable in HCP Terraform. Set 'ENABLE_TFE=1' to run.
--- SKIP: TestAccTFESCIMGroupDataSource_omnibus (0.00s)
=== RUN   TestAccTFESCIMSettingsDataSource_basic
    helper_test.go:237: Skipping test for a feature unavailable in HCP Terraform. Set 'ENABLE_TFE=1' to run.
--- SKIP: TestAccTFESCIMSettingsDataSource_basic (0.00s)
=== RUN   TestAccTFESCIMTokenDataSource_omnibus
    helper_test.go:237: Skipping test for a feature unavailable in HCP Terraform. Set 'ENABLE_TFE=1' to run.
--- SKIP: TestAccTFESCIMTokenDataSource_omnibus (0.00s)
=== RUN   TestAccTFESSHKeyDataSource_basic
--- PASS: TestAccTFESSHKeyDataSource_basic (3.61s)
=== RUN   TestAccTFETeamAccessDataSource_basic
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFETeamAccessDataSource_basic (0.55s)
=== RUN   TestAccTFETeamProjectAccessDataSource_basic
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFETeamProjectAccessDataSource_basic (0.56s)
=== RUN   TestAccTFETeamProjectCustomAccessDataSource_basic
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFETeamProjectCustomAccessDataSource_basic (0.58s)
=== RUN   TestAccTFETeamProjectCustomAccessDataSource_policyOverrides
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFETeamProjectCustomAccessDataSource_policyOverrides (0.50s)
=== RUN   TestAccTFETeamProjectCustomAccessDataSource_basic_with_project_variable_sets
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFETeamProjectCustomAccessDataSource_basic_with_project_variable_sets (0.52s)
=== RUN   TestAccTFETeamDataSource_basic
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFETeamDataSource_basic (0.57s)
=== RUN   TestAccTFETeamDataSource_ssoTeamId
    subscription_updater_test.go:134: failed to enumerate feature sets: resource not found
--- FAIL: TestAccTFETeamDataSource_ssoTeamId (0.51s)
=== RUN   TestAccTFESCIMTeamDataSource_omnibus
    helper_test.go:237: Skipping test for a feature unavailable in HCP Terraform. Set 'ENABLE_TFE=1' to run.
--- SKIP: TestAccTFESCIMTeamDataSource_omnibus (0.00s)
=== RUN   TestAccTFETeamsDataSource_basic
    data_source_teams_test.go:32: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error creating team team-foo-6230752632024369392 for organization tst-terraform-6230752632024369392: missing entitlements to create teams
        
          with tfe_team.foo,
          on terraform_plugin_test.tf line 12, in resource "tfe_team" "foo":
          12: resource "tfe_team" "foo" {
        
        
        Error: Error creating team team-bar-6230752632024369392 for organization tst-terraform-6230752632024369392: missing entitlements to create teams
        
          with tfe_team.bar,
          on terraform_plugin_test.tf line 17, in resource "tfe_team" "bar":
          17: resource "tfe_team" "bar" {
        
--- FAIL: TestAccTFETeamsDataSource_basic (1.58s)
=== RUN   TestAccTFEOrgMaxTokenTTLPolicyDataSource_basic
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEOrgMaxTokenTTLPolicyDataSource_basic (0.00s)
=== RUN   TestAccTFEOrgMaxTokenTTLPolicyDataSource_withResource
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEOrgMaxTokenTTLPolicyDataSource_withResource (0.00s)
=== RUN   TestAccTFEVariableSetsDataSource_basic
--- PASS: TestAccTFEVariableSetsDataSource_basic (3.96s)
=== RUN   TestAccTFEVariableSetsDataSource_full
--- PASS: TestAccTFEVariableSetsDataSource_full (5.18s)
=== RUN   TestAccTFEVariableSetsDataSource_ProjectOwned
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEVariableSetsDataSource_ProjectOwned (0.00s)
=== RUN   TestAccTFEVariablesDataSource_basic
--- PASS: TestAccTFEVariablesDataSource_basic (4.37s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (3.78s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (4.05s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_prefixWildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_prefixWildcard (4.01s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_suffixWildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_suffixWildcard (3.98s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_noMatch
--- PASS: TestAccTFEWorkspaceIDsDataSource_noMatch (3.93s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_substringWildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_substringWildcard (3.90s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_tags
--- PASS: TestAccTFEWorkspaceIDsDataSource_tags (3.78s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_tagBindingFilters
--- PASS: TestAccTFEWorkspaceIDsDataSource_tagBindingFilters (11.19s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_searchByTagAndName
--- PASS: TestAccTFEWorkspaceIDsDataSource_searchByTagAndName (3.92s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_empty
--- PASS: TestAccTFEWorkspaceIDsDataSource_empty (0.48s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_namesEmpty
--- PASS: TestAccTFEWorkspaceIDsDataSource_namesEmpty (4.29s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_excludeTags
--- PASS: TestAccTFEWorkspaceIDsDataSource_excludeTags (4.16s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_sameTagInTagNamesAndExcludeTags
--- PASS: TestAccTFEWorkspaceIDsDataSource_sameTagInTagNamesAndExcludeTags (3.76s)
=== RUN   TestAccTFEWorkspaceRunTaskDataSource_basic
    helper_test.go:249: Skipping tests for Run Tasks. Set 'RUN_TASKS_URL' to enabled this tests.
--- SKIP: TestAccTFEWorkspaceRunTaskDataSource_basic (0.00s)
=== RUN   TestAccTFEWorkspaceDataSource_remoteStateConsumers
--- PASS: TestAccTFEWorkspaceDataSource_remoteStateConsumers (12.19s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (3.28s)
=== RUN   TestAccTFEWorkspaceDataSource_tagBindings
--- PASS: TestAccTFEWorkspaceDataSource_tagBindings (3.55s)
=== RUN   TestAccTFEWorkspaceDataSourceWithTriggerPatterns
--- PASS: TestAccTFEWorkspaceDataSourceWithTriggerPatterns (2.13s)
=== RUN   TestAccTFEWorkspaceDataSource_readAutoDestroyAt
    data_source_workspace_test.go:248: Step 2/2 error: Check failed: Check 1/2 error: data.tfe_workspace.foobar: Attribute 'auto_destroy_at' expected "2100-01-01T00:00:00Z", got ""
        Check 2/2 error: data.tfe_workspace.foobar: Attribute 'inherits_project_auto_destroy' expected "false", got "true"
--- FAIL: TestAccTFEWorkspaceDataSource_readAutoDestroyAt (4.87s)
=== RUN   TestAccTFEWorkspaceDataSource_readAutoDestroyDuration
    data_source_workspace_test.go:270: Step 2/2 error: Check failed: Check 1/2 error: data.tfe_workspace.foobar: Attribute 'auto_destroy_activity_duration' expected "1d", got ""
        Check 2/2 error: data.tfe_workspace.foobar: Attribute 'inherits_project_auto_destroy' expected "false", got "true"
--- FAIL: TestAccTFEWorkspaceDataSource_readAutoDestroyDuration (4.65s)
=== RUN   TestAccTFEWorkspaceDataSource_readProjectIDDefault
--- PASS: TestAccTFEWorkspaceDataSource_readProjectIDDefault (3.79s)
=== RUN   TestAccTFEWorkspaceDataSource_readProjectIDNonDefault
--- PASS: TestAccTFEWorkspaceDataSource_readProjectIDNonDefault (3.94s)
=== RUN   TestAccTFEWorkspaceDataSource_readHYOKEnabled
    helper_test.go:263: Skipping tests for HYOK. Set 'ENABLE_HYOK' to enable tests.
--- SKIP: TestAccTFEWorkspaceDataSource_readHYOKEnabled (0.00s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-tfe/internal/provider	369.029s
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
FAIL
```

### For the action:

```
% TF_ACC=1 go test ./internal/provider/... --run="QueryRun"

=== RUN   TestAccTFEQueryRun_WithExplicitConfigVersion
2026/07/02 15:58:26 [DEBUG] Configuring client for host "app.staging.terraform.io"
2026/07/02 15:58:26 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
--- PASS: TestAccTFEQueryRun_WithExplicitConfigVersion (33.88s)
=== RUN   TestAccTFEQueryRun_WaitForLatestConfiguration
--- PASS: TestAccTFEQueryRun_WaitForLatestConfiguration (32.94s)
=== RUN   TestAccTFEQueryRun_ValidationErrors
--- PASS: TestAccTFEQueryRun_ValidationErrors (22.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	89.993s
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]

```


## Rollback Plan

Reverting the PR is sufficient. 

## Changes to Security Controls

N/A
