### PR TITLE
Validate provider set scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 * **New Resource:** `r/tfe_tag_policy_set` and `r/tfe_tag_policy_set_exclusion`: Adds resources to manage tag-based inclusion and exclusion on policy sets. **NOTE:** This feature is currently in beta and is not available to all users. By @anubhav-goel [#2093](https://github.com/hashicorp/terraform-provider-tfe/pull/2093)
 
 BUG FIXES:
+* `r/tfe_provider_set`: Fix validation to reject provider sets when `global` is false or omitted and no project or workspace scopes are configured.
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
 
 

--- a/internal/provider/data_source_provider_set_test.go
+++ b/internal/provider/data_source_provider_set_test.go
@@ -280,7 +280,7 @@ resource "tfe_provider_set" "foobar" {
   description         = "Provider Set description"
   %s
   provider_source     = "registry.terraform.io/hashicorp/aws"
-  global              = false
+  global              = true
   provider_config_hcl = <<-EOT
 provider "aws" {
   region = "us-east-1"

--- a/internal/provider/resource_tfe_provider_set.go
+++ b/internal/provider/resource_tfe_provider_set.go
@@ -232,13 +232,9 @@ func modelFromTFEProviderSet(
 	return m, diags
 }
 
-// ModifyPlan is used to enforce that when global is updated from false to
-// true, workspace_ids and project_ids must be empty, since global provider
-// sets cannot have workspaces or projects attached. This is necessary
-// because the API will automatically detach all workspaces and projects when
-// a provider set is updated to global, which would be unexpected and
-// potentially destructive behavior for users if it were allowed to happen
-// implicitly.
+// ModifyPlan enforces that provider sets are either global or scoped to at
+// least one project or workspace. It also prevents implicitly detaching scopes
+// when a scoped provider set is updated to global.
 func (r *resourceTFEProviderSet) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		return
@@ -259,12 +255,27 @@ func (r *resourceTFEProviderSet) ModifyPlan(ctx context.Context, req resource.Mo
 		return
 	}
 
+	if plan.Global.IsUnknown() {
+		return
+	}
+
+	workspaceCount := plan.WorkspaceIDs.Length(plan.collectionLengthOptions())
+	projectCount := plan.ProjectIDs.Length(plan.collectionLengthOptions())
+
 	if !plan.Global.ValueBool() {
+		scopesUnknown := plan.WorkspaceIDs.IsUnknown() || plan.ProjectIDs.IsUnknown()
+		if !scopesUnknown && workspaceCount == 0 && projectCount == 0 {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("global"),
+				"Invalid Attribute Combination",
+				"global must be true unless workspace_ids or project_ids are set",
+			)
+		}
 		return
 	}
 
 	// Validate workspace_ids is not set
-	if plan.WorkspaceIDs.Length(plan.collectionLengthOptions()) > 0 {
+	if workspaceCount > 0 {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("workspace_ids"),
 			"Invalid Attribute Combination",
@@ -272,7 +283,7 @@ func (r *resourceTFEProviderSet) ModifyPlan(ctx context.Context, req resource.Mo
 		)
 	}
 	// Validate project_ids is not set
-	if plan.ProjectIDs.Length(plan.collectionLengthOptions()) > 0 {
+	if projectCount > 0 {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("project_ids"),
 			"Invalid Attribute Combination",

--- a/internal/provider/resource_tfe_provider_set_test.go
+++ b/internal/provider/resource_tfe_provider_set_test.go
@@ -73,10 +73,13 @@ func TestAccTFEProviderSet_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccTFEProviderSet_no_global_no_relationship(org.Name),
+				Config: testAccTFEProviderSet_basic_updated(org.Name),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"tfe_provider_set.foobar",
+							plancheck.ResourceActionUpdate,
+						),
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
@@ -95,42 +98,6 @@ func TestAccTFEProviderSet_basic(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"tfe_provider_set.foobar", "provider_config_hcl", "provider \"google\" {\n\tregion = \"us-central1\"\n}\n",
-					),
-					resource.TestCheckNoResourceAttr(
-						"tfe_provider_set.foobar", "provider_config_hcl_wo",
-					),
-					resource.TestCheckNoResourceAttr(
-						"tfe_provider_set.foobar", "provider_config_hcl_wo_version",
-					),
-					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "organization", org.Name,
-					),
-					resource.TestCheckNoResourceAttr(
-						"tfe_provider_set.foobar", "project_ids",
-					),
-					resource.TestCheckNoResourceAttr(
-						"tfe_provider_set.foobar", "workspace_ids",
-					),
-				),
-			},
-			{
-				Config: testAccTFEProviderSet_basic(org.Name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
-					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "name", "tst-terraform",
-					),
-					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "description", "Provider Set description",
-					),
-					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "global", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
-					),
-					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "provider_config_hcl", "provider \"aws\" {\n\tregion = \"us-east-1\"\n}\n",
 					),
 					resource.TestCheckNoResourceAttr(
 						"tfe_provider_set.foobar", "provider_config_hcl_wo",
@@ -258,70 +225,6 @@ func TestAccTFEProviderSet_global(
 	})
 }
 
-func TestAccTFEProviderSet_update_to_global_with_no_relationships(
-	t *testing.T,
-) {
-	skipUnlessBeta(t)
-	tfeClient, err := getClientUsingEnv()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
-		Name:  tfe.String("tst-" + randomString(t)),
-		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
-	})
-	defer orgCleanup()
-
-	providerSet := &tfe.ProviderSet{}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEProviderSet_no_global_no_relationship(org.Name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
-					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "global", "false",
-					),
-					resource.TestCheckNoResourceAttr(
-						"tfe_provider_set.foobar", "project_ids",
-					),
-					resource.TestCheckNoResourceAttr(
-						"tfe_provider_set.foobar", "workspace_ids",
-					),
-				),
-			},
-			{
-				Config: testAccTFEProviderSet_global(org.Name),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(
-							"tfe_provider_set.foobar",
-							plancheck.ResourceActionUpdate,
-						),
-					},
-				},
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEProviderSetExists("tfe_provider_set.foobar", providerSet),
-					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "global", "true",
-					),
-					resource.TestCheckNoResourceAttr(
-						"tfe_provider_set.foobar", "project_ids",
-					),
-					resource.TestCheckNoResourceAttr(
-						"tfe_provider_set.foobar", "workspace_ids",
-					),
-				),
-			},
-		},
-	})
-}
-
 func TestAccTFEProviderSet_minimal(t *testing.T) {
 	skipUnlessBeta(t)
 	tfeClient, err := getClientUsingEnv()
@@ -356,7 +259,7 @@ func TestAccTFEProviderSet_minimal(t *testing.T) {
 						"tfe_provider_set.foobar", "description", "",
 					),
 					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "global", "false",
+						"tfe_provider_set.foobar", "global", "true",
 					),
 					resource.TestCheckResourceAttr(
 						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
@@ -466,7 +369,7 @@ func TestAccTFEProviderSet_wo(t *testing.T) {
 						"tfe_provider_set.foobar", "description", "",
 					),
 					resource.TestCheckResourceAttr(
-						"tfe_provider_set.foobar", "global", "false",
+						"tfe_provider_set.foobar", "global", "true",
 					),
 					resource.TestCheckResourceAttr(
 						"tfe_provider_set.foobar", "provider_source", "registry.terraform.io/hashicorp/aws",
@@ -526,6 +429,10 @@ func TestAccTFEProviderSet_validation(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEProviderSet_no_global_no_relationship("my-org"),
+				ExpectError: regexp.MustCompile("global must be true unless workspace_ids or project_ids are set"),
+			},
 			{
 				Config:      testAccTFEProviderSet_conflict("workspace_ids", "ws-1234123412341234"),
 				ExpectError: regexp.MustCompile("workspace_ids cannot be set when global is true"),
@@ -758,27 +665,7 @@ EOT
 }`, organization)
 }
 
-func testAccTFEProviderSet_global(organization string) string {
-	return fmt.Sprintf(`
-locals {
-    organization_name = "%s"
-}
-
-resource "tfe_provider_set" "foobar" {
-  name                = "tst-terraform"
-  description         = "Provider Set description"
-  organization        = local.organization_name
-	provider_source     = "registry.terraform.io/hashicorp/aws"
-	global              = true
-	provider_config_hcl = <<-EOT
-provider "aws" {
-	region = "us-east-1"
-}
-EOT
-}`, organization)
-}
-
-func testAccTFEProviderSet_no_global_no_relationship(organization string) string {
+func testAccTFEProviderSet_basic_updated(organization string) string {
 	return fmt.Sprintf(`
 locals {
     organization_name = "%s"
@@ -805,6 +692,48 @@ provider "google" {
 	region = "us-central1"
 }
 EOT
+
+  project_ids =   [ tfe_project.foo.id ]
+  workspace_ids = [ tfe_workspace.foo.id ]
+}`, organization)
+}
+
+func testAccTFEProviderSet_global(organization string) string {
+	return fmt.Sprintf(`
+locals {
+    organization_name = "%s"
+}
+
+resource "tfe_provider_set" "foobar" {
+  name                = "tst-terraform"
+  description         = "Provider Set description"
+  organization        = local.organization_name
+	provider_source     = "registry.terraform.io/hashicorp/aws"
+	global              = true
+	provider_config_hcl = <<-EOT
+provider "aws" {
+	region = "us-east-1"
+}
+EOT
+}`, organization)
+}
+
+func testAccTFEProviderSet_no_global_no_relationship(organization string) string {
+	return fmt.Sprintf(`
+locals {
+    organization_name = "%s"
+}
+
+resource "tfe_provider_set" "foobar" {
+  name                = "tst-terraform-updated"
+  description         = "Provider Set description updated"
+  organization        = local.organization_name
+	provider_source     = "registry.terraform.io/hashicorp/google"
+	provider_config_hcl = <<-EOT
+provider "google" {
+	region = "us-central1"
+}
+EOT
 }`, organization)
 }
 
@@ -818,6 +747,7 @@ resource "tfe_provider_set" "foobar" {
 	%s
   name                = "tst-terraform"
 	provider_source     = "registry.terraform.io/hashicorp/aws"
+	global              = true
 	provider_config_hcl = <<-EOT
 provider "aws" {
 	region = "us-east-1"
@@ -832,6 +762,7 @@ resource "tfe_provider_set" "foobar" {
 	organization        = "my-org"
   name                = "tst-terraform"
 	provider_source     = "registry.terraform.io/hashicorp/aws"
+	global              = true
 }`
 }
 
@@ -847,6 +778,7 @@ resource "tfe_provider_set" "foobar" {
   name                           = "tst-terraform"
 	organization                   = local.organization_name
 	provider_source                = "registry.terraform.io/hashicorp/aws"
+	global                         = true
 	provider_config_hcl_wo_version = local.version
 	provider_config_hcl_wo         = <<-EOT
 provider "aws" {
@@ -882,6 +814,7 @@ resource "tfe_provider_set" "foobar" {
   name                           = local.name
 	organization                   = local.organization_name
 	provider_source                = "registry.terraform.io/hashicorp/aws"
+	global                         = true
 	provider_config_hcl = <<-EOT
 provider "aws" {
 	region = "us-east-1"
@@ -900,6 +833,7 @@ resource "tfe_provider_set" "foobar" {
   name                           = "provider-source-test"
 	organization                   = local.organization_name
 	provider_source                = local.provider_source
+	global                         = true
 	provider_config_hcl = <<-EOT
 provider "aws" {
 	region = "us-east-1"

--- a/internal/provider/resource_tfe_provider_set_test.go
+++ b/internal/provider/resource_tfe_provider_set_test.go
@@ -430,7 +430,7 @@ func TestAccTFEProviderSet_validation(t *testing.T) {
 		ProtoV6ProviderFactories: testAccMuxedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFEProviderSet_no_global_no_relationship("my-org"),
+				Config:      testAccTFEProviderSet_invalid_no_global_no_scopes("my-org"),
 				ExpectError: regexp.MustCompile("global must be true unless workspace_ids or project_ids are set"),
 			},
 			{

--- a/internal/provider/resource_tfe_provider_set_test.go
+++ b/internal/provider/resource_tfe_provider_set_test.go
@@ -718,7 +718,7 @@ EOT
 }`, organization)
 }
 
-func testAccTFEProviderSet_no_global_no_relationship(organization string) string {
+func testAccTFEProviderSet_invalid_no_global_no_scopes(organization string) string {
 	return fmt.Sprintf(`
 locals {
     organization_name = "%s"

--- a/website/docs/r/provider_set.html.markdown
+++ b/website/docs/r/provider_set.html.markdown
@@ -77,10 +77,10 @@ The following arguments are supported:
 * `name` - (Required) Name of the provider set.
 * `provider_source` - (Required) Source address of the provider, e.g. `registry.terraform.io/hashicorp/tfe`.
 * `description` - (Optional) Description of the provider set.
-* `global` - (Optional) Whether the provider set applies globally. Defaults to `false`.
+* `global` - (Optional) Whether the provider set applies globally. Defaults to `false`. When `global` is `false` or omitted, at least one of `workspace_ids` or `project_ids` must be set.
 * `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
-* `workspace_ids` - (Optional) IDs of the workspaces attached to the provider set. Cannot be set if `global` is `true`.
-* `project_ids` - (Optional) IDs of the projects attached to the provider set. Cannot be set if `global` is `true`.
+* `workspace_ids` - (Optional) IDs of the workspaces attached to the provider set. Required if `global` is `false` or omitted and `project_ids` is not set. Cannot be set if `global` is `true`.
+* `project_ids` - (Optional) IDs of the projects attached to the provider set. Required if `global` is `false` or omitted and `workspace_ids` is not set. Cannot be set if `global` is `true`.
 * `provider_config_hcl` - (Optional) Provider configuration HCL stored in Terraform state.
 * `provider_config_hcl_wo` - (Optional, [Write-Only](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments), Sensitive) Provider configuration HCL that is never stored in state. Cannot be used with `provider_config_hcl`.
 * `provider_config_hcl_wo_version` - (Optional) Version identifier required when `provider_config_hcl_wo` is set to trigger updates.


### PR DESCRIPTION
## Description

This updates `tfe_provider_set` validation so provider sets must either be global or scoped to at least one project or workspace.

Previously, a provider set could be planned with `global` omitted/defaulting to `false` and without `workspace_ids` or `project_ids`, which created an unusable provider set. This change adds plan-time validation to reject that configuration.

Changes included:

- Add `ModifyPlan` validation for non-global provider sets with no scopes.
- Keep existing validation that prevents `workspace_ids` or `project_ids` from being set when `global = true`.
- Add test coverage for the invalid no-scope provider set case.
- Update acceptance test fixtures that intentionally create no-scope provider sets to use `global = true`.
- Preserve valid update coverage for scoped provider sets.
- Update provider set documentation and changelog.

- [x] Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)
- [x] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)

## Testing plan

The main bug case is a provider set with `global` omitted/defaulting to `false` and no `workspace_ids` or `project_ids`.

Example invalid configuration:

```hcl
resource "tfe_provider_set" "ps" {
  name            = "demo"
  provider_source = "registry.terraform.io/hashicorp/aws"

  provider_config_hcl = <<EOT
provider "aws" {
  region = "us-east-1"
}
EOT
}
```

This should now fail validation because the provider set is neither global nor scoped to any project/workspace.

I also validated that a valid scoped provider set can still be created and updated.

## External links

N/A

## Output from acceptance tests

Local focused tests:

```sh
$ go test ./internal/provider -run '^TestAccTFEProviderSet_validation$' -count=1
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   0.588s

$ go test ./internal/provider -run '^TestAccTFEProviderSet_basic$' -count=1
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   1.917s

$ go test ./internal/provider -run '^TestAccTFEProviderSetDataSource_' -count=1
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   3.021s

$ go test ./internal/provider -run 'TestFrameworkProviderResources_includeProviderSet|TestTFEProviderSetNotImportableInPrepStub' -count=1
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   0.433s
```

Acceptance validation test:

```sh
$ TEST=./internal/provider TESTARGS='-run ^TestAccTFEProviderSet_validation$' ENABLE_BETA=1 make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test ./internal/provider -v -run ^TestAccTFEProviderSet_validation -timeout 15m
=== RUN   TestAccTFEProviderSet_validation
--- PASS: TestAccTFEProviderSet_validation (5.77s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   6.184s
```

Also validated the basic provider-set create/update acceptance path:

```text
$ TEST=./internal/provider TESTARGS='-run ^TestAccTFEProviderSet_basic$' ENABLE_BETA=1 make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test ./internal/provider -v -run ^TestAccTFEProviderSet_basic -timeout 15m
=== RUN   TestAccTFEProviderSet_basic
--- PASS: TestAccTFEProviderSet_basic (13.12s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   13.567s
```

## Rollback Plan

If this change needs to be rolled back, revert this PR. That would restore the previous provider set validation behavior.

## Changes to Security Controls

No changes to security controls.