### PR TITLE
Tf 38377 automated validation of descriptions for presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ site/
 
 # Docgen artifacts
 failure_info.json
+missing_descriptions.json

--- a/examples/error_exceptions.json
+++ b/examples/error_exceptions.json
@@ -1,5 +1,6 @@
 {
   "no_description_required": [
+    "provider/provider/."
   ],
   "no_example_required": [
     "ephemeral-resources/tfe_agent_token",

--- a/examples/error_exceptions.json
+++ b/examples/error_exceptions.json
@@ -1,4 +1,6 @@
 {
+  "no_description_required": [
+  ],
   "no_example_required": [
     "ephemeral-resources/tfe_agent_token",
     "ephemeral-resources/tfe_audit_trail_token",

--- a/scripts/validate-schema-descriptions.sh
+++ b/scripts/validate-schema-descriptions.sh
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 # Usage:
-#   ./scripts/validate-schema-descriptions.sh
+#   ./scripts/validate-schema-descriptions.sh [-o <json output file; ./missing_descriptions.json>] [-e <exceptions file; examples/error_exceptions.json>] [--help]
 #
 # Exit codes:
-#   0 - Complete success
-#   3 - Warning that unused execptions were found in error_execptions
-#   5 - Errors found regarding missing descriptions
-#   6 - Required commands (terraform, jq, go) not found
-#   7 - Provider directory not found or its schema could not be generated
+#  0 - Complete success
+#  1 - Generic errors (including command line args)
+#  3 - Warning: stale entries found in no_description_required
+#  5 - Errors found: one or more components, attributes, or blocks are missing descriptions
+#  6 - Required commands (terraform, jq, go) not found
+#  7 - Provider directory not found or its schema could not be generated
 
 
 # Crash on error
@@ -21,6 +22,44 @@ SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 PROVIDER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 EXCEPTIONS_FILE="${PROVIDER_DIR}/examples/error_exceptions.json"
 JSON_OUTPUT_NAME="missing_descriptions.json"
+
+# Arg parsing
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--output)
+            JSON_OUTPUT_NAME="$2"
+            shift 2
+            ;;
+        -e|--exceptions)
+            EXCEPTIONS_FILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Validates that every provider schema attribute and block has a non-empty description."
+            echo ""
+            echo "Options:"
+            echo "  -o, --output FILE        Output JSON file for failures (default: ./missing_descriptions.json)"
+            echo "  -e, --exceptions FILE    JSON file with description exceptions (default: examples/error_exceptions.json)"
+            echo "  -h, --help               Show this help message"
+            echo ""
+            echo "Exit Codes:"
+            echo "  0 - Complete success"
+            echo "  1 - Generic errors (including command line args)"
+            echo "  3 - Warning: stale entries found in no_description_required"
+            echo "  5 - Errors found: one or more components, attributes, or blocks are missing descriptions"
+            echo "  6 - Required commands (terraform, jq, go) not found"
+            echo "  7 - Provider directory not found or its schema could not be generated"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use -h or --help for usage information"
+            exit 1
+            ;;
+    esac
+done
 
 # Check dependencies
 # These can erroneously pass if the command name exists, but don't refer to the real tool
@@ -39,7 +78,14 @@ if ! command -v go >/dev/null 2>&1; then
     exit 6
 fi
 
-if [ ! -f "${EXCEPTIONS_FILE}" ]; then
+# Check if EXCEPTIONS_FILE exists and make it absolute, if provided via -e
+if [ "${EXCEPTIONS_FILE}" != "${PROVIDER_DIR}/examples/error_exceptions.json" ]; then
+    if [ ! -f "${EXCEPTIONS_FILE}" ]; then
+        echo "Error: Exceptions file does not exist: ${EXCEPTIONS_FILE}" >&2
+        exit 7
+    fi
+    EXCEPTIONS_FILE="$(cd "$(dirname "${EXCEPTIONS_FILE}")" && pwd)/$(basename "${EXCEPTIONS_FILE}")"
+elif [ ! -f "${EXCEPTIONS_FILE}" ]; then
     echo "Warning: error_exceptions.json not found at ${EXCEPTIONS_FILE}" >&2
     echo "Proceeding without exceptions..." >&2
 fi
@@ -49,9 +95,8 @@ echo "Generating provider schema..."
 TEMP_DIR=$(mktemp -d)
 PROVIDER_SCHEMA="${TEMP_DIR}/provider-schema.json"
 
-# Excit cleanup trap
+# Exit cleanup trap
 trap 'rm -rf "${TEMP_DIR}"' EXIT INT TERM
-
 
 # Build provider binary
 GOOS="${GOOS:-$(go env GOOS)}"

--- a/scripts/validate-schema-descriptions.sh
+++ b/scripts/validate-schema-descriptions.sh
@@ -229,7 +229,7 @@ RAW_MISSING=$(jq -r '
   | (
       # Check component-level description on the root block
       if ($root_block.description // "") == "" then
-        "\("MISSING_COMPONENT")\t\($schema_type)/\($resource_name)\t(component)"
+        "\("MISSING_COMPONENT")\t\($schema_type)/\($resource_name)\t."
       else empty
       end
     ),

--- a/scripts/validate-schema-descriptions.sh
+++ b/scripts/validate-schema-descriptions.sh
@@ -136,9 +136,6 @@ if ! jq -e '.provider_schemas["registry.terraform.io/hashicorp/tfe"]' "${PROVIDE
     exit 7
 fi
 
-
-
-
 # Load no_description_required list from exceptions file
 NO_DESCRIPTION_REQUIRED=()
 if [ -f "${EXCEPTIONS_FILE}" ]; then
@@ -215,6 +212,7 @@ RAW_MISSING=$(jq -r '
 
   .provider_schemas["registry.terraform.io/hashicorp/tfe"]
   | to_entries[]
+  | select(.key != "resource_identity_schemas")
   | .key as $schema_type
   | .value
   | (

--- a/scripts/validate-schema-descriptions.sh
+++ b/scripts/validate-schema-descriptions.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Copyright IBM Corp. 2018, 2026
+# SPDX-License-Identifier: MPL-2.0
+#
+# Usage:
+#   ./scripts/validate-schema-descriptions.sh
+#
+# Exit codes:
+#   0 - Complete success
+#   3 - Warning that unused execptions were found in error_execptions
+#   5 - Errors found regarding missing descriptions
+#   6 - Required commands (terraform, jq, go) not found
+#   7 - Provider directory not found or its schema could not be generated
+
+
+# Crash on error
+set -e
+
+# Variables with defaults
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+PROVIDER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+EXCEPTIONS_FILE="${PROVIDER_DIR}/examples/error_exceptions.json"
+JSON_OUTPUT_NAME="missing_descriptions.json"
+
+# Check dependencies
+# These can erroneously pass if the command name exists, but don't refer to the real tool
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq command not found. Please install jq for JSON processing." >&2
+    exit 6
+fi
+
+if ! command -v terraform >/dev/null 2>&1; then
+    echo "Error: terraform command not found. Please install Terraform." >&2
+    exit 6
+fi
+
+if ! command -v go >/dev/null 2>&1; then
+    echo "Error: go command not found. Please install Go." >&2
+    exit 6
+fi
+
+if [ ! -f "${EXCEPTIONS_FILE}" ]; then
+    echo "Warning: error_exceptions.json not found at ${EXCEPTIONS_FILE}" >&2
+    echo "Proceeding without exceptions..." >&2
+fi
+
+# Generate provider schema to temporary file
+echo "Generating provider schema..."
+TEMP_DIR=$(mktemp -d)
+PROVIDER_SCHEMA="${TEMP_DIR}/provider-schema.json"
+
+# Excit cleanup trap
+trap 'rm -rf "${TEMP_DIR}"' EXIT INT TERM
+
+
+# Build provider binary
+GOOS="${GOOS:-$(go env GOOS)}"
+GOARCH="${GOARCH:-$(go env GOARCH)}"
+if [ -z "${GOOS}" ] || [ -z "${GOARCH}" ]; then
+    echo "Error: could not determine GOOS/GOARCH from go env." >&2
+    exit 7
+fi
+OS_ARCH="${GOOS}_${GOARCH}"
+PLUGIN_DIR="${TEMP_DIR}/plugins/registry.terraform.io/hashicorp/tfe/0.0.1/${OS_ARCH}" # tfe version is somewhat arbitrary for our particular usage of terraform init; this is the same as in tfplugindocs
+mkdir -p "${PLUGIN_DIR}"
+PROVIDER_BINARY="${PLUGIN_DIR}/terraform-provider-tfe"
+if ! (cd "${PROVIDER_DIR}" && go build -o "${PROVIDER_BINARY}" 2>&1) >/dev/null; then
+    echo "Error: failed to build provider binary." >&2
+    exit 7
+fi
+
+# Create minimal provider configuration
+cat > "${TEMP_DIR}/provider.tf" <<EOF
+provider "tfe" {
+}
+EOF
+
+# Initialize and extract schema
+if ! (cd "${TEMP_DIR}" && terraform init -get=false -plugin-dir=./plugins >/dev/null 2>&1); then
+    echo "Error: terraform init failed for provider schema generation." >&2
+    exit 7
+fi
+if ! (cd "${TEMP_DIR}" && terraform providers schema -json > "${PROVIDER_SCHEMA}" 2>/dev/null); then
+    echo "Error: terraform providers schema failed." >&2
+    exit 7
+fi
+
+# Verify the schema file is valid JSON and contains the expected provider key
+if ! jq -e '.provider_schemas["registry.terraform.io/hashicorp/tfe"]' "${PROVIDER_SCHEMA}" >/dev/null 2>&1; then
+    echo "Error: provider schema is missing or invalid. The provider may not have been found." >&2
+    exit 7
+fi
+
+
+
+
+# Load no_description_required list from exceptions file
+NO_DESCRIPTION_REQUIRED=()
+if [ -f "${EXCEPTIONS_FILE}" ]; then
+    # Extract the no_description_required array
+    while IFS= read -r entry; do
+        NO_DESCRIPTION_REQUIRED+=("${entry}")
+    done < <(jq -r '.no_description_required[]? // empty' "${EXCEPTIONS_FILE}" 2>/dev/null)
+fi
+
+# Check if an attribute or block path is covered by any entry in no_description_required.
+# An entry can match at three levels of granularity:
+#   "schema_type/resource_name/attr.path"  - exact attribute or block path
+#   "schema_type/resource_name/"           - all root-level attributes and blocks only
+#                                            (trailing slash; does not match nested paths)
+#   "schema_type/resource_name"            - entire component (all paths, any depth)
+# 0 on true, 1 on false
+is_description_not_required() {
+    local resource_key="$1"   # schema_type/resource_name
+    local attr_path="$2"      # dot-separated path within the block
+
+    for entry in "${NO_DESCRIPTION_REQUIRED[@]}"; do
+        # Exact match: schema_type/resource_name/attr.path
+        if [ "${entry}" = "${resource_key}/${attr_path}" ]; then
+            return 0
+        fi
+        # Root-level only: schema_type/resource_name/ (trailing slash)
+        # Matches only when attr_path contains no dots (i.e. not a nested path)
+        if [ "${entry}" = "${resource_key}/" ] && [[ "${attr_path}" != *.* ]]; then
+            return 0
+        fi
+        # Entire component: schema_type/resource_name (no slash suffix)
+        if [ "${entry}" = "${resource_key}" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+echo "Validating schema descriptions for provider components..."
+echo ""
+
+# Recurse through and find issues
+# A description is only considered present if it is non-empty.
+# Three kinds are emitted: MISSING_COMPONENT, MISSING_BLOCK, MISSING_ATTR
+RAW_MISSING=$(jq -r '
+  def walk_block(prefix):
+    . as $b
+    | (
+        # Check block-level description (only for nested blocks, not the root block)
+        if prefix != "" and (($b.description // "") == "")
+        then { kind: "MISSING_BLOCK", path: prefix }
+        else empty
+        end
+      ),
+      (
+        # Check each attribute for a non-empty description
+        if $b | has("attributes") then
+          $b.attributes | to_entries[] |
+          select((.value.description // "") == "") |
+          { kind: "MISSING_ATTR", path: (if prefix == "" then .key else "\(prefix).\(.key)" end) }
+        else empty
+        end
+      ),
+      (
+        # Recurse into nested block_types
+        if $b | has("block_types") then
+          $b.block_types | to_entries[] |
+          .key as $bt_name |
+          .value.block | walk_block(if prefix == "" then $bt_name else "\(prefix).\($bt_name)" end)
+        else empty
+        end
+      )
+    ;
+
+  .provider_schemas["registry.terraform.io/hashicorp/tfe"]
+  | to_entries[]
+  | .key as $schema_type
+  | .value
+  | (
+      # provider is a single block directly at .block; all others are maps of resources
+      if $schema_type == "provider" then
+        [{ key: "provider", value: . }]
+      else
+        to_entries
+      end
+    )
+  | .[]
+  | .key as $resource_name
+  | .value.block as $root_block
+  | (
+      # Check component-level description on the root block
+      if ($root_block.description // "") == "" then
+        "\("MISSING_COMPONENT")\t\($schema_type)/\($resource_name)\t(component)"
+      else empty
+      end
+    ),
+    (
+      $root_block | walk_block("") |
+      "\(.kind)\t\($schema_type)/\($resource_name)\t\(.path)"
+    )
+' "${PROVIDER_SCHEMA}")
+
+# Apply exceptions to the raw missing list
+MISSING_DESCRIPTIONS=()
+UNEXPECTED_DESCRIPTIONS=()
+while IFS=$'\t' read -r kind resource_key attr_path; do
+    [ -z "${kind}" ] && continue
+    if ! is_description_not_required "${resource_key}" "${attr_path}"; then
+        MISSING_DESCRIPTIONS+=("${kind}"$'\t'"${resource_key}"$'\t'"${attr_path}")
+    fi
+done <<< "${RAW_MISSING}"
+
+# Detect unused exceptions
+for entry in "${NO_DESCRIPTION_REQUIRED[@]}"; do
+    stale=true
+    while IFS=$'\t' read -r _kind rk ap; do
+        [ -z "${_kind}" ] && continue
+        # Exact
+        [ "${entry}" = "${rk}/${ap}" ] && stale=false && break
+        # Root-level (trailing slash)
+        [ "${entry}" = "${rk}/" ] && [[ "${ap}" != *.* ]] && stale=false && break
+        # Whole component
+        [ "${entry}" = "${rk}" ] && stale=false && break
+    done <<< "${RAW_MISSING}"
+
+    if [ "${stale}" = true ]; then
+        UNEXPECTED_DESCRIPTIONS+=("${entry}: listed in no_description_required but description is now present")
+    fi
+done
+
+# Report unused exceptions
+# Separate so it's always present
+if [ ${#UNEXPECTED_DESCRIPTIONS[@]} -gt 0 ]; then
+    echo ""
+    echo "The following entries in no_description_required now have descriptions:"
+    echo ""
+    for unexpected in "${UNEXPECTED_DESCRIPTIONS[@]}"; do
+        echo "  - ${unexpected}"
+    done
+    echo ""
+    echo "Consider removing these entries from no_description_required in error_exceptions.json"
+    echo ""
+fi
+
+# Collapse into the standard exit codes and write JSON output should errors exist
+if [ ${#MISSING_DESCRIPTIONS[@]} -gt 0 ]; then
+    # Build a JSON object: { "schema_type/resource_name": { "attr.path": "MISSING_KIND", ... } }
+    json_output="{}"
+    for item in "${MISSING_DESCRIPTIONS[@]}"; do
+        IFS=$'\t' read -r kind resource_key attr_path <<< "${item}"
+        json_output=$(echo "${json_output}" | jq \
+            --arg rk "${resource_key}" \
+            --arg path "${attr_path}" \
+            --arg kind "${kind}" \
+            '.[$rk][$path] = $kind')
+    done
+    jq -S '.' <<< "${json_output}" > "${JSON_OUTPUT_NAME}"
+    echo "Validation errors found. See ${JSON_OUTPUT_NAME} for details."
+    exit 5
+elif [ ${#UNEXPECTED_DESCRIPTIONS[@]} -gt 0 ]; then
+    exit 3
+fi
+
+echo "All validations passed successfully."
+exit 0


### PR DESCRIPTION
## Description

Due to the large number of description fields that should exist in the provider and due to the relative ease by which an accident ignoring some description field occurs, there is merited some tool which guarantees (at minimum) non-empty presence of descriptions for all components in the provider. This PR provides that tool in the form of `validate-schema-descriptions.sh` and provides a mechanism to ignore specified empty description fields. 

This PR is structurally similar to #2116 

## Testing plan

A file is provided to guide and ease testing: [test-validate-schema-descriptions](https://gist.github.com/gbaker-ibm/a99571d8d4a634dfe285d1758839647d)

## Output from acceptance tests

From the provided file: 

```
========================================================
 validate-schema-descriptions.sh
========================================================

--- CASE 1: all descriptions present (exit 0) ---
  PASS: [all descriptions present] (exit 0)

--- CASE 2: top-level attribute description empty (exit 5) ---
  PASS: [missing attr description (empty)] (exit 5)

--- CASE 3: top-level attribute description key absent (exit 5) ---
  PASS: [missing attr description (key absent)] (exit 5)

--- CASE 4: nested block description missing (exit 5) ---
  PASS: [missing block description] (exit 5)

--- CASE 5: nested attribute description missing (exit 5) ---
  PASS: [missing nested attr description] (exit 5)

--- CASE 6: doubly-nested attribute description missing (exit 5) ---
  PASS: [missing doubly-nested attr description] (exit 5)

--- CASE 7: doubly-nested block description missing (exit 5) ---
  PASS: [missing doubly-nested block description] (exit 5)

--- CASE 8: component-level description missing (exit 5) ---
  PASS: [missing component description] (exit 5)

--- CASE 9: component-level description key absent (exit 5) ---
  PASS: [missing component description (key absent)] (exit 5)

--- CASE 10: missing description in data source (exit 5) ---
  PASS: [missing data source attr description] (exit 5)

--- CASE 11: missing description in ephemeral resource (exit 5) ---
  PASS: [missing ephemeral resource attr description] (exit 5)

--- CASE 12: missing description in provider block (exit 5) ---
  PASS: [missing provider attr description] (exit 5)

--- CASE 13: resource with empty block is clean (exit 0) ---
  PASS: [empty block resource is clean] (exit 0)

--- CASE 14: missing description in action schema (exit 5) ---
  PASS: [missing action schema attr description] (exit 5)

--- CASE 15: nesting_mode "single" — missing block description (exit 5) ---
  PASS: [missing single-nesting block description] (exit 5)

--- CASE 16: nesting_mode "single" — missing attribute description (exit 5) ---
  PASS: [missing single-nesting attr description] (exit 5)

--- CASE 17: nesting_mode "set" — missing attribute description (exit 5) ---
  PASS: [missing set-nesting attr description] (exit 5)

--- CASE 18: resource_identity_schemas not walked (exit 0) ---
  PASS: [resource_identity_schemas ignored cleanly] (exit 0)

--- CASE 19: exception suppresses a missing attribute (exit 0) ---
  PASS: [missing attr suppressed by exception] (exit 0)

--- CASE 20: exception suppresses a missing component description (exit 0) ---
  PASS: [missing component description suppressed by exception] (exit 0)

--- CASE 21: exception suppresses multiple missing items (exit 0) ---
  PASS: [multiple missing items suppressed] (exit 0)

--- CASE 22: exception suppresses a doubly-nested path (exit 0) ---
  PASS: [doubly-nested missing attr suppressed] (exit 0)

--- CASE 23: exception suppresses some but not all missing items (exit 5) ---
  PASS: [partial exception still fails] (exit 5)

--- CASE 24: whole-component exception suppresses all (exit 0) ---
  PASS: [whole-component exception suppresses all] (exit 0)

--- CASE 25: whole-component exception does not cover other sections (exit 5) ---
  PASS: [whole-component exception does not cover other sections] (exit 5)

--- CASE 26: whole-component exception is stale (exit 3) ---
  PASS: [whole-component exception is stale] (exit 3)

--- CASE 27: root-level exception does not suppress nested items (exit 5) ---
  PASS: [root-level exception does not suppress nested items] (exit 5)

--- CASE 28: root-level exception suppresses all root-level missing (exit 0) ---
  PASS: [root-level exception suppresses all root-level missing] (exit 0)

--- CASE 29: root-level exception is stale (exit 3) ---
  PASS: [root-level exception is stale] (exit 3)

--- CASE 30: root-level exception not stale with nested missing (exit 5) ---
  PASS: [root-level exception not stale with nested missing] (exit 5)

--- CASE 31: stale exception (exit 3) ---
  PASS: [stale exception] (exit 3)

--- CASE 32: real failure wins over stale exception (exit 5) ---
  PASS: [real failure wins over stale exception] (exit 5)

--- CASE 33: exception for non-existent resource is stale (exit 3) ---
  PASS: [non-existent resource exception is stale] (exit 3)

--- CASE 34: no_description_required key absent from exceptions file (exit 0) ---
  PASS: [missing key in exceptions file is safe] (exit 0)

--- CASE 35: schema file is invalid JSON (exit 7) ---
  PASS: [invalid schema JSON] (exit 7)

--- CASE 36: schema missing expected provider key (exit 7) ---
  PASS: [wrong provider key] (exit 7)

--- CASE 37: --help (exit 0) ---
  PASS: [--help] (exit 0)

--- CASE 38: unknown flag (exit 1) ---
  PASS: [unknown flag] (exit 1)

--- CASE 39: -o custom output filename (exit 5) ---
  PASS: [-o writes to custom path] (exit 5)
  PASS: custom output file is non-empty

--- CASE 40: -e loads exceptions from an alternate file (exit 0) ---
  PASS: [-e uses alternate exceptions file] (exit 0)

--- CASE 41: -e points to non-existent exceptions file (exit 7) ---
  PASS: [-e missing file] (exit 7)

========================================================
 Test run complete — 41 passed, 0 failed
========================================================
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

A rollback of the PR is sufficient. 

## Changes to Security Controls

N/A
