### PR TITLE
hyok_enabled should be a computed attr on workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+BREAKING CHANGES:
+* `r/tfe_workspace`: The `hyok_enabled` attribute was incorrectly marked as optional, instead of computed and read-only. This means that it could be set in the configuration, even though it would have no effect on the HCP Terraform workspace. This bug has been resolved, but will mean that any `tfe_workspace` which specifies `hyok_enabled` will see an error after upgrade, and will need to remove the attribute. By @JarrettSpiker [#2134](https://github.com/hashicorp/terraform-provider-tfe/pull/2134)
+
+BUG FIXES:
+* `r/tfe_workspace`: Fixed a provider bug where `hyok_enabled` was not being set as a computed read-only attribute, causing unreconcilable drift to occur when HYOK was enabled on a provider-managed workspace. By @JarrettSpiker [#2134](https://github.com/hashicorp/terraform-provider-tfe/pull/2134)
+
+
 ## v0.79.0
 
 FEATURES:
@@ -14,7 +21,6 @@ BUG FIXES:
 * `r/tfe_provider_set`: Fix validation to reject provider sets when `global` is false or omitted and no project or workspace scopes are configured.
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
 * Fixed a provider bug where a failed no-code module update could reference an uninitialized module ID [#2122](https://github.com/hashicorp/terraform-provider-tfe/pull/2122)
-* `r/tfe_workspace`: Fixed a provider bug where `hyok_enabled` was not being set as a computed read-only attribute, causing unreconcilable drift to occur when HYOK was enabled on a provider-managed workspace. By @JarrettSpiker [#2134](https://github.com/hashicorp/terraform-provider-tfe/pull/2134)
 
 ENHANCEMENTS:
 * `r/tfe_project_notification_configuration` and `r/tfe_team_notification_configuration`: update url attributes to be sensitive, by @kadenluang [#2120](https://github.com/hashicorp/terraform-provider-tfe/pull/2120)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ ENHANCEMENTS:
 BUG FIXES:
 * `r/tfe_provider_set`: Fix validation to reject provider sets when `global` is false or omitted and no project or workspace scopes are configured.
 * Removed two documentation files for resources that do not exist and that are not planned. By @brandonc [#2100](https://github.com/hashicorp/terraform-provider-tfe/pull/2100)
-* Fixed  a provider bug where a failed no-code module update could reference an uninitialized module ID [#2122](https://github.com/hashicorp/terraform-provider-tfe/pull/2122)
+* Fixed a provider bug where a failed no-code module update could reference an uninitialized module ID [#2122](https://github.com/hashicorp/terraform-provider-tfe/pull/2122)
+* `r/tfe_workspace`: Fixed a provider bug where `hyok_enabled` was not being set as a computed read-only attribute, causing unreconcilable drift to occur when HYOK was enabled on a provider-managed workspace. By @JarrettSpiker [#2134](https://github.com/hashicorp/terraform-provider-tfe/pull/2134)
 
 ENHANCEMENTS:
 * `r/tfe_project_notification_configuration` and `r/tfe_team_notification_configuration`: update url attributes to be sensitive, by @kadenluang [#2120](https://github.com/hashicorp/terraform-provider-tfe/pull/2120)

--- a/internal/provider/resource_tfe_workspace.go
+++ b/internal/provider/resource_tfe_workspace.go
@@ -415,7 +415,7 @@ func resourceTFEWorkspace() *schema.Resource {
 			},
 			"hyok_enabled": {
 				Type:        schema.TypeBool,
-				Optional:    true,
+				Computed:    true,
 				Description: "Whether HYOK (Hold Your Own Key) is enabled for the workspace. Available only in HCP Terraform.",
 			},
 		},

--- a/internal/provider/resource_tfe_workspace_test.go
+++ b/internal/provider/resource_tfe_workspace_test.go
@@ -2996,7 +2996,8 @@ func TestAccTFEWorkspace_HYOKEnabled(t *testing.T) {
 				Config: testAccTFEWorkspaceConfig(org.Name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("tfe_workspace.foobar", "organization", org.Name),
-					resource.TestCheckResourceAttrSet("tfe_workspace.foobar", "hyok_enabled"),
+					resource.TestCheckResourceAttr("tfe_workspace.foobar", "hyok_enabled", "false"),
+					// it is not feasible in tests to create a workspace with hyok_enabled=true, so we just check that the attribute is present and false
 				),
 			},
 		},

--- a/website/docs/cdktf/python/d/workspace.html.markdown
+++ b/website/docs/cdktf/python/d/workspace.html.markdown
@@ -53,7 +53,7 @@ In addition to all arguments above, the following attributes are exported:
 * `environment` - The environment of the workspace.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument). Cannot be true if `project_remote_state` is true.
-* `hyok_enabled` - (Optional) Whether HYOK is enabled for the workspace.
+* `hyok_enabled` - (Available only in HCP Terraform) Whether HYOK is enabled for the workspace.
 * `inherits_project_auto_destroy` - Indicates whether this workspace inherits project auto destroy settings.
 * `locked` - Indicates whether the workspace is locked.
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` or `project_remote_state` is set to `true`.

--- a/website/docs/cdktf/python/d/workspace.html.markdown
+++ b/website/docs/cdktf/python/d/workspace.html.markdown
@@ -53,7 +53,7 @@ In addition to all arguments above, the following attributes are exported:
 * `environment` - The environment of the workspace.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument). Cannot be true if `project_remote_state` is true.
-* `hyok_enabled` - (Available only in HCP Terraform) Whether HYOK is enabled for the workspace.
+* `hyok_enabled` - (Optional) Whether HYOK is enabled for the workspace.
 * `inherits_project_auto_destroy` - Indicates whether this workspace inherits project auto destroy settings.
 * `locked` - Indicates whether the workspace is locked.
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` or `project_remote_state` is set to `true`.

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -43,7 +43,7 @@ In addition to all arguments above, the following attributes are exported:
 * `environment` - The environment of the workspace.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `global_remote_state` - (Optional) Whether the workspace should allow all workspaces in the organization to access its state data during runs. If false, then only specifically approved workspaces can access its state (determined by the `remote_state_consumer_ids` argument). Cannot be true if `project_remote_state` is true.
-* `hyok_enabled` - (Optional) Whether HYOK is enabled for the workspace.
+* `hyok_enabled` - (Available only in HCP Terraform) Whether HYOK is enabled for the workspace.
 * `inherits_project_auto_destroy` - Indicates whether this workspace inherits project auto destroy settings.
 * `locked` - Indicates whether the workspace is locked.
 * `remote_state_consumer_ids` - (Optional) A set of workspace IDs that will be set as the remote state consumers for the given workspace. Cannot be used if `global_remote_state` or `project_remote_state` is set to `true`.


### PR DESCRIPTION
## Description

Fixes a bug where enabling HYOK on a provider-managed workspace causes drift to show up in runs. The intended flow for enabling HYOK (for the time being) is to create your workspace and then manually enable HYOK either though the UI or API. However, this would result in the next terraform run attempting to set hyok_enabled back to false...which is cannot do, because the provider does not actually try to modify that attribute.

It was meant to be computed (read-only), not optional. 

Currently it is not possible to enable HYOK using the provider. This is something we intend to tackle separately, using a different resource for HYOK enablement.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1. Test that `hyok_enabled` can no longer be set on the workspace resource
2. Test that drift doesn't occur when hyok is enabled on a workspace outside of the provider
3. Test that other resources can read the `tfe_workspace.whatever.hyok_enabled` attribute properly

## External links
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#request-body)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
❯ go test -test.fullpath=true -timeout 3000s -run ^TestAccTFEWorkspace_HYOKEnabled$ github.com/hashicorp/terraform-provider-tfe/internal/provider
ok  	github.com/hashicorp/terraform-provider-tfe/internal/provider	2.003s
...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan
We can revert the PR. The attribute already doesnt do anything

## Changes to Security Controls
None
-->
