### PR TITLE
Fix inconsistent sensitive token result for project notification config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ BREAKING CHANGES:
 
 BUG FIXES:
 * `r/tfe_workspace`: Fixed a provider bug where `hyok_enabled` was not being set as a computed read-only attribute, causing unreconcilable drift to occur when HYOK was enabled on a provider-managed workspace. By @JarrettSpiker [#2134](https://github.com/hashicorp/terraform-provider-tfe/pull/2134)
-
+* `r/tfe_project_notification_configuration`: Fix `Provider produced inconsistent result after apply` error on the sensitive `token` attribute when creating a configuration (such as `slack`) without a `token`. By @maed223 [#2140](https://github.com/hashicorp/terraform-provider-tfe/pull/2140)
+* `r/tfe_project_notification_configuration`: Fix `Provider produced inconsistent result after apply` errors on the `triggers`, `email_addresses`, and `email_user_ids` attributes when they are configured as an empty set (`[]`). By @maed223 [#2140](https://github.com/hashicorp/terraform-provider-tfe/pull/2140)
 
 ## v0.79.0
 

--- a/internal/provider/resource_tfe_project_notification_configuration.go
+++ b/internal/provider/resource_tfe_project_notification_configuration.go
@@ -73,6 +73,10 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 	}
 
 	if len(v.EmailAddresses) == 0 {
+		// email_addresses is optional and computed, so returning an empty set
+		// (rather than null) is accepted post-apply for both an explicit empty
+		// set and an omitted value. This differs from triggers, which is not
+		// computed and therefore must echo the exact planned value.
 		result.EmailAddresses = types.SetValueMust(types.StringType, []attr.Value{})
 	} else {
 		emailAddresses, diags := types.SetValueFrom(ctx, types.StringType, v.EmailAddresses)
@@ -96,6 +100,9 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 	}
 
 	if len(v.EmailUsers) == 0 {
+		// email_user_ids is optional and computed, so an empty set is accepted
+		// post-apply for both an explicit empty set and an omitted value (see
+		// the email_addresses note above).
 		result.EmailUserIDs = types.SetValueMust(types.StringType, []attr.Value{})
 	} else {
 		emailUserIDs := make([]attr.Value, len(v.EmailUsers))

--- a/internal/provider/resource_tfe_project_notification_configuration.go
+++ b/internal/provider/resource_tfe_project_notification_configuration.go
@@ -61,7 +61,7 @@ type modelTFEProjectNotificationConfiguration struct {
 
 // modelFromTFEProjectNotificationConfiguration builds a modelTFEProjectNotificationConfiguration
 // struct from a tfe.NotificationConfiguration value.
-func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfiguration, tokenWOVersion types.Int64, lastValue types.String) (*modelTFEProjectNotificationConfiguration, diag.Diagnostics) {
+func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfiguration, tokenWOVersion types.Int64, lastValue types.String, priorTriggers types.Set) (*modelTFEProjectNotificationConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	result := modelTFEProjectNotificationConfiguration{
 		ID:              types.StringValue(v.ID),
@@ -73,7 +73,7 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 	}
 
 	if len(v.EmailAddresses) == 0 {
-		result.EmailAddresses = types.SetNull(types.StringType)
+		result.EmailAddresses = types.SetValueMust(types.StringType, []attr.Value{})
 	} else {
 		emailAddresses, diags := types.SetValueFrom(ctx, types.StringType, v.EmailAddresses)
 		if diags != nil && diags.HasError() {
@@ -83,7 +83,10 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 	}
 
 	if len(v.Triggers) == 0 {
-		result.Triggers = types.SetNull(types.StringType)
+		// triggers is optional and not computed, so preserve the configured
+		// intent (an explicit empty set vs. null) to avoid an inconsistent
+		// result after apply.
+		result.Triggers = priorTriggers
 	} else {
 		triggers, diags := types.SetValueFrom(ctx, types.StringType, v.Triggers)
 		if diags != nil && diags.HasError() {
@@ -93,7 +96,7 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 	}
 
 	if len(v.EmailUsers) == 0 {
-		result.EmailUserIDs = types.SetNull(types.StringType)
+		result.EmailUserIDs = types.SetValueMust(types.StringType, []attr.Value{})
 	} else {
 		emailUserIDs := make([]attr.Value, len(v.EmailUsers))
 		for i, emailUser := range v.EmailUsers {
@@ -369,7 +372,7 @@ func (r *resourceTFEProjectNotificationConfiguration) Create(ctx context.Context
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue, plan.Triggers)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -401,7 +404,7 @@ func (r *resourceTFEProjectNotificationConfiguration) Read(ctx context.Context, 
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, state.TokenWOVersion, state.Token)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, state.TokenWOVersion, state.Token, state.Triggers)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -496,7 +499,7 @@ func (r *resourceTFEProjectNotificationConfiguration) Update(ctx context.Context
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue, plan.Triggers)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/resource_tfe_project_notification_configuration.go
+++ b/internal/provider/resource_tfe_project_notification_configuration.go
@@ -70,7 +70,6 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 		Enabled:         types.BoolValue(v.Enabled),
 		ProjectID:       types.StringValue(v.SubscribableChoice.Project.ID),
 		TokenWOVersion:  tokenWOVersion,
-		Token:           types.StringValue(""),
 	}
 
 	if len(v.EmailAddresses) == 0 {

--- a/internal/provider/resource_tfe_project_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_project_notification_configuration_test.go
@@ -195,6 +195,46 @@ func TestAccTFEProjectNotificationConfiguration_validateSchemaAttributesSlack(t 
 	})
 }
 
+func TestAccTFEProjectNotificationConfiguration_slack(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	notificationConfiguration := &tfe.NotificationConfiguration{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectNotificationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProjectNotificationConfiguration_slack(org.Name, project.ID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProjectNotificationConfigurationExists(
+						"tfe_project_notification_configuration.foobar", notificationConfiguration),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "destination_type", "slack"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "name", "notification_slack"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url", runTasksURL()),
+					resource.TestCheckNoResourceAttr(
+						"tfe_project_notification_configuration.foobar", "token"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckTFEProjectNotificationConfigurationExists(n string, notificationConfiguration *tfe.NotificationConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -373,6 +413,20 @@ resource "tfe_project_notification_configuration" "foobar" {
   enabled          = true
   token            = "1234567890_update"
   triggers         = ["change_request:created"]
+  url              = "%s"
+  project_id       = "%s"
+}`, orgName, runTasksURL(), projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_slack(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_slack"
+  destination_type = "slack"
   url              = "%s"
   project_id       = "%s"
 }`, orgName, runTasksURL(), projectID)

--- a/internal/provider/resource_tfe_project_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_project_notification_configuration_test.go
@@ -46,6 +46,8 @@ func TestAccTFEProjectNotificationConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_project_notification_configuration.foobar", "name", "notification_basic"),
 					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "token", "1234567890"),
+					resource.TestCheckResourceAttr(
 						"tfe_project_notification_configuration.foobar", "triggers.#", "0"),
 					resource.TestCheckResourceAttr(
 						"tfe_project_notification_configuration.foobar", "url", runTasksURL()),
@@ -127,6 +129,8 @@ func TestAccTFEProjectNotificationConfiguration_update(t *testing.T) {
 						"tfe_project_notification_configuration.foobar", "destination_type", "generic"),
 					resource.TestCheckResourceAttr(
 						"tfe_project_notification_configuration.foobar", "name", "notification_basic"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "token", "1234567890"),
 					resource.TestCheckResourceAttr(
 						"tfe_project_notification_configuration.foobar", "triggers.#", "0"),
 					resource.TestCheckResourceAttr(
@@ -275,10 +279,6 @@ func testAccCheckTFEProjectNotificationConfigurationAttributes(notificationConfi
 			return fmt.Errorf("bad enabled: %t", notificationConfiguration.Enabled)
 		}
 
-		if notificationConfiguration.Token != "1234567890" {
-			return fmt.Errorf("bad token: %s", notificationConfiguration.Token)
-		}
-
 		if len(notificationConfiguration.Triggers) != 0 {
 			return fmt.Errorf("bad triggers: %v", notificationConfiguration.Triggers)
 		}
@@ -331,15 +331,11 @@ func testAccCheckTFEProjectNotificationConfigurationAttributesUpdate(notificatio
 			return fmt.Errorf("bad enabled: %t", notificationConfiguration.Enabled)
 		}
 
-		if notificationConfiguration.Token != "1234567890_update" {
-			return fmt.Errorf("bad token: %s", notificationConfiguration.Token)
-		}
-
 		if len(notificationConfiguration.Triggers) != 1 {
 			return fmt.Errorf("bad triggers: %v", notificationConfiguration.Triggers)
 		}
 
-		if !reflect.DeepEqual(notificationConfiguration.Triggers, []string{"change_request:created"}) {
+		if !reflect.DeepEqual(notificationConfiguration.Triggers, []string{"run:applying"}) {
 			return fmt.Errorf("bad triggers: %v", notificationConfiguration.Triggers)
 		}
 
@@ -412,7 +408,7 @@ resource "tfe_project_notification_configuration" "foobar" {
   destination_type = "generic"
   enabled          = true
   token            = "1234567890_update"
-  triggers         = ["change_request:created"]
+  triggers         = ["run:applying"]
   url              = "%s"
   project_id       = "%s"
 }`, orgName, runTasksURL(), projectID)


### PR DESCRIPTION
## Description

`tfe_project_notification_configuration` without the `token` attribute provided fails during update:

```
Error: Provider produced inconsistent result after apply
When applying changes to tfe_project_notification_configuration.slack["prj-xuA7Y1sogoBLKHto"], provider "provider[\"registry.terraform.io/hashicorp/tfe\"]" produced an unexpected new value: .token: inconsistent values for sensitive attribute.

This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

`token` is optional and non-computed, so the post apply state value is required to equal the planned value (`null` when the user omits it). Previously the result defaulted to`types.StringValue("")`, so without a given token attribute the provider returns `""` while the plan shows `null`. The fix here is to remove the empty string default so the optional token defaults to null.

A set of fixes in the same vain went in for `triggers`, `email_addresses`, and `email_user_ids` attributes to properly handle empty/null cases which were surfaced by running the test suite locally. Previously they produced errors on apply.

## Testing

Added an integration test, also made some testing changes to get the existing tests passing (failures were hidden under `skipUnlessBeta`). The separate changes consist of:
1. Removing assertions of the token value against the read call, the API doesn't return the token value
2. Use a valid project trigger, previously used `change_request:created` which isn't valid for the project level.

## Output from acceptance tests
```
=== RUN   TestAccTFEProjectNotificationConfiguration_basic
--- PASS: TestAccTFEProjectNotificationConfiguration_basic (3.69s)
=== RUN   TestAccTFEProjectNotificationConfiguration_emailUserIDs
--- PASS: TestAccTFEProjectNotificationConfiguration_emailUserIDs (2.25s)
=== RUN   TestAccTFEProjectNotificationConfiguration_update
--- PASS: TestAccTFEProjectNotificationConfiguration_update (3.24s)
=== RUN   TestAccTFEProjectNotificationConfiguration_validateSchemaAttributesSlack
--- PASS: TestAccTFEProjectNotificationConfiguration_validateSchemaAttributesSlack (1.15s)
=== RUN   TestAccTFEProjectNotificationConfiguration_slack
--- PASS: TestAccTFEProjectNotificationConfiguration_slack (2.22s)
...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
