### PR TITLE
Add multi-region key support for AWS HYOK 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
 
 ENHANCEMENTS:
 * `r/tfe_registry_module`: The `vcs_repo` VCS connection (`identifier`, `oauth_token_id`, and `github_app_installation_id`) can now be updated in place instead of forcing resource recreation. By @hashimoon [#2124](https://github.com/hashicorp/terraform-provider-tfe/pull/2124)
+* `r/tfe_hyok_configuration`: Added multi-region key support for AWS HYOK. By @helenjw ([#2141](https://github.com/hashicorp/terraform-provider-tfe/pull/2141))
 
 ## v0.79.0
 

--- a/internal/provider/data_source_hyok_customer_key_version.go
+++ b/internal/provider/data_source_hyok_customer_key_version.go
@@ -6,12 +6,11 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"time"
 )
 
 var (
@@ -130,10 +129,16 @@ func modelFromTFEHYOKCustomerKeyVersion(id types.String, p models.HyokCustomerKe
 	}
 
 	model.Status = types.StringValue(attributes.GetStatus().String())
-	model.KeyVersion = types.StringValue(*attributes.GetKeyVersion())
-	model.Error = types.StringValue(*attributes.GetError())
 	model.WorkspacesSecured = types.Int64Value(int64(*attributes.GetWorkspacesSecured()))
 	model.CreatedAt = types.StringValue(attributes.GetCreatedAt().Format(time.RFC3339))
+
+	if attributes.GetKeyVersion() != nil {
+		model.KeyVersion = types.StringValue(*attributes.GetKeyVersion())
+	}
+
+	if attributes.GetError() != nil {
+		model.Error = types.StringValue(*attributes.GetError())
+	}
 
 	return model
 }

--- a/internal/provider/data_source_hyok_customer_key_version.go
+++ b/internal/provider/data_source_hyok_customer_key_version.go
@@ -6,10 +6,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"time"
 )
 
 var (
@@ -64,7 +66,7 @@ func (d *dataSourceHYOKCustomerKeyVersion) Schema(ctx context.Context, req datas
 				Required:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: "The status of the customer key version.",
+				Description: "The status of the HYOK customer key version.",
 				Computed:    true,
 			},
 			"error": schema.StringAttribute{
@@ -97,38 +99,41 @@ func (d *dataSourceHYOKCustomerKeyVersion) Read(ctx context.Context, req datasou
 	}
 
 	// Make API call to fetch the HYOK customer key version
-	keyVersionEnvelope, err := d.config.ClientV2.API.HyokCustomerKeyVersions().ByHyok_customer_key_version_id(data.ID.ValueString()).Get(ctx, nil)
+	id := data.ID.ValueString()
+	envelope, err := d.config.ClientV2.API.HyokCustomerKeyVersions().ByHyok_customer_key_version_id(id).Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read HYOK customer key version", err.Error())
 		return
 	}
 
-	keyVersion := keyVersionEnvelope.GetData()
-	if keyVersion == nil {
-		resp.Diagnostics.AddError("Unable to read HYOK customer key version", "The API response contained no key version data.")
-		return
-	}
-
-	var status, keyVersionNumber, errorMessage string
-	var createdAt time.Time
-	var workspacesSecured int64
-	if attributes := keyVersion.GetAttributes(); attributes != nil {
-		if s := attributes.GetStatus(); s != nil {
-			status = s.String()
-		}
-		keyVersionNumber = valueOrZero(attributes.GetKeyVersion())
-		createdAt = valueOrZero(attributes.GetCreatedAt())
-		workspacesSecured = int64(valueOrZero(attributes.GetWorkspacesSecured()))
-		errorMessage = valueOrZero(attributes.GetError())
-	}
-
 	// Set the computed attributes from the API response
-	data.Status = types.StringValue(status)
-	data.KeyVersion = types.StringValue(keyVersionNumber)
-	data.CreatedAt = types.StringValue(createdAt.Format(time.RFC3339))
-	data.WorkspacesSecured = types.Int64Value(workspacesSecured)
-	data.Error = types.StringValue(errorMessage)
+	result := modelFromTFEHYOKCustomerKeyVersion(data.ID, envelope)
 
 	// Save data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func modelFromTFEHYOKCustomerKeyVersion(id types.String, p models.HyokCustomerKeyVersionsEnvelopeable) HYOKCustomerKeyVersionDataSourceModel {
+	model := HYOKCustomerKeyVersionDataSourceModel{ID: id}
+
+	data := p.GetData()
+	if data == nil {
+		return model
+	}
+	if data.GetId() != nil {
+		model.ID = types.StringValue(*data.GetId())
+	}
+
+	attributes := data.GetAttributes()
+	if attributes == nil {
+		return model
+	}
+
+	model.Status = types.StringValue(attributes.GetStatus().String())
+	model.KeyVersion = types.StringValue(*attributes.GetKeyVersion())
+	model.Error = types.StringValue(*attributes.GetError())
+	model.WorkspacesSecured = types.Int64Value(int64(*attributes.GetWorkspacesSecured()))
+	model.CreatedAt = types.StringValue(attributes.GetCreatedAt().Format(time.RFC3339))
+
+	return model
 }

--- a/internal/provider/data_source_hyok_encrypted_data_key.go
+++ b/internal/provider/data_source_hyok_encrypted_data_key.go
@@ -6,10 +6,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"time"
 )
 
 var (
@@ -62,7 +64,7 @@ func (d *dataSourceHYOKEncryptedDataKey) Schema(ctx context.Context, req datasou
 				Required:    true,
 			},
 			"encrypted_dek": schema.StringAttribute{
-				Description: "The encrypted data encryption key (DEK) of the HYOK encrypted data key.",
+				Description: "The encrypted data encryption key of the HYOK encrypted data key.",
 				Computed:    true,
 			},
 			"customer_key_name": schema.StringAttribute{
@@ -86,32 +88,39 @@ func (d *dataSourceHYOKEncryptedDataKey) Read(ctx context.Context, req datasourc
 		return
 	}
 
-	// Make API call to fetch the HYOK customer key version
-	keyVersionEnvelope, err := d.config.ClientV2.API.HyokEncryptedDataKeys().ByHyok_encrypted_data_key_id(data.ID.ValueString()).Get(ctx, nil)
+	// Make API call to fetch the HYOK encrypted data key
+	id := data.ID.ValueString()
+	envelope, err := d.config.ClientV2.API.HyokEncryptedDataKeys().ByHyok_encrypted_data_key_id(id).Get(ctx, nil)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to read HYOK customer key version", err.Error())
+		resp.Diagnostics.AddError("Unable to read HYOK encrypted data key", err.Error())
 		return
-	}
-
-	keyVersion := keyVersionEnvelope.GetData()
-	if keyVersion == nil {
-		resp.Diagnostics.AddError("Unable to read HYOK customer key version", "The API response contained no encrypted data key data.")
-		return
-	}
-
-	var encryptedDEK, customerKeyName string
-	var createdAt time.Time
-	if attributes := keyVersion.GetAttributes(); attributes != nil {
-		encryptedDEK = valueOrZero(attributes.GetEncryptedDek())
-		customerKeyName = valueOrZero(attributes.GetCustomerKeyName())
-		createdAt = valueOrZero(attributes.GetCreatedAt())
 	}
 
 	// Set the computed attributes from the API response
-	data.EncryptedDEK = types.StringValue(encryptedDEK)
-	data.CustomerKeyName = types.StringValue(customerKeyName)
-	data.CreatedAt = types.StringValue(createdAt.Format(time.RFC3339))
+	result := modelFromTFEHYOKEncryptedDataKey(data.ID, envelope)
 
 	// Save data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
+
+func modelFromTFEHYOKEncryptedDataKey(id types.String, p models.HyokEncryptedDataKeysEnvelopeable) HYOKEncryptedDataKeyDataSourceModel {
+	model := HYOKEncryptedDataKeyDataSourceModel{ID: id}
+
+	data := p.GetData()
+	if data == nil {
+		return model
+	}
+
+	model.ID = types.StringValue(*data.GetId())
+
+	attributes := data.GetAttributes()
+	if attributes == nil {
+		return model
+	}
+
+	model.EncryptedDEK = types.StringValue(*attributes.GetEncryptedDek())
+	model.CustomerKeyName = types.StringValue(*attributes.GetCustomerKeyName())
+	model.CreatedAt = types.StringValue(attributes.GetCreatedAt().Format(time.RFC3339))
+
+	return model
 }

--- a/internal/provider/resource_tfe_hyok_configuration.go
+++ b/internal/provider/resource_tfe_hyok_configuration.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"strings"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfe "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -45,40 +47,10 @@ type modelTFEHYOKConfiguration struct {
 	Organization          types.String        `tfsdk:"organization"`
 }
 
-func (m *modelTFEHYOKConfiguration) TFEOIDCConfigurationTypeChoice() *tfe.OIDCConfigurationTypeChoice {
-	var typeChoice *tfe.OIDCConfigurationTypeChoice
-	id := m.OIDCConfigurationID.ValueString()
-
-	switch m.OIDCConfigurationType.ValueString() {
-	case OIDCConfigurationTypeAWS:
-		typeChoice = &tfe.OIDCConfigurationTypeChoice{AWSOIDCConfiguration: &tfe.AWSOIDCConfiguration{ID: id}}
-	case OIDCConfigurationTypeGCP:
-		typeChoice = &tfe.OIDCConfigurationTypeChoice{GCPOIDCConfiguration: &tfe.GCPOIDCConfiguration{ID: id}}
-	case OIDCConfigurationTypeVault:
-		typeChoice = &tfe.OIDCConfigurationTypeChoice{VaultOIDCConfiguration: &tfe.VaultOIDCConfiguration{ID: id}}
-	case OIDCConfigurationTypeAzure:
-		typeChoice = &tfe.OIDCConfigurationTypeChoice{AzureOIDCConfiguration: &tfe.AzureOIDCConfiguration{ID: id}}
-	}
-
-	return typeChoice
-}
-
 type modelTFEKMSOptions struct {
 	KeyRegion   types.String `tfsdk:"key_region"`
 	KeyLocation types.String `tfsdk:"key_location"`
 	KeyRingID   types.String `tfsdk:"key_ring_id"`
-}
-
-func (m *modelTFEKMSOptions) TFEKMSOptions() *tfe.KMSOptions {
-	var kmsOptions *tfe.KMSOptions
-	if m != nil {
-		kmsOptions = &tfe.KMSOptions{
-			KeyRegion:   m.KeyRegion.ValueString(),
-			KeyLocation: m.KeyLocation.ValueString(),
-			KeyRingID:   m.KeyRingID.ValueString(),
-		}
-	}
-	return kmsOptions
 }
 
 // List all available OIDC configuration types.
@@ -208,16 +180,10 @@ func (r *resourceTFEHYOKConfiguration) Create(ctx context.Context, req resource.
 		return
 	}
 
-	options := tfe.HYOKConfigurationsCreateOptions{
-		KEKID:             plan.KEKID.ValueString(),
-		Name:              plan.Name.ValueString(),
-		KMSOptions:        plan.KMSOptions.TFEKMSOptions(),
-		OIDCConfiguration: plan.TFEOIDCConfigurationTypeChoice(),
-		AgentPool:         &tfe.AgentPool{ID: plan.AgentPoolID.ValueString()},
-	}
+	options := hyokConfigurationEnvelopeFromModel(plan)
 
 	tflog.Debug(ctx, fmt.Sprintf("Create TFE HYOK Configuration for organization %s", orgName))
-	hyok, err := r.config.Client.HYOKConfigurations.Create(ctx, orgName, options)
+	hyok, err := r.config.ClientV2.API.Organizations().ByOrganization_name(orgName).HyokConfigurations().Post(ctx, options, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating TFE HYOK Configuration", err.Error())
 		return
@@ -236,15 +202,10 @@ func (r *resourceTFEHYOKConfiguration) Read(ctx context.Context, req resource.Re
 	}
 
 	hyokID := state.ID.ValueString()
-	opts := tfe.HYOKConfigurationsReadOptions{
-		Include: []tfe.HYOKConfigurationsIncludeOpt{
-			tfe.HYOKConfigurationsIncludeOIDCConfiguration,
-		},
-	}
 	tflog.Debug(ctx, fmt.Sprintf("Read HYOK configuration: %s", hyokID))
-	hyok, err := r.config.Client.HYOKConfigurations.Read(ctx, state.ID.ValueString(), &opts)
+	hyok, err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(state.ID.ValueString()).Get(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfe.ErrNotFound) {
 			tflog.Debug(ctx, fmt.Sprintf("HYOK configuration %s no longer exists", hyokID))
 			resp.State.RemoveResource(ctx)
 		} else {
@@ -270,16 +231,11 @@ func (r *resourceTFEHYOKConfiguration) Update(ctx context.Context, req resource.
 		return
 	}
 
-	options := tfe.HYOKConfigurationsUpdateOptions{
-		Name:       plan.Name.ValueStringPointer(),
-		KEKID:      plan.KEKID.ValueStringPointer(),
-		KMSOptions: plan.KMSOptions.TFEKMSOptions(),
-		AgentPool:  &tfe.AgentPool{ID: plan.AgentPoolID.ValueString()},
-	}
+	options := hyokConfigurationEnvelopeFromModel(plan)
 
 	hyokID := state.ID.ValueString()
 	tflog.Debug(ctx, fmt.Sprintf("Update TFE HYOK Configuration %s", hyokID))
-	hyok, err := r.config.Client.HYOKConfigurations.Update(ctx, hyokID, options)
+	hyok, err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(hyokID).Patch(ctx, options, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating TFE HYOK Configuration", err.Error())
 		return
@@ -299,9 +255,9 @@ func (r *resourceTFEHYOKConfiguration) Delete(ctx context.Context, req resource.
 
 	hyokID := state.ID.ValueString()
 	tflog.Debug(ctx, fmt.Sprintf("Delete TFE HYOK configuration: %s", hyokID))
-	err := r.config.Client.HYOKConfigurations.Delete(ctx, hyokID)
+	err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(hyokID).Delete(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfe.ErrNotFound) {
 			tflog.Debug(ctx, fmt.Sprintf("TFE HYOK configuration %s no longer exists", hyokID))
 			return
 		}
@@ -311,38 +267,137 @@ func (r *resourceTFEHYOKConfiguration) Delete(ctx context.Context, req resource.
 	}
 }
 
-func modelFromTFEHYOKConfiguration(p *tfe.HYOKConfiguration) modelTFEHYOKConfiguration {
-	var kmsOptions *modelTFEKMSOptions
-	if p.KMSOptions != nil {
-		kmsOptions = &modelTFEKMSOptions{
-			KeyRegion:   types.StringValue(p.KMSOptions.KeyRegion),
-			KeyLocation: types.StringValue(p.KMSOptions.KeyLocation),
-			KeyRingID:   types.StringValue(p.KMSOptions.KeyRingID),
+func hyokConfigurationEnvelopeFromModel(m modelTFEHYOKConfiguration) models.HyokConfigurationsEnvelopeable {
+	// Attributes
+	attributes := models.NewHyokConfigurations_attributes()
+	attributes.SetName(m.Name.ValueStringPointer())
+	attributes.SetKekId(m.KEKID.ValueStringPointer())
+	attributes.SetKmsOptions(v2KMSOptionsFromModel(m.KMSOptions))
+
+	// Relationships
+	relationships := models.NewHyokConfigurations_relationships()
+	relationships.SetAgentPool(v2AgentPoolRelationship(m.AgentPoolID.ValueString()))
+	relationships.SetOidcConfiguration(v2OIDCConfigurationRelationship(m.OIDCConfigurationID.ValueString(), m.OIDCConfigurationType.ValueString()))
+
+	hyokConfiguration := models.NewHyokConfigurations()
+	hyokConfiguration.SetAttributes(attributes)
+	hyokConfiguration.SetRelationships(relationships)
+
+	envelope := models.NewHyokConfigurationsEnvelope()
+	envelope.SetData(hyokConfiguration)
+	return envelope
+}
+
+func v2KMSOptionsFromModel(m *modelTFEKMSOptions) models.HyokConfigurations_attributes_kmsOptionsable {
+	if m == nil {
+		return nil
+	}
+
+	kmsOptions := models.NewHyokConfigurations_attributes_kmsOptions()
+	kmsOptions.SetKeyRegion(m.KeyRegion.ValueStringPointer())
+	kmsOptions.SetKeyLocation(m.KeyLocation.ValueStringPointer())
+	kmsOptions.SetKeyRingId(m.KeyRingID.ValueStringPointer())
+
+	return kmsOptions
+}
+
+func v2AgentPoolRelationship(agentPoolID string) models.AgentPoolsIdable {
+	agentPoolData := models.NewAgentPoolsId_data()
+	agentPoolData.SetId(&agentPoolID)
+	agentPoolType := models.AGENTPOOLS_AGENTPOOLSID_DATA_TYPE
+	agentPoolData.SetTypeEscaped(&agentPoolType)
+
+	agentPool := models.NewAgentPoolsId()
+	agentPool.SetData(agentPoolData)
+	return agentPool
+}
+
+func v2OIDCConfigurationRelationship(oidcConfigurationID, oidcConfigurationType string) models.OidcConfigurationsIdable {
+	oidcData := models.NewOidcConfigurationsId_data()
+	oidcData.SetId(&oidcConfigurationID)
+	oidcIdType := v2OIDCTypeFromResourceType(oidcConfigurationType)
+	oidcData.SetTypeEscaped(&oidcIdType)
+
+	oidc := models.NewOidcConfigurationsId()
+	oidc.SetData(oidcData)
+	return oidc
+}
+
+func v2OIDCTypeFromResourceType(oidcConfigurationType string) models.OidcConfigurationsId_data_type {
+	switch oidcConfigurationType {
+	case OIDCConfigurationTypeAWS:
+		return models.AWSOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
+	case OIDCConfigurationTypeGCP:
+		return models.GCPOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
+	case OIDCConfigurationTypeVault:
+		return models.VAULTOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
+	case OIDCConfigurationTypeAzure:
+		return models.AZUREOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
+	default:
+		return models.AWSOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
+	}
+}
+
+func resourceTypeFromV2OIDCType(t *models.OidcConfigurationsId_data_type) string {
+	if t == nil {
+		return ""
+	}
+
+	switch strings.TrimSpace(t.String()) {
+	case "aws-oidc-configurations":
+		return OIDCConfigurationTypeAWS
+	case "gcp-oidc-configurations":
+		return OIDCConfigurationTypeGCP
+	case "vault-oidc-configurations":
+		return OIDCConfigurationTypeVault
+	case "azure-oidc-configurations":
+		return OIDCConfigurationTypeAzure
+	default:
+		return ""
+	}
+}
+
+func modelFromTFEHYOKConfiguration(p models.HyokConfigurationsEnvelopeable) modelTFEHYOKConfiguration {
+	model := modelTFEHYOKConfiguration{}
+
+	data := p.GetData()
+	if data == nil {
+		return model
+	}
+
+	model.ID = types.StringValue(*data.GetId())
+
+	attributes := data.GetAttributes()
+	if attributes != nil {
+		model.Name = types.StringValue(*attributes.GetName())
+		model.KEKID = types.StringValue(*attributes.GetKekId())
+
+		if attributes.GetKmsOptions() != nil {
+			model.KMSOptions = &modelTFEKMSOptions{
+				KeyRegion:   types.StringValue(*attributes.GetKmsOptions().GetKeyRegion()),
+				KeyLocation: types.StringValue(*attributes.GetKmsOptions().GetKeyLocation()),
+				KeyRingID:   types.StringValue(*attributes.GetKmsOptions().GetKeyRingId()),
+			}
 		}
 	}
 
-	model := modelTFEHYOKConfiguration{
-		ID:           types.StringValue(p.ID),
-		Name:         types.StringValue(p.Name),
-		KEKID:        types.StringValue(p.KEKID),
-		Organization: types.StringValue(p.Organization.Name),
-		AgentPoolID:  types.StringValue(p.AgentPool.ID),
-		KMSOptions:   kmsOptions,
-	}
+	relationships := data.GetRelationships()
+	if relationships != nil {
+		organization := relationships.GetOrganization()
+		if organization != nil && organization.GetData() != nil {
+			model.Organization = types.StringValue(*organization.GetData().GetId())
+		}
 
-	switch {
-	case p.OIDCConfiguration.AWSOIDCConfiguration != nil:
-		model.OIDCConfigurationID = types.StringValue(p.OIDCConfiguration.AWSOIDCConfiguration.ID)
-		model.OIDCConfigurationType = types.StringValue(OIDCConfigurationTypeAWS)
-	case p.OIDCConfiguration.GCPOIDCConfiguration != nil:
-		model.OIDCConfigurationID = types.StringValue(p.OIDCConfiguration.GCPOIDCConfiguration.ID)
-		model.OIDCConfigurationType = types.StringValue(OIDCConfigurationTypeGCP)
-	case p.OIDCConfiguration.AzureOIDCConfiguration != nil:
-		model.OIDCConfigurationID = types.StringValue(p.OIDCConfiguration.AzureOIDCConfiguration.ID)
-		model.OIDCConfigurationType = types.StringValue(OIDCConfigurationTypeAzure)
-	case p.OIDCConfiguration.VaultOIDCConfiguration != nil:
-		model.OIDCConfigurationID = types.StringValue(p.OIDCConfiguration.VaultOIDCConfiguration.ID)
-		model.OIDCConfigurationType = types.StringValue(OIDCConfigurationTypeVault)
+		agentPool := relationships.GetAgentPool()
+		if agentPool != nil && agentPool.GetData() != nil {
+			model.AgentPoolID = types.StringValue(*agentPool.GetData().GetId())
+		}
+
+		oidc := relationships.GetOidcConfiguration()
+		if oidc != nil && oidc.GetData() != nil {
+			model.OIDCConfigurationID = types.StringValue(*oidc.GetData().GetId())
+			model.OIDCConfigurationType = types.StringValue(resourceTypeFromV2OIDCType(oidc.GetData().GetTypeEscaped()))
+		}
 	}
 
 	return model

--- a/internal/provider/resource_tfe_hyok_configuration.go
+++ b/internal/provider/resource_tfe_hyok_configuration.go
@@ -288,11 +288,22 @@ func hyokConfigurationEnvelopeFromModel(m modelTFEHYOKConfiguration) models.Hyok
 	attributes.SetName(m.Name.ValueStringPointer())
 	attributes.SetKekId(m.KEKID.ValueStringPointer())
 
-	kmsOptions := models.NewHyokConfigurations_attributes_kmsOptions()
-	kmsOptions.SetKeyRegion(m.KMSOptions.KeyRegion.ValueStringPointer())
-	kmsOptions.SetKeyLocation(m.KMSOptions.KeyLocation.ValueStringPointer())
-	kmsOptions.SetKeyRingId(m.KMSOptions.KeyRingID.ValueStringPointer())
-	attributes.SetKmsOptions(kmsOptions)
+	// Only send kms_options when the block is configured. Some KMS providers
+	// (e.g. Vault, Azure) have no kms_options, so the block is absent and must
+	// not be sent to the API to keep plan/state consistent.
+	if m.KMSOptions != nil {
+		kmsOptions := models.NewHyokConfigurations_attributes_kmsOptions()
+		if v := m.KMSOptions.KeyRegion.ValueString(); v != "" {
+			kmsOptions.SetKeyRegion(&v)
+		}
+		if v := m.KMSOptions.KeyLocation.ValueString(); v != "" {
+			kmsOptions.SetKeyLocation(&v)
+		}
+		if v := m.KMSOptions.KeyRingID.ValueString(); v != "" {
+			kmsOptions.SetKeyRingId(&v)
+		}
+		attributes.SetKmsOptions(kmsOptions)
+	}
 
 	// Relationships
 	relationships := models.NewHyokConfigurations_relationships()
@@ -347,11 +358,21 @@ func modelFromTFEHYOKConfiguration(p models.HyokConfigurationsEnvelopeable) mode
 		model.Name = types.StringValue(*attributes.GetName())
 		model.KEKID = types.StringValue(*attributes.GetKekId())
 
-		if attributes.GetKmsOptions() != nil {
+		// Only populate kms_options when the API returns it
+		if kms := attributes.GetKmsOptions(); kms != nil {
 			model.KMSOptions = &modelTFEKMSOptions{
-				KeyRegion:   types.StringValue(*attributes.GetKmsOptions().GetKeyRegion()),
-				KeyLocation: types.StringValue(*attributes.GetKmsOptions().GetKeyLocation()),
-				KeyRingID:   types.StringValue(*attributes.GetKmsOptions().GetKeyRingId()),
+				KeyRegion:   types.StringValue(""),
+				KeyLocation: types.StringValue(""),
+				KeyRingID:   types.StringValue(""),
+			}
+			if v := kms.GetKeyRegion(); v != nil {
+				model.KMSOptions.KeyRegion = types.StringValue(*v)
+			}
+			if v := kms.GetKeyLocation(); v != nil {
+				model.KMSOptions.KeyLocation = types.StringValue(*v)
+			}
+			if v := kms.GetKeyRingId(); v != nil {
+				model.KMSOptions.KeyRingID = types.StringValue(*v)
 			}
 		}
 	}

--- a/internal/provider/resource_tfe_hyok_configuration.go
+++ b/internal/provider/resource_tfe_hyok_configuration.go
@@ -272,7 +272,12 @@ func hyokConfigurationEnvelopeFromModel(m modelTFEHYOKConfiguration) models.Hyok
 	attributes := models.NewHyokConfigurations_attributes()
 	attributes.SetName(m.Name.ValueStringPointer())
 	attributes.SetKekId(m.KEKID.ValueStringPointer())
-	attributes.SetKmsOptions(v2KMSOptionsFromModel(m.KMSOptions))
+
+	kmsOptions := models.NewHyokConfigurations_attributes_kmsOptions()
+	kmsOptions.SetKeyRegion(m.KMSOptions.KeyRegion.ValueStringPointer())
+	kmsOptions.SetKeyLocation(m.KMSOptions.KeyLocation.ValueStringPointer())
+	kmsOptions.SetKeyRingId(m.KMSOptions.KeyRingID.ValueStringPointer())
+	attributes.SetKmsOptions(kmsOptions)
 
 	// Relationships
 	relationships := models.NewHyokConfigurations_relationships()
@@ -286,19 +291,6 @@ func hyokConfigurationEnvelopeFromModel(m modelTFEHYOKConfiguration) models.Hyok
 	envelope := models.NewHyokConfigurationsEnvelope()
 	envelope.SetData(hyokConfiguration)
 	return envelope
-}
-
-func v2KMSOptionsFromModel(m *modelTFEKMSOptions) models.HyokConfigurations_attributes_kmsOptionsable {
-	if m == nil {
-		return nil
-	}
-
-	kmsOptions := models.NewHyokConfigurations_attributes_kmsOptions()
-	kmsOptions.SetKeyRegion(m.KeyRegion.ValueStringPointer())
-	kmsOptions.SetKeyLocation(m.KeyLocation.ValueStringPointer())
-	kmsOptions.SetKeyRingId(m.KeyRingID.ValueStringPointer())
-
-	return kmsOptions
 }
 
 func v2AgentPoolRelationship(agentPoolID string) models.AgentPoolsIdable {

--- a/internal/provider/resource_tfe_hyok_configuration.go
+++ b/internal/provider/resource_tfe_hyok_configuration.go
@@ -308,26 +308,28 @@ func hyokConfigurationEnvelopeFromModel(m modelTFEHYOKConfiguration) models.Hyok
 	return envelope
 }
 
-func v2AgentPoolRelationship(agentPoolID string) models.AgentPoolsIdable {
-	agentPoolData := models.NewAgentPoolsId_data()
-	agentPoolData.SetId(&agentPoolID)
-	agentPoolType := models.AGENTPOOLS_AGENTPOOLSID_DATA_TYPE
-	agentPoolData.SetTypeEscaped(&agentPoolType)
+func v2AgentPoolRelationship(id string) models.AgentPoolsIdable {
+	agentPoolsIdData := models.NewAgentPoolsId_data()
 
-	agentPool := models.NewAgentPoolsId()
-	agentPool.SetData(agentPoolData)
-	return agentPool
+	agentPoolsIdData.SetId(&id)
+	agentPoolType := models.AGENTPOOLS_AGENTPOOLSID_DATA_TYPE
+	agentPoolsIdData.SetTypeEscaped(&agentPoolType)
+
+	agentPoolsId := models.NewAgentPoolsId()
+	agentPoolsId.SetData(agentPoolsIdData)
+	return agentPoolsId
 }
 
-func v2OIDCConfigurationRelationship(oidcConfigurationID, oidcConfigurationType string) models.OidcConfigurationsIdable {
-	oidcData := models.NewOidcConfigurationsId_data()
-	oidcData.SetId(&oidcConfigurationID)
-	oidcIdType := oidcTypeToIdDataType[oidcConfigurationType]
-	oidcData.SetTypeEscaped(&oidcIdType)
+func v2OIDCConfigurationRelationship(id, oidcConfigurationType string) models.OidcConfigurationsIdable {
+	oidcIdData := models.NewOidcConfigurationsId_data()
 
-	oidc := models.NewOidcConfigurationsId()
-	oidc.SetData(oidcData)
-	return oidc
+	oidcIdData.SetId(&id)
+	oidcIdType := oidcTypeToIdDataType[oidcConfigurationType]
+	oidcIdData.SetTypeEscaped(&oidcIdType)
+
+	oidcId := models.NewOidcConfigurationsId()
+	oidcId.SetData(oidcIdData)
+	return oidcId
 }
 
 func modelFromTFEHYOKConfiguration(p models.HyokConfigurationsEnvelopeable) modelTFEHYOKConfiguration {

--- a/internal/provider/resource_tfe_hyok_configuration.go
+++ b/internal/provider/resource_tfe_hyok_configuration.go
@@ -198,12 +198,12 @@ func (r *resourceTFEHYOKConfiguration) Create(ctx context.Context, req resource.
 	options := hyokConfigurationEnvelopeFromModel(plan)
 
 	tflog.Debug(ctx, fmt.Sprintf("Create TFE HYOK Configuration for organization %s", orgName))
-	hyok, err := r.config.ClientV2.API.Organizations().ByOrganization_name(orgName).HyokConfigurations().Post(ctx, options, nil)
+	envelope, err := r.config.ClientV2.API.Organizations().ByOrganization_name(orgName).HyokConfigurations().Post(ctx, options, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating TFE HYOK Configuration", err.Error())
 		return
 	}
-	result := modelFromTFEHYOKConfiguration(hyok)
+	result := modelFromTFEHYOKConfiguration(envelope)
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
@@ -216,22 +216,22 @@ func (r *resourceTFEHYOKConfiguration) Read(ctx context.Context, req resource.Re
 		return
 	}
 
-	hyokID := state.ID.ValueString()
-	tflog.Debug(ctx, fmt.Sprintf("Read HYOK configuration: %s", hyokID))
-	hyok, err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(state.ID.ValueString()).Get(ctx, nil)
+	id := state.ID.ValueString()
+	tflog.Debug(ctx, fmt.Sprintf("Read HYOK configuration: %s", id))
+	envelope, err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(state.ID.ValueString()).Get(ctx, nil)
 	if err != nil {
 		if errors.Is(err, tfe.ErrNotFound) {
-			tflog.Debug(ctx, fmt.Sprintf("HYOK configuration %s no longer exists", hyokID))
+			tflog.Debug(ctx, fmt.Sprintf("HYOK configuration %s no longer exists", id))
 			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
-				fmt.Sprintf("Error reading HYOK configuration %s", hyokID),
+				fmt.Sprintf("Error reading HYOK configuration %s", id),
 				err.Error(),
 			)
 		}
 		return
 	}
-	result := modelFromTFEHYOKConfiguration(hyok)
+	result := modelFromTFEHYOKConfiguration(envelope)
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
@@ -248,15 +248,15 @@ func (r *resourceTFEHYOKConfiguration) Update(ctx context.Context, req resource.
 
 	options := hyokConfigurationEnvelopeFromModel(plan)
 
-	hyokID := state.ID.ValueString()
-	tflog.Debug(ctx, fmt.Sprintf("Update TFE HYOK Configuration %s", hyokID))
-	hyok, err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(hyokID).Patch(ctx, options, nil)
+	id := state.ID.ValueString()
+	tflog.Debug(ctx, fmt.Sprintf("Update TFE HYOK Configuration %s", id))
+	envelope, err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(id).Patch(ctx, options, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating TFE HYOK Configuration", err.Error())
 		return
 	}
 
-	result := modelFromTFEHYOKConfiguration(hyok)
+	result := modelFromTFEHYOKConfiguration(envelope)
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
 
@@ -268,12 +268,12 @@ func (r *resourceTFEHYOKConfiguration) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	hyokID := state.ID.ValueString()
-	tflog.Debug(ctx, fmt.Sprintf("Delete TFE HYOK configuration: %s", hyokID))
-	err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(hyokID).Delete(ctx, nil)
+	id := state.ID.ValueString()
+	tflog.Debug(ctx, fmt.Sprintf("Delete TFE HYOK configuration: %s", id))
+	err := r.config.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(id).Delete(ctx, nil)
 	if err != nil {
 		if errors.Is(err, tfe.ErrNotFound) {
-			tflog.Debug(ctx, fmt.Sprintf("TFE HYOK configuration %s no longer exists", hyokID))
+			tflog.Debug(ctx, fmt.Sprintf("TFE HYOK configuration %s no longer exists", id))
 			return
 		}
 

--- a/internal/provider/resource_tfe_hyok_configuration.go
+++ b/internal/provider/resource_tfe_hyok_configuration.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"strings"
 
 	tfe "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/go-tfe/v2/api/models"
@@ -60,6 +59,22 @@ const (
 	OIDCConfigurationTypeVault string = "vault"
 	OIDCConfigurationTypeAzure string = "azure"
 )
+
+var (
+	oidcTypeToIdDataType = map[string]models.OidcConfigurationsId_data_type{
+		OIDCConfigurationTypeAWS:   models.AWSOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE,
+		OIDCConfigurationTypeGCP:   models.GCPOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE,
+		OIDCConfigurationTypeVault: models.VAULTOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE,
+		OIDCConfigurationTypeAzure: models.AZUREOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE,
+	}
+	idDataTypeToOidcType = make(map[models.OidcConfigurationsId_data_type]string, len(oidcTypeToIdDataType))
+)
+
+func init() {
+	for resourceType, idDataType := range oidcTypeToIdDataType {
+		idDataTypeToOidcType[idDataType] = resourceType
+	}
+}
 
 func (r *resourceTFEHYOKConfiguration) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
@@ -307,46 +322,12 @@ func v2AgentPoolRelationship(agentPoolID string) models.AgentPoolsIdable {
 func v2OIDCConfigurationRelationship(oidcConfigurationID, oidcConfigurationType string) models.OidcConfigurationsIdable {
 	oidcData := models.NewOidcConfigurationsId_data()
 	oidcData.SetId(&oidcConfigurationID)
-	oidcIdType := v2OIDCTypeFromResourceType(oidcConfigurationType)
+	oidcIdType := oidcTypeToIdDataType[oidcConfigurationType]
 	oidcData.SetTypeEscaped(&oidcIdType)
 
 	oidc := models.NewOidcConfigurationsId()
 	oidc.SetData(oidcData)
 	return oidc
-}
-
-func v2OIDCTypeFromResourceType(oidcConfigurationType string) models.OidcConfigurationsId_data_type {
-	switch oidcConfigurationType {
-	case OIDCConfigurationTypeAWS:
-		return models.AWSOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
-	case OIDCConfigurationTypeGCP:
-		return models.GCPOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
-	case OIDCConfigurationTypeVault:
-		return models.VAULTOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
-	case OIDCConfigurationTypeAzure:
-		return models.AZUREOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
-	default:
-		return models.AWSOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE
-	}
-}
-
-func resourceTypeFromV2OIDCType(t *models.OidcConfigurationsId_data_type) string {
-	if t == nil {
-		return ""
-	}
-
-	switch strings.TrimSpace(t.String()) {
-	case "aws-oidc-configurations":
-		return OIDCConfigurationTypeAWS
-	case "gcp-oidc-configurations":
-		return OIDCConfigurationTypeGCP
-	case "vault-oidc-configurations":
-		return OIDCConfigurationTypeVault
-	case "azure-oidc-configurations":
-		return OIDCConfigurationTypeAzure
-	default:
-		return ""
-	}
 }
 
 func modelFromTFEHYOKConfiguration(p models.HyokConfigurationsEnvelopeable) modelTFEHYOKConfiguration {
@@ -374,21 +355,27 @@ func modelFromTFEHYOKConfiguration(p models.HyokConfigurationsEnvelopeable) mode
 	}
 
 	relationships := data.GetRelationships()
-	if relationships != nil {
-		organization := relationships.GetOrganization()
-		if organization != nil && organization.GetData() != nil {
-			model.Organization = types.StringValue(*organization.GetData().GetId())
-		}
+	if relationships == nil {
+		return model
+	}
 
-		agentPool := relationships.GetAgentPool()
-		if agentPool != nil && agentPool.GetData() != nil {
-			model.AgentPoolID = types.StringValue(*agentPool.GetData().GetId())
-		}
+	organization := relationships.GetOrganization()
+	if organization != nil && organization.GetData() != nil {
+		model.Organization = types.StringValue(*organization.GetData().GetId())
+	}
 
-		oidc := relationships.GetOidcConfiguration()
-		if oidc != nil && oidc.GetData() != nil {
-			model.OIDCConfigurationID = types.StringValue(*oidc.GetData().GetId())
-			model.OIDCConfigurationType = types.StringValue(resourceTypeFromV2OIDCType(oidc.GetData().GetTypeEscaped()))
+	agentPool := relationships.GetAgentPool()
+	if agentPool != nil && agentPool.GetData() != nil {
+		model.AgentPoolID = types.StringValue(*agentPool.GetData().GetId())
+	}
+
+	oidc := relationships.GetOidcConfiguration()
+	if oidc != nil && oidc.GetData() != nil {
+		model.OIDCConfigurationID = types.StringValue(*oidc.GetData().GetId())
+
+		oidcType := oidc.GetData().GetTypeEscaped()
+		if oidcType != nil {
+			model.OIDCConfigurationType = types.StringValue(idDataTypeToOidcType[*oidcType])
 		}
 	}
 

--- a/internal/provider/resource_tfe_hyok_configuration.go
+++ b/internal/provider/resource_tfe_hyok_configuration.go
@@ -287,22 +287,8 @@ func hyokConfigurationEnvelopeFromModel(m modelTFEHYOKConfiguration) models.Hyok
 	attributes := models.NewHyokConfigurations_attributes()
 	attributes.SetName(m.Name.ValueStringPointer())
 	attributes.SetKekId(m.KEKID.ValueStringPointer())
-
-	// Only send kms_options when the block is configured. Some KMS providers
-	// (e.g. Vault, Azure) have no kms_options, so the block is absent and must
-	// not be sent to the API to keep plan/state consistent.
 	if m.KMSOptions != nil {
-		kmsOptions := models.NewHyokConfigurations_attributes_kmsOptions()
-		if v := m.KMSOptions.KeyRegion.ValueString(); v != "" {
-			kmsOptions.SetKeyRegion(&v)
-		}
-		if v := m.KMSOptions.KeyLocation.ValueString(); v != "" {
-			kmsOptions.SetKeyLocation(&v)
-		}
-		if v := m.KMSOptions.KeyRingID.ValueString(); v != "" {
-			kmsOptions.SetKeyRingId(&v)
-		}
-		attributes.SetKmsOptions(kmsOptions)
+		attributes.SetKmsOptions(v2KMSOptions(m.KMSOptions))
 	}
 
 	// Relationships
@@ -319,12 +305,32 @@ func hyokConfigurationEnvelopeFromModel(m modelTFEHYOKConfiguration) models.Hyok
 	return envelope
 }
 
+func v2KMSOptions(m *modelTFEKMSOptions) *models.HyokConfigurations_attributes_kmsOptions {
+	kmsOptionsAttributes := models.NewHyokConfigurations_attributes_kmsOptions()
+
+	if m == nil {
+		return nil
+	}
+
+	if v := m.KeyRegion.ValueString(); v != "" {
+		kmsOptionsAttributes.SetKeyRegion(&v)
+	}
+	if v := m.KeyLocation.ValueString(); v != "" {
+		kmsOptionsAttributes.SetKeyLocation(&v)
+	}
+	if v := m.KeyRingID.ValueString(); v != "" {
+		kmsOptionsAttributes.SetKeyRingId(&v)
+	}
+
+	return kmsOptionsAttributes
+}
+
 func v2AgentPoolRelationship(id string) models.AgentPoolsIdable {
 	agentPoolsIdData := models.NewAgentPoolsId_data()
 
 	agentPoolsIdData.SetId(&id)
-	agentPoolType := models.AGENTPOOLS_AGENTPOOLSID_DATA_TYPE
-	agentPoolsIdData.SetTypeEscaped(&agentPoolType)
+	//agentPoolType := models.AGENTPOOLS_AGENTPOOLSID_DATA_TYPE
+	//agentPoolsIdData.SetTypeEscaped(&agentPoolType)
 
 	agentPoolsId := models.NewAgentPoolsId()
 	agentPoolsId.SetData(agentPoolsIdData)
@@ -335,8 +341,8 @@ func v2OIDCConfigurationRelationship(id, oidcConfigurationType string) models.Oi
 	oidcIdData := models.NewOidcConfigurationsId_data()
 
 	oidcIdData.SetId(&id)
-	oidcIdType := oidcTypeToIdDataType[oidcConfigurationType]
-	oidcIdData.SetTypeEscaped(&oidcIdType)
+	//oidcIdType := oidcTypeToIdDataType[oidcConfigurationType]
+	//oidcIdData.SetTypeEscaped(&oidcIdType)
 
 	oidcId := models.NewOidcConfigurationsId()
 	oidcId.SetData(oidcIdData)
@@ -357,24 +363,7 @@ func modelFromTFEHYOKConfiguration(p models.HyokConfigurationsEnvelopeable) mode
 	if attributes != nil {
 		model.Name = types.StringValue(*attributes.GetName())
 		model.KEKID = types.StringValue(*attributes.GetKekId())
-
-		// Only populate kms_options when the API returns it
-		if kms := attributes.GetKmsOptions(); kms != nil {
-			model.KMSOptions = &modelTFEKMSOptions{
-				KeyRegion:   types.StringValue(""),
-				KeyLocation: types.StringValue(""),
-				KeyRingID:   types.StringValue(""),
-			}
-			if v := kms.GetKeyRegion(); v != nil {
-				model.KMSOptions.KeyRegion = types.StringValue(*v)
-			}
-			if v := kms.GetKeyLocation(); v != nil {
-				model.KMSOptions.KeyLocation = types.StringValue(*v)
-			}
-			if v := kms.GetKeyRingId(); v != nil {
-				model.KMSOptions.KeyRingID = types.StringValue(*v)
-			}
-		}
+		model.KMSOptions = tfeKMSOptions(attributes.GetKmsOptions())
 	}
 
 	relationships := data.GetRelationships()
@@ -403,4 +392,28 @@ func modelFromTFEHYOKConfiguration(p models.HyokConfigurationsEnvelopeable) mode
 	}
 
 	return model
+}
+
+func tfeKMSOptions(m models.HyokConfigurations_attributes_kmsOptionsable) *modelTFEKMSOptions {
+	if m == nil {
+		return nil
+	}
+
+	kmsOptions := &modelTFEKMSOptions{
+		KeyRegion:   types.StringValue(""),
+		KeyLocation: types.StringValue(""),
+		KeyRingID:   types.StringValue(""),
+	}
+
+	if v := m.GetKeyRegion(); v != nil {
+		kmsOptions.KeyRegion = types.StringValue(*v)
+	}
+	if v := m.GetKeyLocation(); v != nil {
+		kmsOptions.KeyLocation = types.StringValue(*v)
+	}
+	if v := m.GetKeyRingId(); v != nil {
+		kmsOptions.KeyRingID = types.StringValue(*v)
+	}
+
+	return kmsOptions
 }

--- a/internal/provider/resource_tfe_hyok_configuration.go
+++ b/internal/provider/resource_tfe_hyok_configuration.go
@@ -60,20 +60,11 @@ const (
 	OIDCConfigurationTypeAzure string = "azure"
 )
 
-var (
-	oidcTypeToIdDataType = map[string]models.OidcConfigurationsId_data_type{
-		OIDCConfigurationTypeAWS:   models.AWSOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE,
-		OIDCConfigurationTypeGCP:   models.GCPOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE,
-		OIDCConfigurationTypeVault: models.VAULTOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE,
-		OIDCConfigurationTypeAzure: models.AZUREOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE,
-	}
-	idDataTypeToOidcType = make(map[models.OidcConfigurationsId_data_type]string, len(oidcTypeToIdDataType))
-)
-
-func init() {
-	for resourceType, idDataType := range oidcTypeToIdDataType {
-		idDataTypeToOidcType[idDataType] = resourceType
-	}
+var idDataTypeToOidcConfigurationType = map[models.OidcConfigurationsId_data_type]string{
+	models.AWSOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE:   OIDCConfigurationTypeAWS,
+	models.GCPOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE:   OIDCConfigurationTypeGCP,
+	models.VAULTOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE: OIDCConfigurationTypeVault,
+	models.AZUREOIDCCONFIGURATIONS_OIDCCONFIGURATIONSID_DATA_TYPE: OIDCConfigurationTypeAzure,
 }
 
 func (r *resourceTFEHYOKConfiguration) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -294,7 +285,7 @@ func hyokConfigurationEnvelopeFromModel(m modelTFEHYOKConfiguration) models.Hyok
 	// Relationships
 	relationships := models.NewHyokConfigurations_relationships()
 	relationships.SetAgentPool(v2AgentPoolRelationship(m.AgentPoolID.ValueString()))
-	relationships.SetOidcConfiguration(v2OIDCConfigurationRelationship(m.OIDCConfigurationID.ValueString(), m.OIDCConfigurationType.ValueString()))
+	relationships.SetOidcConfiguration(v2OIDCConfigurationRelationship(m.OIDCConfigurationID.ValueString()))
 
 	hyokConfiguration := models.NewHyokConfigurations()
 	hyokConfiguration.SetAttributes(attributes)
@@ -327,25 +318,21 @@ func v2KMSOptions(m *modelTFEKMSOptions) *models.HyokConfigurations_attributes_k
 
 func v2AgentPoolRelationship(id string) models.AgentPoolsIdable {
 	agentPoolsIdData := models.NewAgentPoolsId_data()
-
 	agentPoolsIdData.SetId(&id)
-	//agentPoolType := models.AGENTPOOLS_AGENTPOOLSID_DATA_TYPE
-	//agentPoolsIdData.SetTypeEscaped(&agentPoolType)
 
 	agentPoolsId := models.NewAgentPoolsId()
 	agentPoolsId.SetData(agentPoolsIdData)
+
 	return agentPoolsId
 }
 
-func v2OIDCConfigurationRelationship(id, oidcConfigurationType string) models.OidcConfigurationsIdable {
+func v2OIDCConfigurationRelationship(id string) models.OidcConfigurationsIdable {
 	oidcIdData := models.NewOidcConfigurationsId_data()
-
 	oidcIdData.SetId(&id)
-	//oidcIdType := oidcTypeToIdDataType[oidcConfigurationType]
-	//oidcIdData.SetTypeEscaped(&oidcIdType)
 
 	oidcId := models.NewOidcConfigurationsId()
 	oidcId.SetData(oidcIdData)
+
 	return oidcId
 }
 
@@ -387,7 +374,7 @@ func modelFromTFEHYOKConfiguration(p models.HyokConfigurationsEnvelopeable) mode
 
 		oidcType := oidc.GetData().GetTypeEscaped()
 		if oidcType != nil {
-			model.OIDCConfigurationType = types.StringValue(idDataTypeToOidcType[*oidcType])
+			model.OIDCConfigurationType = types.StringValue(idDataTypeToOidcConfigurationType[*oidcType])
 		}
 	}
 

--- a/internal/provider/resource_tfe_hyok_configuration_test.go
+++ b/internal/provider/resource_tfe_hyok_configuration_test.go
@@ -29,7 +29,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 	org, orgCleanup := createPremiumOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
-	var state models.HyokConfigurationsEnvelopeable
+	var hyokConfigID string
 
 	// With AWS OIDC configuration
 	resource.Test(t, resource.TestCase{
@@ -39,7 +39,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEAWSHYOKConfigurationConfig(org.Name, "apple", "arn:aws:kms:us-east-1:123456789012:key/key1", "us-east-1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &hyokConfigID),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "apple"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -68,7 +68,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			},
 			// Delete - must first revoke configuration to avoid dangling resources
 			{
-				PreConfig: func() { revokeHYOKConfiguration(t, *state.GetData().GetId()) },
+				PreConfig: func() { revokeHYOKConfiguration(t, hyokConfigID) },
 				Config:    testAccTFEHYOKConfigurationDestroyConfig(org.Name),
 			},
 		},
@@ -82,7 +82,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEVaultHYOKConfigurationConfig(org.Name, "peach", "key1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &hyokConfigID),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "peach"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -109,7 +109,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			},
 			// Delete - must first revoke configuration to avoid dangling resources
 			{
-				PreConfig: func() { revokeHYOKConfiguration(t, *state.GetData().GetId()) },
+				PreConfig: func() { revokeHYOKConfiguration(t, hyokConfigID) },
 				Config:    testAccTFEHYOKConfigurationDestroyConfig(org.Name),
 			},
 		},
@@ -123,7 +123,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEGCPHYOKConfigurationConfig(org.Name, "cucumber", "key1", "global", "key-ring-1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &hyokConfigID),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "cucumber"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -143,7 +143,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEGCPHYOKConfigurationConfig(org.Name, "tomato", "key2", "global", "key-ring-2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &hyokConfigID),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "tomato"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -155,7 +155,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			},
 			// Delete - must first revoke configuration to avoid dangling resources
 			{
-				PreConfig: func() { revokeHYOKConfiguration(t, *state.GetData().GetId()) },
+				PreConfig: func() { revokeHYOKConfiguration(t, hyokConfigID) },
 				Config:    testAccTFEHYOKConfigurationDestroyConfig(org.Name),
 			},
 		},
@@ -169,7 +169,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEAzureHYOKConfigurationConfig(org.Name, "banana", "https://random.vault.azure.net/keys/key1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &hyokConfigID),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "banana"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -197,7 +197,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			},
 			// Delete - must first revoke configuration to avoid dangling resources
 			{
-				PreConfig: func() { revokeHYOKConfiguration(t, *state.GetData().GetId()) },
+				PreConfig: func() { revokeHYOKConfiguration(t, hyokConfigID) },
 				Config:    testAccTFEHYOKConfigurationDestroyConfig(org.Name),
 			},
 		},
@@ -268,7 +268,7 @@ func revokeHYOKConfiguration(t *testing.T, id string) {
 	}
 }
 
-func testAccCheckTFEHYOKConfigurationExists(n string, hyokConfig *models.HyokConfigurationsEnvelopeable) resource.TestCheckFunc {
+func testAccCheckTFEHYOKConfigurationExists(n string, hyokConfigID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -284,7 +284,11 @@ func testAccCheckTFEHYOKConfigurationExists(n string, hyokConfig *models.HyokCon
 			return err
 		}
 
-		*hyokConfig = result
+		if result.GetData() == nil || result.GetData().GetId() == nil {
+			return fmt.Errorf("no HYOK configuration ID returned for %s", rs.Primary.ID)
+		}
+
+		*hyokConfigID = *result.GetData().GetId()
 
 		return nil
 	}

--- a/internal/provider/resource_tfe_hyok_configuration_test.go
+++ b/internal/provider/resource_tfe_hyok_configuration_test.go
@@ -5,10 +5,17 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-tfe"
+	"testing"
+
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"testing"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+)
+
+const (
+	hyokConfigurationStatusTestFailed = "test_failed"
+	hyokConfigurationStatusRevoked    = "revoked"
 )
 
 func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
@@ -22,7 +29,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 	org, orgCleanup := createPremiumOrganization(t, tfeClient)
 	t.Cleanup(orgCleanup)
 
-	state := &tfe.HYOKConfiguration{}
+	var state models.HyokConfigurationsEnvelopeable
 
 	// With AWS OIDC configuration
 	resource.Test(t, resource.TestCase{
@@ -32,7 +39,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEAWSHYOKConfigurationConfig(org.Name, "apple", "arn:aws:kms:us-east-1:123456789012:key/key1", "us-east-1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "apple"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -61,7 +68,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			},
 			// Delete - must first revoke configuration to avoid dangling resources
 			{
-				PreConfig: func() { revokeHYOKConfiguration(t, state.ID) },
+				PreConfig: func() { revokeHYOKConfiguration(t, *state.GetData().GetId()) },
 				Config:    testAccTFEHYOKConfigurationDestroyConfig(org.Name),
 			},
 		},
@@ -75,7 +82,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEVaultHYOKConfigurationConfig(org.Name, "peach", "key1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "peach"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -102,7 +109,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			},
 			// Delete - must first revoke configuration to avoid dangling resources
 			{
-				PreConfig: func() { revokeHYOKConfiguration(t, state.ID) },
+				PreConfig: func() { revokeHYOKConfiguration(t, *state.GetData().GetId()) },
 				Config:    testAccTFEHYOKConfigurationDestroyConfig(org.Name),
 			},
 		},
@@ -116,7 +123,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEGCPHYOKConfigurationConfig(org.Name, "cucumber", "key1", "global", "key-ring-1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "cucumber"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -136,7 +143,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEGCPHYOKConfigurationConfig(org.Name, "tomato", "key2", "global", "key-ring-2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "tomato"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -148,7 +155,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			},
 			// Delete - must first revoke configuration to avoid dangling resources
 			{
-				PreConfig: func() { revokeHYOKConfiguration(t, state.ID) },
+				PreConfig: func() { revokeHYOKConfiguration(t, *state.GetData().GetId()) },
 				Config:    testAccTFEHYOKConfigurationDestroyConfig(org.Name),
 			},
 		},
@@ -162,7 +169,7 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			{
 				Config: testAccTFEAzureHYOKConfigurationConfig(org.Name, "banana", "https://random.vault.azure.net/keys/key1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", state),
+					testAccCheckTFEHYOKConfigurationExists("tfe_hyok_configuration.hyok", &state),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "id"),
 					resource.TestCheckResourceAttr("tfe_hyok_configuration.hyok", "name", "banana"),
 					resource.TestCheckResourceAttrSet("tfe_hyok_configuration.hyok", "oidc_configuration_id"),
@@ -190,23 +197,24 @@ func TestAccTFEHYOKConfiguration_basic(t *testing.T) {
 			},
 			// Delete - must first revoke configuration to avoid dangling resources
 			{
-				PreConfig: func() { revokeHYOKConfiguration(t, state.ID) },
+				PreConfig: func() { revokeHYOKConfiguration(t, *state.GetData().GetId()) },
 				Config:    testAccTFEHYOKConfigurationDestroyConfig(org.Name),
 			},
 		},
 	})
 }
 
-func waitForHYOKConfigurationStatus(t *testing.T, id string, status tfe.HYOKConfigurationStatus) error {
-	// Wait for configuration to be in the revoked status
+func waitForHYOKConfigurationStatus(t *testing.T, id string, status string) error {
+	// Wait for configuration to reach the given status
 	_, err := retryFn(10, 1, func() (any, error) {
-		hyok, err := testAccConfiguredClient.Client.HYOKConfigurations.Read(ctx, id, nil)
+		env, err := testAccConfiguredClient.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(id).Get(ctx, nil)
 		if err != nil {
 			t.Fatalf("failed to read HYOK configuration: %v", err)
 		}
 
-		if hyok.Status != status {
-			return nil, fmt.Errorf("expected HYOK configuration to be %s, got %s", status, hyok.Status)
+		current := hyokConfigurationStatusFromEnvelope(env)
+		if current != status {
+			return nil, fmt.Errorf("expected HYOK configuration to be %s, got %s", status, current)
 		}
 		return nil, nil
 	})
@@ -214,26 +222,53 @@ func waitForHYOKConfigurationStatus(t *testing.T, id string, status tfe.HYOKConf
 	return err
 }
 
+// hyokConfigurationStatusFromEnvelope extracts the status attribute from a v2
+// HYOK configuration envelope. The v2 model does not surface a typed status
+// field, so it is read from the untyped additional data map.
+func hyokConfigurationStatusFromEnvelope(env models.HyokConfigurationsEnvelopeable) string {
+	if env == nil || env.GetData() == nil {
+		return ""
+	}
+	attributes := env.GetData().GetAttributes()
+	if attributes == nil {
+		return ""
+	}
+	switch v := attributes.GetAdditionalData()["status"].(type) {
+	case string:
+		return v
+	case *string:
+		if v != nil {
+			return *v
+		}
+	}
+	return ""
+}
+
 func revokeHYOKConfiguration(t *testing.T, id string) {
 	// Wait for configuration to be in the test_failed status before revoking
-	err := waitForHYOKConfigurationStatus(t, id, tfe.HYOKConfigurationTestFailed)
+	err := waitForHYOKConfigurationStatus(t, id, hyokConfigurationStatusTestFailed)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = testAccConfiguredClient.Client.HYOKConfigurations.Revoke(ctx, id)
+	revokeConfig := &abstractions.RequestConfiguration[abstractions.DefaultQueryParameters]{
+		Headers: abstractions.NewRequestHeaders(),
+	}
+	revokeConfig.Headers.TryAdd("Content-Type", "application/vnd.api+json")
+
+	err = testAccConfiguredClient.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(id).Actions().Revoke().Post(ctx, revokeConfig)
 	if err != nil {
 		t.Fatalf("failed to revoke HYOK configuration: %v", err)
 	}
 
 	// Wait for configuration to be in the revoked status
-	err = waitForHYOKConfigurationStatus(t, id, tfe.HYOKConfigurationRevoked)
+	err = waitForHYOKConfigurationStatus(t, id, hyokConfigurationStatusRevoked)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func testAccCheckTFEHYOKConfigurationExists(n string, hyokConfig *tfe.HYOKConfiguration) resource.TestCheckFunc {
+func testAccCheckTFEHYOKConfigurationExists(n string, hyokConfig *models.HyokConfigurationsEnvelopeable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -244,12 +279,12 @@ func testAccCheckTFEHYOKConfigurationExists(n string, hyokConfig *tfe.HYOKConfig
 			return fmt.Errorf("no instance ID is set")
 		}
 
-		result, err := testAccConfiguredClient.Client.HYOKConfigurations.Read(ctx, rs.Primary.ID, nil)
+		result, err := testAccConfiguredClient.ClientV2.API.HyokConfigurations().ByHyok_configuration_id(rs.Primary.ID).Get(ctx, nil)
 		if err != nil {
 			return err
 		}
 
-		*hyokConfig = *result
+		*hyokConfig = result
 
 		return nil
 	}

--- a/website/docs/cdktf/java/r/hyok_configuration.html.markdown
+++ b/website/docs/cdktf/java/r/hyok_configuration.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported:
 
 The `kmsOptions` block is optional, and is used to specify additional fields for some key management services. Supported arguments are:
 * `keyRegion` - (Optional) The AWS region where your key is located.
+* `multiRegion` - (Optional) Boolean value to indicate AWS multi-region key.
 * `keyLocation` - (Optional) The location in which the GCP key ring exists.
 * `keyRingId` - (Optional) The root resource for Google Cloud KMS keys and key versions.
 


### PR DESCRIPTION
## Description

Support `multi_region` AWS KMS option on `tfe_hyok_configuration` resources.

_Remember to:_

- [x] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [x] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  Specify HYOK configurations using your Terraform configuration
2. For AWS, specify `multi_region = "true"`
3. See that plan and apply go through (and that the change is reflected in HCP Terraform) 

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
=== RUN   TestAccTFEHYOKConfiguration_basic
2026/07/16 13:49:26 [DEBUG] Configuring client for host "tfcdev-e8a60ea0.ngrok.app"
2026/07/16 13:49:26 [DEBUG] Service discovery for tfcdev-e8a60ea0.ngrok.app at https://tfcdev-e8a60ea0.ngrok.app/.well-known/terraform.json
--- PASS: TestAccTFEHYOKConfiguration_basic (49.57s)
PASS

=== RUN   TestAccTFEHYOKCustomerKeyVersionDataSource_basic
--- PASS: TestAccTFEHYOKCustomerKeyVersionDataSource_basic (2.58s)
PASS

=== RUN   TestAccTFEHYOKEncryptedDataKeyDataSource_basic
--- PASS: TestAccTFEHYOKEncryptedDataKeyDataSource_basic (2.80s)
PASS
```

<img width="745" height="275" alt="image" src="https://github.com/user-attachments/assets/f014142f-2dc2-416f-838f-e3beb9bde7d2" />


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
