### PR TITLE
Generate an additional token value `GITHUB_TOKEN1` for CI test run

### DIFF
--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -40,6 +40,9 @@ inputs:
   testing-github-token:
     description: The GitHub token used for testing scenarios
     required: false
+  testing-github-token-2:
+    description: A second GitHub token used for testing scenarios that require two distinct tokens (e.g. TestAccTFEOAuthClient_updateOAuthTokenID)
+    required: false
   enterprise:
     description: Test enterprise features (`hostname` must be running in ON_PREM mode)
     required: false
@@ -127,6 +130,7 @@ runs:
         GITHUB_WORKSPACE_IDENTIFIER: "svc-team-tf-core-cloud/terraform-random-module"
         GITHUB_WORKSPACE_BRANCH: "main"
         GITHUB_TOKEN: "${{ inputs.testing-github-token }}"
+        GITHUB_TOKEN2: "${{ inputs.testing-github-token-2 }}"
         MOD_PROVIDER: github.com/hashicorp/terraform-provider-tfe
         MOD_TFE: github.com/hashicorp/terraform-provider-tfe/internal/provider
         MOD_VERSION: github.com/hashicorp/terraform-provider-tfe/version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
+          testing-github-token-2: ${{ secrets.TESTING_GITHUB_TOKEN2 }}
           datadog-workflow-token: ${{ secrets.TF_WORKFLOW_DATADOG_API_KEY }}
           admin_configuration_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.configuration }}
           admin_provision_licenses_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.provision-licenses }}

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -45,6 +45,7 @@ jobs:
           hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
+          testing-github-token-2: ${{ secrets.TESTING_GITHUB_TOKEN2 }}
           enterprise: "1"
           # Skip SAML/SCIM here; they run serially in the singleton-tests job.
           skip: "TestAccTFESAML|TestAccTFESCIM"


### PR DESCRIPTION
## Description

`TestAccTFEOAuthClient_updateOAuthTokenID` requires a second GitHub token (`GITHUB_TOKEN2`) in addition to `GITHUB_TOKEN`. This token is used to validate that updating a `tfe_oauth_client`'s `oauth_token_id` from one token to a distinct second token works correctly. Because `GITHUB_TOKEN2` was never provided in CI, the test was always skipped (`t.Skip("Please set GITHUB_TOKEN2 to run this test")`).

This PR wires a second testing GitHub token through the CI setup so the test can run.

## Changes

- **`.github/actions/test-provider-tfe/action.yml`**
  - Added a new optional input `testing-github-token-2`.
  - Exported it as the `GITHUB_TOKEN2` env var in the "Run Tests" step (maps to `envGithubToken2` in the test suite).
- **`.github/workflows/ci.yml`**
  - Passed `testing-github-token-2: ${{ secrets.TESTING_GITHUB_TOKEN2 }}` to the composite action.
- **`.github/workflows/nightly-tfe-test.yml`**
  - Passed `testing-github-token-2: ${{ secrets.TESTING_GITHUB_TOKEN2 }}` to the `tests` job.

## Required setup (before merge)

A new repository/org secret **`TESTING_GITHUB_TOKEN2`** must be created, containing a GitHub PAT from a **different** account/token than `TESTING_GITHUB_TOKEN`. The two tokens must be distinct because the test updates the OAuth client from token 1 to token 2.

> Note: If the secret is absent, GitHub resolves it to an empty string and the test simply remains skipped so this change is safe to merge, but the test will only actually run once the secret exists.

## Testing

- CI will execute `TestAccTFEOAuthClient_updateOAuthTokenID` once `TESTING_GITHUB_TOKEN2` is configured (previously skipped).

## Related

- Test added in https://github.com/hashicorp/terraform-provider-tfe/pull/1631

_Remember to:_

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_
- [ ] _Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)_

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._
- [Related PR](https://hashicorp.atlassian.net/browse/TF-25096)

## Output from acceptance tests

_Please run applicable acceptance tests locally and include the output here. See [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md) to learn how to run acceptance tests._

_If you are an external contributor, your contribution(s) will first be reviewed before running them against the project's CI pipeline._

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
