### PR TITLE
ci: remove Datadog test visibility reporting (IOPS-1759)

### DIFF
--- a/.github/actions/test-provider-tfe/action.yml
+++ b/.github/actions/test-provider-tfe/action.yml
@@ -58,10 +58,6 @@ inputs:
     description: The mock run tasks URL to use for testing.
     required: false
     default: "http://testing-mocks.tfe:22180/runtasks/pass"
-  datadog-workflow-token:
-    description: Datadog API key for test optimization
-    required: false
-  
 
 runs:
   using: composite
@@ -101,13 +97,6 @@ runs:
         # When tests are split and run concurrently, lists_tests arg in ci.yml will skip the TestAccTFESAMLSettings_omnibus test suite
         list: ${{ inputs.list_tests }}
     
-    - name: Configure Datadog Test Optimization
-      uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
-      with:
-        languages: go
-        api_key: ${{ inputs.datadog-workflow-token }}
-        site: datadoghq.com 
-
     - name: Run Tests
       shell: bash
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
           testing-github-token-2: ${{ secrets.TESTING_GITHUB_TOKEN2 }}
-          datadog-workflow-token: ${{ secrets.TF_WORKFLOW_DATADOG_API_KEY }}
           admin_configuration_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.configuration }}
           admin_provision_licenses_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.provision-licenses }}
           admin_security_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.security-maintenance }}


### PR DESCRIPTION
## Description

Remove Datadog test visibility reporting from the CI pipeline. The `datadog/test-visibility-github-action` step was uploading JUnit XML test results to Datadog on every PR and push to main. Since we are moving off Datadog, this reporting is no longer needed.

Removed:
- `datadog-workflow-token` input from `.github/actions/test-provider-tfe/action.yml`
- `Configure Datadog Test Optimization` step from the composite action
- `datadog-workflow-token` secret passthrough from `.github/workflows/ci.yml`

The `TF_WORKFLOW_DATADOG_API_KEY` repository secret can also be deleted from GitHub repo settings as a follow-up cleanup.

- [ ] _Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)_

## Testing plan

1. Merge this PR
1. Verify that CI runs complete without any Datadog test visibility steps
1. Confirm no JUnit XML uploads appear in Datadog UI after the next CI run

## External links

- [JIRA: IOPS-1759](https://hashicorp.atlassian.net/browse/IOPS-1759)

## Output from acceptance tests

No acceptance tests required — CI workflow-only change with no provider code modifications.

## Rollback Plan

If a change needs to be reverted, re-add the `Configure Datadog Test Optimization` step and `datadog-workflow-token` input to the composite action, and restore the secret passthrough in `ci.yml`.

## Changes to Security Controls

Removes the passthrough of the `TF_WORKFLOW_DATADOG_API_KEY` secret from CI, reducing the secret surface area exposed in GitHub Actions workflows.