### PR TITLE
feat: write only URL support for r/tfe_project_notification_configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 BREAKING CHANGES:
 * `r/tfe_workspace`: The `hyok_enabled` attribute was incorrectly marked as optional, instead of computed and read-only. This means that it could be set in the configuration, even though it would have no effect on the HCP Terraform workspace. This bug has been resolved, but will mean that any `tfe_workspace` which specifies `hyok_enabled` will see an error after upgrade, and will need to remove the attribute. By @JarrettSpiker [#2134](https://github.com/hashicorp/terraform-provider-tfe/pull/2134)
 
+ENHANCEMENTS:
+* `r/tfe_project_notification_configuration`: Add `url_wo` and `url_wo_version` attribute support. By @Maed223 [#2150](https://github.com/hashicorp/terraform-provider-tfe/pull/2150)
+
 BUG FIXES:
 * `r/tfe_workspace`: Fixed a provider bug where `hyok_enabled` was not being set as a computed read-only attribute, causing unreconcilable drift to occur when HYOK was enabled on a provider-managed workspace. By @JarrettSpiker [#2134](https://github.com/hashicorp/terraform-provider-tfe/pull/2134)
 * `r/tfe_project_notification_configuration`: Fix `Provider produced inconsistent result after apply` error on the sensitive `token` attribute when creating a configuration (such as `slack`) without a `token`. By @maed223 [#2140](https://github.com/hashicorp/terraform-provider-tfe/pull/2140)

--- a/internal/provider/resource_tfe_project_notification_configuration.go
+++ b/internal/provider/resource_tfe_project_notification_configuration.go
@@ -1,10 +1,12 @@
-// Copyright IBM Corp. 2018, 2025
+// Copyright IBM Corp. 2018, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -30,6 +33,7 @@ import (
 var _ resource.Resource = &resourceTFEProjectNotificationConfiguration{}
 var _ resource.ResourceWithConfigure = &resourceTFEProjectNotificationConfiguration{}
 var _ resource.ResourceWithImportState = &resourceTFEProjectNotificationConfiguration{}
+var _ resource.ResourceWithModifyPlan = &resourceTFEProjectNotificationConfiguration{}
 
 func NewProjectNotificationConfigurationResource() resource.Resource {
 	return &resourceTFEProjectNotificationConfiguration{}
@@ -56,12 +60,14 @@ type modelTFEProjectNotificationConfiguration struct {
 	TokenWOVersion  types.Int64  `tfsdk:"token_wo_version"`
 	Triggers        types.Set    `tfsdk:"triggers"`
 	URL             types.String `tfsdk:"url"`
+	URLWO           types.String `tfsdk:"url_wo"`
+	URLWOVersion    types.Int64  `tfsdk:"url_wo_version"`
 	ProjectID       types.String `tfsdk:"project_id"`
 }
 
 // modelFromTFEProjectNotificationConfiguration builds a modelTFEProjectNotificationConfiguration
 // struct from a tfe.NotificationConfiguration value.
-func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfiguration, tokenWOVersion types.Int64, lastValue types.String, priorTriggers types.Set) (*modelTFEProjectNotificationConfiguration, diag.Diagnostics) {
+func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfiguration, tokenWOVersion types.Int64, urlWOVersion types.Int64, lastValue types.String, priorTriggers types.Set) (*modelTFEProjectNotificationConfiguration, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	result := modelTFEProjectNotificationConfiguration{
 		ID:              types.StringValue(v.ID),
@@ -70,6 +76,7 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 		Enabled:         types.BoolValue(v.Enabled),
 		ProjectID:       types.StringValue(v.SubscribableChoice.Project.ID),
 		TokenWOVersion:  tokenWOVersion,
+		URLWOVersion:    urlWOVersion,
 	}
 
 	if len(v.EmailAddresses) == 0 {
@@ -120,7 +127,10 @@ func modelFromTFEProjectNotificationConfiguration(v *tfe.NotificationConfigurati
 		result.Token = types.StringNull()
 	}
 
-	if v.URL != "" {
+	isURLWriteOnly := !urlWOVersion.IsNull()
+	if isURLWriteOnly {
+		result.URL = types.StringNull()
+	} else if v.URL != "" {
 		result.URL = types.StringValue(v.URL)
 	}
 
@@ -272,13 +282,14 @@ func (r *resourceTFEProjectNotificationConfiguration) Schema(ctx context.Context
 			},
 
 			"url": schema.StringAttribute{
-				Description: "The HTTP or HTTPS URL where notification requests will be made. This value must not be provided if `email_addresses` or `email_user_ids` is present, or if `destination_type` is `email`.",
+				Description: "The HTTP or HTTPS URL where notification requests will be made. This value must not be provided if `email_addresses` or `email_user_ids` is present, or if `destination_type` is `email`. Use `url_wo` instead to prevent the URL from being stored in state.",
 				Optional:    true,
 				Sensitive:   true,
 				Validators: []validator.String{
-					validators.AttributeRequiredIfValueString(
+					validators.AttributeRequiredIfValueStringUnlessOtherSet(
 						"destination_type",
 						[]string{"generic", "microsoft-teams", "slack"},
+						"url_wo",
 					),
 					validators.AttributeValueConflictValidator(
 						"destination_type",
@@ -287,7 +298,44 @@ func (r *resourceTFEProjectNotificationConfiguration) Schema(ctx context.Context
 					stringvalidator.ConflictsWith(
 						path.MatchRelative().AtParent().AtName("email_addresses"),
 						path.MatchRelative().AtParent().AtName("email_user_ids"),
+						path.MatchRelative().AtParent().AtName("url_wo"),
 					),
+				},
+			},
+
+			"url_wo": schema.StringAttribute{
+				Description: "Write-only alternative to `url`. The HTTP or HTTPS URL where notification requests will be made. Use this instead of `url` to prevent the URL from being stored in state. Changes are detected automatically via a hash stored in private state; increment `url_wo_version` manually to force an update without changing the value.",
+				Optional:    true,
+				WriteOnly:   true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					validators.AttributeRequiredIfValueStringUnlessOtherSet(
+						"destination_type",
+						[]string{"generic", "microsoft-teams", "slack"},
+						"url",
+					),
+					validators.AttributeValueConflictValidator(
+						"destination_type",
+						[]string{"email"},
+					),
+					stringvalidator.ConflictsWith(
+						path.MatchRelative().AtParent().AtName("email_addresses"),
+						path.MatchRelative().AtParent().AtName("email_user_ids"),
+						path.MatchRelative().AtParent().AtName("url"),
+					),
+				},
+			},
+
+			"url_wo_version": schema.Int64Attribute{
+				Description: "Tracks the version of the write-only URL. When `url_wo` is set and this attribute is not explicitly configured, the provider automatically detects URL changes via a hash stored in private state and increments this value. Set this manually to force a URL update without changing the value, or for maximum privacy (disables hash storage).",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.Int64{
+					int64validator.ConflictsWith(path.MatchRoot("url")),
+					int64validator.AlsoRequires(path.MatchRoot("url_wo")),
 				},
 			},
 
@@ -336,6 +384,11 @@ func (r *resourceTFEProjectNotificationConfiguration) Create(ctx context.Context
 		lastTokenValue = plan.Token
 	}
 
+	// Set URL from `url_wo` if set, otherwise use the normal value
+	if !config.URLWO.IsNull() {
+		options.URL = config.URLWO.ValueStringPointer()
+	}
+
 	// Add triggers set to the options struct
 	var triggers []types.String
 	if diags := plan.Triggers.ElementsAs(ctx, &triggers, true); diags != nil && diags.HasError() {
@@ -379,11 +432,15 @@ func (r *resourceTFEProjectNotificationConfiguration) Create(ctx context.Context
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue, plan.Triggers)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, plan.URLWOVersion, lastTokenValue, plan.Triggers)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
+
+	// Store hashes in private state for auto change detection
+	storeWOHash(ctx, resp.Private, "token_wo_hash", config.TokenWO, &resp.Diagnostics)
+	storeWOHash(ctx, resp.Private, "url_wo_hash", config.URLWO, &resp.Diagnostics)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
@@ -411,7 +468,7 @@ func (r *resourceTFEProjectNotificationConfiguration) Read(ctx context.Context, 
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, state.TokenWOVersion, state.Token, state.Triggers)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, state.TokenWOVersion, state.URLWOVersion, state.Token, state.Triggers)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -463,6 +520,11 @@ func (r *resourceTFEProjectNotificationConfiguration) Update(ctx context.Context
 		}
 	}
 
+	// check is needed to prevent accidentally unsetting the URL when no changes to url or url_wo were made
+	if u := r.determineURLForUpdate(plan, state, config); u != nil {
+		options.URL = u
+	}
+
 	// Add triggers set to the options struct
 	triggers := make([]types.String, len(plan.Triggers.Elements()))
 	if diags := plan.Triggers.ElementsAs(ctx, &triggers, true); diags != nil && diags.HasError() {
@@ -506,11 +568,15 @@ func (r *resourceTFEProjectNotificationConfiguration) Update(ctx context.Context
 		return
 	}
 
-	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, lastTokenValue, plan.Triggers)
+	result, diags := modelFromTFEProjectNotificationConfiguration(pnc, config.TokenWOVersion, plan.URLWOVersion, lastTokenValue, plan.Triggers)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
+
+	// Update hashes in private state for auto change detection
+	storeWOHash(ctx, resp.Private, "token_wo_hash", config.TokenWO, &resp.Diagnostics)
+	storeWOHash(ctx, resp.Private, "url_wo_hash", config.URLWO, &resp.Diagnostics)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
@@ -536,6 +602,127 @@ func (r *resourceTFEProjectNotificationConfiguration) Delete(ctx context.Context
 
 func (r *resourceTFEProjectNotificationConfiguration) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+}
+
+// ModifyPlan implements resource.ResourceWithModifyPlan. It auto-manages token_wo_version
+// and url_wo_version by hashing the write-only values and incrementing the version when
+// the hash changes, unless the version is explicitly set in config (manual mode).
+// It also blocks switching from a write-only attribute to its plaintext equivalent, which
+// would expose a previously secret value in state.
+func (r *resourceTFEProjectNotificationConfiguration) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Skip on destroy
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Block write-only → plaintext transitions on existing resources
+	if !req.State.Raw.IsNull() {
+		blockWOToPlaintextTransition(ctx, req, resp, "token_wo_version", "token")
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		blockWOToPlaintextTransition(ctx, req, resp, "url_wo_version", "url")
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	r.modifyPlanWOVersion(ctx, req, resp, "token_wo", "token_wo_version", "token_wo_hash")
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.modifyPlanWOVersion(ctx, req, resp, "url_wo", "url_wo_version", "url_wo_hash")
+}
+
+// modifyPlanWOVersion manages the auto-detection version for a write-only attribute.
+// If the version attribute is explicitly set in config (manual mode), no auto-detection is performed.
+func (r *resourceTFEProjectNotificationConfiguration) modifyPlanWOVersion(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+	woAttr, versionAttr, hashKey string,
+) {
+	// If version is explicitly set in config, use manual mode — skip auto-detection
+	var configVersion types.Int64
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root(versionAttr), &configVersion)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !configVersion.IsNull() {
+		return
+	}
+
+	// Get write-only value from config
+	var woValue types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root(woAttr), &woValue)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if woValue.IsNull() || woValue.IsUnknown() {
+		// Write-only value not set — clear the version
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(versionAttr), types.Int64Null())...)
+		return
+	}
+
+	newHash := computeWOHash(woValue.ValueString())
+
+	// On create (no prior state), set initial version to 1
+	if req.State.Raw.IsNull() {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(versionAttr), types.Int64Value(1))...)
+		return
+	}
+
+	// On update: compare new hash against stored hash in private state
+	storedHashBytes, diags := req.Private.GetKey(ctx, hashKey)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var storedHash string
+	if storedHashBytes != nil {
+		if err := json.Unmarshal(storedHashBytes, &storedHash); err != nil {
+			resp.Diagnostics.AddError("Failed to decode "+woAttr+" hash", err.Error())
+			return
+		}
+	}
+
+	if !bytes.Equal([]byte(newHash), []byte(storedHash)) {
+		// Hash changed — increment version
+		var stateVersion types.Int64
+		resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root(versionAttr), &stateVersion)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		currentVersion := int64(0)
+		if !stateVersion.IsNull() && !stateVersion.IsUnknown() {
+			currentVersion = stateVersion.ValueInt64()
+		}
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root(versionAttr), types.Int64Value(currentVersion+1))...)
+	}
+}
+
+// determineURLForUpdate is invoked only after terraform determines that an attribute update is needed.
+// It prevents accidentally unsetting the URL when changes to other attributes trigger an update.
+// Returns nil if no URL update is needed.
+func (r *resourceTFEProjectNotificationConfiguration) determineURLForUpdate(plan, state, config modelTFEProjectNotificationConfiguration) *string {
+	usingWriteOnlyInPlan := !plan.URLWOVersion.IsNull()
+	usingWriteOnlyInState := !state.URLWOVersion.IsNull()
+
+	// Case 1: Switching FROM url TO url_wo
+	if !usingWriteOnlyInState && usingWriteOnlyInPlan && !config.URLWO.IsNull() {
+		return config.URLWO.ValueStringPointer()
+	}
+	// Case 2: url_wo version changed in plan (auto-detected hash change or manual increment)
+	if usingWriteOnlyInPlan && plan.URLWOVersion.ValueInt64() != state.URLWOVersion.ValueInt64() && !config.URLWO.IsNull() {
+		return config.URLWO.ValueStringPointer()
+	}
+	// Case 3: Regular url changed
+	if state.URL.ValueString() != plan.URL.ValueString() {
+		return plan.URL.ValueStringPointer()
+	}
+	return nil
 }
 
 // determineTokenForUpdate is invoked only after terraform determines that an attribute update is needed.

--- a/internal/provider/resource_tfe_project_notification_configuration_test.go
+++ b/internal/provider/resource_tfe_project_notification_configuration_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018, 2025
+// Copyright IBM Corp. 2018, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider
@@ -10,8 +10,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccTFEProjectNotificationConfiguration_basic(t *testing.T) {
@@ -487,4 +490,214 @@ resource "tfe_project_notification_configuration" "foobar" {
 func preCheckTFEProjectNotificationConfiguration(t *testing.T) {
 	testAccPreCheck(t)
 	skipIfEnterprise(t)
+}
+
+// TestAccTFEProjectNotificationConfiguration_urlWriteOnly tests auto-managed url_wo:
+// - create with url_wo (version auto-set to 1)
+// - update with changed url value (version auto-increments to 2)
+// - same url again (version stays at 2)
+func TestAccTFEProjectNotificationConfiguration_urlWriteOnly(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	notificationConfiguration := &tfe.NotificationConfiguration{}
+	compareValuesSame := statecheck.CompareValue(compare.ValuesSame())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectNotificationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create with url_wo — version should be auto-set to 1
+				Config: testAccTFEProjectNotificationConfiguration_urlWriteOnly(org.Name, project.ID, runTasksURL()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEProjectNotificationConfigurationExists(
+						"tfe_project_notification_configuration.foobar", notificationConfiguration),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "destination_type", "generic"),
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("tfe_project_notification_configuration.foobar", "url_wo"),
+					resource.TestCheckNoResourceAttr("tfe_project_notification_configuration.foobar", "url"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					compareValuesSame.AddStateValue(
+						"tfe_project_notification_configuration.foobar", tfjsonpath.New("id"),
+					),
+				},
+			},
+			{
+				// Update with a different URL — version should auto-increment to 2
+				Config: testAccTFEProjectNotificationConfiguration_urlWriteOnly(org.Name, project.ID, runTasksURL()+"?updated=true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("tfe_project_notification_configuration.foobar", "url_wo"),
+					resource.TestCheckNoResourceAttr("tfe_project_notification_configuration.foobar", "url"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Same resource, not recreated
+					compareValuesSame.AddStateValue(
+						"tfe_project_notification_configuration.foobar", tfjsonpath.New("id"),
+					),
+				},
+			},
+			{
+				// Same URL again — version should stay at 2 (no hash change)
+				Config: testAccTFEProjectNotificationConfiguration_urlWriteOnly(org.Name, project.ID, runTasksURL()+"?updated=true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url_wo_version", "2"),
+				),
+			},
+			{
+				// Attempting to switch from url_wo to plaintext url should be blocked
+				Config:      testAccTFEProjectNotificationConfiguration_basic(org.Name, project.ID),
+				ExpectError: regexp.MustCompile(`Cannot switch from write-only to plaintext`),
+			},
+		},
+	})
+}
+
+// TestAccTFEProjectNotificationConfiguration_urlWriteOnlyManualVersion tests manual url_wo_version mode:
+// explicitly setting url_wo_version disables hash auto-detection.
+func TestAccTFEProjectNotificationConfiguration_urlWriteOnlyManualVersion(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProjectNotificationConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProjectNotificationConfiguration_urlWriteOnlyManual(org.Name, project.ID, runTasksURL(), 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("tfe_project_notification_configuration.foobar", "url_wo"),
+					resource.TestCheckNoResourceAttr("tfe_project_notification_configuration.foobar", "url"),
+				),
+			},
+			{
+				// Increment version manually to trigger URL update
+				Config: testAccTFEProjectNotificationConfiguration_urlWriteOnlyManual(org.Name, project.ID, runTasksURL()+"?v2=true", 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"tfe_project_notification_configuration.foobar", "url_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccTFEProjectNotificationConfiguration_urlWriteOnlyValidation tests that schema
+// validators reject invalid combinations for url_wo.
+func TestAccTFEProjectNotificationConfiguration_urlWriteOnlyValidation(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, cleanupOrg := createStandardOrganization(t, tfeClient)
+	t.Cleanup(cleanupOrg)
+
+	project := createProject(t, tfeClient, org.Name, tfe.ProjectCreateOptions{
+		Name: "test-project",
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheckTFEProjectNotificationConfiguration(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEProjectNotificationConfiguration_urlAndUrlWriteOnly(org.Name, project.ID),
+				ExpectError: regexp.MustCompile(`Attribute "url_wo" cannot be specified when "url" is specified`),
+			},
+			{
+				Config:      testAccTFEProjectNotificationConfiguration_urlWriteOnlyVersionWithoutURL(org.Name, project.ID),
+				ExpectError: regexp.MustCompile(`Attribute "url_wo" must be specified when "url_wo_version" is specified`),
+			},
+		},
+	})
+}
+
+func testAccTFEProjectNotificationConfiguration_urlWriteOnly(orgName, projectID, url string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_basic"
+  destination_type = "generic"
+  url_wo           = "%s"
+  project_id       = "%s"
+}`, orgName, url, projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_urlWriteOnlyManual(orgName, projectID, url string, version int64) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_basic"
+  destination_type = "generic"
+  url_wo           = "%s"
+  url_wo_version   = %d
+  project_id       = "%s"
+}`, orgName, url, version, projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_urlAndUrlWriteOnly(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_basic"
+  destination_type = "generic"
+  url              = "%s"
+  url_wo           = "%s"
+  project_id       = "%s"
+}`, orgName, runTasksURL(), runTasksURL(), projectID)
+}
+
+func testAccTFEProjectNotificationConfiguration_urlWriteOnlyVersionWithoutURL(orgName, projectID string) string {
+	return fmt.Sprintf(`
+data "tfe_organization" "foobar" {
+  name = "%s"
+}
+
+resource "tfe_project_notification_configuration" "foobar" {
+  name             = "notification_basic"
+  destination_type = "generic"
+  url_wo_version   = 1
+  project_id       = "%s"
+}`, orgName, projectID)
 }


### PR DESCRIPTION
Fixes: #2104

## Description

Adds `wo_url` attributes/support for the project notification configuration resource, in the manner/style of the notification configuration resource prior art.

## Testing plan

Added integration tests

## Output from acceptance tests

```
--- PASS: TestAccTFEProjectNotificationConfiguration_basic (3.80s)
=== RUN   TestAccTFEProjectNotificationConfiguration_emailUserIDs
--- PASS: TestAccTFEProjectNotificationConfiguration_emailUserIDs (2.36s)
=== RUN   TestAccTFEProjectNotificationConfiguration_update
--- PASS: TestAccTFEProjectNotificationConfiguration_update (3.16s)
=== RUN   TestAccTFEProjectNotificationConfiguration_validateSchemaAttributesSlack
--- PASS: TestAccTFEProjectNotificationConfiguration_validateSchemaAttributesSlack (1.32s)
=== RUN   TestAccTFEProjectNotificationConfiguration_slack
--- PASS: TestAccTFEProjectNotificationConfiguration_slack (3.02s)
=== RUN   TestAccTFEProjectNotificationConfiguration_urlWriteOnly
--- PASS: TestAccTFEProjectNotificationConfiguration_urlWriteOnly (5.00s)
=== RUN   TestAccTFEProjectNotificationConfiguration_urlWriteOnlyManualVersion
--- PASS: TestAccTFEProjectNotificationConfiguration_urlWriteOnlyManualVersion (3.67s)
=== RUN   TestAccTFEProjectNotificationConfiguration_urlWriteOnlyValidation
--- PASS: TestAccTFEProjectNotificationConfiguration_urlWriteOnlyValidation (1.12s)
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
