### PR TITLE
migrate low risk data sources to go tfe v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260715214333-9f9363a22e27
+	github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260721234329-1df1e92d693a
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
@@ -97,5 +97,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/hashicorp/go-tfe/v2 => ../go-tfe/v2

--- a/go.mod
+++ b/go.mod
@@ -97,3 +97,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/hashicorp/go-tfe/v2 => ../go-tfe/v2

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260721234329-1df1e92d693a
+	github.com/hashicorp/go-tfe/v2 v2.3.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,6 @@ github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
 github.com/hashicorp/go-tfe v1.109.0 h1:zWusjKHkWBdkmgzUc1OizccnlcOiCe/Y0FzOQMQLets=
 github.com/hashicorp/go-tfe v1.109.0/go.mod h1:d8js2OmMnCq58gEh26mCS81nD8Aj7HmG6IO1b80gM78=
-github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260715214333-9f9363a22e27 h1:BV7OsOkU6ZnV2BMnYgWtPetzhOalgmpyJBL8jBd1SB4=
-github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260715214333-9f9363a22e27/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
 github.com/hashicorp/go-tfe v1.109.0 h1:zWusjKHkWBdkmgzUc1OizccnlcOiCe/Y0FzOQMQLets=
 github.com/hashicorp/go-tfe v1.109.0/go.mod h1:d8js2OmMnCq58gEh26mCS81nD8Aj7HmG6IO1b80gM78=
+github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260721234329-1df1e92d693a h1:lgndgJdXopZ7s4R8/QaoeDmjrtpx7teqrmJjZ2kUmW8=
+github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260721234329-1df1e92d693a/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
 github.com/hashicorp/go-tfe v1.109.0 h1:zWusjKHkWBdkmgzUc1OizccnlcOiCe/Y0FzOQMQLets=
 github.com/hashicorp/go-tfe v1.109.0/go.mod h1:d8js2OmMnCq58gEh26mCS81nD8Aj7HmG6IO1b80gM78=
-github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260721234329-1df1e92d693a h1:lgndgJdXopZ7s4R8/QaoeDmjrtpx7teqrmJjZ2kUmW8=
-github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260721234329-1df1e92d693a/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
+github.com/hashicorp/go-tfe/v2 v2.3.0 h1:sWj1/aRSwdgA6FVT6vVKGRkUm53BqN/+JQnafvpLotU=
+github.com/hashicorp/go-tfe/v2 v2.3.0/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/client_v2_helpers.go
+++ b/internal/provider/client_v2_helpers.go
@@ -1,0 +1,31 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"github.com/hashicorp/go-tfe/v2/api/models"
+)
+
+// valueOrZero dereferences an optional pointer returned by a go-tfe v2
+// generated getter, returning the type's zero value when the pointer is nil.
+// This preserves go-tfe v1 behavior, where absent JSON:API attributes were
+// left as zero values instead of nil pointers.
+func valueOrZero[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+	return *p
+}
+
+// nextPageNumber returns the next page number from a go-tfe v2 list response
+// pagination object, or nil when there are no more pages. Callers should
+// follow next-page rather than relying on total-pages/total-count, which some
+// endpoints omit.
+func nextPageNumber(p models.Paginationable) *int32 {
+	if p == nil {
+		return nil
+	}
+	return p.GetNextPage()
+}

--- a/internal/provider/client_v2_helpers.go
+++ b/internal/provider/client_v2_helpers.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"github.com/hashicorp/go-tfe/v2/api/models"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 // valueOrZero dereferences an optional pointer returned by a go-tfe v2
@@ -28,4 +29,53 @@ func nextPageNumber(p models.Paginationable) *int32 {
 		return nil
 	}
 	return p.GetNextPage()
+}
+
+// paginationMetaGetter is satisfied by every go-tfe v2 generated list
+// response's `meta` type (e.g. ItemSshKeysGetResponse_meta,
+// ItemTeamsGetResponse_meta): each is a distinct generated type, but all of
+// them implement GetPagination() identically.
+type paginationMetaGetter interface {
+	GetPagination() models.Paginationable
+}
+
+// nextPageFromMeta returns the next page number from a go-tfe v2 list
+// response's `meta` field, or nil when meta or pagination is absent or there
+// are no more pages.
+func nextPageFromMeta(meta paginationMetaGetter) *int32 {
+	if meta == nil {
+		return nil
+	}
+	return nextPageNumber(meta.GetPagination())
+}
+
+// withQueryParams wraps a go-tfe v2 generated query-parameters struct in the
+// kiota-abstractions RequestConfiguration envelope that every generated
+// request builder's Get/List method expects.
+func withQueryParams[T any](queryParams *T) *abstractions.RequestConfiguration[T] {
+	return &abstractions.RequestConfiguration[T]{QueryParameters: queryParams}
+}
+
+// includedUserGetter is satisfied by every go-tfe v2 generated `included`
+// array element type (e.g. the composed-type wrappers for both the
+// organization-memberships list and single-item responses): each is a
+// distinct generated type, but all of them implement GetUsers() identically.
+type includedUserGetter interface {
+	GetUsers() models.Usersable
+}
+
+// findIncludedUser returns the full user record with the given ID from a
+// JSON:API `included` array, or nil when it is not present. Requires the
+// go-tfe v2 client to correctly discriminate composed `included` array
+// elements by their JSON:API `type`.
+func findIncludedUser[T includedUserGetter](included []T, userID string) models.Usersable {
+	if userID == "" {
+		return nil
+	}
+	for _, record := range included {
+		if user := record.GetUsers(); user != nil && valueOrZero(user.GetId()) == userID {
+			return user
+		}
+	}
+	return nil
 }

--- a/internal/provider/data_source_current_user.go
+++ b/internal/provider/data_source_current_user.go
@@ -83,23 +83,37 @@ func (d *dataSourceCurrentUser) Configure(_ context.Context, req datasource.Conf
 func (d *dataSourceCurrentUser) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
 	tflog.Debug(ctx, "Reading current user")
 
-	user, err := d.config.Client.Users.ReadCurrent(ctx)
+	userEnvelope, err := d.config.ClientV2.API.Account().Details().Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read current user", err.Error())
 		return
 	}
 
+	user := userEnvelope.GetData()
+	if user == nil {
+		resp.Diagnostics.AddError("Unable to read current user", "The API response contained no user data.")
+		return
+	}
+
+	var username, email string
+	var isServiceAccount bool
+	if attributes := user.GetAttributes(); attributes != nil {
+		username = valueOrZero(attributes.GetUsername())
+		email = valueOrZero(attributes.GetEmail())
+		isServiceAccount = valueOrZero(attributes.GetIsServiceAccount())
+	}
+
 	model := modelCurrentUser{
-		ID:               types.StringValue(user.ID),
-		Username:         types.StringValue(user.Username),
-		Email:            types.StringValue(user.Email),
-		IsServiceAccount: types.BoolValue(user.IsServiceAccount),
+		ID:               types.StringValue(valueOrZero(user.GetId())),
+		Username:         types.StringValue(username),
+		Email:            types.StringValue(email),
+		IsServiceAccount: types.BoolValue(isServiceAccount),
 	}
 
 	tflog.Trace(ctx, "Read current user successfully", map[string]any{
-		"user_id":            user.ID,
-		"username":           user.Username,
-		"is_service_account": user.IsServiceAccount,
+		"user_id":            valueOrZero(user.GetId()),
+		"username":           username,
+		"is_service_account": isServiceAccount,
 	})
 
 	diags := resp.State.Set(ctx, &model)

--- a/internal/provider/data_source_hyok_customer_key_version.go
+++ b/internal/provider/data_source_hyok_customer_key_version.go
@@ -97,18 +97,37 @@ func (d *dataSourceHYOKCustomerKeyVersion) Read(ctx context.Context, req datasou
 	}
 
 	// Make API call to fetch the HYOK customer key version
-	keyVersion, err := d.config.Client.HYOKCustomerKeyVersions.Read(ctx, data.ID.ValueString())
+	keyVersionEnvelope, err := d.config.ClientV2.API.HyokCustomerKeyVersions().ByHyok_customer_key_version_id(data.ID.ValueString()).Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read HYOK customer key version", err.Error())
 		return
 	}
 
+	keyVersion := keyVersionEnvelope.GetData()
+	if keyVersion == nil {
+		resp.Diagnostics.AddError("Unable to read HYOK customer key version", "The API response contained no key version data.")
+		return
+	}
+
+	var status, keyVersionNumber, errorMessage string
+	var createdAt time.Time
+	var workspacesSecured int64
+	if attributes := keyVersion.GetAttributes(); attributes != nil {
+		if s := attributes.GetStatus(); s != nil {
+			status = s.String()
+		}
+		keyVersionNumber = valueOrZero(attributes.GetKeyVersion())
+		createdAt = valueOrZero(attributes.GetCreatedAt())
+		workspacesSecured = int64(valueOrZero(attributes.GetWorkspacesSecured()))
+		errorMessage = valueOrZero(attributes.GetError())
+	}
+
 	// Set the computed attributes from the API response
-	data.Status = types.StringValue(string(keyVersion.Status))
-	data.KeyVersion = types.StringValue(keyVersion.KeyVersion)
-	data.CreatedAt = types.StringValue(keyVersion.CreatedAt.Format(time.RFC3339))
-	data.WorkspacesSecured = types.Int64Value(int64(keyVersion.WorkspacesSecured))
-	data.Error = types.StringValue(keyVersion.Error)
+	data.Status = types.StringValue(status)
+	data.KeyVersion = types.StringValue(keyVersionNumber)
+	data.CreatedAt = types.StringValue(createdAt.Format(time.RFC3339))
+	data.WorkspacesSecured = types.Int64Value(workspacesSecured)
+	data.Error = types.StringValue(errorMessage)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/data_source_hyok_encrypted_data_key.go
+++ b/internal/provider/data_source_hyok_encrypted_data_key.go
@@ -87,16 +87,30 @@ func (d *dataSourceHYOKEncryptedDataKey) Read(ctx context.Context, req datasourc
 	}
 
 	// Make API call to fetch the HYOK customer key version
-	keyVersion, err := d.config.Client.HYOKEncryptedDataKeys.Read(ctx, data.ID.ValueString())
+	keyVersionEnvelope, err := d.config.ClientV2.API.HyokEncryptedDataKeys().ByHyok_encrypted_data_key_id(data.ID.ValueString()).Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read HYOK customer key version", err.Error())
 		return
 	}
 
+	keyVersion := keyVersionEnvelope.GetData()
+	if keyVersion == nil {
+		resp.Diagnostics.AddError("Unable to read HYOK customer key version", "The API response contained no encrypted data key data.")
+		return
+	}
+
+	var encryptedDEK, customerKeyName string
+	var createdAt time.Time
+	if attributes := keyVersion.GetAttributes(); attributes != nil {
+		encryptedDEK = valueOrZero(attributes.GetEncryptedDek())
+		customerKeyName = valueOrZero(attributes.GetCustomerKeyName())
+		createdAt = valueOrZero(attributes.GetCreatedAt())
+	}
+
 	// Set the computed attributes from the API response
-	data.EncryptedDEK = types.StringValue(keyVersion.EncryptedDEK)
-	data.CustomerKeyName = types.StringValue(keyVersion.CustomerKeyName)
-	data.CreatedAt = types.StringValue(keyVersion.CreatedAt.Format(time.RFC3339))
+	data.EncryptedDEK = types.StringValue(encryptedDEK)
+	data.CustomerKeyName = types.StringValue(customerKeyName)
+	data.CreatedAt = types.StringValue(createdAt.Format(time.RFC3339))
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/data_source_organization_members.go
+++ b/internal/provider/data_source_organization_members.go
@@ -84,7 +84,7 @@ func dataSourceTFEOrganizationMembersRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	members, membersWaiting, err := fetchOrganizationMembers(config.Client, organizationName)
+	members, membersWaiting, err := fetchOrganizationMembers(config.ClientV2, organizationName)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/data_source_organization_membership.go
+++ b/internal/provider/data_source_organization_membership.go
@@ -6,6 +6,15 @@
 // docs/new-resources.md if planning to use this code as boilerplate for
 // a new resource.
 
+// go-tfe v2 migration exception: this data source intentionally remains on
+// the go-tfe v1 client. It depends on `include=user` side-loaded user records
+// (for the `username` attribute and name/email lookups), but the generated v2
+// client cannot deserialize JSON:API `included` arrays: the composed-type
+// factories (e.g. CreateOrganizationsFromDiscriminatorValue) do not
+// discriminate on the JSON:API `type` field, so the first composed type
+// always wins and GetUsers() is always nil. Migrate once the upstream
+// generated client discriminates included records by type.
+
 package provider
 
 import (

--- a/internal/provider/data_source_organization_membership.go
+++ b/internal/provider/data_source_organization_membership.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/go-tfe/v2/api/organizationmemberships"
 	membershipitem "github.com/hashicorp/go-tfe/v2/api/organizationmemberships/item"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func dataSourceTFEOrganizationMembership() *schema.Resource {
@@ -98,11 +97,9 @@ func dataSourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interf
 
 	includeUser := membershipitem.USER_GETINCLUDEQUERYPARAMETERTYPE
 
-	membershipResponse, err := config.ClientV2.API.OrganizationMemberships().ByOrganization_membership_id(orgMemberID).Get(context.Background(), &abstractions.RequestConfiguration[organizationmemberships.WithOrganization_membership_ItemRequestBuilderGetQueryParameters]{
-		QueryParameters: &organizationmemberships.WithOrganization_membership_ItemRequestBuilderGetQueryParameters{
-			Include: &includeUser,
-		},
-	})
+	membershipResponse, err := config.ClientV2.API.OrganizationMemberships().ByOrganization_membership_id(orgMemberID).Get(context.Background(), withQueryParams(&organizationmemberships.WithOrganization_membership_ItemRequestBuilderGetQueryParameters{
+		Include: &includeUser,
+	}))
 	if err != nil {
 		if errors.Is(err, tfev2.ErrNotFound) {
 			d.SetId("")
@@ -129,15 +126,7 @@ func dataSourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interf
 		}
 	}
 
-	var membershipUsername string
-	for _, record := range membershipResponse.GetIncluded() {
-		if u := record.GetUsers(); u != nil && userID != "" && valueOrZero(u.GetId()) == userID {
-			if userAttributes := u.GetAttributes(); userAttributes != nil {
-				membershipUsername = valueOrZero(userAttributes.GetUsername())
-			}
-			break
-		}
-	}
+	_, membershipUsername := userEmailAndUsername(findIncludedUser(membershipResponse.GetIncluded(), userID))
 
 	d.Set("email", membershipEmail)
 	d.Set("organization", organizationName)

--- a/internal/provider/data_source_organization_membership.go
+++ b/internal/provider/data_source_organization_membership.go
@@ -6,15 +6,6 @@
 // docs/new-resources.md if planning to use this code as boilerplate for
 // a new resource.
 
-// go-tfe v2 migration exception: this data source intentionally remains on
-// the go-tfe v1 client. It depends on `include=user` side-loaded user records
-// (for the `username` attribute and name/email lookups), but the generated v2
-// client cannot deserialize JSON:API `included` arrays: the composed-type
-// factories (e.g. CreateOrganizationsFromDiscriminatorValue) do not
-// discriminate on the JSON:API `type` field, so the first composed type
-// always wins and GetUsers() is always nil. Migrate once the upstream
-// generated client discriminates included records by type.
-
 package provider
 
 import (
@@ -22,8 +13,11 @@ import (
 	"errors"
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfev2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/organizationmemberships"
+	membershipitem "github.com/hashicorp/go-tfe/v2/api/organizationmemberships/item"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func dataSourceTFEOrganizationMembership() *schema.Resource {
@@ -92,33 +86,63 @@ func dataSourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interf
 	}
 
 	if orgMemberID == "" {
-		orgMember, err := fetchOrganizationMemberByNameOrEmail(context.Background(), config.Client, organization, username, email)
+		orgMember, err := fetchOrganizationMemberByNameOrEmailV2(context.Background(), config.ClientV2, organization, username, email)
 		if err != nil {
 			return fmt.Errorf("could not find organization membership for organization %s: %w", organization, err)
 		}
 
-		orgMemberID = orgMember.ID
+		orgMemberID = valueOrZero(orgMember.GetId())
 	}
 
 	d.SetId(orgMemberID)
 
-	options := tfe.OrganizationMembershipReadOptions{
-		Include: []tfe.OrgMembershipIncludeOpt{tfe.OrgMembershipUser},
-	}
+	includeUser := membershipitem.USER_GETINCLUDEQUERYPARAMETERTYPE
 
-	membership, err := config.Client.OrganizationMemberships.ReadWithOptions(context.Background(), orgMemberID, options)
+	membershipResponse, err := config.ClientV2.API.OrganizationMemberships().ByOrganization_membership_id(orgMemberID).Get(context.Background(), &abstractions.RequestConfiguration[organizationmemberships.WithOrganization_membership_ItemRequestBuilderGetQueryParameters]{
+		QueryParameters: &organizationmemberships.WithOrganization_membership_ItemRequestBuilderGetQueryParameters{
+			Include: &includeUser,
+		},
+	})
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfev2.ErrNotFound) {
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("error reading configuration of membership %s: %w", orgMemberID, err)
 	}
 
-	d.Set("email", membership.Email)
-	d.Set("organization", membership.Organization.Name)
-	d.Set("user_id", membership.User.ID)
-	d.Set("username", membership.User.Username)
+	membership := membershipResponse.GetData()
+	if membership == nil {
+		return fmt.Errorf("error reading configuration of membership %s: response contained no membership data", orgMemberID)
+	}
+
+	var membershipEmail string
+	if attributes := membership.GetAttributes(); attributes != nil {
+		membershipEmail = valueOrZero(attributes.GetEmail())
+	}
+
+	var organizationName string
+	userID := organizationMembershipUserID(membership)
+	if relationships := membership.GetRelationships(); relationships != nil {
+		if org := relationships.GetOrganization(); org != nil && org.GetData() != nil {
+			organizationName = valueOrZero(org.GetData().GetId())
+		}
+	}
+
+	var membershipUsername string
+	for _, record := range membershipResponse.GetIncluded() {
+		if u := record.GetUsers(); u != nil && userID != "" && valueOrZero(u.GetId()) == userID {
+			if userAttributes := u.GetAttributes(); userAttributes != nil {
+				membershipUsername = valueOrZero(userAttributes.GetUsername())
+			}
+			break
+		}
+	}
+
+	d.Set("email", membershipEmail)
+	d.Set("organization", organizationName)
+	d.Set("user_id", userID)
+	d.Set("username", membershipUsername)
 
 	return nil
 }

--- a/internal/provider/data_source_organization_membership.go
+++ b/internal/provider/data_source_organization_membership.go
@@ -95,10 +95,8 @@ func dataSourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interf
 
 	d.SetId(orgMemberID)
 
-	includeUser := membershipitem.USER_GETINCLUDEQUERYPARAMETERTYPE
-
 	membershipResponse, err := config.ClientV2.API.OrganizationMemberships().ByOrganization_membership_id(orgMemberID).Get(context.Background(), withQueryParams(&organizationmemberships.WithOrganization_membership_ItemRequestBuilderGetQueryParameters{
-		Include: &includeUser,
+		Include: []membershipitem.GetIncludeQueryParameterType{membershipitem.USER_GETINCLUDEQUERYPARAMETERTYPE},
 	}))
 	if err != nil {
 		if errors.Is(err, tfev2.ErrNotFound) {

--- a/internal/provider/data_source_organization_run_task.go
+++ b/internal/provider/data_source_organization_run_task.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -33,15 +33,36 @@ type modelDataTFEOrganizationRunTaskV0 struct {
 	URL          types.String `tfsdk:"url"`
 }
 
-func dataModelFromTFEOrganizationRunTask(v *tfe.RunTask) modelDataTFEOrganizationRunTaskV0 {
+func dataModelFromTFEOrganizationRunTask(v models.Tasksable, organization string) modelDataTFEOrganizationRunTaskV0 {
+	var category, description, name, url string
+	var enabled bool
+	if attributes := v.GetAttributes(); attributes != nil {
+		category = valueOrZero(attributes.GetCategory())
+		description = valueOrZero(attributes.GetDescription())
+		enabled = valueOrZero(attributes.GetEnabled())
+		name = valueOrZero(attributes.GetName())
+		url = valueOrZero(attributes.GetUrl())
+	}
+
+	// Prefer the organization name from the task's organization relationship,
+	// falling back to the requested organization when it is absent.
+	organizationName := organization
+	if relationships := v.GetRelationships(); relationships != nil {
+		if org := relationships.GetOrganization(); org != nil && org.GetData() != nil {
+			if id := org.GetData().GetId(); id != nil && *id != "" {
+				organizationName = *id
+			}
+		}
+	}
+
 	result := modelDataTFEOrganizationRunTaskV0{
-		Category:     types.StringValue(v.Category),
-		Description:  types.StringValue(v.Description),
-		Enabled:      types.BoolValue(v.Enabled),
-		ID:           types.StringValue(v.ID),
-		Name:         types.StringValue(v.Name),
-		Organization: types.StringValue(v.Organization.Name),
-		URL:          types.StringValue(v.URL),
+		Category:     types.StringValue(category),
+		Description:  types.StringValue(description),
+		Enabled:      types.BoolValue(enabled),
+		ID:           types.StringValue(valueOrZero(v.GetId())),
+		Name:         types.StringValue(name),
+		Organization: types.StringValue(organizationName),
+		URL:          types.StringValue(url),
 	}
 
 	return result
@@ -133,7 +154,7 @@ func (d *dataSourceOrganizationRunTask) Read(ctx context.Context, req datasource
 		return
 	}
 
-	task, err := fetchOrganizationRunTask(data.Name.ValueString(), organization, d.config.Client)
+	task, err := fetchOrganizationRunTaskV2(ctx, data.Name.ValueString(), organization, d.config.ClientV2)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Organization Run Task",
 			fmt.Sprintf("Could not read Run Task %q in organization %q, unexpected error: %s", data.Name.String(), organization, err.Error()),
@@ -142,7 +163,7 @@ func (d *dataSourceOrganizationRunTask) Read(ctx context.Context, req datasource
 	}
 
 	// We can never read the HMACkey (Write-only) so assume it's the default (empty)
-	result := dataModelFromTFEOrganizationRunTask(task)
+	result := dataModelFromTFEOrganizationRunTask(task, organization)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)

--- a/internal/provider/data_source_organization_run_task.go
+++ b/internal/provider/data_source_organization_run_task.go
@@ -154,7 +154,7 @@ func (d *dataSourceOrganizationRunTask) Read(ctx context.Context, req datasource
 		return
 	}
 
-	task, err := fetchOrganizationRunTaskV2(ctx, data.Name.ValueString(), organization, d.config.ClientV2)
+	task, err := fetchOrganizationRunTaskV2(data.Name.ValueString(), organization, d.config.ClientV2)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Organization Run Task",
 			fmt.Sprintf("Could not read Run Task %q in organization %q, unexpected error: %s", data.Name.String(), organization, err.Error()),

--- a/internal/provider/data_source_organization_run_task_global_settings.go
+++ b/internal/provider/data_source_organization_run_task_global_settings.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -87,7 +88,7 @@ func (d *dataSourceOrganizationRunTaskGlobalSettings) Read(ctx context.Context, 
 
 	taskID := data.TaskID.ValueString()
 
-	task, err := d.config.Client.RunTasks.Read(ctx, taskID)
+	taskEnvelope, err := d.config.ClientV2.API.Tasks().ById(taskID).Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error retrieving task",
 			fmt.Sprintf("Error retrieving task %s: %s", taskID, err.Error()),
@@ -95,6 +96,10 @@ func (d *dataSourceOrganizationRunTaskGlobalSettings) Read(ctx context.Context, 
 		return
 	}
 
+	var task models.Tasksable
+	if taskEnvelope != nil {
+		task = taskEnvelope.GetData()
+	}
 	if task == nil {
 		resp.Diagnostics.AddError("Error retrieving task",
 			fmt.Sprintf("Error retrieving task %s", taskID),
@@ -102,15 +107,51 @@ func (d *dataSourceOrganizationRunTaskGlobalSettings) Read(ctx context.Context, 
 		return
 	}
 
-	if task.Global == nil {
+	if taskGlobalConfiguration(task) == nil {
 		resp.Diagnostics.AddWarning("Error retrieving task",
 			fmt.Sprintf("The task %s exists however it does not support global run tasks.", taskID),
 		)
 		return
 	}
 
-	result := dataModelFromTFEOrganizationRunTaskGlobalSettings(*task)
+	result := dataModelFromTFEOrganizationRunTaskGlobalSettingsV2(task)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
+}
+
+// taskGlobalConfiguration returns the task's global configuration attribute,
+// or nil when it is not present in the response.
+func taskGlobalConfiguration(task models.Tasksable) models.Tasks_attributes_globalConfigurationable {
+	if attributes := task.GetAttributes(); attributes != nil {
+		return attributes.GetGlobalConfiguration()
+	}
+	return nil
+}
+
+// dataModelFromTFEOrganizationRunTaskGlobalSettingsV2 is the go-tfe v2
+// counterpart of dataModelFromTFEOrganizationRunTaskGlobalSettings. The v1
+// version remains until the tfe_organization_run_task_global_settings
+// resource is migrated.
+func dataModelFromTFEOrganizationRunTaskGlobalSettingsV2(v models.Tasksable) modelDataTFEOrganizationRunTaskGlobalSettings {
+	result := modelDataTFEOrganizationRunTaskGlobalSettings{
+		Enabled:          types.BoolNull(),
+		ID:               types.StringValue(valueOrZero(v.GetId())),
+		TaskID:           types.StringValue(valueOrZero(v.GetId())),
+		EnforcementLevel: types.StringNull(),
+		Stages:           types.ListNull(types.StringType),
+	}
+
+	global := taskGlobalConfiguration(v)
+	if global == nil {
+		return result
+	}
+
+	result.Enabled = types.BoolValue(valueOrZero(global.GetEnabled()))
+	result.EnforcementLevel = types.StringValue(valueOrZero(global.GetEnforcementLevel()))
+	if stages, err := types.ListValueFrom(ctx, types.StringType, global.GetStages()); err == nil {
+		result.Stages = stages
+	}
+
+	return result
 }

--- a/internal/provider/data_source_ssh_key.go
+++ b/internal/provider/data_source_ssh_key.go
@@ -11,8 +11,9 @@ package provider
 import (
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func dataSourceTFESSHKey() *schema.Resource {
@@ -53,29 +54,38 @@ func dataSourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// Create an options struct.
-	options := &tfe.SSHKeyListOptions{}
+	// Create the query parameters.
+	pageSize := int32(100)
+	queryParams := &organizations.ItemSshKeysRequestBuilderGetQueryParameters{
+		Pagesize: &pageSize,
+	}
 
 	for {
-		l, err := config.Client.SSHKeys.List(ctx, organization, options)
+		l, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).SshKeys().Get(ctx, &abstractions.RequestConfiguration[organizations.ItemSshKeysRequestBuilderGetQueryParameters]{
+			QueryParameters: queryParams,
+		})
 		if err != nil {
 			return fmt.Errorf("Error retrieving SSH keys: %w", err)
 		}
 
-		for _, k := range l.Items {
-			if k.Name == name {
-				d.SetId(k.ID)
+		for _, k := range l.GetData() {
+			if attributes := k.GetAttributes(); attributes != nil && valueOrZero(attributes.GetName()) == name {
+				d.SetId(valueOrZero(k.GetId()))
 				return nil
 			}
 		}
 
 		// Exit the loop when we've seen all pages.
-		if l.CurrentPage >= l.TotalPages {
+		var nextPage *int32
+		if meta := l.GetMeta(); meta != nil {
+			nextPage = nextPageNumber(meta.GetPagination())
+		}
+		if nextPage == nil {
 			break
 		}
 
 		// Update the page number to get the next page.
-		options.PageNumber = l.NextPage
+		queryParams.Pagenumber = nextPage
 	}
 
 	return fmt.Errorf("could not find SSH key %s/%s", organization, name)

--- a/internal/provider/data_source_ssh_key.go
+++ b/internal/provider/data_source_ssh_key.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func dataSourceTFESSHKey() *schema.Resource {
@@ -61,9 +60,7 @@ func dataSourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	for {
-		l, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).SshKeys().Get(ctx, &abstractions.RequestConfiguration[organizations.ItemSshKeysRequestBuilderGetQueryParameters]{
-			QueryParameters: queryParams,
-		})
+		l, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).SshKeys().Get(ctx, withQueryParams(queryParams))
 		if err != nil {
 			return fmt.Errorf("Error retrieving SSH keys: %w", err)
 		}
@@ -76,10 +73,7 @@ func dataSourceTFESSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// Exit the loop when we've seen all pages.
-		var nextPage *int32
-		if meta := l.GetMeta(); meta != nil {
-			nextPage = nextPageNumber(meta.GetPagination())
-		}
+		nextPage := nextPageFromMeta(l.GetMeta())
 		if nextPage == nil {
 			break
 		}

--- a/internal/provider/data_source_team.go
+++ b/internal/provider/data_source_team.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func dataSourceTFETeam() *schema.Resource {
@@ -84,11 +83,9 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 	teamsBuilder := config.ClientV2.API.Organizations().ByOrganization_name(organization).Teams()
 
 	filterNames := name
-	tl, err := teamsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
-		QueryParameters: &organizations.ItemTeamsRequestBuilderGetQueryParameters{
-			Filternames: &filterNames,
-		},
-	})
+	tl, err := teamsBuilder.Get(ctx, withQueryParams(&organizations.ItemTeamsRequestBuilderGetQueryParameters{
+		Filternames: &filterNames,
+	}))
 	if err != nil {
 		return fmt.Errorf("Error retrieving teams: %w", err)
 	}
@@ -120,19 +117,14 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 				}
 			}
 
-			var nextPage *int32
-			if meta := tl.GetMeta(); meta != nil {
-				nextPage = nextPageNumber(meta.GetPagination())
-			}
+			nextPage := nextPageFromMeta(tl.GetMeta())
 			if nextPage == nil {
 				break
 			}
 
 			queryParams.Pagenumber = nextPage
 
-			tl, err = teamsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
-				QueryParameters: queryParams,
-			})
+			tl, err = teamsBuilder.Get(ctx, withQueryParams(queryParams))
 			if err != nil {
 				return fmt.Errorf("Error retrieving teams: %w", err)
 			}

--- a/internal/provider/data_source_team.go
+++ b/internal/provider/data_source_team.go
@@ -12,8 +12,10 @@ import (
 	"fmt"
 	"time"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/v2/api/models"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func dataSourceTFETeam() *schema.Resource {
@@ -79,68 +81,100 @@ func dataSourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	tl, err := config.Client.Teams.List(ctx, organization, &tfe.TeamListOptions{
-		Names: []string{name},
+	teamsBuilder := config.ClientV2.API.Organizations().ByOrganization_name(organization).Teams()
+
+	filterNames := name
+	tl, err := teamsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
+		QueryParameters: &organizations.ItemTeamsRequestBuilderGetQueryParameters{
+			Filternames: &filterNames,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("Error retrieving teams: %w", err)
 	}
 
-	switch len(tl.Items) {
+	items := tl.GetData()
+	switch len(items) {
 	case 0:
 		return fmt.Errorf("could not find team %s/%s", organization, name)
 	case 1:
 		// We check this just in case a user's TFE instance only has one team
 		// and doesn't support the filter query param
-		if tl.Items[0].Name != name {
+		if teamName(items[0]) != name {
 			return fmt.Errorf("could not find team %s/%s", organization, name)
 		}
 
-		setTeamResourceData(d, tl.Items[0])
+		setTeamResourceData(d, items[0])
 		return nil
 	default:
-		options := &tfe.TeamListOptions{}
+		pageSize := int32(100)
+		queryParams := &organizations.ItemTeamsRequestBuilderGetQueryParameters{
+			Pagesize: &pageSize,
+		}
 
 		for {
-			for _, team := range tl.Items {
-				if team.Name == name {
+			for _, team := range items {
+				if teamName(team) == name {
 					setTeamResourceData(d, team)
 					return nil
 				}
 			}
 
-			if tl.CurrentPage >= tl.TotalPages {
+			var nextPage *int32
+			if meta := tl.GetMeta(); meta != nil {
+				nextPage = nextPageNumber(meta.GetPagination())
+			}
+			if nextPage == nil {
 				break
 			}
 
-			options.PageNumber = tl.NextPage
+			queryParams.Pagenumber = nextPage
 
-			tl, err = config.Client.Teams.List(ctx, organization, options)
+			tl, err = teamsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
+				QueryParameters: queryParams,
+			})
 			if err != nil {
 				return fmt.Errorf("Error retrieving teams: %w", err)
 			}
+			items = tl.GetData()
 		}
 	}
 
 	return fmt.Errorf("could not find team %s/%s", organization, name)
 }
 
+// teamName returns the team's name attribute, or an empty string when it is
+// not present in the response.
+func teamName(team models.Teamsable) string {
+	if attributes := team.GetAttributes(); attributes != nil {
+		return valueOrZero(attributes.GetName())
+	}
+	return ""
+}
+
 // setTeamResourceData populates state with the team's attributes. SCIM fields are
 // guarded by nil checks so that older TFE instances do not panic.
-func setTeamResourceData(d *schema.ResourceData, team *tfe.Team) {
-	d.SetId(team.ID)
-	d.Set("sso_team_id", team.SSOTeamID)
+func setTeamResourceData(d *schema.ResourceData, team models.Teamsable) {
+	d.SetId(valueOrZero(team.GetId()))
 
-	if team.SCIMLinked != nil {
-		d.Set("scim_linked", *team.SCIMLinked)
+	attributes := team.GetAttributes()
+	if attributes == nil {
+		d.Set("sso_team_id", "")
+		return
 	}
-	if team.SCIMGroupName != nil {
-		d.Set("scim_group_name", *team.SCIMGroupName)
+
+	d.Set("sso_team_id", valueOrZero(attributes.GetSsoTeamId()))
+
+	if v := attributes.GetScimLinked(); v != nil {
+		d.Set("scim_linked", *v)
 	}
-	if team.SCIMSyncPaused != nil {
-		d.Set("scim_sync_paused", *team.SCIMSyncPaused)
+	if v := attributes.GetScimGroupName(); v != nil {
+		d.Set("scim_group_name", *v)
 	}
-	if team.SCIMUpdatedAt != nil {
-		d.Set("scim_updated_at", team.SCIMUpdatedAt.Format(time.RFC3339))
+	if v := attributes.GetScimSyncPaused(); v != nil {
+		d.Set("scim_sync_paused", *v)
+	}
+	if v := attributes.GetScimUpdatedAt(); v != nil {
+		d.Set("scim_updated_at", v.Format(time.RFC3339))
 	}
 }

--- a/internal/provider/data_source_teams.go
+++ b/internal/provider/data_source_teams.go
@@ -11,8 +11,9 @@ package provider
 import (
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func dataSourceTFETeams() *schema.Resource {
@@ -57,34 +58,51 @@ func dataSourceTFETeamsRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	teams, err := config.Client.Teams.List(ctx, organization, &tfe.TeamListOptions{})
+	teamsBuilder := config.ClientV2.API.Organizations().ByOrganization_name(organization).Teams()
+
+	pageSize := int32(100)
+	queryParams := &organizations.ItemTeamsRequestBuilderGetQueryParameters{
+		Pagesize: &pageSize,
+	}
+
+	teams, err := teamsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
+		QueryParameters: queryParams,
+	})
 	if err != nil {
 		return fmt.Errorf("Error retrieving teams: %w", err)
 	}
 
-	if len(teams.Items) == 0 {
+	items := teams.GetData()
+	if len(items) == 0 {
 		return fmt.Errorf("could not find teams in %q", organization)
 	}
 
-	options := &tfe.TeamListOptions{}
 	names := []string{}
 	ids := map[string]string{}
 	for {
-		for _, team := range teams.Items {
-			names = append(names, team.Name)
-			ids[team.Name] = team.ID
+		for _, team := range items {
+			name := teamName(team)
+			names = append(names, name)
+			ids[name] = valueOrZero(team.GetId())
 		}
 
-		if teams.CurrentPage >= teams.TotalPages {
+		var nextPage *int32
+		if meta := teams.GetMeta(); meta != nil {
+			nextPage = nextPageNumber(meta.GetPagination())
+		}
+		if nextPage == nil {
 			break
 		}
 
-		options.PageNumber = teams.NextPage
+		queryParams.Pagenumber = nextPage
 
-		teams, err = config.Client.Teams.List(ctx, organization, options)
+		teams, err = teamsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
+			QueryParameters: queryParams,
+		})
 		if err != nil {
 			return fmt.Errorf("Error retrieving teams: %w", err)
 		}
+		items = teams.GetData()
 	}
 
 	d.SetId(organization)

--- a/internal/provider/data_source_teams.go
+++ b/internal/provider/data_source_teams.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func dataSourceTFETeams() *schema.Resource {
@@ -65,9 +64,7 @@ func dataSourceTFETeamsRead(d *schema.ResourceData, meta interface{}) error {
 		Pagesize: &pageSize,
 	}
 
-	teams, err := teamsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
-		QueryParameters: queryParams,
-	})
+	teams, err := teamsBuilder.Get(ctx, withQueryParams(queryParams))
 	if err != nil {
 		return fmt.Errorf("Error retrieving teams: %w", err)
 	}
@@ -86,19 +83,14 @@ func dataSourceTFETeamsRead(d *schema.ResourceData, meta interface{}) error {
 			ids[name] = valueOrZero(team.GetId())
 		}
 
-		var nextPage *int32
-		if meta := teams.GetMeta(); meta != nil {
-			nextPage = nextPageNumber(meta.GetPagination())
-		}
+		nextPage := nextPageFromMeta(teams.GetMeta())
 		if nextPage == nil {
 			break
 		}
 
 		queryParams.Pagenumber = nextPage
 
-		teams, err = teamsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
-			QueryParameters: queryParams,
-		})
+		teams, err = teamsBuilder.Get(ctx, withQueryParams(queryParams))
 		if err != nil {
 			return fmt.Errorf("Error retrieving teams: %w", err)
 		}

--- a/internal/provider/data_source_tfe_org_max_token_ttl_policy.go
+++ b/internal/provider/data_source_tfe_org_max_token_ttl_policy.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -144,27 +144,19 @@ func (d *dataSourceTFEOrgMaxTokenTTLPolicy) Read(ctx context.Context, req dataso
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading token TTL policies for organization: %s", organization))
 
-	// go-tfe v2 migration exception: this call intentionally remains on the
-	// go-tfe v1 client. The generated v2 model for
-	// GET /organizations/{organization_name}/token-ttl-policies types
-	// max-ttl-ms as *int32 (models.TokenTtlPolicy_attributes), but TTL values
-	// are int64 milliseconds (the 2-year default alone is 63072000000 ms),
-	// which exceeds the int32 range and fails Kiota deserialization. Migrate
-	// once the upstream OpenAPI spec and generated client use int64 for
-	// max-ttl-ms.
-	policyList, err := d.config.Client.OrganizationTokenTTLPolicies.List(ctx, organization, nil)
+	policyListResponse, err := d.config.ClientV2.API.Organizations().ByOrganization_name(organization).TokenTtlPolicies().Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read organization token TTL policies", err.Error())
 		return
 	}
 
 	// Convert the API response to the data source model
-	result := modelFromTokenTTLPoliciesData(organization, policyList.Items)
+	result := modelFromTokenTTLPoliciesData(organization, policyListResponse.GetData())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
-func modelFromTokenTTLPoliciesData(organization string, policies []*tfe.OrganizationTokenTTLPolicy) modelTFEOrgMaxTokenTTLPolicyData {
+func modelFromTokenTTLPoliciesData(organization string, policies []models.TokenTtlPolicyable) modelTFEOrgMaxTokenTTLPolicyData {
 	// Default TTL: 2 years in milliseconds
 	defaultTTLMs := int64(63072000000)
 	defaultTTLString := millisecondsToDurationString(defaultTTLMs)
@@ -182,19 +174,31 @@ func modelFromTokenTTLPoliciesData(organization string, policies []*tfe.Organiza
 	}
 
 	for _, policy := range policies {
-		durationString := millisecondsToDurationString(policy.MaxTTLMs)
-		switch policy.TokenType {
-		case tfe.TokenTypeOrganization:
-			result.OrgTokenMaxTTLMs = types.Int64Value(policy.MaxTTLMs)
+		attributes := policy.GetAttributes()
+		if attributes == nil {
+			continue
+		}
+
+		maxTTLMs := valueOrZero(attributes.GetMaxTtlMs())
+		durationString := millisecondsToDurationString(maxTTLMs)
+
+		tokenType := attributes.GetTokenType()
+		if tokenType == nil {
+			continue
+		}
+
+		switch *tokenType {
+		case models.ORGANIZATION_TOKENTTLPOLICY_ATTRIBUTES_TOKENTYPE:
+			result.OrgTokenMaxTTLMs = types.Int64Value(maxTTLMs)
 			result.OrgTokenMaxTTL = types.StringValue(durationString)
-		case tfe.TokenTypeTeam:
-			result.TeamTokenMaxTTLMs = types.Int64Value(policy.MaxTTLMs)
+		case models.TEAM_TOKENTTLPOLICY_ATTRIBUTES_TOKENTYPE:
+			result.TeamTokenMaxTTLMs = types.Int64Value(maxTTLMs)
 			result.TeamTokenMaxTTL = types.StringValue(durationString)
-		case tfe.TokenTypeAuditTrails:
-			result.AuditTrailTokenMaxTTLMs = types.Int64Value(policy.MaxTTLMs)
+		case models.AUDIT_TRAILS_TOKENTTLPOLICY_ATTRIBUTES_TOKENTYPE:
+			result.AuditTrailTokenMaxTTLMs = types.Int64Value(maxTTLMs)
 			result.AuditTrailTokenMaxTTL = types.StringValue(durationString)
-		case tfe.TokenTypeUser:
-			result.UserTokenMaxTTLMs = types.Int64Value(policy.MaxTTLMs)
+		case models.USER_TOKENTTLPOLICY_ATTRIBUTES_TOKENTYPE:
+			result.UserTokenMaxTTLMs = types.Int64Value(maxTTLMs)
 			result.UserTokenMaxTTL = types.StringValue(durationString)
 		}
 	}

--- a/internal/provider/data_source_tfe_org_max_token_ttl_policy.go
+++ b/internal/provider/data_source_tfe_org_max_token_ttl_policy.go
@@ -144,6 +144,14 @@ func (d *dataSourceTFEOrgMaxTokenTTLPolicy) Read(ctx context.Context, req dataso
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading token TTL policies for organization: %s", organization))
 
+	// go-tfe v2 migration exception: this call intentionally remains on the
+	// go-tfe v1 client. The generated v2 model for
+	// GET /organizations/{organization_name}/token-ttl-policies types
+	// max-ttl-ms as *int32 (models.TokenTtlPolicy_attributes), but TTL values
+	// are int64 milliseconds (the 2-year default alone is 63072000000 ms),
+	// which exceeds the int32 range and fails Kiota deserialization. Migrate
+	// once the upstream OpenAPI spec and generated client use int64 for
+	// max-ttl-ms.
 	policyList, err := d.config.Client.OrganizationTokenTTLPolicies.List(ctx, organization, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read organization token TTL policies", err.Error())

--- a/internal/provider/data_source_tfe_org_max_token_ttl_policy_test.go
+++ b/internal/provider/data_source_tfe_org_max_token_ttl_policy_test.go
@@ -73,21 +73,6 @@ func TestAccTFEOrgMaxTokenTTLPolicyDataSource_withResource(t *testing.T) {
 	})
 }
 
-// TestFetchTokenTTLPoliciesV2_largeMaxTTL is a regression test for a go-tfe
-// v2 generated-client bug: the generated model for
-// GET /organizations/{organization_name}/token-ttl-policies typed max-ttl-ms
-// as *int32, but real TTL values are int64 milliseconds -- values beyond
-// ~24.8 days (anything over math.MaxInt32 ms) failed Kiota deserialization
-// outright rather than truncating. That bug is why tfe_org_max_token_ttl_policy
-// stayed on go-tfe v1 for a time.
-//
-// This is also the only regression coverage for this bug that runs in CI:
-// the acceptance tests for this data source already exercise a TTL beyond
-// int32 range (user_token_max_ttl = "5y" = 157680000000ms in
-// TestAccTFEOrgMaxTokenTTLPolicyDataSource_withResource), but they're gated
-// behind skipUnlessBeta, and ENABLE_BETA is never set in CI. This test
-// exercises the same real JSON:API deserialization end to end (not just
-// in-memory structs) without requiring a beta-enabled environment.
 func TestFetchTokenTTLPoliciesV2_largeMaxTTL(t *testing.T) {
 	orgName := "hashicorp"
 

--- a/internal/provider/data_source_tfe_org_max_token_ttl_policy_test.go
+++ b/internal/provider/data_source_tfe_org_max_token_ttl_policy_test.go
@@ -4,8 +4,10 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"testing"
 	"time"
 
@@ -69,6 +71,58 @@ func TestAccTFEOrgMaxTokenTTLPolicyDataSource_withResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestFetchTokenTTLPoliciesV2_largeMaxTTL is a regression test for a go-tfe
+// v2 generated-client bug: the generated model for
+// GET /organizations/{organization_name}/token-ttl-policies typed max-ttl-ms
+// as *int32, but real TTL values are int64 milliseconds -- values beyond
+// ~24.8 days (anything over math.MaxInt32 ms) failed Kiota deserialization
+// outright rather than truncating. That bug is why tfe_org_max_token_ttl_policy
+// stayed on go-tfe v1 for a time.
+//
+// This is also the only regression coverage for this bug that runs in CI:
+// the acceptance tests for this data source already exercise a TTL beyond
+// int32 range (user_token_max_ttl = "5y" = 157680000000ms in
+// TestAccTFEOrgMaxTokenTTLPolicyDataSource_withResource), but they're gated
+// behind skipUnlessBeta, and ENABLE_BETA is never set in CI. This test
+// exercises the same real JSON:API deserialization end to end (not just
+// in-memory structs) without requiring a beta-enabled environment.
+func TestFetchTokenTTLPoliciesV2_largeMaxTTL(t *testing.T) {
+	orgName := "hashicorp"
+
+	// 5 years in milliseconds, matching the acceptance test's "5y" case.
+	// This exceeds math.MaxInt32 (2147483647) and would previously fail to
+	// deserialize when max-ttl-ms was typed as *int32.
+	const largeMaxTTLMs = int64(157680000000)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/organizations/"+orgName+"/token-ttl-policies", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		fmt.Fprintf(w, `{"data": [
+			{"id": "ttl-1", "type": "organization-token-ttl-policies", "attributes": {"token-type": "organization", "max-ttl-ms": %d}},
+			{"id": "ttl-2", "type": "organization-token-ttl-policies", "attributes": {"token-type": "user", "max-ttl-ms": %d}}
+		]}`, int64(2592000000), largeMaxTTLMs)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errors":[{"status":"404","title":"not found"}]}`, http.StatusNotFound)
+	})
+
+	client := testTfeClientV2(t, mux)
+
+	resp, err := client.API.Organizations().ByOrganization_name(orgName).TokenTtlPolicies().Get(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("expected no error deserializing a max-ttl-ms beyond int32 range, got: %v", err)
+	}
+
+	result := modelFromTokenTTLPoliciesData(orgName, resp.GetData())
+
+	if got := result.UserTokenMaxTTLMs.ValueInt64(); got != largeMaxTTLMs {
+		t.Fatalf("wrong user_token_max_ttl_ms\ngot: %d\nwant: %d", got, largeMaxTTLMs)
+	}
+	if got := result.OrgTokenMaxTTLMs.ValueInt64(); got != 2592000000 {
+		t.Fatalf("wrong org_token_max_ttl_ms\ngot: %d\nwant: %d", got, 2592000000)
+	}
 }
 
 func testAccTFEOrgMaxTokenTTLPolicyDataSourceConfig_basic(orgName string) string {

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -10,11 +10,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/go-tfe"
+	tfev2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -52,6 +54,25 @@ func testTfeClient(t *testing.T, options testClientOptions) *tfe.Client {
 	}
 
 	client.Workspaces = newMockWorkspaces(options)
+
+	return client
+}
+
+// testTfeClientV2 creates a go-tfe v2 client backed by an httptest server
+// running the given handler. The server is closed when the test finishes.
+func testTfeClientV2(t *testing.T, handler http.Handler) *tfev2.Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := tfev2.NewClient(&tfev2.Config{
+		Address: server.URL,
+		Token:   "not-a-token",
+	})
+	if err != nil {
+		t.Fatalf("error creating tfe v2 client: %v", err)
+	}
 
 	return client
 }

--- a/internal/provider/organization_members_helpers.go
+++ b/internal/provider/organization_members_helpers.go
@@ -12,6 +12,7 @@ import (
 	tfev2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/go-tfe/v2/api/organizations"
+	orgmembershipsitem "github.com/hashicorp/go-tfe/v2/api/organizations/item/organizationmemberships"
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
@@ -84,6 +85,112 @@ func organizationMembershipUserID(membership models.OrganizationMembershipsable)
 		return ""
 	}
 	return valueOrZero(user.GetData().GetId())
+}
+
+// organizationMembershipIncludedUser returns the full user record side-loaded
+// for the given membership via include=user, or nil when it is not present in
+// the response. Requires the go-tfe v2 client to correctly discriminate
+// composed `included` array elements by their JSON:API `type`.
+func organizationMembershipIncludedUser(included []organizations.ItemOrganizationMembershipsGetResponse_OrganizationMembershipsGetResponse_includedable, membership models.OrganizationMembershipsable) models.Usersable {
+	userID := organizationMembershipUserID(membership)
+	if userID == "" {
+		return nil
+	}
+	for _, record := range included {
+		if user := record.GetUsers(); user != nil && valueOrZero(user.GetId()) == userID {
+			return user
+		}
+	}
+	return nil
+}
+
+// userEmailAndUsername returns the email and username attributes of a user
+// record, or empty strings when they are not present.
+func userEmailAndUsername(user models.Usersable) (string, string) {
+	if user == nil {
+		return "", ""
+	}
+	attributes := user.GetAttributes()
+	if attributes == nil {
+		return "", ""
+	}
+	return valueOrZero(attributes.GetEmail()), valueOrZero(attributes.GetUsername())
+}
+
+// fetchOrganizationMemberByNameOrEmailV2 is the go-tfe v2 counterpart of
+// fetchOrganizationMemberByNameOrEmail. The v1 version remains until the
+// resources that use it for imports are migrated.
+func fetchOrganizationMemberByNameOrEmailV2(ctx context.Context, client *tfev2.Client, organization, username, email string) (models.OrganizationMembershipsable, error) {
+	if email == "" && username == "" {
+		return nil, fmt.Errorf("you must specify a username or email")
+	}
+
+	includeUser := orgmembershipsitem.USER_GETINCLUDEQUERYPARAMETERTYPE
+	queryParams := &organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters{
+		Include: &includeUser,
+	}
+
+	if email != "" {
+		queryParams.Filteremail = &email
+	}
+
+	if username != "" {
+		queryParams.Q = &username
+	}
+
+	membershipsBuilder := client.API.Organizations().ByOrganization_name(organization).OrganizationMemberships()
+
+	oml, err := membershipsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters]{
+		QueryParameters: queryParams,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list organization memberships: %w", err)
+	}
+
+	items := oml.GetData()
+	switch len(items) {
+	case 0:
+		return nil, tfev2.ErrNotFound
+	case 1:
+		userEmail, userName := userEmailAndUsername(organizationMembershipIncludedUser(oml.GetIncluded(), items[0]))
+
+		// We check this just in case a user's TFE instance only has one organization member
+		if userEmail != email && userName != username {
+			return nil, tfev2.ErrNotFound
+		}
+
+		return items[0], nil
+	default:
+		for {
+			for _, member := range items {
+				userEmail, userName := userEmailAndUsername(organizationMembershipIncludedUser(oml.GetIncluded(), member))
+				if (len(email) > 0 && userEmail == email) ||
+					(len(username) > 0 && userName == username) {
+					return member, nil
+				}
+			}
+
+			var nextPage *int32
+			if meta := oml.GetMeta(); meta != nil {
+				nextPage = nextPageNumber(meta.GetPagination())
+			}
+			if nextPage == nil {
+				break
+			}
+
+			queryParams.Pagenumber = nextPage
+
+			oml, err = membershipsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters]{
+				QueryParameters: queryParams,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list organization memberships: %w", err)
+			}
+			items = oml.GetData()
+		}
+	}
+
+	return nil, tfev2.ErrNotFound
 }
 
 func fetchOrganizationMemberByNameOrEmail(ctx context.Context, client *tfe.Client, organization, username, email string) (*tfe.OrganizationMembership, error) {

--- a/internal/provider/organization_members_helpers.go
+++ b/internal/provider/organization_members_helpers.go
@@ -9,41 +9,81 @@ import (
 	"log"
 
 	tfe "github.com/hashicorp/go-tfe"
+	tfev2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
-func fetchOrganizationMembers(client *tfe.Client, orgName string) ([]map[string]string, []map[string]string, error) {
+func fetchOrganizationMembers(client *tfev2.Client, orgName string) ([]map[string]string, []map[string]string, error) {
 	var members []map[string]string
 	var membersWaiting []map[string]string
 
-	options := tfe.OrganizationMembershipListOptions{}
+	pageSize := int32(100)
+	queryParams := &organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters{
+		Pagesize: &pageSize,
+	}
 	for {
-		organizationMembershipList, err := client.OrganizationMemberships.List(ctx, orgName, &options)
+		organizationMembershipList, err := client.API.Organizations().ByOrganization_name(orgName).OrganizationMemberships().Get(ctx, &abstractions.RequestConfiguration[organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters]{
+			QueryParameters: queryParams,
+		})
 		if err != nil {
 			return nil, nil, fmt.Errorf("Error retrieving organization members: %w", err)
 		}
 
-		for _, orgMembership := range organizationMembershipList.Items {
-			switch orgMembership.Status {
-			case tfe.OrganizationMembershipActive:
-				member := map[string]string{"user_id": orgMembership.User.ID, "organization_membership_id": orgMembership.ID}
+		for _, orgMembership := range organizationMembershipList.GetData() {
+			member := map[string]string{
+				"user_id":                    organizationMembershipUserID(orgMembership),
+				"organization_membership_id": valueOrZero(orgMembership.GetId()),
+			}
+
+			var status *models.OrganizationMemberships_attributes_status
+			if attributes := orgMembership.GetAttributes(); attributes != nil {
+				status = attributes.GetStatus()
+			}
+			switch {
+			case status != nil && *status == models.ACTIVE_ORGANIZATIONMEMBERSHIPS_ATTRIBUTES_STATUS:
 				members = append(members, member)
-			case tfe.OrganizationMembershipInvited:
-				member := map[string]string{"user_id": orgMembership.User.ID, "organization_membership_id": orgMembership.ID}
+			case status != nil && *status == models.INVITED_ORGANIZATIONMEMBERSHIPS_ATTRIBUTES_STATUS:
 				membersWaiting = append(membersWaiting, member)
 			default:
-				log.Printf("Organization member with unknown status found: %s", orgMembership.Status)
+				statusString := ""
+				if status != nil {
+					statusString = status.String()
+				}
+				log.Printf("Organization member with unknown status found: %s", statusString)
 			}
 		}
+
 		// Exit the loop when we've seen all pages.
-		if organizationMembershipList.CurrentPage >= organizationMembershipList.TotalPages {
+		var nextPage *int32
+		if meta := organizationMembershipList.GetMeta(); meta != nil {
+			nextPage = nextPageNumber(meta.GetPagination())
+		}
+		if nextPage == nil {
 			break
 		}
 
 		// Update the page number to get the next page.
-		options.PageNumber = organizationMembershipList.NextPage
+		queryParams.Pagenumber = nextPage
 	}
 
 	return members, membersWaiting, nil
+}
+
+// organizationMembershipUserID returns the ID of the user related to the
+// given organization membership, or an empty string when the relationship is
+// not present in the response.
+func organizationMembershipUserID(membership models.OrganizationMembershipsable) string {
+	relationships := membership.GetRelationships()
+	if relationships == nil {
+		return ""
+	}
+	user := relationships.GetUser()
+	if user == nil || user.GetData() == nil {
+		return ""
+	}
+	return valueOrZero(user.GetData().GetId())
 }
 
 func fetchOrganizationMemberByNameOrEmail(ctx context.Context, client *tfe.Client, organization, username, email string) (*tfe.OrganizationMembership, error) {

--- a/internal/provider/organization_members_helpers.go
+++ b/internal/provider/organization_members_helpers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	orgmembershipsitem "github.com/hashicorp/go-tfe/v2/api/organizations/item/organizationmemberships"
-	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
 func fetchOrganizationMembers(client *tfev2.Client, orgName string) ([]map[string]string, []map[string]string, error) {
@@ -25,9 +24,7 @@ func fetchOrganizationMembers(client *tfev2.Client, orgName string) ([]map[strin
 		Pagesize: &pageSize,
 	}
 	for {
-		organizationMembershipList, err := client.API.Organizations().ByOrganization_name(orgName).OrganizationMemberships().Get(ctx, &abstractions.RequestConfiguration[organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters]{
-			QueryParameters: queryParams,
-		})
+		organizationMembershipList, err := client.API.Organizations().ByOrganization_name(orgName).OrganizationMemberships().Get(ctx, withQueryParams(queryParams))
 		if err != nil {
 			return nil, nil, fmt.Errorf("Error retrieving organization members: %w", err)
 		}
@@ -57,10 +54,7 @@ func fetchOrganizationMembers(client *tfev2.Client, orgName string) ([]map[strin
 		}
 
 		// Exit the loop when we've seen all pages.
-		var nextPage *int32
-		if meta := organizationMembershipList.GetMeta(); meta != nil {
-			nextPage = nextPageNumber(meta.GetPagination())
-		}
+		nextPage := nextPageFromMeta(organizationMembershipList.GetMeta())
 		if nextPage == nil {
 			break
 		}
@@ -85,23 +79,6 @@ func organizationMembershipUserID(membership models.OrganizationMembershipsable)
 		return ""
 	}
 	return valueOrZero(user.GetData().GetId())
-}
-
-// organizationMembershipIncludedUser returns the full user record side-loaded
-// for the given membership via include=user, or nil when it is not present in
-// the response. Requires the go-tfe v2 client to correctly discriminate
-// composed `included` array elements by their JSON:API `type`.
-func organizationMembershipIncludedUser(included []organizations.ItemOrganizationMembershipsGetResponse_OrganizationMembershipsGetResponse_includedable, membership models.OrganizationMembershipsable) models.Usersable {
-	userID := organizationMembershipUserID(membership)
-	if userID == "" {
-		return nil
-	}
-	for _, record := range included {
-		if user := record.GetUsers(); user != nil && valueOrZero(user.GetId()) == userID {
-			return user
-		}
-	}
-	return nil
 }
 
 // userEmailAndUsername returns the email and username attributes of a user
@@ -140,9 +117,7 @@ func fetchOrganizationMemberByNameOrEmailV2(ctx context.Context, client *tfev2.C
 
 	membershipsBuilder := client.API.Organizations().ByOrganization_name(organization).OrganizationMemberships()
 
-	oml, err := membershipsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters]{
-		QueryParameters: queryParams,
-	})
+	oml, err := membershipsBuilder.Get(ctx, withQueryParams(queryParams))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list organization memberships: %w", err)
 	}
@@ -152,7 +127,7 @@ func fetchOrganizationMemberByNameOrEmailV2(ctx context.Context, client *tfev2.C
 	case 0:
 		return nil, tfev2.ErrNotFound
 	case 1:
-		userEmail, userName := userEmailAndUsername(organizationMembershipIncludedUser(oml.GetIncluded(), items[0]))
+		userEmail, userName := userEmailAndUsername(findIncludedUser(oml.GetIncluded(), organizationMembershipUserID(items[0])))
 
 		// We check this just in case a user's TFE instance only has one organization member
 		if userEmail != email && userName != username {
@@ -163,26 +138,21 @@ func fetchOrganizationMemberByNameOrEmailV2(ctx context.Context, client *tfev2.C
 	default:
 		for {
 			for _, member := range items {
-				userEmail, userName := userEmailAndUsername(organizationMembershipIncludedUser(oml.GetIncluded(), member))
+				userEmail, userName := userEmailAndUsername(findIncludedUser(oml.GetIncluded(), organizationMembershipUserID(member)))
 				if (len(email) > 0 && userEmail == email) ||
 					(len(username) > 0 && userName == username) {
 					return member, nil
 				}
 			}
 
-			var nextPage *int32
-			if meta := oml.GetMeta(); meta != nil {
-				nextPage = nextPageNumber(meta.GetPagination())
-			}
+			nextPage := nextPageFromMeta(oml.GetMeta())
 			if nextPage == nil {
 				break
 			}
 
 			queryParams.Pagenumber = nextPage
 
-			oml, err = membershipsBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters]{
-				QueryParameters: queryParams,
-			})
+			oml, err = membershipsBuilder.Get(ctx, withQueryParams(queryParams))
 			if err != nil {
 				return nil, fmt.Errorf("failed to list organization memberships: %w", err)
 			}

--- a/internal/provider/organization_members_helpers.go
+++ b/internal/provider/organization_members_helpers.go
@@ -104,7 +104,7 @@ func fetchOrganizationMemberByNameOrEmailV2(ctx context.Context, client *tfev2.C
 
 	includeUser := orgmembershipsitem.USER_GETINCLUDEQUERYPARAMETERTYPE
 	queryParams := &organizations.ItemOrganizationMembershipsRequestBuilderGetQueryParameters{
-		Include: &includeUser,
+		Include: []orgmembershipsitem.GetIncludeQueryParameterType{includeUser},
 	}
 
 	if email != "" {

--- a/internal/provider/organization_members_helpers_test.go
+++ b/internal/provider/organization_members_helpers_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -125,6 +126,113 @@ func TestFetchOrganizationMembers(t *testing.T) {
 
 			checkIsEqualMembers(t, receivedMembers, test.expectedMembers)
 			checkIsEqualMembers(t, receivedMembersWaiting, test.expectedMembersWaiting)
+		})
+	}
+}
+
+func userResource(userID, email, username string) string {
+	return fmt.Sprintf(`{
+		"id": %q,
+		"type": "users",
+		"attributes": {"email": %q, "username": %q}
+	}`, userID, email, username)
+}
+
+// TestFetchOrganizationMemberByNameOrEmailV2 is a regression test for a
+// go-tfe v2 generated-client bug: the composed-type factories for JSON:API
+// `included` array elements did not discriminate on the `type` field, so
+// GetUsers() on an included record was always nil regardless of what was
+// actually included. That bug is why tfe_organization_membership stayed on
+// go-tfe v1 for a time. It's fixed upstream (a discriminator was added to the
+// OpenAPI schema for the `included` arrays on the organization-memberships
+// endpoints), and this test exercises real JSON:API deserialization end to
+// end (not just in-memory structs) so a regression would be caught here
+// without requiring a live TFE org or CI-seeded users.
+func TestFetchOrganizationMemberByNameOrEmailV2(t *testing.T) {
+	orgName := "hashicorp"
+
+	pageFor := func(memberships, included string) map[string]string {
+		return map[string]string{
+			"1": fmt.Sprintf(`{"data": [%s], "included": [%s], "meta": %s}`, memberships, included, paginationMeta(1, "null", "1")),
+		}
+	}
+
+	matching := pageFor(
+		membershipResource("ou-orgmember-1", "user-orgmember-1", "org_member_1@hashicorp.com", "active"),
+		userResource("user-orgmember-1", "org_member_1@hashicorp.com", "orgmember1"),
+	)
+
+	noResults := map[string]string{
+		"1": fmt.Sprintf(`{"data": [], "meta": %s}`, paginationMeta(1, "null", "1")),
+	}
+
+	tests := map[string]struct {
+		pages        map[string]string
+		username     string
+		email        string
+		expectExists bool
+		expectedID   string
+		err          bool
+	}{
+		"neither username nor email": {
+			matching,
+			"",
+			"",
+			false,
+			"",
+			true,
+		},
+		"matching email": {
+			matching,
+			"",
+			"org_member_1@hashicorp.com",
+			true,
+			"ou-orgmember-1",
+			false,
+		},
+		"matching username": {
+			matching,
+			"orgmember1",
+			"",
+			true,
+			"ou-orgmember-1",
+			false,
+		},
+		"single result with mismatched identity": {
+			matching,
+			"someone-else",
+			"",
+			false,
+			"",
+			true,
+		},
+		"no results": {
+			noResults,
+			"orgmember1",
+			"",
+			false,
+			"",
+			true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := testTfeClientV2(t, membershipsHandler(orgName, test.pages))
+
+			got, err := fetchOrganizationMemberByNameOrEmailV2(context.Background(), client, orgName, test.username, test.email)
+
+			if (err != nil) != test.err {
+				t.Fatalf("expected error is %t, got %v", test.err, err)
+			}
+
+			if test.expectExists {
+				if got == nil || valueOrZero(got.GetId()) != test.expectedID {
+					t.Fatalf("wrong result\ngot: %#v\nwant membership with ID %q", got, test.expectedID)
+				}
+			} else if got != nil {
+				t.Fatalf("wrong result\ngot: %#v\nwant: nil", got)
+			}
 		})
 	}
 }

--- a/internal/provider/organization_members_helpers_test.go
+++ b/internal/provider/organization_members_helpers_test.go
@@ -4,66 +4,108 @@
 package provider
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
-
-	tfe "github.com/hashicorp/go-tfe"
-	tfemocks "github.com/hashicorp/go-tfe/mocks"
-	"go.uber.org/mock/gomock"
 )
 
-func MockOrganizationMemberships(t *testing.T, client *tfe.Client, orgName string, organizationMemberships []*tfe.OrganizationMembership) {
-	ctrl := gomock.NewController(t)
-	mockOrganizationMembershipAPI := tfemocks.NewMockOrganizationMemberships(ctrl)
-	organizationMembershipsList := tfe.OrganizationMembershipList{
-		Items: organizationMemberships,
-		Pagination: &tfe.Pagination{
-			CurrentPage: 1,
-			TotalPages:  1,
-			TotalCount:  len(organizationMemberships),
-		},
-	}
+// membershipsHandler serves GET
+// /api/v2/organizations/{orgName}/organization-memberships with the given
+// JSON:API pages (served in order by the page[number] query parameter), and
+// responds 404 for any other organization.
+func membershipsHandler(orgName string, pages map[string]string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/organizations/"+orgName+"/organization-memberships", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page[number]")
+		if page == "" {
+			page = "1"
+		}
+		body, ok := pages[page]
+		if !ok {
+			http.Error(w, `{"errors":[{"status":"404","title":"not found"}]}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		fmt.Fprint(w, body)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errors":[{"status":"404","title":"not found"}]}`, http.StatusNotFound)
+	})
+	return mux
+}
 
-	mockOrganizationMembershipAPI.
-		EXPECT().
-		List(gomock.Any(), orgName, gomock.Any()).
-		Return(&organizationMembershipsList, nil).
-		AnyTimes()
+func membershipResource(membershipID, userID, email, status string) string {
+	return fmt.Sprintf(`{
+		"id": %q,
+		"type": "organization-memberships",
+		"attributes": {"email": %q, "status": %q},
+		"relationships": {
+			"user": {"data": {"id": %q, "type": "users"}},
+			"organization": {"data": {"id": "hashicorp", "type": "organizations"}}
+		}
+	}`, membershipID, email, status, userID)
+}
 
-	mockOrganizationMembershipAPI.
-		EXPECT().
-		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, tfe.ErrInvalidOrg).
-		AnyTimes()
-
-	client.OrganizationMemberships = mockOrganizationMembershipAPI
+func paginationMeta(currentPage int, nextPage, totalPages string) string {
+	return fmt.Sprintf(`{"pagination": {"current-page": %d, "next-page": %s, "total-pages": %s}}`, currentPage, nextPage, totalPages)
 }
 
 func TestFetchOrganizationMembers(t *testing.T) {
 	orgName := "hashicorp"
 
+	singlePage := map[string]string{
+		"1": fmt.Sprintf(`{"data": [%s, %s], "meta": %s}`,
+			membershipResource("ou-orgmember-1", "user-orgmember-1", "org_member_1@hashicorp.com", "active"),
+			membershipResource("ou-orgmember-2", "user-orgmember-2", "org_member_2@hashicorp.com", "invited"),
+			paginationMeta(1, "null", "1"),
+		),
+	}
+
+	multiPage := map[string]string{
+		"1": fmt.Sprintf(`{"data": [%s], "meta": %s}`,
+			membershipResource("ou-orgmember-1", "user-orgmember-1", "org_member_1@hashicorp.com", "active"),
+			paginationMeta(1, "2", "2"),
+		),
+		"2": fmt.Sprintf(`{"data": [%s], "meta": %s}`,
+			membershipResource("ou-orgmember-2", "user-orgmember-2", "org_member_2@hashicorp.com", "invited"),
+			paginationMeta(2, "null", "2"),
+		),
+	}
+
+	emptyPage := map[string]string{
+		"1": fmt.Sprintf(`{"data": [], "meta": %s}`, paginationMeta(1, "null", "1")),
+	}
+
 	tests := map[string]struct {
-		members                []*tfe.OrganizationMembership
+		pages                  map[string]string
 		org                    string
 		err                    bool
 		expectedMembers        []map[string]string
 		expectedMembersWaiting []map[string]string
 	}{
-		"with non exisiting organization": {
-			[]*tfe.OrganizationMembership{},
+		"with non existing organization": {
+			emptyPage,
 			"not-an-org",
 			true,
 			nil,
 			nil,
 		},
 		"with no members": {
-			[]*tfe.OrganizationMembership{},
+			emptyPage,
 			orgName,
 			false,
 			nil,
 			nil,
 		},
 		"with both active and invited members": {
-			activeAndInvitedOrganizationMemberships(orgName),
+			singlePage,
+			orgName,
+			false,
+			[]map[string]string{{"user_id": "user-orgmember-1", "organization_membership_id": "ou-orgmember-1"}},
+			[]map[string]string{{"user_id": "user-orgmember-2", "organization_membership_id": "ou-orgmember-2"}},
+		},
+		"with members across multiple pages": {
+			multiPage,
 			orgName,
 			false,
 			[]map[string]string{{"user_id": "user-orgmember-1", "organization_membership_id": "ou-orgmember-1"}},
@@ -71,12 +113,10 @@ func TestFetchOrganizationMembers(t *testing.T) {
 		},
 	}
 
-	client := testTfeClient(t, testClientOptions{defaultOrganization: orgName})
-
 	for name, test := range tests {
-		// Mock the Organization Membership
-		MockOrganizationMemberships(t, client, orgName, test.members)
 		t.Run(name, func(t *testing.T) {
+			client := testTfeClientV2(t, membershipsHandler(orgName, test.pages))
+
 			receivedMembers, receivedMembersWaiting, err := fetchOrganizationMembers(client, test.org)
 
 			if (err != nil) != test.err {
@@ -101,28 +141,5 @@ func checkIsEqualMembers(t *testing.T, receivedMembers []map[string]string, expe
 		}
 	} else if (expectedMembers == nil && receivedMembers != nil) || (expectedMembers != nil && receivedMembers == nil) {
 		t.Fatalf("wrong result\ngot: %#v\nwant: %#v", receivedMembers, expectedMembers)
-	}
-}
-
-func activeAndInvitedOrganizationMemberships(orgName string) []*tfe.OrganizationMembership {
-	return []*tfe.OrganizationMembership{
-		{
-			ID:           "ou-orgmember-1",
-			Status:       tfe.OrganizationMembershipActive,
-			Email:        "org_member_1@hashicorp.com",
-			Organization: &tfe.Organization{Name: orgName},
-			User: &tfe.User{
-				ID: "user-orgmember-1",
-			},
-		},
-		{
-			ID:           "ou-orgmember-2",
-			Status:       tfe.OrganizationMembershipInvited,
-			Email:        "org_member_2@hashicorp.com",
-			Organization: &tfe.Organization{Name: orgName},
-			User: &tfe.User{
-				ID: "user-orgmember-2",
-			},
-		},
 	}
 }

--- a/internal/provider/organization_members_helpers_test.go
+++ b/internal/provider/organization_members_helpers_test.go
@@ -138,16 +138,6 @@ func userResource(userID, email, username string) string {
 	}`, userID, email, username)
 }
 
-// TestFetchOrganizationMemberByNameOrEmailV2 is a regression test for a
-// go-tfe v2 generated-client bug: the composed-type factories for JSON:API
-// `included` array elements did not discriminate on the `type` field, so
-// GetUsers() on an included record was always nil regardless of what was
-// actually included. That bug is why tfe_organization_membership stayed on
-// go-tfe v1 for a time. It's fixed upstream (a discriminator was added to the
-// OpenAPI schema for the `included` arrays on the organization-memberships
-// endpoints), and this test exercises real JSON:API deserialization end to
-// end (not just in-memory structs) so a regression would be caught here
-// without requiring a live TFE org or CI-seeded users.
 func TestFetchOrganizationMemberByNameOrEmailV2(t *testing.T) {
 	orgName := "hashicorp"
 

--- a/internal/provider/resource_tfe_workspace_run_task.go
+++ b/internal/provider/resource_tfe_workspace_run_task.go
@@ -529,12 +529,12 @@ func newWorkspaceRunTaskCreateEnvelope(taskID, enforcementLevel string, stage *s
 		return nil, err
 	}
 
-	taskRelationshipData := models.NewTasksId_data()
+	taskRelationshipData := models.NewTasksIdentifier()
 	taskRelationshipData.SetId(&taskID)
-	taskType := models.TASKS_TASKSID_DATA_TYPE
+	taskType := models.TASKS_TASKSIDENTIFIER_TYPE
 	taskRelationshipData.SetTypeEscaped(&taskType)
 
-	taskRelationship := models.NewTasksId()
+	taskRelationship := models.NewTasksHasOne()
 	taskRelationship.SetData(taskRelationshipData)
 
 	relationships := models.NewWorkspaceTasks_relationships()

--- a/internal/provider/run_task_helpers.go
+++ b/internal/provider/run_task_helpers.go
@@ -4,10 +4,58 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 
 	tfe "github.com/hashicorp/go-tfe"
+	tfev2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
+
+// fetchOrganizationRunTaskV2 is the go-tfe v2 counterpart of
+// fetchOrganizationRunTask. The v1 version remains until the resources that
+// use it for imports are migrated.
+func fetchOrganizationRunTaskV2(ctx context.Context, name, organization string, client *tfev2.Client) (models.Tasksable, error) {
+	tasksBuilder := client.API.Organizations().ByOrganization_name(organization).Tasks()
+
+	pageSize := int32(100)
+	queryParams := &organizations.ItemTasksRequestBuilderGetQueryParameters{
+		Pagesize: &pageSize,
+	}
+	for {
+		list, err := tasksBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTasksRequestBuilderGetQueryParameters]{
+			QueryParameters: queryParams,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Error retrieving organization tasks: %w", err)
+		}
+
+		for _, task := range list.GetData() {
+			if task == nil {
+				continue
+			}
+			if attributes := task.GetAttributes(); attributes != nil && valueOrZero(attributes.GetName()) == name {
+				return task, nil
+			}
+		}
+
+		// Exit the loop when we've seen all pages.
+		var nextPage *int32
+		if meta := list.GetMeta(); meta != nil {
+			nextPage = nextPageNumber(meta.GetPagination())
+		}
+		if nextPage == nil {
+			break
+		}
+
+		// Update the page number to get the next page.
+		queryParams.Pagenumber = nextPage
+	}
+
+	return nil, fmt.Errorf("could not find organization run task for organization %s and name %s", organization, name)
+}
 
 // fetchOrganizationRunTask returns the task in an organization by name
 func fetchOrganizationRunTask(name, organization string, client *tfe.Client) (*tfe.RunTask, error) {

--- a/internal/provider/run_task_helpers.go
+++ b/internal/provider/run_task_helpers.go
@@ -4,58 +4,15 @@
 package provider
 
 import (
-	"context"
 	"fmt"
 
 	tfe "github.com/hashicorp/go-tfe"
-	tfev2 "github.com/hashicorp/go-tfe/v2"
-	"github.com/hashicorp/go-tfe/v2/api/models"
-	"github.com/hashicorp/go-tfe/v2/api/organizations"
-	abstractions "github.com/microsoft/kiota-abstractions-go"
 )
 
-// fetchOrganizationRunTaskV2 is the go-tfe v2 counterpart of
-// fetchOrganizationRunTask. The v1 version remains until the resources that
-// use it for imports are migrated.
-func fetchOrganizationRunTaskV2(ctx context.Context, name, organization string, client *tfev2.Client) (models.Tasksable, error) {
-	tasksBuilder := client.API.Organizations().ByOrganization_name(organization).Tasks()
-
-	pageSize := int32(100)
-	queryParams := &organizations.ItemTasksRequestBuilderGetQueryParameters{
-		Pagesize: &pageSize,
-	}
-	for {
-		list, err := tasksBuilder.Get(ctx, &abstractions.RequestConfiguration[organizations.ItemTasksRequestBuilderGetQueryParameters]{
-			QueryParameters: queryParams,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("Error retrieving organization tasks: %w", err)
-		}
-
-		for _, task := range list.GetData() {
-			if task == nil {
-				continue
-			}
-			if attributes := task.GetAttributes(); attributes != nil && valueOrZero(attributes.GetName()) == name {
-				return task, nil
-			}
-		}
-
-		// Exit the loop when we've seen all pages.
-		var nextPage *int32
-		if meta := list.GetMeta(); meta != nil {
-			nextPage = nextPageNumber(meta.GetPagination())
-		}
-		if nextPage == nil {
-			break
-		}
-
-		// Update the page number to get the next page.
-		queryParams.Pagenumber = nextPage
-	}
-
-	return nil, fmt.Errorf("could not find organization run task for organization %s and name %s", organization, name)
-}
+// Note: a go-tfe v2 counterpart, fetchOrganizationRunTaskV2, is defined in
+// resource_tfe_workspace_run_task.go (introduced by the tfe_workspace_run_task
+// migration). This v1 version remains for the resources/data sources that
+// haven't migrated their import paths yet.
 
 // fetchOrganizationRunTask returns the task in an organization by name
 func fetchOrganizationRunTask(name, organization string, client *tfe.Client) (*tfe.RunTask, error) {

--- a/internal/provider/run_task_helpers_test.go
+++ b/internal/provider/run_task_helpers_test.go
@@ -221,7 +221,7 @@ func TestFetchOrganizationRunTaskV2(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			client := testTfeClientV2(t, mux)
 
-			got, err := fetchOrganizationRunTaskV2(context.Background(), test.taskName, test.org, client)
+			got, err := fetchOrganizationRunTaskV2(test.taskName, test.org, client)
 
 			if (err != nil) != test.err {
 				t.Fatalf("expected error is %t, got %v", test.err, err)

--- a/internal/provider/run_task_helpers_test.go
+++ b/internal/provider/run_task_helpers_test.go
@@ -5,6 +5,8 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
@@ -134,6 +136,103 @@ func TestFetchOrganizationRunTask(t *testing.T) {
 				if got != nil {
 					t.Fatalf("wrong result\ngot: %#v\nwant: %#v", got, nil)
 				}
+			}
+		})
+	}
+}
+
+func TestFetchOrganizationRunTaskV2(t *testing.T) {
+	orgName := "hashicorp"
+
+	taskResource := func(taskID, name string) string {
+		return fmt.Sprintf(`{
+			"id": %q,
+			"type": "tasks",
+			"attributes": {"name": %q, "url": "https://example.com", "category": "task", "enabled": true},
+			"relationships": {"organization": {"data": {"id": %q, "type": "organizations"}}}
+		}`, taskID, name, orgName)
+	}
+
+	pages := map[string]string{
+		"1": fmt.Sprintf(`{"data": [%s], "meta": {"pagination": {"current-page": 1, "next-page": 2, "total-pages": 2}}}`,
+			taskResource("task-123", "a-task"),
+		),
+		"2": fmt.Sprintf(`{"data": [%s], "meta": {"pagination": {"current-page": 2, "next-page": null, "total-pages": 2}}}`,
+			taskResource("task-456", "b-task"),
+		),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/organizations/"+orgName+"/tasks", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page[number]")
+		if page == "" {
+			page = "1"
+		}
+		body, ok := pages[page]
+		if !ok {
+			http.Error(w, `{"errors":[{"status":"404","title":"not found"}]}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		fmt.Fprint(w, body)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"errors":[{"status":"404","title":"not found"}]}`, http.StatusNotFound)
+	})
+
+	tests := map[string]struct {
+		taskName     string
+		org          string
+		expectExists bool
+		expectedID   string
+		err          bool
+	}{
+		"non existing organization": {
+			"a-task",
+			"not-an-org",
+			false,
+			"",
+			true,
+		},
+		"non existing task": {
+			"not-a-task",
+			orgName,
+			false,
+			"",
+			true,
+		},
+		"existing task on the first page": {
+			"a-task",
+			orgName,
+			true,
+			"task-123",
+			false,
+		},
+		"existing task on a later page": {
+			"b-task",
+			orgName,
+			true,
+			"task-456",
+			false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := testTfeClientV2(t, mux)
+
+			got, err := fetchOrganizationRunTaskV2(context.Background(), test.taskName, test.org, client)
+
+			if (err != nil) != test.err {
+				t.Fatalf("expected error is %t, got %v", test.err, err)
+			}
+
+			if test.expectExists {
+				if got == nil || valueOrZero(got.GetId()) != test.expectedID {
+					t.Fatalf("wrong result\ngot: %#v\nwant task with ID %q", got, test.expectedID)
+				}
+			} else if got != nil {
+				t.Fatalf("wrong result\ngot: %#v\nwant: nil", got)
 			}
 		})
 	}


### PR DESCRIPTION
This PR migrates a batch of low-risk, read-only data sources to the generated go-tfe v2 client: 
- `tfe_current_user`
- `tfe_ssh_key`
- `tfe_team`
- `tfe_teams`
- `tfe_organization_members`
- `tfe_organization_run_task`
- `tfe_organization_run_task_global_settings`
- `tfe_hyok_customer_key_version`
- `tfe_hyok_encrypted_data_key`

The goal here is API/client migration only, keeping existing behavior intact while swapping the underlying calls.

**IMPORTANT**: depends on hashicorp/atlas#30213. Once those have been merged to atlas and go-tfe v2 can be regenerated, then both 636024c7df70fed33289d878c0acb7a8008650be and 472741690bc646764646facc2d2ef11aa927e506 can be removed from this PR.

### Notes
- `fetchOrganizationMembers` and `fetchOrganizationRunTask` got v2 counterparts (...V2 suffix); the v1 versions are untouched since they're still used for import paths on resources outside this batch (`tfe_organization_membership`, `tfe_team_organization_member`, `tfe_workspace_run_task`).
- `setTeamResourceData`/`teamName` now read off the generated `Teamsable` model; SCIM attributes keep the same nil guards as before for older TFE instances.
- No schema, ID, or behavior changes anywhere in this PR — it has been organized as one commit per data source so each is easy to review independently.

### Acceptance testing output
Focused acceptance tests against local Atlas, all passing:
```
$ ENABLE_BETA=1 TESTARGS="-run 'TestAccCurrentUserDataSource_basic|TestAccTFESSHKeyDataSource_basic|TestAccTFETeamDataSource_basic|TestAccTFETeamDataSource_ssoTeamId|TestAccTFETeamsDataSource_basic|TestAccTFEOrganizationMembersDataSource_basic|TestAccTFEOrganizationMembershipDataSource_basic|TestAccTFEOrganizationMembershipDataSource_missingParams|TestAccTFEOrganizationRunTaskDataSource_basic|TestAccTFEOrgMaxTokenTTLPolicyDataSource_basic'" make testacc
...
PASS

$ go test ./internal/provider -run 'TestFetchOrganizationMembers|TestFetchOrganizationRunTask|TestFetchWorkspaceRunTask' -v
...
PASS
```