### PR TITLE
Add provider set priority support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ENHANCEMENTS:
 * Documentation generation now inserts attribute and resource deprecation guidance into the generated schema docs. By @gbaker-ibm [#2144](https://github.com/hashicorp/terraform-provider-tfe/pull/2144)
 * Corrected and reorganized schema fields across the provider, including placing deprecation marks into those previously noted as deprecated by the documentation. By @gbaker-ibm [#2144](https://github.com/hashicorp/terraform-provider-tfe/pull/2144)
 * `r/tfe_project_notification_configuration`: Add `url_wo` and `url_wo_version` attribute support. By @Maed223 [#2150](https://github.com/hashicorp/terraform-provider-tfe/pull/2150)
+* `r/tfe_provider_set`, `d/tfe_provider_set`: Add `priority` support for managing whether a Provider Set takes priority over Provider Sets with more specific scopes. By @AadarshIBM [#2154](https://github.com/hashicorp/terraform-provider-tfe/pull/2154)
 * `r/tfe_workspace_run`: Destroy runs against workspaces with no configuration version (e.g. empty workspaces that never had a configuration uploaded) are now treated as a no-op success instead of returning an error. ([#2145](https://github.com/hashicorp/terraform-provider-tfe/pull/2145))
 
 BREAKING CHANGES:

--- a/examples/resources/tfe_provider_set/resource.tf
+++ b/examples/resources/tfe_provider_set/resource.tf
@@ -5,6 +5,7 @@ resource "tfe_provider_set" "standard" {
   description     = "Reusable provider config for selected workspaces"
   organization    = "example-org"
   provider_source = "registry.terraform.io/hashicorp/aws"
+  priority        = true
   workspace_ids = [
     "ws-exampleaaaa11111",
     "ws-examplebbbb22222",

--- a/internal/provider/data_source_provider_set.go
+++ b/internal/provider/data_source_provider_set.go
@@ -48,6 +48,10 @@ func (d *dataSourceTFEProviderSet) Schema(
 				Description: "Whether the provider set applies globally.",
 				Computed:    true,
 			},
+			"priority": schema.BoolAttribute{
+				Description: "Whether the provider set takes priority over provider sets with more specific scopes.",
+				Computed:    true,
+			},
 			"organization": schema.StringAttribute{
 				Description: "Name of the organization. If omitted, organization must be defined in the provider config.",
 				Computed:    true,
@@ -76,6 +80,7 @@ type modelDataSourceTFEProviderSet struct {
 	Name           types.String `tfsdk:"name"`
 	Description    types.String `tfsdk:"description"`
 	Global         types.Bool   `tfsdk:"global"`
+	Priority       types.Bool   `tfsdk:"priority"`
 	Organization   types.String `tfsdk:"organization"`
 	WorkspaceIDs   types.Set    `tfsdk:"workspace_ids"`
 	ProjectIDs     types.Set    `tfsdk:"project_ids"`
@@ -112,6 +117,8 @@ func modelDataSourceFromTFEProviderSet(
 			global = *g
 		}
 		m.Global = types.BoolValue(global)
+
+		m.Priority = providerSetPriorityValue(attrs.GetPriority())
 
 		if source := attrs.GetProviderSource(); source != nil {
 			m.ProviderSource = types.StringValue(*source)

--- a/internal/provider/data_source_provider_set_test.go
+++ b/internal/provider/data_source_provider_set_test.go
@@ -7,9 +7,43 @@ import (
 	"testing"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestProviderSetDataSourceModelPriority(t *testing.T) {
+	t.Parallel()
+
+	priorityTrue := true
+	priorityFalse := false
+	for _, test := range []struct {
+		name     string
+		priority *bool
+		want     bool
+	}{
+		{name: "true", priority: &priorityTrue, want: true},
+		{name: "false", priority: &priorityFalse},
+		{name: "nil"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			attributes := models.NewProviderSets_attributes()
+			attributes.SetPriority(test.priority)
+			providerSet := models.NewProviderSets()
+			providerSet.SetAttributes(attributes)
+
+			result, diags := modelDataSourceFromTFEProviderSet(context.Background(), providerSet)
+			require.False(t, diags.HasError(), "%v", diags)
+			assert.False(t, result.Priority.IsNull())
+			assert.False(t, result.Priority.IsUnknown())
+			assert.Equal(t, test.want, result.Priority.ValueBool())
+		})
+	}
+}
 
 func TestAccTFEProviderSetDataSource_read(t *testing.T) {
 	skipUnlessBeta(t)
@@ -50,6 +84,9 @@ func TestAccTFEProviderSetDataSource_read(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"data.tfe_provider_set.foobar", "global", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"data.tfe_provider_set.foobar", "priority", "true",
 					),
 					resource.TestCheckResourceAttr(
 						"data.tfe_provider_set.foobar", "project_ids.#", "1",
@@ -249,6 +286,7 @@ resource "tfe_provider_set" "foobar" {
   organization        = local.organization
   provider_source     = "registry.terraform.io/hashicorp/aws"
   global              = false
+  priority            = true
   provider_config_hcl = <<-EOT
 provider "aws" {
   region = "us-east-1"

--- a/internal/provider/resource_tfe_provider_set.go
+++ b/internal/provider/resource_tfe_provider_set.go
@@ -48,6 +48,7 @@ type modelTFEProviderSet struct {
 	Name           types.String `tfsdk:"name"`
 	Description    types.String `tfsdk:"description"`
 	Global         types.Bool   `tfsdk:"global"`
+	Priority       types.Bool   `tfsdk:"priority"`
 	Organization   types.String `tfsdk:"organization"`
 	WorkspaceIDs   types.Set    `tfsdk:"workspace_ids"`
 	ProjectIDs     types.Set    `tfsdk:"project_ids"`
@@ -99,6 +100,12 @@ func (r *resourceTFEProviderSet) Schema(ctx context.Context, req resource.Schema
 			},
 			"global": schema.BoolAttribute{
 				Description: "Whether the provider set applies globally.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"priority": schema.BoolAttribute{
+				Description: "Whether the provider set takes priority over provider sets with more specific scopes. Defaults to false.",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
@@ -279,6 +286,8 @@ func setModelFromProviderSetAttributes(m *modelTFEProviderSet, attrs models.Prov
 	}
 	m.Global = types.BoolValue(global)
 
+	m.Priority = providerSetPriorityValue(attrs.GetPriority())
+
 	if source := attrs.GetProviderSource(); source != nil {
 		m.ProviderSource = types.StringValue(*source)
 	}
@@ -288,6 +297,13 @@ func setModelFromProviderSetAttributes(m *modelTFEProviderSet, attrs models.Prov
 		configurationHcl = *hcl
 	}
 	return configurationHcl
+}
+
+func providerSetPriorityValue(priority *bool) types.Bool {
+	if priority == nil {
+		return types.BoolValue(false)
+	}
+	return types.BoolValue(*priority)
 }
 
 // providerSetOrganizationID extracts the organization ID from a provider
@@ -442,13 +458,14 @@ func providerSetProjectsRelationship(ids []string) models.ProjectsHasManyable {
 
 // newProviderSetAttributes builds the attributes shared by provider set
 // create and update requests.
-func newProviderSetAttributes(name, description, providerSource, configurationHcl string, global bool) *models.ProviderSets_attributes {
+func newProviderSetAttributes(name, description, providerSource, configurationHcl string, global, priority bool) *models.ProviderSets_attributes {
 	attributes := models.NewProviderSets_attributes()
 	attributes.SetName(&name)
 	attributes.SetDescription(&description)
 	attributes.SetProviderSource(&providerSource)
 	attributes.SetConfigurationHcl(&configurationHcl)
 	attributes.SetGlobal(&global)
+	attributes.SetPriority(&priority)
 	return attributes
 }
 
@@ -461,6 +478,7 @@ func newProviderSetCreateEnvelope(organization string, plan modelTFEProviderSet,
 		plan.ProviderSource.ValueString(),
 		configurationHcl,
 		plan.Global.ValueBool(),
+		plan.Priority.ValueBool(),
 	)
 
 	orgType := models.ORGANIZATIONS_ORGANIZATIONSIDENTIFIER_TYPE
@@ -497,6 +515,7 @@ func newProviderSetUpdateEnvelope(id string, plan modelTFEProviderSet, configura
 		plan.ProviderSource.ValueString(),
 		configurationHcl,
 		plan.Global.ValueBool(),
+		plan.Priority.ValueBool(),
 	)
 
 	relationships := models.NewProviderSets_relationships()

--- a/internal/provider/resource_tfe_provider_set_test.go
+++ b/internal/provider/resource_tfe_provider_set_test.go
@@ -5,16 +5,121 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"testing"
 
 	tfe "github.com/hashicorp/go-tfe"
+	tfev2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNewProviderSetEnvelopesPrioritySerialization(t *testing.T) {
+	t.Parallel()
+
+	client, err := tfev2.NewClient(&tfev2.Config{
+		Address: "https://example.com",
+		Token:   "test-token",
+	})
+	require.NoError(t, err)
+
+	for _, priority := range []bool{true, false} {
+		t.Run(fmt.Sprintf("priority_%t", priority), func(t *testing.T) {
+			t.Parallel()
+
+			plan := modelTFEProviderSet{
+				Name:           types.StringValue("provider-set"),
+				Description:    types.StringValue("description"),
+				Global:         types.BoolValue(false),
+				Priority:       types.BoolValue(priority),
+				ProviderSource: types.StringValue("registry.terraform.io/hashicorp/aws"),
+				ProjectIDs:     types.SetNull(types.StringType),
+				WorkspaceIDs:   types.SetNull(types.StringType),
+			}
+			configurationHCL := `provider "aws" {}`
+
+			createRequest, err := client.API.Organizations().
+				ByOrganization_name("organization").
+				ProviderSets().
+				ToPostRequestInformation(
+					context.Background(),
+					newProviderSetCreateEnvelope("organization", plan, configurationHCL),
+					nil,
+				)
+			require.NoError(t, err)
+
+			updateRequest, err := client.API.ProviderSets().
+				ByProvider_set_id("provset-1234567890123456").
+				ToPatchRequestInformation(
+					context.Background(),
+					newProviderSetUpdateEnvelope("provset-1234567890123456", plan, configurationHCL),
+					nil,
+				)
+			require.NoError(t, err)
+
+			for name, content := range map[string][]byte{
+				"create": createRequest.Content,
+				"update": updateRequest.Content,
+			} {
+				t.Run(name, func(t *testing.T) {
+					var payload struct {
+						Data struct {
+							Attributes struct {
+								Priority *bool `json:"priority"`
+							} `json:"attributes"`
+						} `json:"data"`
+					}
+					require.NoError(t, json.Unmarshal(content, &payload))
+					require.NotNil(t, payload.Data.Attributes.Priority)
+					assert.Equal(t, priority, *payload.Data.Attributes.Priority)
+				})
+			}
+		})
+	}
+}
+
+func TestProviderSetModelPriority(t *testing.T) {
+	t.Parallel()
+
+	priorityTrue := true
+	priorityFalse := false
+	for _, test := range []struct {
+		name     string
+		priority *bool
+		want     bool
+	}{
+		{name: "true", priority: &priorityTrue, want: true},
+		{name: "false", priority: &priorityFalse},
+		{name: "nil"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			attributes := models.NewProviderSets_attributes()
+			attributes.SetPriority(test.priority)
+			providerSet := models.NewProviderSets()
+			providerSet.SetAttributes(attributes)
+
+			result, diags := modelFromTFEProviderSet(
+				context.Background(),
+				providerSet,
+				types.Int64Null(),
+			)
+			require.False(t, diags.HasError(), "%v", diags)
+			assert.False(t, result.Priority.IsNull())
+			assert.False(t, result.Priority.IsUnknown())
+			assert.Equal(t, test.want, result.Priority.ValueBool())
+		})
+	}
+}
 
 func TestAccTFEProviderSet_basic(t *testing.T) {
 	skipUnlessBeta(t)
@@ -114,6 +219,60 @@ func TestAccTFEProviderSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_provider_set.foobar", "workspace_ids.#", "1",
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEProviderSet_priority(t *testing.T) {
+	skipUnlessBeta(t)
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	org, orgCleanup := createOrganization(t, tfeClient, tfe.OrganizationCreateOptions{
+		Name:  tfe.String("tst-" + randomString(t)),
+		Email: tfe.String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+	})
+	defer orgCleanup()
+
+	resourceName := "tfe_provider_set.foobar"
+	priorityTrue := true
+	priorityFalse := false
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEProviderSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEProviderSet_priority(org.Name, nil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "priority", "false"),
+				),
+			},
+			{
+				Config: testAccTFEProviderSet_priority(org.Name, &priorityTrue),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "priority", "true"),
+				),
+			},
+			{
+				Config: testAccTFEProviderSet_priority(org.Name, &priorityFalse),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "priority", "false"),
 				),
 			},
 		},
@@ -663,6 +822,27 @@ EOT
   project_ids =   [ tfe_project.foo.id ]
   workspace_ids = [ tfe_workspace.foo.id ]
 }`, organization)
+}
+
+func testAccTFEProviderSet_priority(organization string, priority *bool) string {
+	priorityConfig := "// priority omitted"
+	if priority != nil {
+		priorityConfig = fmt.Sprintf("priority = %t", *priority)
+	}
+
+	return fmt.Sprintf(`
+resource "tfe_provider_set" "foobar" {
+  name                = "priority-test"
+  organization        = %q
+  provider_source     = "registry.terraform.io/hashicorp/aws"
+  global              = true
+  %s
+  provider_config_hcl = <<-EOT
+provider "aws" {
+  region = "us-east-1"
+}
+EOT
+}`, organization, priorityConfig)
 }
 
 func testAccTFEProviderSet_basic_updated(organization string) string {

--- a/website/docs/d/provider_set.html.markdown
+++ b/website/docs/d/provider_set.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `provider_source` -  Source address of the provider, e.g. `registry.terraform.io/hashicorp/tfe`.
 * `description` -  Description of the provider set.
 * `global` -  Whether the provider set applies globally.
+* `priority` -  Whether the provider set takes priority over provider sets with more specific scopes.
 * `workspace_ids` -  IDs of the workspaces attached to the provider set.
 * `project_ids` -  IDs of the projects attached to the provider set.
 

--- a/website/docs/r/provider_set.html.markdown
+++ b/website/docs/r/provider_set.html.markdown
@@ -23,6 +23,7 @@ resource "tfe_provider_set" "standard" {
   description     = "Reusable provider config for selected workspaces"
   organization    = "example-org"
   provider_source = "registry.terraform.io/hashicorp/aws"
+  priority        = true
   workspace_ids = [
     "ws-exampleaaaa11111",
     "ws-examplebbbb22222",
@@ -78,6 +79,7 @@ The following arguments are supported:
 * `provider_source` - (Required) Source address of the provider, e.g. `registry.terraform.io/hashicorp/tfe`.
 * `description` - (Optional) Description of the provider set.
 * `global` - (Optional) Whether the provider set applies globally. Defaults to `false`. When `global` is `false` or omitted, at least one of `workspace_ids` or `project_ids` must be set.
+* `priority` - (Optional) Whether the provider set takes priority over provider sets with more specific scopes. Defaults to `false`.
 * `organization` - (Optional) Name of the organization. If omitted, organization must be defined in the provider config.
 * `workspace_ids` - (Optional) IDs of the workspaces attached to the provider set. Required if `global` is `false` or omitted and `project_ids` is not set. Cannot be set if `global` is `true`.
 * `project_ids` - (Optional) IDs of the projects attached to the provider set. Required if `global` is `false` or omitted and `workspace_ids` is not set. Cannot be set if `global` is `true`.


### PR DESCRIPTION
## Description

Adds support for the Provider Set `priority` attribute in the TFE provider.

This PR:

- Adds `priority` to the `tfe_provider_set` resource, with a default of `false`.
- Adds `priority` to the `tfe_provider_set` data source.
- Sends both `priority = true` and `priority = false` to the API.
- Reads the priority value back into Terraform state.
- Adds unit and acceptance test coverage.
- Updates the example, documentation, and changelog.

The Provider Set migration to `go-tfe/v2` was completed in #2158. This PR builds on that work and only adds priority support.

The backend remains responsible for deciding which Provider Set takes precedence.

- [x] Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)
- [x] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)

## Testing plan

1. Verify that omitting `priority` results in `false`.
2. Set `priority = true` and confirm it is sent and read back correctly.
3. Update `priority` from `true` back to `false`.
4. Confirm priority changes update the existing Provider Set instead of replacing it.
5. Verify that the Provider Set data source reads the priority value.
6. Verify that existing relationships and write-only HCL behavior remain unchanged.

## External links

- Jira: https://hashicorp.atlassian.net/browse/NOCODE-107
- Related Provider Set v2 migration: https://github.com/hashicorp/terraform-provider-tfe/pull/2158

## Test results

Focused Provider Set tests passed using the repository's committed dependencies:

```sh
GOWORK=off go test ./internal/provider \
  -run '^Test(ProviderSet.*|NewProviderSet.*|ModelFromTFEProviderSet|TFEProviderSetNotImportableInPrepStub|FrameworkProviderResources_includeProviderSet)$' \
  -count=1
```

The following checks also passed:

```sh
GOWORK=off go vet ./...
GOWORK=off make fmtcheck
git diff origin/main...HEAD --check
```

Additional priority tests and race testing also passed.

The following acceptance tests passed against a feature-enabled staging organization:

- `TestAccTFEProviderSet_priority`
  - Confirmed that omitted `priority` defaults to `false`.
  - Confirmed that priority can be updated from `false` to `true` and back to `false`.
  - Confirmed that priority changes update the existing Provider Set instead of replacing it.

- `TestAccTFEProviderSetDataSource_read`
  - Confirmed that the data source reads `priority = true`.

The staging organization was used through a temporary local test change. That change was reverted and is not included in this PR.

## Rollback Plan

To roll back this change, revert the PR. No state migration is required.

## Changes to Security Controls

No changes to access controls, authorization, encryption, or logging.