### PR TITLE
Migration for tfe_provider_set resource and data source from go-tfe v1 to go-tfe v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260715214333-9f9363a22e27
+	github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260727173559-908c574bd976
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260727173559-908c574bd976
+	github.com/hashicorp/go-tfe/v2 v2.3.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
 github.com/hashicorp/go-tfe v1.109.0 h1:zWusjKHkWBdkmgzUc1OizccnlcOiCe/Y0FzOQMQLets=
 github.com/hashicorp/go-tfe v1.109.0/go.mod h1:d8js2OmMnCq58gEh26mCS81nD8Aj7HmG6IO1b80gM78=
-github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260715214333-9f9363a22e27 h1:BV7OsOkU6ZnV2BMnYgWtPetzhOalgmpyJBL8jBd1SB4=
-github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260715214333-9f9363a22e27/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
+github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260727173559-908c574bd976 h1:a55cwxXx+Yw6uExHWGVzqJq8C4bvqDAxyyX5lvPHmBE=
+github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260727173559-908c574bd976/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
 github.com/hashicorp/go-tfe v1.109.0 h1:zWusjKHkWBdkmgzUc1OizccnlcOiCe/Y0FzOQMQLets=
 github.com/hashicorp/go-tfe v1.109.0/go.mod h1:d8js2OmMnCq58gEh26mCS81nD8Aj7HmG6IO1b80gM78=
-github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260727173559-908c574bd976 h1:a55cwxXx+Yw6uExHWGVzqJq8C4bvqDAxyyX5lvPHmBE=
-github.com/hashicorp/go-tfe/v2 v2.2.1-0.20260727173559-908c574bd976/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
+github.com/hashicorp/go-tfe/v2 v2.3.0 h1:sWj1/aRSwdgA6FVT6vVKGRkUm53BqN/+JQnafvpLotU=
+github.com/hashicorp/go-tfe/v2 v2.3.0/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/data_source_provider_set.go
+++ b/internal/provider/data_source_provider_set.go
@@ -5,9 +5,11 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfe "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -80,48 +82,96 @@ type modelDataSourceTFEProviderSet struct {
 	ProviderSource types.String `tfsdk:"provider_source"`
 }
 
-// modelDataSourceFromTFEProviderSet builds a modelDataSourceFromTFEProviderSet struct from a tfe.ProviderSet
+// modelDataSourceFromTFEProviderSet builds a modelDataSourceTFEProviderSet struct from a v2 provider set resource.
 func modelDataSourceFromTFEProviderSet(
 	ctx context.Context,
-	v tfe.ProviderSet,
+	v models.ProviderSetsable,
 ) (m modelDataSourceTFEProviderSet, diags diag.Diagnostics) {
-	organization := ""
-	if v.Organization != nil {
-		organization = v.Organization.Name
-	}
-
-	// Initialize all fields from the provided API struct
 	m = modelDataSourceTFEProviderSet{
-		ID:             types.StringValue(v.ID),
-		Name:           types.StringValue(v.Name),
-		Description:    types.StringValue(v.Description),
-		Global:         types.BoolValue(v.Global),
-		Organization:   types.StringValue(organization),
-		ProviderSource: types.StringValue(v.ProviderSource),
-		ProjectIDs:     types.SetNull(types.StringType),
-		WorkspaceIDs:   types.SetNull(types.StringType),
+		ProjectIDs:   types.SetNull(types.StringType),
+		WorkspaceIDs: types.SetNull(types.StringType),
 	}
 
-	projectIDs := make([]string, len(v.Projects))
-	for i, project := range v.Projects {
-		projectIDs[i] = project.ID
+	if id := v.GetId(); id != nil {
+		m.ID = types.StringValue(*id)
+	}
+
+	if attrs := v.GetAttributes(); attrs != nil {
+		if name := attrs.GetName(); name != nil {
+			m.Name = types.StringValue(*name)
+		}
+
+		description := ""
+		if d := attrs.GetDescription(); d != nil {
+			description = *d
+		}
+		m.Description = types.StringValue(description)
+
+		var global bool
+		if g := attrs.GetGlobal(); g != nil {
+			global = *g
+		}
+		m.Global = types.BoolValue(global)
+
+		if source := attrs.GetProviderSource(); source != nil {
+			m.ProviderSource = types.StringValue(*source)
+		}
+	}
+
+	relationships := v.GetRelationships()
+
+	organization := ""
+	if relationships != nil {
+		if orgRel := relationships.GetOrganization(); orgRel != nil {
+			if orgData := orgRel.GetData(); orgData != nil {
+				if id := orgData.GetId(); id != nil {
+					organization = *id
+				}
+			}
+		}
+	}
+	m.Organization = types.StringValue(organization)
+
+	if relationships == nil {
+		return m, diags
 	}
 
 	var d diag.Diagnostics
 
-	if len(projectIDs) > 0 {
-		m.ProjectIDs, d = types.SetValueFrom(ctx, types.StringType, projectIDs)
-		diags.Append(d...)
+	if projectsRel := relationships.GetProjects(); projectsRel != nil {
+		projectData := projectsRel.GetData()
+		projectIDs := make([]string, 0, len(projectData))
+		for _, p := range projectData {
+			if p == nil {
+				continue
+			}
+			if id := p.GetId(); id != nil {
+				projectIDs = append(projectIDs, *id)
+			}
+		}
+		if len(projectIDs) > 0 {
+			m.ProjectIDs, d = types.SetValueFrom(ctx, types.StringType, projectIDs)
+			diags.Append(d...)
+		}
 	}
 
-	workspaceIDs := make([]string, len(v.Workspaces))
-	for i, workspace := range v.Workspaces {
-		workspaceIDs[i] = workspace.ID
+	if workspacesRel := relationships.GetWorkspaces(); workspacesRel != nil {
+		workspaceData := workspacesRel.GetData()
+		workspaceIDs := make([]string, 0, len(workspaceData))
+		for _, w := range workspaceData {
+			if w == nil {
+				continue
+			}
+			if id := w.GetId(); id != nil {
+				workspaceIDs = append(workspaceIDs, *id)
+			}
+		}
+		if len(workspaceIDs) > 0 {
+			m.WorkspaceIDs, d = types.SetValueFrom(ctx, types.StringType, workspaceIDs)
+			diags.Append(d...)
+		}
 	}
-	if len(workspaceIDs) > 0 {
-		m.WorkspaceIDs, d = types.SetValueFrom(ctx, types.StringType, workspaceIDs)
-		diags.Append(d...)
-	}
+
 	return m, diags
 }
 
@@ -184,12 +234,23 @@ func (d *dataSourceTFEProviderSet) Read(
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Read provider set: %s", config.Name.ValueString()))
-	ps, err := d.config.Client.ProviderSets.ReadByName(ctx, organization, config.Name.ValueString())
+	psEnvelope, err := d.config.ClientV2.API.Organizations().ByOrganization_name(organization).ProviderSets().ByProvider_set_name(config.Name.ValueString()).Get(ctx, nil)
 	if err != nil {
+		// Preserve the v1 client's "resource not found" wording for not-found
+		// errors, since go-tfe/v2 returns "404 Not Found" instead.
+		if errors.Is(err, tfe.ErrNotFound) {
+			resp.Diagnostics.AddError("Error retrieving provider set", "resource not found")
+			return
+		}
 		resp.Diagnostics.AddError("Error retrieving provider set", err.Error())
 		return
 	}
-	m, diags := modelDataSourceFromTFEProviderSet(ctx, *ps)
+	if psEnvelope == nil || psEnvelope.GetData() == nil {
+		resp.Diagnostics.AddError("Error retrieving provider set", "no data was returned by the API")
+		return
+	}
+
+	m, diags := modelDataSourceFromTFEProviderSet(ctx, psEnvelope.GetData())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_provider_set.go
+++ b/internal/provider/data_source_provider_set.go
@@ -120,17 +120,7 @@ func modelDataSourceFromTFEProviderSet(
 
 	relationships := v.GetRelationships()
 
-	organization := ""
-	if relationships != nil {
-		if orgRel := relationships.GetOrganization(); orgRel != nil {
-			if orgData := orgRel.GetData(); orgData != nil {
-				if id := orgData.GetId(); id != nil {
-					organization = *id
-				}
-			}
-		}
-	}
-	m.Organization = types.StringValue(organization)
+	m.Organization = types.StringValue(providerSetOrganizationID(relationships))
 
 	if relationships == nil {
 		return m, diags

--- a/internal/provider/resource_tfe_provider_set.go
+++ b/internal/provider/resource_tfe_provider_set.go
@@ -408,34 +408,34 @@ func providerSetRelationshipIDs(s types.Set) []string {
 
 // providerSetWorkspacesRelationship builds the workspaces relationship for a
 // provider set create/update request from the given workspace IDs.
-func providerSetWorkspacesRelationship(ids []string) models.ProviderSets_relationships_workspacesable {
-	wsType := models.WORKSPACES_PROVIDERSETS_RELATIONSHIPS_WORKSPACES_DATA_TYPE
-	data := make([]models.ProviderSets_relationships_workspaces_dataable, len(ids))
+func providerSetWorkspacesRelationship(ids []string) models.WorkspacesHasManyable {
+	wsType := models.WORKSPACES_WORKSPACESIDENTIFIER_TYPE
+	data := make([]models.WorkspacesIdentifierable, len(ids))
 	for i, id := range ids {
-		d := models.NewProviderSets_relationships_workspaces_data()
+		d := models.NewWorkspacesIdentifier()
 		d.SetId(&id)
 		d.SetTypeEscaped(&wsType)
 		data[i] = d
 	}
 
-	rel := models.NewProviderSets_relationships_workspaces()
+	rel := models.NewWorkspacesHasMany()
 	rel.SetData(data)
 	return rel
 }
 
 // providerSetProjectsRelationship builds the projects relationship for a
 // provider set create/update request from the given project IDs.
-func providerSetProjectsRelationship(ids []string) models.ProviderSets_relationships_projectsable {
-	projType := models.PROJECTS_PROVIDERSETS_RELATIONSHIPS_PROJECTS_DATA_TYPE
-	data := make([]models.ProviderSets_relationships_projects_dataable, len(ids))
+func providerSetProjectsRelationship(ids []string) models.ProjectsHasManyable {
+	projType := models.PROJECTS_PROJECTSIDENTIFIER_TYPE
+	data := make([]models.ProjectsIdentifierable, len(ids))
 	for i, id := range ids {
-		d := models.NewProviderSets_relationships_projects_data()
+		d := models.NewProjectsIdentifier()
 		d.SetId(&id)
 		d.SetTypeEscaped(&projType)
 		data[i] = d
 	}
 
-	rel := models.NewProviderSets_relationships_projects()
+	rel := models.NewProjectsHasMany()
 	rel.SetData(data)
 	return rel
 }
@@ -463,11 +463,11 @@ func newProviderSetCreateEnvelope(organization string, plan modelTFEProviderSet,
 		plan.Global.ValueBool(),
 	)
 
-	orgType := models.ORGANIZATIONS_PROVIDERSETS_RELATIONSHIPS_ORGANIZATION_DATA_TYPE
-	orgData := models.NewProviderSets_relationships_organization_data()
+	orgType := models.ORGANIZATIONS_ORGANIZATIONSIDENTIFIER_TYPE
+	orgData := models.NewOrganizationsIdentifier()
 	orgData.SetId(&organization)
 	orgData.SetTypeEscaped(&orgType)
-	orgRel := models.NewProviderSets_relationships_organization()
+	orgRel := models.NewOrganizationsHasOne()
 	orgRel.SetData(orgData)
 
 	relationships := models.NewProviderSets_relationships()

--- a/internal/provider/resource_tfe_provider_set.go
+++ b/internal/provider/resource_tfe_provider_set.go
@@ -9,7 +9,8 @@ import (
 	"fmt"
 	"regexp"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfe "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -183,52 +184,110 @@ func (r *resourceTFEProviderSet) Schema(ctx context.Context, req resource.Schema
 	}
 }
 
-// modelFromTFEProviderSet builds a modelFromTFEProviderSet struct from a tfe.ProviderSet
+// modelFromTFEProviderSet builds a modelTFEProviderSet struct from a v2 provider set resource.
 func modelFromTFEProviderSet(
 	ctx context.Context,
-	v tfe.ProviderSet,
+	v models.ProviderSetsable,
 	providerConfigHCLWOVersion types.Int64,
 ) (m modelTFEProviderSet, diags diag.Diagnostics) {
-	// Initialize all fields from the provided API struct
 	m = modelTFEProviderSet{
-		ID:             types.StringValue(v.ID),
-		Name:           types.StringValue(v.Name),
-		Description:    types.StringValue(v.Description),
-		Global:         types.BoolValue(v.Global),
-		Organization:   types.StringValue(v.Organization.Name),
-		ProviderSource: types.StringValue(v.ProviderSource),
-		ProjectIDs:     types.SetNull(types.StringType),
-		WorkspaceIDs:   types.SetNull(types.StringType),
+		ProjectIDs:   types.SetNull(types.StringType),
+		WorkspaceIDs: types.SetNull(types.StringType),
 	}
+
+	if id := v.GetId(); id != nil {
+		m.ID = types.StringValue(*id)
+	}
+
+	var configurationHcl string
+	if attrs := v.GetAttributes(); attrs != nil {
+		if name := attrs.GetName(); name != nil {
+			m.Name = types.StringValue(*name)
+		}
+
+		description := ""
+		if d := attrs.GetDescription(); d != nil {
+			description = *d
+		}
+		m.Description = types.StringValue(description)
+
+		var global bool
+		if g := attrs.GetGlobal(); g != nil {
+			global = *g
+		}
+		m.Global = types.BoolValue(global)
+
+		if source := attrs.GetProviderSource(); source != nil {
+			m.ProviderSource = types.StringValue(*source)
+		}
+
+		if hcl := attrs.GetConfigurationHcl(); hcl != nil {
+			configurationHcl = *hcl
+		}
+	}
+
+	relationships := v.GetRelationships()
+
+	var organization string
+	if relationships != nil {
+		if orgRel := relationships.GetOrganization(); orgRel != nil {
+			if orgData := orgRel.GetData(); orgData != nil {
+				if id := orgData.GetId(); id != nil {
+					organization = *id
+				}
+			}
+		}
+	}
+	m.Organization = types.StringValue(organization)
 
 	if !providerConfigHCLWOVersion.IsNull() {
 		m.ProviderConfigHCL = types.StringNull()
 		m.ProviderConfigHCLWOVersion = providerConfigHCLWOVersion
 	} else {
-		m.ProviderConfigHCL = types.StringValue(v.ConfigurationHcl)
+		m.ProviderConfigHCL = types.StringValue(configurationHcl)
 		m.ProviderConfigHCLWOVersion = types.Int64Null()
 	}
 
-	projectIDs := make([]string, len(v.Projects))
-	for i, project := range v.Projects {
-		projectIDs[i] = project.ID
+	if relationships == nil {
+		return m, diags
 	}
 
 	var d diag.Diagnostics
 
-	if len(projectIDs) > 0 {
-		m.ProjectIDs, d = types.SetValueFrom(ctx, types.StringType, projectIDs)
-		diags.Append(d...)
+	if projectsRel := relationships.GetProjects(); projectsRel != nil {
+		projectData := projectsRel.GetData()
+		projectIDs := make([]string, 0, len(projectData))
+		for _, p := range projectData {
+			if p == nil {
+				continue
+			}
+			if id := p.GetId(); id != nil {
+				projectIDs = append(projectIDs, *id)
+			}
+		}
+		if len(projectIDs) > 0 {
+			m.ProjectIDs, d = types.SetValueFrom(ctx, types.StringType, projectIDs)
+			diags.Append(d...)
+		}
 	}
 
-	workspaceIDs := make([]string, len(v.Workspaces))
-	for i, workspace := range v.Workspaces {
-		workspaceIDs[i] = workspace.ID
+	if workspacesRel := relationships.GetWorkspaces(); workspacesRel != nil {
+		workspaceData := workspacesRel.GetData()
+		workspaceIDs := make([]string, 0, len(workspaceData))
+		for _, w := range workspaceData {
+			if w == nil {
+				continue
+			}
+			if id := w.GetId(); id != nil {
+				workspaceIDs = append(workspaceIDs, *id)
+			}
+		}
+		if len(workspaceIDs) > 0 {
+			m.WorkspaceIDs, d = types.SetValueFrom(ctx, types.StringType, workspaceIDs)
+			diags.Append(d...)
+		}
 	}
-	if len(workspaceIDs) > 0 {
-		m.WorkspaceIDs, d = types.SetValueFrom(ctx, types.StringType, workspaceIDs)
-		diags.Append(d...)
-	}
+
 	return m, diags
 }
 
@@ -311,32 +370,131 @@ func (r *resourceTFEProviderSet) Configure(ctx context.Context, req resource.Con
 	r.config = client
 }
 
-// tfeWorkspacesFromModel converts the workspace IDs in the model to a slice of
-// tfe.Workspace pointers for API calls.
-func tfeWorkspacesFromModel(m modelTFEProviderSet) []*tfe.Workspace {
-	if m.WorkspaceIDs.IsNull() || m.WorkspaceIDs.IsUnknown() {
-		return []*tfe.Workspace{}
+// providerSetRelationshipIDs converts a Set of string IDs from the model into
+// a plain string slice, always returning a non-nil (possibly empty) slice so
+// that the resulting relationship is explicitly set to the plan's exact
+// desired state, including clearing it.
+func providerSetRelationshipIDs(s types.Set) []string {
+	if s.IsNull() || s.IsUnknown() {
+		return []string{}
 	}
-	workspaces := make([]*tfe.Workspace, m.WorkspaceIDs.Length(m.collectionLengthOptions()))
-
-	for i, v := range m.WorkspaceIDs.Elements() {
-		workspaces[i] = &tfe.Workspace{ID: v.(types.String).ValueString()}
+	elements := s.Elements()
+	ids := make([]string, len(elements))
+	for i, v := range elements {
+		ids[i] = v.(types.String).ValueString()
 	}
-	return workspaces
+	return ids
 }
 
-// tfeProjectsFromModel converts the project IDs in the model to a slice of
-// tfe.Project pointers for API calls.
-func tfeProjectsFromModel(m modelTFEProviderSet) []*tfe.Project {
-	if m.ProjectIDs.IsNull() || m.ProjectIDs.IsUnknown() {
-		return []*tfe.Project{}
+// providerSetWorkspacesRelationship builds the workspaces relationship for a
+// provider set create/update request from the given workspace IDs.
+func providerSetWorkspacesRelationship(ids []string) models.ProviderSets_relationships_workspacesable {
+	wsType := models.WORKSPACES_PROVIDERSETS_RELATIONSHIPS_WORKSPACES_DATA_TYPE
+	data := make([]models.ProviderSets_relationships_workspaces_dataable, len(ids))
+	for i, id := range ids {
+		id := id
+		d := models.NewProviderSets_relationships_workspaces_data()
+		d.SetId(&id)
+		d.SetTypeEscaped(&wsType)
+		data[i] = d
 	}
-	projects := make([]*tfe.Project, m.ProjectIDs.Length(m.collectionLengthOptions()))
 
-	for i, v := range m.ProjectIDs.Elements() {
-		projects[i] = &tfe.Project{ID: v.(types.String).ValueString()}
+	rel := models.NewProviderSets_relationships_workspaces()
+	rel.SetData(data)
+	return rel
+}
+
+// providerSetProjectsRelationship builds the projects relationship for a
+// provider set create/update request from the given project IDs.
+func providerSetProjectsRelationship(ids []string) models.ProviderSets_relationships_projectsable {
+	projType := models.PROJECTS_PROVIDERSETS_RELATIONSHIPS_PROJECTS_DATA_TYPE
+	data := make([]models.ProviderSets_relationships_projects_dataable, len(ids))
+	for i, id := range ids {
+		id := id
+		d := models.NewProviderSets_relationships_projects_data()
+		d.SetId(&id)
+		d.SetTypeEscaped(&projType)
+		data[i] = d
 	}
-	return projects
+
+	rel := models.NewProviderSets_relationships_projects()
+	rel.SetData(data)
+	return rel
+}
+
+// newProviderSetAttributes builds the attributes shared by provider set
+// create and update requests.
+func newProviderSetAttributes(name, description, providerSource, configurationHcl string, global bool) *models.ProviderSets_attributes {
+	attributes := models.NewProviderSets_attributes()
+	attributes.SetName(&name)
+	attributes.SetDescription(&description)
+	attributes.SetProviderSource(&providerSource)
+	attributes.SetConfigurationHcl(&configurationHcl)
+	attributes.SetGlobal(&global)
+	return attributes
+}
+
+// newProviderSetCreateEnvelope builds the request body for creating a
+// provider set belonging to the given organization.
+func newProviderSetCreateEnvelope(organization string, plan modelTFEProviderSet, configurationHcl string) *models.ProviderSetsEnvelope {
+	attributes := newProviderSetAttributes(
+		plan.Name.ValueString(),
+		plan.Description.ValueString(),
+		plan.ProviderSource.ValueString(),
+		configurationHcl,
+		plan.Global.ValueBool(),
+	)
+
+	orgType := models.ORGANIZATIONS_PROVIDERSETS_RELATIONSHIPS_ORGANIZATION_DATA_TYPE
+	orgData := models.NewProviderSets_relationships_organization_data()
+	orgData.SetId(&organization)
+	orgData.SetTypeEscaped(&orgType)
+	orgRel := models.NewProviderSets_relationships_organization()
+	orgRel.SetData(orgData)
+
+	relationships := models.NewProviderSets_relationships()
+	relationships.SetOrganization(orgRel)
+	relationships.SetWorkspaces(providerSetWorkspacesRelationship(providerSetRelationshipIDs(plan.WorkspaceIDs)))
+	relationships.SetProjects(providerSetProjectsRelationship(providerSetRelationshipIDs(plan.ProjectIDs)))
+
+	ps := models.NewProviderSets()
+	ps.SetAttributes(attributes)
+	ps.SetRelationships(relationships)
+	psType := models.PROVIDERSETS_PROVIDERSETS_TYPE
+	ps.SetTypeEscaped(&psType)
+
+	envelope := models.NewProviderSetsEnvelope()
+	envelope.SetData(ps)
+	return envelope
+}
+
+// newProviderSetUpdateEnvelope builds the request body for updating an
+// existing provider set. The organization relationship is immutable
+// (organization changes force resource replacement) and is intentionally
+// left unset.
+func newProviderSetUpdateEnvelope(id string, plan modelTFEProviderSet, configurationHcl string) *models.ProviderSetsEnvelope {
+	attributes := newProviderSetAttributes(
+		plan.Name.ValueString(),
+		plan.Description.ValueString(),
+		plan.ProviderSource.ValueString(),
+		configurationHcl,
+		plan.Global.ValueBool(),
+	)
+
+	relationships := models.NewProviderSets_relationships()
+	relationships.SetWorkspaces(providerSetWorkspacesRelationship(providerSetRelationshipIDs(plan.WorkspaceIDs)))
+	relationships.SetProjects(providerSetProjectsRelationship(providerSetRelationshipIDs(plan.ProjectIDs)))
+
+	ps := models.NewProviderSets()
+	ps.SetId(&id)
+	ps.SetAttributes(attributes)
+	ps.SetRelationships(relationships)
+	psType := models.PROVIDERSETS_PROVIDERSETS_TYPE
+	ps.SetTypeEscaped(&psType)
+
+	envelope := models.NewProviderSetsEnvelope()
+	envelope.SetData(ps)
+	return envelope
 }
 
 // Create handles the creation of the resource by making an API call to create a
@@ -364,16 +522,7 @@ func (r *resourceTFEProviderSet) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	options := tfe.ProviderSetCreateOptions{
-		Name:             plan.Name.ValueString(),
-		Description:      plan.Description.ValueStringPointer(),
-		ProviderSource:   plan.ProviderSource.ValueString(),
-		Global:           plan.Global.ValueBoolPointer(),
-		Workspaces:       tfeWorkspacesFromModel(plan),
-		Projects:         tfeProjectsFromModel(plan),
-		ConfigurationHcl: plan.ProviderConfigHCL.ValueString(),
-	}
-
+	configurationHcl := plan.ProviderConfigHCL.ValueString()
 	if !config.ProviderConfigHCLWO.IsNull() {
 		tflog.Debug(
 			ctx,
@@ -382,25 +531,34 @@ func (r *resourceTFEProviderSet) Create(ctx context.Context, req resource.Create
 				plan.Name.ValueString(),
 			),
 		)
-		options.ConfigurationHcl = config.ProviderConfigHCLWO.ValueString()
+		configurationHcl = config.ProviderConfigHCLWO.ValueString()
 	}
+
+	envelope := newProviderSetCreateEnvelope(orgName, plan, configurationHcl)
 
 	tflog.Debug(ctx,
 		fmt.Sprintf(
 			"Creating provider set with name: %s, organization: %s",
-			options.Name,
+			plan.Name.ValueString(),
 			orgName,
 		))
-	ps, err := r.config.Client.ProviderSets.Create(ctx, orgName, options)
+	psEnvelope, err := r.config.ClientV2.API.Organizations().ByOrganization_name(orgName).ProviderSets().Post(ctx, envelope, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating provider set",
-			fmt.Sprintf("Couldn't create provider set %s: %s", options.Name, err.Error()),
+			fmt.Sprintf("Couldn't create provider set %s: %s", plan.Name.ValueString(), err.Error()),
+		)
+		return
+	}
+	if psEnvelope == nil || psEnvelope.GetData() == nil {
+		resp.Diagnostics.AddError(
+			"Error creating provider set",
+			fmt.Sprintf("Couldn't create provider set %s: no data was returned by the API", plan.Name.ValueString()),
 		)
 		return
 	}
 
-	result, diags := modelFromTFEProviderSet(ctx, *ps, config.ProviderConfigHCLWOVersion)
+	result, diags := modelFromTFEProviderSet(ctx, psEnvelope.GetData(), config.ProviderConfigHCLWOVersion)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -419,10 +577,10 @@ func (r *resourceTFEProviderSet) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 	providerSetID := state.ID.ValueString()
-	ps, err := r.config.Client.ProviderSets.Read(ctx, providerSetID)
+	psEnvelope, err := r.config.ClientV2.API.ProviderSets().ByProvider_set_id(providerSetID).Get(ctx, nil)
 	if err != nil {
 		// If it's gone: that's not an error, but we are done.
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfe.ErrNotFound) {
 			tflog.Debug(
 				ctx, fmt.Sprintf(
 					"Provider Set %s no longer exists", providerSetID,
@@ -438,9 +596,18 @@ func (r *resourceTFEProviderSet) Read(ctx context.Context, req resource.ReadRequ
 
 		return
 	}
+	if psEnvelope == nil || psEnvelope.GetData() == nil {
+		tflog.Debug(
+			ctx, fmt.Sprintf(
+				"Provider Set %s no longer exists", providerSetID,
+			),
+		)
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// update state
-	result, diags := modelFromTFEProviderSet(ctx, *ps, state.ProviderConfigHCLWOVersion)
+	result, diags := modelFromTFEProviderSet(ctx, psEnvelope.GetData(), state.ProviderConfigHCLWOVersion)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -468,23 +635,7 @@ func (r *resourceTFEProviderSet) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	// Get the organization name from resource or provider config
-	var orgName string
-	resp.Diagnostics.Append(r.config.dataOrDefaultOrganization(ctx, req.Config, &orgName)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	options := tfe.ProviderSetUpdateOptions{
-		Name:             plan.Name.ValueStringPointer(),
-		Description:      plan.Description.ValueStringPointer(),
-		ProviderSource:   plan.ProviderSource.ValueStringPointer(),
-		Global:           plan.Global.ValueBoolPointer(),
-		Workspaces:       tfeWorkspacesFromModel(plan),
-		Projects:         tfeProjectsFromModel(plan),
-		ConfigurationHcl: plan.ProviderConfigHCL.ValueStringPointer(),
-	}
-
+	configurationHcl := plan.ProviderConfigHCL.ValueString()
 	if !config.ProviderConfigHCLWO.IsNull() {
 		tflog.Debug(
 			ctx,
@@ -493,15 +644,17 @@ func (r *resourceTFEProviderSet) Update(ctx context.Context, req resource.Update
 				plan.Name.ValueString(),
 			),
 		)
-		options.ConfigurationHcl = config.ProviderConfigHCLWO.ValueStringPointer()
+		configurationHcl = config.ProviderConfigHCLWO.ValueString()
 	}
+
+	envelope := newProviderSetUpdateEnvelope(plan.ID.ValueString(), plan, configurationHcl)
 
 	tflog.Debug(ctx,
 		fmt.Sprintf(
 			"Updating provider set %s",
 			plan.ID.String(),
 		))
-	ps, err := r.config.Client.ProviderSets.Update(ctx, plan.ID.ValueString(), options)
+	psEnvelope, err := r.config.ClientV2.API.ProviderSets().ByProvider_set_id(plan.ID.ValueString()).Patch(ctx, envelope, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating provider set",
@@ -509,8 +662,15 @@ func (r *resourceTFEProviderSet) Update(ctx context.Context, req resource.Update
 		)
 		return
 	}
+	if psEnvelope == nil || psEnvelope.GetData() == nil {
+		resp.Diagnostics.AddError(
+			"Error updating provider set",
+			fmt.Sprintf("Couldn't update provider set %s: no data was returned by the API", plan.ID.String()),
+		)
+		return
+	}
 
-	result, diags := modelFromTFEProviderSet(ctx, *ps, config.ProviderConfigHCLWOVersion)
+	result, diags := modelFromTFEProviderSet(ctx, psEnvelope.GetData(), config.ProviderConfigHCLWOVersion)
 	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
@@ -530,9 +690,9 @@ func (r *resourceTFEProviderSet) Delete(ctx context.Context, req resource.Delete
 	providerSetID := state.ID.ValueString()
 
 	tflog.Debug(ctx, fmt.Sprintf("Delete provider set: %s", providerSetID))
-	err := r.config.Client.ProviderSets.Delete(ctx, providerSetID)
+	err := r.config.ClientV2.API.ProviderSets().ByProvider_set_id(providerSetID).Delete(ctx, nil)
 	// Ignore 404s for delete
-	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
+	if err != nil && !errors.Is(err, tfe.ErrNotFound) {
 		resp.Diagnostics.AddError(
 			"Error deleting provider set",
 			fmt.Sprintf("Couldn't delete provider set %s: %s", providerSetID, err.Error()),

--- a/internal/provider/resource_tfe_provider_set.go
+++ b/internal/provider/resource_tfe_provider_set.go
@@ -199,46 +199,11 @@ func modelFromTFEProviderSet(
 		m.ID = types.StringValue(*id)
 	}
 
-	var configurationHcl string
-	if attrs := v.GetAttributes(); attrs != nil {
-		if name := attrs.GetName(); name != nil {
-			m.Name = types.StringValue(*name)
-		}
-
-		description := ""
-		if d := attrs.GetDescription(); d != nil {
-			description = *d
-		}
-		m.Description = types.StringValue(description)
-
-		var global bool
-		if g := attrs.GetGlobal(); g != nil {
-			global = *g
-		}
-		m.Global = types.BoolValue(global)
-
-		if source := attrs.GetProviderSource(); source != nil {
-			m.ProviderSource = types.StringValue(*source)
-		}
-
-		if hcl := attrs.GetConfigurationHcl(); hcl != nil {
-			configurationHcl = *hcl
-		}
-	}
+	configurationHcl := setModelFromProviderSetAttributes(&m, v.GetAttributes())
 
 	relationships := v.GetRelationships()
 
-	var organization string
-	if relationships != nil {
-		if orgRel := relationships.GetOrganization(); orgRel != nil {
-			if orgData := orgRel.GetData(); orgData != nil {
-				if id := orgData.GetId(); id != nil {
-					organization = *id
-				}
-			}
-		}
-	}
-	m.Organization = types.StringValue(organization)
+	m.Organization = types.StringValue(providerSetOrganizationID(relationships))
 
 	if !providerConfigHCLWOVersion.IsNull() {
 		m.ProviderConfigHCL = types.StringNull()
@@ -289,6 +254,61 @@ func modelFromTFEProviderSet(
 	}
 
 	return m, diags
+}
+
+// setModelFromProviderSetAttributes populates m's attribute-derived fields
+// from attrs and returns the configuration HCL, if any.
+func setModelFromProviderSetAttributes(m *modelTFEProviderSet, attrs models.ProviderSets_attributesable) string {
+	if attrs == nil {
+		return ""
+	}
+
+	if name := attrs.GetName(); name != nil {
+		m.Name = types.StringValue(*name)
+	}
+
+	description := ""
+	if d := attrs.GetDescription(); d != nil {
+		description = *d
+	}
+	m.Description = types.StringValue(description)
+
+	var global bool
+	if g := attrs.GetGlobal(); g != nil {
+		global = *g
+	}
+	m.Global = types.BoolValue(global)
+
+	if source := attrs.GetProviderSource(); source != nil {
+		m.ProviderSource = types.StringValue(*source)
+	}
+
+	configurationHcl := ""
+	if hcl := attrs.GetConfigurationHcl(); hcl != nil {
+		configurationHcl = *hcl
+	}
+	return configurationHcl
+}
+
+// providerSetOrganizationID extracts the organization ID from a provider
+// set's relationships, if present.
+func providerSetOrganizationID(relationships models.ProviderSets_relationshipsable) string {
+	if relationships == nil {
+		return ""
+	}
+	orgRel := relationships.GetOrganization()
+	if orgRel == nil {
+		return ""
+	}
+	orgData := orgRel.GetData()
+	if orgData == nil {
+		return ""
+	}
+	id := orgData.GetId()
+	if id == nil {
+		return ""
+	}
+	return *id
 }
 
 // ModifyPlan enforces that provider sets are either global or scoped to at
@@ -392,7 +412,6 @@ func providerSetWorkspacesRelationship(ids []string) models.ProviderSets_relatio
 	wsType := models.WORKSPACES_PROVIDERSETS_RELATIONSHIPS_WORKSPACES_DATA_TYPE
 	data := make([]models.ProviderSets_relationships_workspaces_dataable, len(ids))
 	for i, id := range ids {
-		id := id
 		d := models.NewProviderSets_relationships_workspaces_data()
 		d.SetId(&id)
 		d.SetTypeEscaped(&wsType)
@@ -410,7 +429,6 @@ func providerSetProjectsRelationship(ids []string) models.ProviderSets_relations
 	projType := models.PROJECTS_PROVIDERSETS_RELATIONSHIPS_PROJECTS_DATA_TYPE
 	data := make([]models.ProviderSets_relationships_projects_dataable, len(ids))
 	for i, id := range ids {
-		id := id
 		d := models.NewProviderSets_relationships_projects_data()
 		d.SetId(&id)
 		d.SetTypeEscaped(&projType)

--- a/internal/provider/resource_tfe_workspace_run_task.go
+++ b/internal/provider/resource_tfe_workspace_run_task.go
@@ -529,12 +529,12 @@ func newWorkspaceRunTaskCreateEnvelope(taskID, enforcementLevel string, stage *s
 		return nil, err
 	}
 
-	taskRelationshipData := models.NewTasksId_data()
+	taskRelationshipData := models.NewTasksIdentifier()
 	taskRelationshipData.SetId(&taskID)
-	taskType := models.TASKS_TASKSID_DATA_TYPE
+	taskType := models.TASKS_TASKSIDENTIFIER_TYPE
 	taskRelationshipData.SetTypeEscaped(&taskType)
 
-	taskRelationship := models.NewTasksId()
+	taskRelationship := models.NewTasksHasOne()
 	taskRelationship.SetData(taskRelationshipData)
 
 	relationships := models.NewWorkspaceTasks_relationships()


### PR DESCRIPTION
## Description

Migrates the internal go-tfe client used by `tfe_provider_set` (resource and data source) from `go-tfe` v1 to `go-tfe/v2`. This is part of the broader effort to move the provider off the hand-written v1 client onto the Kiota-generated v2 client, resource by resource.

`go-tfe/v2` did not yet support Provider Sets at the previously pinned version, so this PR also bumps `github.com/hashicorp/go-tfe/v2` to a newer commit (`v2.2.1-0.20260727173559-908c574bd976`) that adds it.

This is an internal-only change:
- No changes to the Terraform schema, attribute names, or plan/apply behavior.
- Client wiring reuses the existing `ConfiguredClient.ClientV2` field already added to the provider by prior v2 migrations (`tfe_ssh_key`, `tfe_registry_module`, `tfe_workspace_run_task`) — no new plumbing needed.
- One intentional compatibility shim: `go-tfe/v2`'s `ErrNotFound.Error()` returns `"404 Not Found"` instead of v1's `"resource not found"`. The data source's `Read` now explicitly maps `errors.Is(err, tfe.ErrNotFound)` to the `"resource not found"` message so existing consumers/tests relying on that text are unaffected.

- [ ] Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md) — not applicable, no user-facing change.
- [ ] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation) — not applicable, schema and docs are unchanged.

## Testing plan

1. Checkout this branch and run `go build ./...`, `go vet ./...`, and `gofmt -l internal/provider/resource_tfe_provider_set.go internal/provider/data_source_provider_set.go` — all should be clean.
1. Run the existing (non-acceptance) unit tests:
go test ./internal/provider/... -run 'TestTFEProviderSetNotImportableInPrepStub|TestFrameworkProviderResources_includeProviderSet' -v


1. Run the full acceptance test suite for this resource/data source against a real TFC/TFE instance (requires credentials — see [testing.md](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/testing.md)):
TESTARGS="-run TestAccTFEProviderSet" make testacc
TESTARGS="-run TestAccTFEProviderSetDataSource" make testacc


1. Confirm behavior is unchanged versus `main` for: create/read/update/delete of a scoped (workspace/project) provider set, a global provider set, write-only HCL (`provider_config_hcl_wo`), out-of-band update/delete detection, and the data source's not-found error paths.

## External links

- [go-tfe v2 documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe/v2)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/provider-sets)

## Output from acceptance tests

```
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEProviderSet -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/client     0.271s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/logging    0.414s [no tests to run]
=== RUN   TestAccTFEProviderSetDataSource_read
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_read (0.00s)
=== RUN   TestAccTFEProviderSetDataSource_read_uninitialized_provider_set
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_read_uninitialized_provider_set (0.00s)
=== RUN   TestAccTFEProviderSetDataSource_read_provider_set_deleted
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_read_provider_set_deleted (0.00s)
=== RUN   TestAccTFEProviderSetDataSource_read_with_default_organization
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_read_with_default_organization (0.00s)
=== RUN   TestAccTFEProviderSetDataSource_validation
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSetDataSource_validation (0.00s)
=== RUN   TestAccTFEProviderSet_basic
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_basic (0.00s)
=== RUN   TestAccTFEProviderSet_update_global_with_relationships
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_update_global_with_relationships (0.00s)
=== RUN   TestAccTFEProviderSet_global
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_global (0.00s)
=== RUN   TestAccTFEProviderSet_minimal
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_minimal (0.00s)
=== RUN   TestAccTFEProviderSet_update_org_force_recreation
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_update_org_force_recreation (0.00s)
=== RUN   TestAccTFEProviderSet_wo
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_wo (0.00s)
=== RUN   TestAccTFEProviderSet_validation
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_validation (0.00s)
=== RUN   TestAccTFEProviderSet_provider_source
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_provider_source (0.00s)
=== RUN   TestAccTFEProviderSet_Read
    helper_test.go:255: Skipping test related to a HCP Terraform and Terraform Enterprise beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestAccTFEProviderSet_Read (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/provider   0.503s
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers   [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers     [no test files]
?       github.com/hashicorp/terraform-provider-tfe/internal/provider/validators        [no test files]
?       github.com/hashicorp/terraform-provider-tfe/version     [no test files]
```

## Rollback Plan

If an issue is discovered post-merge (e.g., an undiscovered v1/v2 behavioral mismatch), revert this PR. Since it only touches `tfe_provider_set`'s internal client usage and pins a specific `go-tfe/v2` version, reverting is a clean, isolated operation with no data migration or state implications — the Terraform schema and wire format to the TFC/TFE API are unchanged.

## Changes to Security Controls

None. This change swaps the internal HTTP client library used to talk to the same TFC/TFE REST API; no changes to authentication, authorization, encryption, or logging behavior.