### PR TITLE
docs: clarify force_regenerate behavior on tfe_team_token

### DIFF
--- a/internal/provider/resource_tfe_team_token.go
+++ b/internal/provider/resource_tfe_team_token.go
@@ -89,7 +89,7 @@ func (r *resourceTFETeamToken) Schema(_ context.Context, _ resource.SchemaReques
 				},
 			},
 			"force_regenerate": schema.BoolAttribute{
-				Description: "Only applies to legacy tokens without descriptions. If set to `true`, a new token will be generated even if a token already exists. This will invalidate the existing token! Regeneration is triggered only when this value changes, so leaving it set to `true` will not regenerate the token on every apply. To regenerate on demand, replace the resource with `terraform apply -replace=\"tfe_team_token.<name>\"`, or use the `replace_triggered_by` lifecycle argument to tie regeneration to changes in another resource. This cannot be set with `description`.",
+				Description: "Only applies to legacy tokens without descriptions. If set to `true`, a new token will be generated even if a token already exists. This will invalidate the existing token! Regeneration is triggered only when this value changes.",
 				Optional:    true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplace(),

--- a/internal/provider/resource_tfe_team_token.go
+++ b/internal/provider/resource_tfe_team_token.go
@@ -89,7 +89,7 @@ func (r *resourceTFETeamToken) Schema(_ context.Context, _ resource.SchemaReques
 				},
 			},
 			"force_regenerate": schema.BoolAttribute{
-				Description: "Only applies to legacy tokens without descriptions. If set to `true`, a new token will be generated even if a token already exists. This will invalidate the existing token! This cannot be set with `description`.",
+				Description: "Only applies to legacy tokens without descriptions. If set to `true`, a new token will be generated even if a token already exists. This will invalidate the existing token! Regeneration is triggered only when this value changes, so leaving it set to `true` will not regenerate the token on every apply. To regenerate on demand, replace the resource with `terraform apply -replace=\"tfe_team_token.<name>\"`, or use the `replace_triggered_by` lifecycle argument to tie regeneration to changes in another resource. This cannot be set with `description`.",
 				Optional:    true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplace(),

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -60,7 +60,7 @@ resource "tfe_team_token" "test" {
 
 - `description` (String) The description of the token, which must be unique per team.
 - `expired_at` (String) The token's expiration date. The expiration date must be a date/time string in RFC3339 format (e.g., "2024-12-31T23:59:59Z"). If no expiration date is supplied, the token will expire 24 months from creation and a warning during plan and apply phases will be displayed.
-- `force_regenerate` (Boolean) Only applies to legacy tokens without descriptions. If set to `true`, a new token will be generated even if a token already exists. This will invalidate the existing token! Regeneration is triggered only when this value changes, so leaving it set to `true` will not regenerate the token on every apply. To regenerate on demand, replace the resource with `terraform apply -replace="tfe_team_token.<name>"`, or use the `replace_triggered_by` lifecycle argument to tie regeneration to changes in another resource. This cannot be set with `description`.
+- `force_regenerate` (Boolean) Only applies to legacy tokens without descriptions. If set to `true`, a new token will be generated even if a token already exists. This will invalidate the existing token! Regeneration is triggered only when this value changes.
 
 ### Read-Only
 

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -60,7 +60,7 @@ resource "tfe_team_token" "test" {
 
 - `description` (String) The description of the token, which must be unique per team.
 - `expired_at` (String) The token's expiration date. The expiration date must be a date/time string in RFC3339 format (e.g., "2024-12-31T23:59:59Z"). If no expiration date is supplied, the token will expire 24 months from creation and a warning during plan and apply phases will be displayed.
-- `force_regenerate` (Boolean) Only applies to legacy tokens without descriptions. If set to `true`, a new token will be generated even if a token already exists. This will invalidate the existing token! This cannot be set with `description`.
+- `force_regenerate` (Boolean) Only applies to legacy tokens without descriptions. If set to `true`, a new token will be generated even if a token already exists. This will invalidate the existing token! Regeneration is triggered only when this value changes, so leaving it set to `true` will not regenerate the token on every apply. To regenerate on demand, replace the resource with `terraform apply -replace="tfe_team_token.<name>"`, or use the `replace_triggered_by` lifecycle argument to tie regeneration to changes in another resource. This cannot be set with `description`.
 
 ### Read-Only
 


### PR DESCRIPTION
## Description

Reorients this PR to a documentation clarification, per review feedback.

The `force_regenerate` attribute on `tfe_team_token` works as intended: it triggers token regeneration when its value *changes* (via the `RequiresReplace` plan modifier), not on every apply. Rather than changing resource behavior, this PR clarifies the attribute's documentation and points users to Terraform's native replacement mechanisms (`terraform apply -replace`, `replace_triggered_by`) for on-demand or scheduled token rotation.

Since docs are now generated by tfplugindocs, the wording lives in the `force_regenerate` `Description` field in `internal/provider/resource_tfe_team_token.go`, with `website/docs/r/team_token.html.markdown` regenerated to match. No resource behavior is changed; the only Go edit is to a description string.

- [ ] ~Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)~ - not needed; no user-facing behavior change
- [x] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)

## Testing plan

1. No behavioral change; the only Go edit is the `Description` string on `force_regenerate`.
2. `docgen generate-docs` and `docgen validate` pass in CI, confirming the committed markdown matches generator output.

## External links

- Related issue: #1257

## Output from acceptance tests

No acceptance tests apply; this change does not alter resource behavior.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

If this change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None. This change only edits a schema description string and its generated documentation.