### PR TITLE
chore: migrate batch #6 to go-tfe/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260804203201-0e0e192e7165
+	github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260820163429-ce5a4ee99d7f
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-tfe/v2 v2.4.0
+	github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260804203201-0e0e192e7165
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
 github.com/hashicorp/go-tfe v1.110.0 h1:R61zw8hgXH+A06rb77GhZXkexjiTls/sPM+lL3G4VsE=
 github.com/hashicorp/go-tfe v1.110.0/go.mod h1:VH4URSfSw6421VEBdfjub/oTINTvT5Mhp4Gd9IA3Ifw=
-github.com/hashicorp/go-tfe/v2 v2.4.0 h1:4ET77SC7Oq2DVwH/HtXWnLyaodEwX4NFho1loeI7Fbg=
-github.com/hashicorp/go-tfe/v2 v2.4.0/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
+github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260804203201-0e0e192e7165 h1:E2aJwp52tbUsllAwmsFqoVmiSnin2kskAu3aq8kKqjo=
+github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260804203201-0e0e192e7165/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/hashicorp/go-slug v1.0.0 h1:aOwhQ1fIbyRAUdBDzXZK2LVmsFFQYuuvJhOM8X9XW
 github.com/hashicorp/go-slug v1.0.0/go.mod h1:Zxkkl8/LfXmhxZO3fLXQUCy3MVXAJK9pybY8WoDPgvs=
 github.com/hashicorp/go-tfe v1.110.0 h1:R61zw8hgXH+A06rb77GhZXkexjiTls/sPM+lL3G4VsE=
 github.com/hashicorp/go-tfe v1.110.0/go.mod h1:VH4URSfSw6421VEBdfjub/oTINTvT5Mhp4Gd9IA3Ifw=
-github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260804203201-0e0e192e7165 h1:E2aJwp52tbUsllAwmsFqoVmiSnin2kskAu3aq8kKqjo=
-github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260804203201-0e0e192e7165/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
+github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260820163429-ce5a4ee99d7f h1:GIUIc2FmLWuWZOfBD9R/6Da8X8n/+/XEWi9Z4ExsXcM=
+github.com/hashicorp/go-tfe/v2 v2.4.1-0.20260820163429-ce5a4ee99d7f/go.mod h1:gosuJ9PH3NLxkCoCW3EIeHHli+5QqLUkboBiUZ1ljCM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/data_source_github_app_installation.go
+++ b/internal/provider/data_source_github_app_installation.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"log"
 
-	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -48,10 +47,6 @@ func dataSourceGHAInstallationRead(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[DEBUG] Reading github app installation")
 
-	var ghai *tfe.GHAInstallation
-	var err error
-
-	// search by name or installation_id
 	var name string
 	var GHInstallationID int
 	vName, ok := d.GetOk("name")
@@ -63,14 +58,15 @@ func dataSourceGHAInstallationRead(d *schema.ResourceData, meta interface{}) err
 	if ok {
 		GHInstallationID = vInstallationID.(int)
 	}
-	ghai, err = fetchGithubAppInstallationByNameOrGHID(ctx, config.Client, name, GHInstallationID)
+
+	id, instID, instName, err := fetchGithubAppInstallationByNameOrGHID(ctx, config, name, GHInstallationID)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(*ghai.ID)
-	d.Set("id", *ghai.ID)
-	d.Set("installation_id", *ghai.InstallationID)
-	d.Set("name", *ghai.Name)
+	d.SetId(id)
+	d.Set("id", id)
+	d.Set("installation_id", instID)
+	d.Set("name", instName)
 	return nil
 }

--- a/internal/provider/data_source_oauth_client.go
+++ b/internal/provider/data_source_oauth_client.go
@@ -175,9 +175,11 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		d.Set("service_provider", valueOrZero(attrs.GetServiceProvider()))
 		d.Set("service_provider_display_name", valueOrZero(attrs.GetServiceProviderDisplayName()))
-		d.Set("organization_scoped", attrs.GetOrganizationScoped() != nil && *attrs.GetOrganizationScoped())
+		d.Set("organization_scoped", attrs.GetOrganizationScoped())
 	}
 
+	d.Set("oauth_token_id", "")
+	d.Set("project_ids", []interface{}{})
 	if rels != nil {
 		if rels.GetOauthTokens() != nil {
 			tokens := rels.GetOauthTokens().GetData()

--- a/internal/provider/data_source_oauth_client.go
+++ b/internal/provider/data_source_oauth_client.go
@@ -10,10 +10,12 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -117,17 +119,12 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 	ctx := context.TODO()
 	config := meta.(ConfiguredClient)
 
-	var oc *tfe.OAuthClient
-	var err error
+	var ocID string
 
 	switch v, ok := d.GetOk("oauth_client_id"); {
 	case ok:
-		oc, err = config.Client.OAuthClients.Read(ctx, v.(string))
-		if err != nil {
-			return fmt.Errorf("Error retrieving OAuth client: %w", err)
-		}
+		ocID = v.(string)
 	default:
-		// search by name or service provider within a specific organization instead
 		organization, err := config.schemaOrDefaultOrganization(d)
 		if err != nil {
 			return err
@@ -144,39 +141,64 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 			serviceProvider = tfe.ServiceProviderType(vServiceProvider.(string))
 		}
 
-		oc, err = fetchOAuthClientByNameOrServiceProvider(ctx, config.Client, organization, name, serviceProvider)
+		id, err := fetchOAuthClientByNameOrServiceProvider(ctx, config, organization, name, serviceProvider)
 		if err != nil {
 			return err
 		}
+		ocID = id
 	}
 
-	d.SetId(oc.ID)
-	d.Set("oauth_client_id", oc.ID)
-	d.Set("api_url", oc.APIURL)
-	d.Set("callback_url", oc.CallbackURL)
-	d.Set("created_at", oc.CreatedAt.Format(time.RFC3339))
-	d.Set("http_url", oc.HTTPURL)
-	if oc.Name != nil {
-		d.Set("name", *oc.Name)
-	}
-	d.Set("service_provider", oc.ServiceProvider)
-	d.Set("service_provider_display_name", oc.ServiceProviderName)
-	d.Set("organization_scoped", oc.OrganizationScoped)
-
-	switch len(oc.OAuthTokens) {
-	case 0:
-		d.Set("oauth_token_id", "")
-	case 1:
-		d.Set("oauth_token_id", oc.OAuthTokens[0].ID)
-	default:
-		return fmt.Errorf("unexpected number of OAuth tokens: %d", len(oc.OAuthTokens))
+	ocEnv, err := config.ClientV2.API.OauthClients().ByOauth_client_id(ocID).Get(ctx, nil)
+	if err != nil {
+		if errors.Is(err, tfeV2.ErrNotFound) {
+			return fmt.Errorf("OAuth client %s not found: %w", ocID, err)
+		}
+		return fmt.Errorf("Error retrieving OAuth client: %w", err)
 	}
 
-	var projectIDs []interface{}
-	for _, project := range oc.Projects {
-		projectIDs = append(projectIDs, project.ID)
+	oc := ocEnv.GetData()
+	attrs := oc.GetAttributes()
+	rels := oc.GetRelationships()
+
+	d.SetId(ocID)
+	d.Set("oauth_client_id", ocID)
+
+	if attrs != nil {
+		d.Set("api_url", valueOrZero(attrs.GetApiUrl()))
+		d.Set("callback_url", valueOrZero(attrs.GetCallbackUrl()))
+		if attrs.GetCreatedAt() != nil {
+			d.Set("created_at", attrs.GetCreatedAt().Format(time.RFC3339))
+		}
+		d.Set("http_url", valueOrZero(attrs.GetHttpUrl()))
+		if n := attrs.GetName(); n != nil {
+			d.Set("name", *n)
+		}
+		d.Set("service_provider", valueOrZero(attrs.GetServiceProvider()))
+		d.Set("service_provider_display_name", valueOrZero(attrs.GetServiceProviderDisplayName()))
+		d.Set("organization_scoped", attrs.GetOrganizationScoped() != nil && *attrs.GetOrganizationScoped())
 	}
-	d.Set("project_ids", projectIDs)
+
+	if rels != nil {
+		if rels.GetOauthTokens() != nil {
+			tokens := rels.GetOauthTokens().GetData()
+			switch len(tokens) {
+			case 0:
+				d.Set("oauth_token_id", "")
+			case 1:
+				d.Set("oauth_token_id", valueOrZero(tokens[0].GetId()))
+			default:
+				return fmt.Errorf("unexpected number of OAuth tokens: %d", len(tokens))
+			}
+		}
+
+		if rels.GetProjects() != nil {
+			var projectIDs []interface{}
+			for _, proj := range rels.GetProjects().GetData() {
+				projectIDs = append(projectIDs, valueOrZero(proj.GetId()))
+			}
+			d.Set("project_ids", projectIDs)
+		}
+	}
 
 	return nil
 }

--- a/internal/provider/data_source_policy_set.go
+++ b/internal/provider/data_source_policy_set.go
@@ -12,7 +12,8 @@ import (
 	"errors"
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -169,92 +170,103 @@ func dataSourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	listOptions := tfe.PolicySetListOptions{}
+	pageSize := int32(100)
+	queryParams := &organizations.ItemPolicySetsRequestBuilderGetQueryParameters{
+		Pagesize:   &pageSize,
+		Searchname: &name,
+	}
 
 	for {
-		policySetList, err := config.Client.PolicySets.List(ctx, organization, &listOptions)
-
+		policySetList, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).PolicySets().Get(ctx, withQueryParams(queryParams))
 		if err != nil {
-			if errors.Is(err, tfe.ErrResourceNotFound) {
+			if errors.Is(err, tfeV2.ErrNotFound) {
 				return fmt.Errorf("could not find policy set %s/%s", organization, name)
 			}
 			return fmt.Errorf("Error retrieving policy set %s: %w", name, err)
 		}
 
-		for _, policySet := range policySetList.Items {
-			// nolint: nestif
-			if policySet.Name == name {
-				d.Set("name", policySet.Name)
-				d.Set("description", policySet.Description)
-				d.Set("global", policySet.Global)
-				d.Set("policies_path", policySet.PoliciesPath)
-				d.Set("policy_update_patterns", policySet.PolicyUpdatePatterns)
-				d.Set("agent_enabled", policySet.AgentEnabled)
+		for _, policySet := range policySetList.GetData() {
+			attrs := policySet.GetAttributes()
+			if attrs == nil || valueOrZero(attrs.GetName()) != name {
+				continue
+			}
+			rels := policySet.GetRelationships()
 
-				if policySet.Kind != "" {
-					d.Set("kind", policySet.Kind)
-				}
+			d.Set("name", valueOrZero(attrs.GetName()))
+			d.Set("description", valueOrZero(attrs.GetDescription()))
+			d.Set("global", attrs.GetGlobal() != nil && *attrs.GetGlobal())
+			d.Set("policies_path", valueOrZero(attrs.GetPoliciesPath()))
+			d.Set("policy_update_patterns", attrs.GetPolicyUpdatePatterns())
+			d.Set("agent_enabled", attrs.GetAgentEnabled() != nil && *attrs.GetAgentEnabled())
 
-				if policySet.Overridable != nil {
-					d.Set("overridable", policySet.Overridable)
-				}
+			if attrs.GetKind() != nil {
+				d.Set("kind", enumStringOrEmpty(attrs.GetKind()))
+			}
+			if attrs.GetOverridable() != nil {
+				d.Set("overridable", *attrs.GetOverridable())
+			}
+			if attrs.GetPolicyToolVersion() != nil {
+				d.Set("policy_tool_version", *attrs.GetPolicyToolVersion())
+			}
 
-				if policySet.PolicyToolVersion != "" {
-					d.Set("policy_tool_version", policySet.PolicyToolVersion)
-				}
+			var vcsRepo []interface{}
+			if attrs.GetVcsRepo() != nil {
+				vr := attrs.GetVcsRepo()
+				vcsRepo = append(vcsRepo, map[string]interface{}{
+					"identifier":                 valueOrZero(vr.GetIdentifier()),
+					"branch":                     valueOrZero(vr.GetBranch()),
+					"ingress_submodules":         vr.GetIngressSubmodules() != nil && *vr.GetIngressSubmodules(),
+					"oauth_token_id":             valueOrZero(vr.GetOauthTokenId()),
+					"github_app_installation_id": valueOrZero(vr.GetGithubAppInstallationId()),
+				})
+			}
+			d.Set("vcs_repo", vcsRepo)
 
-				var vcsRepo []interface{}
-				if policySet.VCSRepo != nil {
-					vcsRepo = append(vcsRepo, map[string]interface{}{
-						"identifier":                 policySet.VCSRepo.Identifier,
-						"branch":                     policySet.VCSRepo.Branch,
-						"ingress_submodules":         policySet.VCSRepo.IngressSubmodules,
-						"oauth_token_id":             policySet.VCSRepo.OAuthTokenID,
-						"github_app_installation_id": policySet.VCSRepo.GHAInstallationID,
-					})
-				}
-				d.Set("vcs_repo", vcsRepo)
-
+			if rels != nil {
 				var policyIDs []interface{}
-				for _, policy := range policySet.Policies {
-					policyIDs = append(policyIDs, policy.ID)
+				if rels.GetPolicies() != nil {
+					for _, p := range rels.GetPolicies().GetData() {
+						policyIDs = append(policyIDs, valueOrZero(p.GetId()))
+					}
 				}
 				d.Set("policy_ids", policyIDs)
 
+				isGlobal := attrs.GetGlobal() != nil && *attrs.GetGlobal()
+
 				var workspaceIDs []interface{}
-				if !policySet.Global {
-					for _, workspace := range policySet.Workspaces {
-						workspaceIDs = append(workspaceIDs, workspace.ID)
+				if !isGlobal && rels.GetWorkspaces() != nil {
+					for _, ws := range rels.GetWorkspaces().GetData() {
+						workspaceIDs = append(workspaceIDs, valueOrZero(ws.GetId()))
 					}
 				}
 				d.Set("workspace_ids", workspaceIDs)
 
 				var excludedWorkspaceIDs []interface{}
-				for _, excludedWorkspace := range policySet.WorkspaceExclusions {
-					excludedWorkspaceIDs = append(excludedWorkspaceIDs, excludedWorkspace.ID)
+				if rels.GetWorkspaceExclusions() != nil {
+					for _, ws := range rels.GetWorkspaceExclusions().GetData() {
+						excludedWorkspaceIDs = append(excludedWorkspaceIDs, valueOrZero(ws.GetId()))
+					}
 				}
 				d.Set("excluded_workspace_ids", excludedWorkspaceIDs)
 
 				var projectIDs []interface{}
-				if !policySet.Global {
-					for _, project := range policySet.Projects {
-						projectIDs = append(projectIDs, project.ID)
+				if !isGlobal && rels.GetProjects() != nil {
+					for _, proj := range rels.GetProjects().GetData() {
+						projectIDs = append(projectIDs, valueOrZero(proj.GetId()))
 					}
 				}
 				d.Set("project_ids", projectIDs)
-
-				d.SetId(policySet.ID)
-
-				return nil
 			}
+
+			d.SetId(valueOrZero(policySet.GetId()))
+			return nil
 		}
-		// Exit the loop when we've seen all pages.
-		if policySetList.CurrentPage >= policySetList.TotalPages {
+
+		nextPage := nextPageFromMeta(policySetList.GetMeta())
+		if nextPage == nil {
 			break
 		}
-
-		// Update the page number to get the next page.
-		listOptions.PageNumber = policySetList.NextPage
+		queryParams.Pagenumber = nextPage
 	}
 	return fmt.Errorf("could not find policy set %s/%s", organization, name)
 }

--- a/internal/provider/github_app_installation_helpers.go
+++ b/internal/provider/github_app_installation_helpers.go
@@ -6,60 +6,67 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
-	"github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/githubappinstallations"
 )
 
-func fetchGithubAppInstallationByNameOrGHID(ctx context.Context, tfeClient *tfe.Client, name string, installationID int) (*tfe.GHAInstallation, error) {
-	// Paginate through all GithubAppInstallation; if multiple pages
-	// of results are returned by the API, use the options variable to increment
-	// the page number until all results have been retrieved.
-	//
-	// Within the pagination loop, loop again through each result on each page.
-	// If 'name' was set, then match against the 'Name' field. If 'installation_id'
-	// was set, then match against the 'installation_id' field. If both are set,
-	// then both must match. All matches are added to the ocMatches slice.
-	//
-	// At the end of the loop, if zero or more than one matches were found, an
-	// error is returned. Otherwise, only one match was found, and that match is
-	// returned.
-	//
+func fetchGithubAppInstallationByNameOrGHID(ctx context.Context, config ConfiguredClient, name string, installationID int) (id string, instID int, instName string, err error) {
 	if name == "" && installationID == 0 {
-		return nil, fmt.Errorf("invalid parameters, either name or installation id must have a value")
+		return "", 0, "", fmt.Errorf("invalid parameters, either name or installation id must have a value")
 	}
-	var ghaInstallation *tfe.GHAInstallation
-	options := &tfe.GHAInstallationListOptions{}
+
+	pageSize := int32(100)
+	queryParams := &githubappinstallations.GithubAppInstallationsRequestBuilderGetQueryParameters{
+		Pagesize: &pageSize,
+	}
+	if name != "" {
+		queryParams.Filtername = &name
+	}
+	if installationID != 0 {
+		idStr := strconv.Itoa(installationID)
+		queryParams.Filterinstallation_id = &idStr
+	}
+
 	for {
-		ghaInstList, err := tfeClient.GHAInstallations.List(ctx, options)
-		if err != nil {
-			return nil, fmt.Errorf("error retrieving Github App Installations: %w", err)
+		list, listErr := config.ClientV2.API.GithubAppInstallations().Get(ctx, withQueryParams(queryParams))
+		if listErr != nil {
+			return "", 0, "", fmt.Errorf("error retrieving Github App Installations: %w", listErr)
 		}
-		for _, item := range ghaInstList.Items {
+
+		for _, item := range list.GetData() {
+			attrs := item.GetAttributes()
+			if attrs == nil {
+				continue
+			}
+			iName := valueOrZero(attrs.GetName())
+			iID := 0
+			if attrs.GetInstallationId() != nil {
+				iID = int(*attrs.GetInstallationId())
+			}
+
+			match := false
 			switch {
 			case name != "" && installationID != 0:
-				if item.Name != nil && *item.Name == name && item.InstallationID != nil && *item.InstallationID == installationID {
-					ghaInstallation = item
-				}
+				match = iName == name && iID == installationID
 			case name != "":
-				if item.Name != nil && *item.Name == name {
-					ghaInstallation = item
-				}
+				match = iName == name
 			case installationID != 0:
-				if *item.InstallationID == installationID {
-					ghaInstallation = item
-				}
+				match = iID == installationID
+			}
+
+			if match {
+				return valueOrZero(item.GetId()), iID, iName, nil
 			}
 		}
 
-		// Exit the loop when we've seen all pages.
-		if ghaInstList.CurrentPage >= ghaInstList.TotalPages {
+		nextPage := nextPageFromMeta(list.GetMeta())
+		if nextPage == nil {
 			break
 		}
-		// Update the page number to get the next page.
-		options.PageNumber = ghaInstList.NextPage
+		queryParams.Pagenumber = nextPage
 	}
-	if ghaInstallation == nil {
-		return nil, fmt.Errorf("no Github App Installation found matching the given parameters")
-	}
-	return ghaInstallation, nil
+
+	return "", 0, "", tfeV2.ErrNotFound
 }

--- a/internal/provider/github_app_installation_helpers.go
+++ b/internal/provider/github_app_installation_helpers.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strconv"
 
-	tfeV2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/go-tfe/v2/api/githubappinstallations"
 )
 
@@ -21,6 +20,8 @@ func fetchGithubAppInstallationByNameOrGHID(ctx context.Context, config Configur
 	queryParams := &githubappinstallations.GithubAppInstallationsRequestBuilderGetQueryParameters{
 		Pagesize: &pageSize,
 	}
+	var matchedID, matchedName string
+	var matchedInstallationID int
 	if name != "" {
 		queryParams.Filtername = &name
 	}
@@ -57,7 +58,9 @@ func fetchGithubAppInstallationByNameOrGHID(ctx context.Context, config Configur
 			}
 
 			if match {
-				return valueOrZero(item.GetId()), iID, iName, nil
+				matchedID = valueOrZero(item.GetId())
+				matchedInstallationID = iID
+				matchedName = iName
 			}
 		}
 
@@ -68,5 +71,8 @@ func fetchGithubAppInstallationByNameOrGHID(ctx context.Context, config Configur
 		queryParams.Pagenumber = nextPage
 	}
 
-	return "", 0, "", tfeV2.ErrNotFound
+	if matchedID == "" {
+		return "", 0, "", fmt.Errorf("no Github App Installation found matching the given parameters")
+	}
+	return matchedID, matchedInstallationID, matchedName, nil
 }

--- a/internal/provider/oauth_client_helpers.go
+++ b/internal/provider/oauth_client_helpers.go
@@ -7,62 +7,60 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-tfe"
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 )
 
-func fetchOAuthClientByNameOrServiceProvider(ctx context.Context, tfeClient *tfe.Client, organization, name string, serviceProvider tfe.ServiceProviderType) (*tfe.OAuthClient, error) {
-	// Paginate through all OAuthClients in the organization; if multiple pages
-	// of results are returned by the API, use the options variable to increment
-	// the page number until all results have been retrieved.
-	//
-	// Within the pagination loop, loop again through each result on each page.
-	// If 'name' was set, then match against the 'Name' field. If 'service_provider'
-	// was set, then match against the 'ServiceProvider' field. If both are set,
-	// then both must match. All matches are added to the ocMatches slice.
-	//
-	// At the end of the loop, if zero or more than one matches were found, an
-	// error is returned. Otherwise, only one match was found, and that match is
-	// returned.
-	//
-	var ocMatches []*tfe.OAuthClient
-	options := &tfe.OAuthClientListOptions{}
+func fetchOAuthClientByNameOrServiceProvider(ctx context.Context, config ConfiguredClient, organization, name string, serviceProvider tfe.ServiceProviderType) (id string, err error) {
+	pageSize := int32(100)
+	queryParams := &organizations.ItemOauthClientsRequestBuilderGetQueryParameters{
+		Pagesize: &pageSize,
+	}
+
+	var matched []string
 	for {
-		ocList, err := tfeClient.OAuthClients.List(ctx, organization, options)
-		if err != nil {
-			return nil, fmt.Errorf("Error retrieving OAuth Clients: %w", err)
+		list, listErr := config.ClientV2.API.Organizations().ByOrganization_name(organization).OauthClients().Get(ctx, withQueryParams(queryParams))
+		if listErr != nil {
+			return "", fmt.Errorf("Error retrieving OAuth Clients: %w", listErr)
 		}
 
-		for _, item := range ocList.Items {
+		for _, item := range list.GetData() {
+			attrs := item.GetAttributes()
+			if attrs == nil {
+				continue
+			}
+			iName := valueOrZero(attrs.GetName())
+			iProvider := valueOrZero(attrs.GetServiceProvider())
+
 			switch {
 			case name != "" && serviceProvider != "":
-				if item.Name != nil && *item.Name == name && item.ServiceProvider == serviceProvider {
-					ocMatches = append(ocMatches, item)
+				if iName == name && iProvider == string(serviceProvider) {
+					matched = append(matched, valueOrZero(item.GetId()))
 				}
 			case name != "":
-				if item.Name != nil && *item.Name == name {
-					ocMatches = append(ocMatches, item)
+				if iName == name {
+					matched = append(matched, valueOrZero(item.GetId()))
 				}
 			case serviceProvider != "":
-				if item.ServiceProvider == serviceProvider {
-					ocMatches = append(ocMatches, item)
+				if iProvider == string(serviceProvider) {
+					matched = append(matched, valueOrZero(item.GetId()))
 				}
 			}
 		}
 
-		// Exit the loop when we've seen all pages.
-		if ocList.CurrentPage >= ocList.TotalPages {
+		nextPage := nextPageFromMeta(list.GetMeta())
+		if nextPage == nil {
 			break
 		}
-
-		// Update the page number to get the next page.
-		options.PageNumber = ocList.NextPage
-	}
-	if len(ocMatches) == 0 {
-		return nil, fmt.Errorf("no OAuthClients found matching the given parameters")
-	}
-	if len(ocMatches) > 1 {
-		return nil, fmt.Errorf("too many OAuthClients were found to match the given parameters. Please narrow your search")
+		queryParams.Pagenumber = nextPage
 	}
 
-	return ocMatches[0], nil
+	if len(matched) == 0 {
+		return "", fmt.Errorf("no OAuthClients found matching the given parameters")
+	}
+	if len(matched) > 1 {
+		return "", fmt.Errorf("too many OAuthClients were found to match the given parameters. Please narrow your search")
+	}
+
+	return matched[0], nil
 }

--- a/internal/provider/resource_tfe_oauth_client.go
+++ b/internal/provider/resource_tfe_oauth_client.go
@@ -9,10 +9,12 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
 	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -215,9 +217,9 @@ func resourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error 
 	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read configuration of OAuth client: %s", d.Id())
-	oc, err := config.Client.OAuthClients.Read(ctx, d.Id())
+	ocEnv, err := config.ClientV2.API.OauthClients().ByOauth_client_id(d.Id()).Get(ctx, nil)
 	if err != nil {
-		if err == tfe.ErrResourceNotFound {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			log.Printf("[DEBUG] OAuth client %s no longer exists", d.Id())
 			d.SetId("")
 			return nil
@@ -225,20 +227,30 @@ func resourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	// Update the config.
-	d.Set("organization", oc.Organization.Name)
-	d.Set("api_url", oc.APIURL)
-	d.Set("http_url", oc.HTTPURL)
-	d.Set("service_provider", string(oc.ServiceProvider))
-	d.Set("organization_scoped", oc.OrganizationScoped)
+	oc := ocEnv.GetData()
+	attrs := oc.GetAttributes()
+	rels := oc.GetRelationships()
 
-	switch len(oc.OAuthTokens) {
-	case 0:
-		d.Set("oauth_token_id", "")
-	case 1:
-		d.Set("oauth_token_id", oc.OAuthTokens[0].ID)
-	default:
-		return fmt.Errorf("unexpected number of OAuth tokens: %d", len(oc.OAuthTokens))
+	if attrs != nil {
+		if rels != nil && rels.GetOrganization() != nil && rels.GetOrganization().GetData() != nil {
+			d.Set("organization", valueOrZero(rels.GetOrganization().GetData().GetId()))
+		}
+		d.Set("api_url", valueOrZero(attrs.GetApiUrl()))
+		d.Set("http_url", valueOrZero(attrs.GetHttpUrl()))
+		d.Set("service_provider", valueOrZero(attrs.GetServiceProvider()))
+		d.Set("organization_scoped", attrs.GetOrganizationScoped() != nil && *attrs.GetOrganizationScoped())
+	}
+
+	if rels != nil && rels.GetOauthTokens() != nil {
+		tokens := rels.GetOauthTokens().GetData()
+		switch len(tokens) {
+		case 0:
+			d.Set("oauth_token_id", "")
+		case 1:
+			d.Set("oauth_token_id", valueOrZero(tokens[0].GetId()))
+		default:
+			return fmt.Errorf("unexpected number of OAuth tokens: %d", len(tokens))
+		}
 	}
 
 	return nil
@@ -248,9 +260,9 @@ func resourceTFEOAuthClientDelete(d *schema.ResourceData, meta interface{}) erro
 	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete OAuth client: %s", d.Id())
-	err := config.Client.OAuthClients.Delete(ctx, d.Id())
+	err := config.ClientV2.API.OauthClients().ByOauth_client_id(d.Id()).Delete(ctx, nil)
 	if err != nil {
-		if err == tfe.ErrResourceNotFound {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			return nil
 		}
 		return fmt.Errorf("Error deleting OAuth client %s: %w", d.Id(), err)

--- a/internal/provider/resource_tfe_oauth_client.go
+++ b/internal/provider/resource_tfe_oauth_client.go
@@ -15,6 +15,7 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -168,46 +169,58 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("private_key is required for service_provider %s", serviceProvider)
 	}
 
-	// Create a new options struct.
-	// The tfe.OAuthClientCreateOptions has omitempty for these values, so if it
-	// is empty, then it will be ignored in the create request
-	options := tfe.OAuthClientCreateOptions{
-		Name:               tfe.String(name),
-		APIURL:             tfe.String(d.Get("api_url").(string)),
-		HTTPURL:            tfe.String(d.Get("http_url").(string)),
-		OAuthToken:         tfe.String(d.Get("oauth_token").(string)),
-		Key:                tfe.String(key),
-		ServiceProvider:    tfe.ServiceProvider(serviceProvider),
-		OrganizationScoped: tfe.Bool(d.Get("organization_scoped").(bool)),
-	}
+	attrs := models.NewOauthClients_attributes()
+	attrs.SetName(ptr(name))
+	attrs.SetApiUrl(ptr(d.Get("api_url").(string)))
+	attrs.SetHttpUrl(ptr(d.Get("http_url").(string)))
+	attrs.SetOauthTokenString(ptr(d.Get("oauth_token").(string)))
+	attrs.SetKey(ptr(key))
+	attrs.SetServiceProvider(ptr(string(serviceProvider)))
+	attrs.SetOrganizationScoped(ptr(d.Get("organization_scoped").(bool)))
 
 	if serviceProvider == tfe.ServiceProviderAzureDevOpsServer {
-		options.PrivateKey = tfe.String(privateKey)
+		attrs.SetPrivateKey(ptr(privateKey))
 	}
 	if serviceProvider == tfe.ServiceProviderBitbucketServer || serviceProvider == tfe.ServiceProviderBitbucketDataCenter {
-		options.RSAPublicKey = tfe.String(rsaPublicKey)
-		options.Secret = tfe.String(secret)
+		attrs.SetRsaPublicKey(ptr(rsaPublicKey))
+		attrs.SetSecret(ptr(secret))
 	}
 	if serviceProvider == tfe.ServiceProviderBitbucket {
-		options.Secret = tfe.String(secret)
-	}
-	if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
-		options.AgentPool = &tfe.AgentPool{ID: *tfe.String(v.(string))}
+		attrs.SetSecret(ptr(secret))
 	}
 
+	body := models.NewOauthClients()
+	body.SetTypeEscaped(ptr(models.OAUTHCLIENTS_OAUTHCLIENTS_TYPE))
+	body.SetAttributes(attrs)
+	if v, ok := d.GetOk("agent_pool_id"); ok && v.(string) != "" {
+		agentPoolData := models.NewAgentPoolsHasOne_data()
+		agentPoolData.SetId(ptr(v.(string)))
+		agentPoolData.SetTypeEscaped(ptr(models.AGENTPOOLS_AGENTPOOLSIDENTIFIER_TYPE))
+		agentPool := models.NewAgentPoolsHasOne()
+		agentPool.SetData(agentPoolData)
+		rels := models.NewOauthClients_relationships()
+		rels.SetAgentPool(agentPool)
+		body.SetRelationships(rels)
+	}
+	env := models.NewOauthClientsEnvelope()
+	env.SetData(body)
+
 	log.Printf("[DEBUG] Create an OAuth client for organization: %s", organization)
-	oc, err := config.Client.OAuthClients.Create(ctx, organization, options)
+	ocEnv, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).OauthClients().Post(ctx, env, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating OAuth client for organization %s: %w", organization, err)
 	}
 
-	d.SetId(oc.ID)
+	oc := ocEnv.GetData()
+	d.SetId(valueOrZero(oc.GetId()))
 
-	if len(oc.OAuthTokens) > 0 {
-		d.Set("oauth_token_id", oc.OAuthTokens[0].ID)
-	} else {
-		d.Set("oauth_token_id", "")
+	d.Set("oauth_token_id", "")
+	if rels := oc.GetRelationships(); rels != nil && rels.GetOauthTokens() != nil {
+		tokens := rels.GetOauthTokens().GetData()
+		if len(tokens) > 0 {
+			d.Set("oauth_token_id", valueOrZero(tokens[0].GetId()))
+		}
 	}
 
 	return resourceTFEOAuthClientRead(d, meta)
@@ -238,9 +251,10 @@ func resourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("api_url", valueOrZero(attrs.GetApiUrl()))
 		d.Set("http_url", valueOrZero(attrs.GetHttpUrl()))
 		d.Set("service_provider", valueOrZero(attrs.GetServiceProvider()))
-		d.Set("organization_scoped", attrs.GetOrganizationScoped() != nil && *attrs.GetOrganizationScoped())
+		d.Set("organization_scoped", attrs.GetOrganizationScoped())
 	}
 
+	d.Set("oauth_token_id", "")
 	if rels != nil && rels.GetOauthTokens() != nil {
 		tokens := rels.GetOauthTokens().GetData()
 		switch len(tokens) {
@@ -274,14 +288,17 @@ func resourceTFEOAuthClientDelete(d *schema.ResourceData, meta interface{}) erro
 func resourceTFEOAuthClientUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
 
-	// Create a new options struct.
-	options := tfe.OAuthClientUpdateOptions{
-		OrganizationScoped: tfe.Bool(d.Get("organization_scoped").(bool)),
-		OAuthToken:         tfe.String(d.Get("oauth_token").(string)),
-	}
+	attrs := models.NewOauthClients_attributes()
+	attrs.SetOrganizationScoped(ptr(d.Get("organization_scoped").(bool)))
+	attrs.SetOauthTokenString(ptr(d.Get("oauth_token").(string)))
+	body := models.NewOauthClients()
+	body.SetTypeEscaped(ptr(models.OAUTHCLIENTS_OAUTHCLIENTS_TYPE))
+	body.SetAttributes(attrs)
+	env := models.NewOauthClientsEnvelope()
+	env.SetData(body)
 
 	log.Printf("[DEBUG] Update OAuth client %s", d.Id())
-	_, err := config.Client.OAuthClients.Update(ctx, d.Id(), options)
+	_, err := config.ClientV2.API.OauthClients().ByOauth_client_id(d.Id()).Patch(ctx, env, nil)
 	if err != nil {
 		return fmt.Errorf("Error updating OAuth client %s: %w", d.Id(), err)
 	}

--- a/internal/provider/resource_tfe_policy.go
+++ b/internal/provider/resource_tfe_policy.go
@@ -200,6 +200,7 @@ func resourceTFEPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	body := models.NewPolicies()
+	body.SetTypeEscaped(ptr(models.POLICIES_POLICIES_TYPE))
 	body.SetAttributes(attrs)
 	env := models.NewPoliciesEnvelope()
 	env.SetData(body)
@@ -300,13 +301,8 @@ func resourceTFEPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("kind", enumStringOrEmpty(attrs.GetKind()))
 
 	//nolint:staticcheck // this is still used by TFE versions older than 202306-1
-	for _, e := range attrs.GetEnforce() {
-		d.Set("enforce_mode", valueOrZero(e.GetMode()))
-		break
-	}
-
-	if q := attrs.GetQuery(); q != nil {
-		d.Set("query", *q)
+	if enforce := attrs.GetEnforce(); len(enforce) == 1 {
+		d.Set("enforce_mode", valueOrZero(enforce[0].GetMode()))
 	}
 
 	content, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Download().Get(ctx, nil)
@@ -361,6 +357,7 @@ func resourceTFEPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		body := models.NewPolicies()
+		body.SetTypeEscaped(ptr(models.POLICIES_POLICIES_TYPE))
 		body.SetAttributes(attrs)
 		env := models.NewPoliciesEnvelope()
 		env.SetData(body)

--- a/internal/provider/resource_tfe_policy.go
+++ b/internal/provider/resource_tfe_policy.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers"
@@ -171,45 +173,54 @@ func resourceTFEPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 		kind = vKind.(string)
 	}
 
-	// Setup common policy options
-	options := &tfe.PolicyCreateOptions{
-		Name: tfe.String(name),
-		Kind: tfe.PolicyKind(kind),
+	attrs := models.NewPolicies_attributes()
+	attrs.SetName(ptr(name))
+	parsedKind, _ := models.ParsePolicies_attributes_kind(kind)
+	if parsedKind != nil {
+		k := parsedKind.(*models.Policies_attributes_kind)
+		attrs.SetKind(k)
 	}
 
 	if desc, ok := d.GetOk("description"); ok {
-		options.Description = tfe.String(desc.(string))
+		attrs.SetDescription(ptr(desc.(string)))
 	}
 
-	//  Setup per-kind policy options
+	var createErr error
 	switch tfe.PolicyKind(kind) {
 	case tfe.Sentinel:
-		options = createSentinelPolicyOptions(options, d)
+		attrs = createSentinelPolicyAttrs(attrs, d)
 	case tfe.OPA:
-		options, err = createOPAPolicyOptions(options, d)
+		attrs, createErr = createOPAPolicyAttrs(attrs, d)
 	default:
-		err = fmt.Errorf(
+		createErr = fmt.Errorf(
 			"unsupported policy kind %s: has to be one of [%s, %s]", kind, string(tfe.Sentinel), string(tfe.OPA))
 	}
-	if err != nil {
-		return err
+	if createErr != nil {
+		return createErr
 	}
+
+	body := models.NewPolicies()
+	body.SetAttributes(attrs)
+	env := models.NewPoliciesEnvelope()
+	env.SetData(body)
+
 	log.Printf("[DEBUG] Create %s policy %s for organization: %s", kind, name, organization)
-	policy, err := config.Client.Policies.Create(ctx, organization, *options)
+	policyEnv, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).Policies().Post(ctx, env, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating %s policy %s for organization %s: %w", kind, name, organization, err)
 	}
 
-	d.SetId(policy.ID)
+	policyID := valueOrZero(policyEnv.GetData().GetId())
+	d.SetId(policyID)
 
-	err = helpers.WriteTFEIdentityWithOrg(d, policy.ID, organization, config.Client.BaseURL().Host)
+	err = helpers.WriteTFEIdentityWithOrg(d, policyID, organization, config.Client.BaseURL().Host)
 	if err != nil {
 		return err
 	}
 
 	log.Printf("[DEBUG] Upload %s policy %s for organization: %s", kind, name, organization)
-	err = config.Client.Policies.Upload(ctx, policy.ID, []byte(d.Get("policy").(string)))
+	_, err = config.ClientV2.API.Policies().ByPolicy_id(policyID).Upload().Put(ctx, []byte(d.Get("policy").(string)), nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error uploading %s policy %s for organization %s: %w", kind, name, organization, err)
@@ -218,45 +229,40 @@ func resourceTFEPolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	return resourceTFEPolicyRead(d, meta)
 }
 
-func createOPAPolicyOptions(options *tfe.PolicyCreateOptions, d *schema.ResourceData) (*tfe.PolicyCreateOptions, error) {
+func createOPAPolicyAttrs(attrs *models.Policies_attributes, d *schema.ResourceData) (*models.Policies_attributes, error) {
 	name := d.Get("name").(string)
 	path := name + ".rego"
-	enforceOpts := &tfe.EnforcementOptions{
-		Path: tfe.String(path),
-	}
-
+	enforceEntry := models.NewPolicies_attributes_enforce()
+	enforceEntry.SetPath(ptr(path))
 	if v, ok := d.GetOk("enforce_mode"); !ok {
-		enforceOpts.Mode = tfe.EnforcementMode(getDefaultEnforcementMode(tfe.OPA))
+		enforceEntry.SetMode(ptr(string(getDefaultEnforcementMode(tfe.OPA))))
 	} else {
-		enforceOpts.Mode = tfe.EnforcementMode(tfe.EnforcementLevel(v.(string)))
+		enforceEntry.SetMode(ptr(v.(string)))
 	}
-
-	options.Enforce = []*tfe.EnforcementOptions{enforceOpts} //nolint:staticcheck // this is still used by TFE versions older than 202306-1
+	//nolint:staticcheck // this is still used by TFE versions older than 202306-1
+	attrs.SetEnforce([]models.Policies_attributes_enforceable{enforceEntry})
 
 	vQuery, ok := d.GetOk("query")
 	if !ok {
-		return options, fmt.Errorf("missing query for OPA policy")
+		return attrs, fmt.Errorf("missing query for OPA policy")
 	}
-	options.Query = tfe.String(vQuery.(string))
-
-	return options, nil
+	attrs.SetQuery(ptr(vQuery.(string)))
+	return attrs, nil
 }
 
-func createSentinelPolicyOptions(options *tfe.PolicyCreateOptions, d *schema.ResourceData) *tfe.PolicyCreateOptions {
+func createSentinelPolicyAttrs(attrs *models.Policies_attributes, d *schema.ResourceData) *models.Policies_attributes {
 	name := d.Get("name").(string)
 	path := name + ".sentinel"
-	enforceOpts := &tfe.EnforcementOptions{
-		Path: tfe.String(path),
-	}
-
+	enforceEntry := models.NewPolicies_attributes_enforce()
+	enforceEntry.SetPath(ptr(path))
 	if v, ok := d.GetOk("enforce_mode"); !ok {
-		enforceOpts.Mode = tfe.EnforcementMode(getDefaultEnforcementMode(tfe.Sentinel))
+		enforceEntry.SetMode(ptr(string(getDefaultEnforcementMode(tfe.Sentinel))))
 	} else {
-		enforceOpts.Mode = tfe.EnforcementMode(tfe.EnforcementLevel(v.(string)))
+		enforceEntry.SetMode(ptr(v.(string)))
 	}
-
-	options.Enforce = []*tfe.EnforcementOptions{enforceOpts} //nolint:staticcheck // this is still used by TFE versions older than 202306-1
-	return options
+	//nolint:staticcheck // this is still used by TFE versions older than 202306-1
+	attrs.SetEnforce([]models.Policies_attributes_enforceable{enforceEntry})
+	return attrs
 }
 
 func getDefaultEnforcementMode(kind tfe.PolicyKind) tfe.EnforcementLevel {
@@ -276,9 +282,9 @@ func resourceTFEPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read policy: %s", d.Id())
-	policy, err := config.Client.Policies.Read(ctx, d.Id())
+	policyEnv, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Get(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			log.Printf("[DEBUG] Policy %s no longer exists", d.Id())
 			d.SetId("")
 			return nil
@@ -286,17 +292,24 @@ func resourceTFEPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading Policy %s: %w", d.Id(), err)
 	}
 
-	// Update the config.
-	d.Set("name", policy.Name)
-	d.Set("description", policy.Description)
-	d.Set("kind", policy.Kind)
+	policy := policyEnv.GetData()
+	attrs := policy.GetAttributes()
+
+	d.Set("name", valueOrZero(attrs.GetName()))
+	d.Set("description", valueOrZero(attrs.GetDescription()))
+	d.Set("kind", enumStringOrEmpty(attrs.GetKind()))
 
 	//nolint:staticcheck // this is still used by TFE versions older than 202306-1
-	if len(policy.Enforce) == 1 {
-		d.Set("enforce_mode", string(policy.Enforce[0].Mode))
+	for _, e := range attrs.GetEnforce() {
+		d.Set("enforce_mode", valueOrZero(e.GetMode()))
+		break
 	}
 
-	content, err := config.Client.Policies.Download(ctx, policy.ID)
+	if q := attrs.GetQuery(); q != nil {
+		d.Set("query", *q)
+	}
+
+	content, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Download().Get(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("Error downloading policy %s: %w", d.Id(), err)
 	}
@@ -307,7 +320,7 @@ func resourceTFEPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	err = helpers.WriteTFEIdentityWithOrg(d, policy.ID, organization, config.Client.BaseURL().Host)
+	err = helpers.WriteTFEIdentityWithOrg(d, d.Id(), organization, config.Client.BaseURL().Host)
 	if err != nil {
 		return err
 	}
@@ -325,33 +338,35 @@ func resourceTFEPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	// nolint:nestif
 	if d.HasChange("description") || d.HasChange("enforce_mode") || d.HasChange("query") {
-		// Create a new options struct.
-		options := tfe.PolicyUpdateOptions{}
+		attrs := models.NewPolicies_attributes()
 
 		if desc, ok := d.GetOk("description"); ok {
-			options.Description = tfe.String(desc.(string))
+			attrs.SetDescription(ptr(desc.(string)))
 		}
 
-		path := d.Get("name").(string) + ".sentinel"
-		if kind == string(tfe.OPA) {
-			path = d.Get("name").(string) + ".rego"
-		}
 		if d.HasChange("enforce_mode") {
-			//nolint:staticcheck // this is still used by TFE versions older than 202306-1
-			options.Enforce = []*tfe.EnforcementOptions{
-				{
-					Path: tfe.String(path),
-					Mode: tfe.EnforcementMode(tfe.EnforcementLevel(d.Get("enforce_mode").(string))),
-				},
+			path := d.Get("name").(string) + ".sentinel"
+			if kind == string(tfe.OPA) {
+				path = d.Get("name").(string) + ".rego"
 			}
+			enforceEntry := models.NewPolicies_attributes_enforce()
+			enforceEntry.SetPath(ptr(path))
+			enforceEntry.SetMode(ptr(d.Get("enforce_mode").(string)))
+			//nolint:staticcheck // this is still used by TFE versions older than 202306-1
+			attrs.SetEnforce([]models.Policies_attributes_enforceable{enforceEntry})
 		}
 
 		if query, ok := d.GetOk("query"); ok {
-			options.Query = tfe.String(query.(string))
+			attrs.SetQuery(ptr(query.(string)))
 		}
 
+		body := models.NewPolicies()
+		body.SetAttributes(attrs)
+		env := models.NewPoliciesEnvelope()
+		env.SetData(body)
+
 		log.Printf("[DEBUG] Update configuration for %s policy: %s", kind, d.Id())
-		_, err := config.Client.Policies.Update(ctx, d.Id(), options)
+		_, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Patch(ctx, env, nil)
 		if err != nil {
 			return fmt.Errorf(
 				"Error updating configuration for %s policy %s: %w", kind, d.Id(), err)
@@ -361,7 +376,7 @@ func resourceTFEPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("policy") {
 		vKind := d.Get("kind").(string)
 		log.Printf("[DEBUG] Update %s policy: %s", vKind, d.Id())
-		err := config.Client.Policies.Upload(ctx, d.Id(), []byte(d.Get("policy").(string)))
+		_, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Upload().Put(ctx, []byte(d.Get("policy").(string)), nil)
 		if err != nil {
 			return fmt.Errorf("Error updating %s policy %s: %w", vKind, d.Id(), err)
 		}
@@ -374,9 +389,9 @@ func resourceTFEPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete policy: %s", d.Id())
-	err := config.Client.Policies.Delete(ctx, d.Id())
+	err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Delete(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			return nil
 		}
 		return fmt.Errorf("Error deleting policy %s: %w", d.Id(), err)

--- a/internal/provider/resource_tfe_policy_set.go
+++ b/internal/provider/resource_tfe_policy_set.go
@@ -289,6 +289,7 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 	for _, policyID := range d.Get("policy_ids").(*schema.Set).List() {
 		item := models.NewPoliciesIdentifier()
 		item.SetId(ptr(policyID.(string)))
+		item.SetTypeEscaped(ptr(models.POLICIES_POLICIESIDENTIFIER_TYPE))
 		policyData = append(policyData, item)
 	}
 	if len(policyData) > 0 {
@@ -301,6 +302,7 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 	for _, workspaceID := range d.Get("workspace_ids").(*schema.Set).List() {
 		item := models.NewWorkspacesIdentifier()
 		item.SetId(ptr(workspaceID.(string)))
+		item.SetTypeEscaped(ptr(models.WORKSPACES_WORKSPACESIDENTIFIER_TYPE))
 		wsData = append(wsData, item)
 	}
 	if len(wsData) > 0 {
@@ -310,6 +312,7 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	body := models.NewPolicySets()
+	body.SetTypeEscaped(ptr(models.POLICYSETS_POLICYSETS_TYPE))
 	body.SetAttributes(attrs)
 	body.SetRelationships(rels)
 	env := models.NewPolicySetsEnvelope()
@@ -511,6 +514,7 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		body := models.NewPolicySets()
+		body.SetTypeEscaped(ptr(models.POLICYSETS_POLICYSETS_TYPE))
 		body.SetAttributes(attrs)
 		env := models.NewPolicySetsEnvelope()
 		env.SetData(body)
@@ -605,6 +609,7 @@ func makeWorkspaceIdentifierArrayDocument(ids []interface{}) *models.WorkspacesI
 	for _, id := range ids {
 		item := models.NewWorkspacesIdentifierArrayDocument_data()
 		item.SetId(ptr(id.(string)))
+		item.SetTypeEscaped(ptr(models.WORKSPACES_WORKSPACESIDENTIFIERARRAYDOCUMENT_DATA_TYPE))
 		data = append(data, item)
 	}
 	body.SetData(data)
@@ -617,6 +622,7 @@ func makePolicyIdentifierArrayDocument(ids []interface{}) *models.PoliciesIdenti
 	for _, id := range ids {
 		item := models.NewPoliciesIdentifierArrayDocument_data()
 		item.SetId(ptr(id.(string)))
+		item.SetTypeEscaped(ptr(models.POLICIES_POLICIESIDENTIFIERARRAYDOCUMENT_DATA_TYPE))
 		data = append(data, item)
 	}
 	body.SetData(data)
@@ -629,6 +635,7 @@ func makeProjectIdentifierArrayDocument(ids []interface{}) *models.ProjectsIdent
 	for _, id := range ids {
 		item := models.NewProjectsIdentifierArrayDocument_data()
 		item.SetId(ptr(id.(string)))
+		item.SetTypeEscaped(ptr(models.PROJECTS_PROJECTSIDENTIFIERARRAYDOCUMENT_DATA_TYPE))
 		data = append(data, item)
 	}
 	body.SetData(data)

--- a/internal/provider/resource_tfe_policy_set.go
+++ b/internal/provider/resource_tfe_policy_set.go
@@ -9,11 +9,15 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
 
 	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
+	"github.com/hashicorp/go-tfe/v2/api/policysets"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers"
@@ -221,92 +225,117 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	// Create a new options struct.
-	options := tfe.PolicySetCreateOptions{
-		Name:   tfe.String(name),
-		Global: tfe.Bool(d.Get("global").(bool)),
-	}
+	attrs := models.NewPolicySets_attributes()
+	attrs.SetName(ptr(name))
+	attrs.SetGlobal(ptr(d.Get("global").(bool)))
 
-	// Process all configured options.
 	if vKind, ok := d.GetOk("kind"); ok {
-		options.Kind = tfe.PolicyKind(vKind.(string))
+		parsedKind, _ := models.ParsePolicySets_attributes_kind(vKind.(string))
+		if parsedKind != nil {
+			k := parsedKind.(*models.PolicySets_attributes_kind)
+			attrs.SetKind(k)
+		}
 	}
 
 	if vOverridable, ok := d.GetOk("overridable"); ok {
-		options.Overridable = tfe.Bool(vOverridable.(bool))
+		attrs.SetOverridable(ptr(vOverridable.(bool)))
 	}
 
 	if vAgentEnabled, ok := d.GetOk("agent_enabled"); ok {
-		options.AgentEnabled = tfe.Bool(vAgentEnabled.(bool))
+		attrs.SetAgentEnabled(ptr(vAgentEnabled.(bool)))
 	}
 
 	if vPolicyToolVersion, ok := d.GetOk("policy_tool_version"); ok {
-		options.PolicyToolVersion = tfe.String(vPolicyToolVersion.(string))
+		attrs.SetPolicyToolVersion(ptr(vPolicyToolVersion.(string)))
 	}
 
 	if vPolicyUpdatePatterns, ok := d.GetOk("policy_update_patterns"); ok {
-		for _, pattern := range vPolicyUpdatePatterns.([]interface{}) {
-			options.PolicyUpdatePatterns = append(options.PolicyUpdatePatterns, pattern.(string))
+		var patterns []string
+		for _, p := range vPolicyUpdatePatterns.([]interface{}) {
+			patterns = append(patterns, p.(string))
 		}
+		attrs.SetPolicyUpdatePatterns(patterns)
 	} else {
-		options.PolicyUpdatePatterns = []string{}
+		attrs.SetPolicyUpdatePatterns([]string{})
 	}
-
 	if d.GetRawConfig().GetAttr("policy_update_patterns").IsNull() {
-		options.PolicyUpdatePatterns = nil
+		attrs.SetPolicyUpdatePatterns(nil)
 	}
 
 	if desc, ok := d.GetOk("description"); ok {
-		options.Description = tfe.String(desc.(string))
+		attrs.SetDescription(ptr(desc.(string)))
 	}
 
 	if policiesPath, ok := d.GetOk("policies_path"); ok {
-		options.PoliciesPath = tfe.String(policiesPath.(string))
+		attrs.SetPoliciesPath(ptr(policiesPath.(string)))
 	}
 
-	for _, policyID := range d.Get("policy_ids").(*schema.Set).List() {
-		options.Policies = append(options.Policies, &tfe.Policy{ID: policyID.(string)})
-	}
-
-	// Get and assert the VCS repo configuration block.
 	if v, ok := d.GetOk("vcs_repo"); ok {
 		vcsRepo := v.([]interface{})[0].(map[string]interface{})
-
-		options.VCSRepo = &tfe.VCSRepoOptions{
-			Identifier:        tfe.String(vcsRepo["identifier"].(string)),
-			IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
-			OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
-			GHAInstallationID: tfe.String(vcsRepo["github_app_installation_id"].(string)),
-		}
-
-		// Only set the branch if one is configured.
+		vcsAttrs := models.NewPolicySets_attributes_vcsRepo()
+		vcsAttrs.SetIdentifier(ptr(vcsRepo["identifier"].(string)))
+		vcsAttrs.SetIngressSubmodules(ptr(vcsRepo["ingress_submodules"].(bool)))
+		vcsAttrs.SetOauthTokenId(ptr(vcsRepo["oauth_token_id"].(string)))
+		vcsAttrs.SetGithubAppInstallationId(ptr(vcsRepo["github_app_installation_id"].(string)))
 		if branch, ok := vcsRepo["branch"].(string); ok && branch != "" {
-			options.VCSRepo.Branch = tfe.String(branch)
+			vcsAttrs.SetBranch(ptr(branch))
 		}
+		attrs.SetVcsRepo(vcsAttrs)
 	}
 
-	for _, workspaceID := range d.Get("workspace_ids").(*schema.Set).List() {
-		options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
+	rels := models.NewPolicySets_relationships()
+
+	var policyData []models.PoliciesIdentifierable
+	for _, policyID := range d.Get("policy_ids").(*schema.Set).List() {
+		item := models.NewPoliciesIdentifier()
+		item.SetId(ptr(policyID.(string)))
+		policyData = append(policyData, item)
 	}
+	if len(policyData) > 0 {
+		policiesRel := models.NewPoliciesHasMany()
+		policiesRel.SetData(policyData)
+		rels.SetPolicies(policiesRel)
+	}
+
+	var wsData []models.WorkspacesIdentifierable
+	for _, workspaceID := range d.Get("workspace_ids").(*schema.Set).List() {
+		item := models.NewWorkspacesIdentifier()
+		item.SetId(ptr(workspaceID.(string)))
+		wsData = append(wsData, item)
+	}
+	if len(wsData) > 0 {
+		wsRel := models.NewWorkspacesHasMany()
+		wsRel.SetData(wsData)
+		rels.SetWorkspaces(wsRel)
+	}
+
+	body := models.NewPolicySets()
+	body.SetAttributes(attrs)
+	body.SetRelationships(rels)
+	env := models.NewPolicySetsEnvelope()
+	env.SetData(body)
 
 	log.Printf("[DEBUG] Create policy set %s for organization: %s", name, organization)
-	policySet, err := config.Client.PolicySets.Create(ctx, organization, options)
+	policySetEnv, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).PolicySets().Post(ctx, env, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating policy set %s for organization %s: %w", name, organization, err)
 	}
+
+	policySetID := valueOrZero(policySetEnv.GetData().GetId())
+
 	_, hasVCSRepo := d.GetOk("vcs_repo")
 	_, hasSlug := d.GetOk("slug")
 	if hasSlug && !hasVCSRepo {
-		err := resourceTFEPolicySetUploadVersion(config.Client, d, policySet.ID)
+		err := resourceTFEPolicySetUploadVersion(config.Client, d, policySetID)
 		if err != nil {
 			return err
 		}
 	}
 
-	d.SetId(policySet.ID)
+	d.SetId(policySetID)
 
-	err = helpers.WriteTFEIdentity(d, policySet.ID, config.Client.BaseURL().Host)
+	err = helpers.WriteTFEIdentity(d, policySetID, config.Client.BaseURL().Host)
 	if err != nil {
 		return err
 	}
@@ -318,9 +347,9 @@ func resourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read policy set: %s", d.Id())
-	policySet, err := config.Client.PolicySets.Read(ctx, d.Id())
+	policySetEnv, err := config.ClientV2.API.PolicySets().ByPolicy_set_id(d.Id()).Get(ctx, nil)
 	if err != nil {
-		if err == tfe.ErrResourceNotFound {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			log.Printf("[DEBUG] Policy set %s no longer exists", d.Id())
 			d.SetId("")
 			return nil
@@ -328,73 +357,74 @@ func resourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading policy set %s: %w", d.Id(), err)
 	}
 
-	// Update the config.
-	d.Set("name", policySet.Name)
-	d.Set("description", policySet.Description)
-	d.Set("global", policySet.Global)
-	d.Set("policies_path", policySet.PoliciesPath)
-	d.Set("policy_update_patterns", policySet.PolicyUpdatePatterns)
-	d.Set("agent_enabled", policySet.AgentEnabled)
+	policySet := policySetEnv.GetData()
+	attrs := policySet.GetAttributes()
+	rels := policySet.GetRelationships()
 
-	if policySet.Organization != nil {
-		d.Set("organization", policySet.Organization.Name)
-	}
+	d.Set("name", valueOrZero(attrs.GetName()))
+	d.Set("description", valueOrZero(attrs.GetDescription()))
+	d.Set("global", valueOrZero(attrs.GetGlobal()))
+	d.Set("policies_path", valueOrZero(attrs.GetPoliciesPath()))
+	d.Set("policy_update_patterns", attrs.GetPolicyUpdatePatterns())
+	d.Set("agent_enabled", valueOrZero(attrs.GetAgentEnabled()))
 
-	// Note: Old API endpoints return an empty string, so use the default in the schema
-	if policySet.Kind != "" {
-		d.Set("kind", policySet.Kind)
-	}
-
-	if policySet.Overridable != nil {
-		d.Set("overridable", policySet.Overridable)
-	}
-
-	if policySet.PolicyToolVersion != "" {
-		d.Set("policy_tool_version", policySet.PolicyToolVersion)
-	}
-
-	// Set VCS policy set options.
-	var vcsRepo []interface{}
-	if policySet.VCSRepo != nil {
-		vcsConfig := map[string]interface{}{
-			"identifier":                 policySet.VCSRepo.Identifier,
-			"ingress_submodules":         policySet.VCSRepo.IngressSubmodules,
-			"oauth_token_id":             policySet.VCSRepo.OAuthTokenID,
-			"github_app_installation_id": policySet.VCSRepo.GHAInstallationID,
+	if rels != nil && rels.GetOrganization() != nil {
+		orgData := rels.GetOrganization().GetData()
+		if orgData != nil {
+			d.Set("organization", valueOrZero(orgData.GetId()))
 		}
+	}
 
-		// Get and assert the VCS repo configuration block.
+	if k := attrs.GetKind(); k != nil {
+		d.Set("kind", k.String())
+	}
+
+	if ov := attrs.GetOverridable(); ov != nil {
+		d.Set("overridable", *ov)
+	}
+
+	if ptv := attrs.GetPolicyToolVersion(); ptv != nil {
+		d.Set("policy_tool_version", *ptv)
+	}
+
+	var vcsRepo []interface{}
+	if vcs := attrs.GetVcsRepo(); vcs != nil {
+		vcsConfig := map[string]interface{}{
+			"identifier":                 valueOrZero(vcs.GetIdentifier()),
+			"ingress_submodules":         valueOrZero(vcs.GetIngressSubmodules()),
+			"oauth_token_id":             valueOrZero(vcs.GetOauthTokenId()),
+			"github_app_installation_id": valueOrZero(vcs.GetGithubAppInstallationId()),
+		}
 		if v, ok := d.GetOk("vcs_repo"); ok {
 			if vcsRepo, ok := v.([]interface{})[0].(map[string]interface{}); ok {
-				// Only set the branch if one is configured.
 				if branch, ok := vcsRepo["branch"].(string); ok && branch != "" {
-					vcsConfig["branch"] = policySet.VCSRepo.Branch
+					vcsConfig["branch"] = valueOrZero(vcs.GetBranch())
 				}
 			}
 		}
-
 		vcsRepo = append(vcsRepo, vcsConfig)
 	}
-
 	d.Set("vcs_repo", vcsRepo)
 
-	// Update the policies.
 	var policyIDs []interface{}
-	for _, policy := range policySet.Policies {
-		policyIDs = append(policyIDs, policy.ID)
+	if rels != nil && rels.GetPolicies() != nil {
+		for _, p := range rels.GetPolicies().GetData() {
+			policyIDs = append(policyIDs, valueOrZero(p.GetId()))
+		}
 	}
 	d.Set("policy_ids", policyIDs)
 
-	// Update the workspaces.
 	var workspaceIDs []interface{}
-	if !policySet.Global {
-		for _, workspace := range policySet.Workspaces {
-			workspaceIDs = append(workspaceIDs, workspace.ID)
+	if !valueOrZero(attrs.GetGlobal()) {
+		if rels != nil && rels.GetWorkspaces() != nil {
+			for _, ws := range rels.GetWorkspaces().GetData() {
+				workspaceIDs = append(workspaceIDs, valueOrZero(ws.GetId()))
+			}
 		}
 	}
 	d.Set("workspace_ids", workspaceIDs)
 
-	err = helpers.WriteTFEIdentity(d, policySet.ID, config.Client.BaseURL().Host)
+	err = helpers.WriteTFEIdentity(d, d.Id(), config.Client.BaseURL().Host)
 	if err != nil {
 		return err
 	}
@@ -408,35 +438,23 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 	name := d.Get("name").(string)
 	global := d.Get("global").(bool)
 
-	// If a user is setting the policy set to "global", make sure the workspaces
-	// that _had_ been set are explicitly removed. This helps keep the policy
-	// set's state in check
 	if global && d.HasChange("global") {
-		// The new set of workspaces will be an empty set, so we don't need it
 		oldWorkspaceIDs, _ := d.GetChange("workspace_ids")
-
 		if oldWorkspaceIDs.(*schema.Set).Len() > 0 {
-			options := tfe.PolicySetRemoveWorkspacesOptions{}
-
-			for _, workspaceID := range oldWorkspaceIDs.(*schema.Set).List() {
-				options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
-			}
-
+			body := makeWorkspaceIdentifierArrayDocument(oldWorkspaceIDs.(*schema.Set).List())
 			log.Printf("[DEBUG] Removing previous workspaces from now-global policy set: %s", d.Id())
-			err := config.Client.PolicySets.RemoveWorkspaces(ctx, d.Id(), options)
+			err := config.ClientV2.API.PolicySets().ByPolicy_set_id(d.Id()).Relationships().Workspaces().Delete(ctx, body, nil)
 			if err != nil {
 				return fmt.Errorf("Error detaching policy set %s from workspaces: %w", d.Id(), err)
 			}
 		}
 	}
 
-	// Don't bother updating the policy set's attributes if they haven't changed
 	fields := []string{
 		"name", "description", "global", "vcs_repo",
 		"overridable", "agent_enabled", "policy_tool_version",
 		"policy_update_patterns",
 	}
-
 	hasAnyChange := false
 	for _, field := range fields {
 		if d.HasChange(field) {
@@ -446,58 +464,59 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if hasAnyChange {
-		// Create a new options struct.
-		options := tfe.PolicySetUpdateOptions{
-			Name:   tfe.String(name),
-			Global: tfe.Bool(global),
-		}
+		attrs := models.NewPolicySets_attributes()
+		attrs.SetName(ptr(name))
+		attrs.SetGlobal(ptr(global))
 
 		if desc, ok := d.GetOk("description"); ok {
-			options.Description = tfe.String(desc.(string))
+			attrs.SetDescription(ptr(desc.(string)))
 		}
 
 		if d.HasChange("overridable") {
-			o := d.Get("overridable").(bool)
-			options.Overridable = tfe.Bool(o)
+			attrs.SetOverridable(ptr(d.Get("overridable").(bool)))
 		}
 
 		if d.HasChange("agent_enabled") {
-			o := d.Get("agent_enabled").(bool)
-			options.AgentEnabled = tfe.Bool(o)
+			attrs.SetAgentEnabled(ptr(d.Get("agent_enabled").(bool)))
 		}
 
 		if policyToolVersion, ok := d.GetOk("policy_tool_version"); ok {
-			options.PolicyToolVersion = tfe.String(policyToolVersion.(string))
+			attrs.SetPolicyToolVersion(ptr(policyToolVersion.(string)))
 		}
 
 		if d.HasChange("policy_update_patterns") {
 			if vPolicyUpdatePatterns, ok := d.GetOk("policy_update_patterns"); ok {
-				for _, pattern := range vPolicyUpdatePatterns.([]interface{}) {
-					options.PolicyUpdatePatterns = append(options.PolicyUpdatePatterns, pattern.(string))
+				var patterns []string
+				for _, p := range vPolicyUpdatePatterns.([]interface{}) {
+					patterns = append(patterns, p.(string))
 				}
+				attrs.SetPolicyUpdatePatterns(patterns)
 			} else {
-				options.PolicyUpdatePatterns = []string{}
+				attrs.SetPolicyUpdatePatterns([]string{})
 			}
-
 			if d.GetRawConfig().GetAttr("policy_update_patterns").IsNull() {
-				options.PolicyUpdatePatterns = nil
+				attrs.SetPolicyUpdatePatterns(nil)
 			}
 		}
 
 		if v, ok := d.GetOk("vcs_repo"); ok {
 			vcsRepo := v.([]interface{})[0].(map[string]interface{})
-
-			options.VCSRepo = &tfe.VCSRepoOptions{
-				Identifier:        tfe.String(vcsRepo["identifier"].(string)),
-				Branch:            tfe.String(vcsRepo["branch"].(string)),
-				IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
-				OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
-				GHAInstallationID: tfe.String(vcsRepo["github_app_installation_id"].(string)),
-			}
+			vcsAttrs := models.NewPolicySets_attributes_vcsRepo()
+			vcsAttrs.SetIdentifier(ptr(vcsRepo["identifier"].(string)))
+			vcsAttrs.SetBranch(ptr(vcsRepo["branch"].(string)))
+			vcsAttrs.SetIngressSubmodules(ptr(vcsRepo["ingress_submodules"].(bool)))
+			vcsAttrs.SetOauthTokenId(ptr(vcsRepo["oauth_token_id"].(string)))
+			vcsAttrs.SetGithubAppInstallationId(ptr(vcsRepo["github_app_installation_id"].(string)))
+			attrs.SetVcsRepo(vcsAttrs)
 		}
 
+		body := models.NewPolicySets()
+		body.SetAttributes(attrs)
+		env := models.NewPolicySetsEnvelope()
+		env.SetData(body)
+
 		log.Printf("[DEBUG] Update configuration for policy set: %s", d.Id())
-		_, err := config.Client.PolicySets.Update(ctx, d.Id(), options)
+		_, err := config.ClientV2.API.PolicySets().ByPolicy_set_id(d.Id()).Patch(ctx, env, nil)
 		if err != nil {
 			return fmt.Errorf(
 				"Error updating configuration for policy set %s: %w", d.Id(), err)
@@ -509,31 +528,19 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 		oldPolicyIDs := oldSet.(*schema.Set).Difference(newSet.(*schema.Set))
 		newPolicyIDs := newSet.(*schema.Set).Difference(oldSet.(*schema.Set))
 
-		// First add the new policies.
 		if newPolicyIDs.Len() > 0 {
-			options := tfe.PolicySetAddPoliciesOptions{}
-
-			for _, policyID := range newPolicyIDs.List() {
-				options.Policies = append(options.Policies, &tfe.Policy{ID: policyID.(string)})
-			}
-
+			body := makePolicyIdentifierArrayDocument(newPolicyIDs.List())
 			log.Printf("[DEBUG] Add policies to policy set: %s", d.Id())
-			err := config.Client.PolicySets.AddPolicies(ctx, d.Id(), options)
+			err := config.ClientV2.API.PolicySets().ByPolicy_set_id(d.Id()).Relationships().Policies().Post(ctx, body, nil)
 			if err != nil {
 				return fmt.Errorf("Error adding policies to policy set %s: %w", d.Id(), err)
 			}
 		}
 
-		// Then remove all the old policies.
 		if oldPolicyIDs.Len() > 0 {
-			options := tfe.PolicySetRemovePoliciesOptions{}
-
-			for _, policyID := range oldPolicyIDs.List() {
-				options.Policies = append(options.Policies, &tfe.Policy{ID: policyID.(string)})
-			}
-
+			body := makePolicyIdentifierArrayDocument(oldPolicyIDs.List())
 			log.Printf("[DEBUG] Remove policies from policy set: %s", d.Id())
-			err := config.Client.PolicySets.RemovePolicies(ctx, d.Id(), options)
+			err := config.ClientV2.API.PolicySets().ByPolicy_set_id(d.Id()).Relationships().Policies().Delete(ctx, body, nil)
 			if err != nil {
 				return fmt.Errorf("Error removing policies from policy set %s: %w", d.Id(), err)
 			}
@@ -552,35 +559,22 @@ func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error 
 		oldWorkspaceIDValues, newWorkspaceIDValues := d.GetChange("workspace_ids")
 		newWorkspaceIDsSet := newWorkspaceIDValues.(*schema.Set)
 		oldWorkspaceIDsSet := oldWorkspaceIDValues.(*schema.Set)
-
 		newWorkspaceIDs := newWorkspaceIDsSet.Difference(oldWorkspaceIDsSet)
 		oldWorkspaceIDs := oldWorkspaceIDsSet.Difference(newWorkspaceIDsSet)
 
-		// First add the new workspaces.
 		if newWorkspaceIDs.Len() > 0 {
-			options := tfe.PolicySetAddWorkspacesOptions{}
-
-			for _, workspaceID := range newWorkspaceIDs.List() {
-				options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
-			}
-
+			body := makeWorkspaceIdentifierArrayDocument(newWorkspaceIDs.List())
 			log.Printf("[DEBUG] Attach policy set to workspaces: %s", d.Id())
-			err := config.Client.PolicySets.AddWorkspaces(ctx, d.Id(), options)
+			err := config.ClientV2.API.PolicySets().ByPolicy_set_id(d.Id()).Relationships().Workspaces().Post(ctx, body, nil)
 			if err != nil {
 				return fmt.Errorf("Error attaching policy set %s to workspaces: %w", d.Id(), err)
 			}
 		}
 
-		// Then remove all the old workspaces.
 		if oldWorkspaceIDs.Len() > 0 {
-			options := tfe.PolicySetRemoveWorkspacesOptions{}
-
-			for _, workspaceID := range oldWorkspaceIDs.List() {
-				options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
-			}
-
+			body := makeWorkspaceIdentifierArrayDocument(oldWorkspaceIDs.List())
 			log.Printf("[DEBUG] Detach policy set from workspaces: %s", d.Id())
-			err := config.Client.PolicySets.RemoveWorkspaces(ctx, d.Id(), options)
+			err := config.ClientV2.API.PolicySets().ByPolicy_set_id(d.Id()).Relationships().Workspaces().Delete(ctx, body, nil)
 			if err != nil {
 				return fmt.Errorf("Error detaching policy set %s from workspaces: %w", d.Id(), err)
 			}
@@ -594,9 +588,9 @@ func resourceTFEPolicySetDelete(d *schema.ResourceData, meta interface{}) error 
 	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete policy set: %s", d.Id())
-	err := config.Client.PolicySets.Delete(ctx, d.Id())
+	err := config.ClientV2.API.PolicySets().ByPolicy_set_id(d.Id()).Delete(ctx, nil)
 	if err != nil {
-		if err == tfe.ErrResourceNotFound {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			return nil
 		}
 		return fmt.Errorf("Error deleting policy set %s: %w", d.Id(), err)
@@ -605,6 +599,61 @@ func resourceTFEPolicySetDelete(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
+func makeWorkspaceIdentifierArrayDocument(ids []interface{}) *models.WorkspacesIdentifierArrayDocument {
+	body := models.NewWorkspacesIdentifierArrayDocument()
+	var data []models.WorkspacesIdentifierArrayDocument_dataable
+	for _, id := range ids {
+		item := models.NewWorkspacesIdentifierArrayDocument_data()
+		item.SetId(ptr(id.(string)))
+		data = append(data, item)
+	}
+	body.SetData(data)
+	return body
+}
+
+func makePolicyIdentifierArrayDocument(ids []interface{}) *models.PoliciesIdentifierArrayDocument {
+	body := models.NewPoliciesIdentifierArrayDocument()
+	var data []models.PoliciesIdentifierArrayDocument_dataable
+	for _, id := range ids {
+		item := models.NewPoliciesIdentifierArrayDocument_data()
+		item.SetId(ptr(id.(string)))
+		data = append(data, item)
+	}
+	body.SetData(data)
+	return body
+}
+
+func makeProjectIdentifierArrayDocument(ids []interface{}) *models.ProjectsIdentifierArrayDocument {
+	body := models.NewProjectsIdentifierArrayDocument()
+	var data []models.ProjectsIdentifierArrayDocument_dataable
+	for _, id := range ids {
+		item := models.NewProjectsIdentifierArrayDocument_data()
+		item.SetId(ptr(id.(string)))
+		data = append(data, item)
+	}
+	body.SetData(data)
+	return body
+}
+
+func makeTagSelectorPostBody(key string, value *string, isExclude bool) policysets.ItemTagSelectorsPostRequestBodyable {
+	item := policysets.NewItemTagSelectorsPostRequestBody_data()
+	item.SetTagKey(&key)
+	item.SetTagValue(value)
+	item.SetIsExclude(&isExclude)
+	body := policysets.NewItemTagSelectorsPostRequestBody()
+	body.SetData([]policysets.ItemTagSelectorsPostRequestBody_dataable{item})
+	return body
+}
+
+func makeTagSelectorDeleteBody(key string, value *string, isExclude bool) policysets.ItemTagSelectorsDeleteRequestBodyable {
+	item := policysets.NewItemTagSelectorsDeleteRequestBody_data()
+	item.SetTagKey(&key)
+	item.SetTagValue(value)
+	item.SetIsExclude(&isExclude)
+	body := policysets.NewItemTagSelectorsDeleteRequestBody()
+	body.SetData([]policysets.ItemTagSelectorsDeleteRequestBody_dataable{item})
+	return body
+}
 func resourceTFEPolicySetUploadVersion(client *tfe.Client, d *schema.ResourceData, policySetID string) error {
 	log.Printf("[DEBUG] Create policy set version for policy set %s.", policySetID)
 	psv, err := client.PolicySetVersions.Create(ctx, policySetID)

--- a/internal/provider/resource_tfe_policy_set_parameter.go
+++ b/internal/provider/resource_tfe_policy_set_parameter.go
@@ -228,6 +228,7 @@ func (r *resourceTFEPolicySetParameter) Create(ctx context.Context, req resource
 	attrs.SetValue(value)
 
 	body := models.NewVars()
+	body.SetTypeEscaped(ptr(models.VARS_VARS_TYPE))
 	body.SetAttributes(attrs)
 	env := models.NewVarsEnvelope()
 	env.SetData(body)
@@ -298,6 +299,7 @@ func (r *resourceTFEPolicySetParameter) Update(ctx context.Context, req resource
 	}
 
 	body := models.NewVars()
+	body.SetTypeEscaped(ptr(models.VARS_VARS_TYPE))
 	body.SetAttributes(attrs)
 	env := models.NewVarsEnvelope()
 	env.SetData(body)

--- a/internal/provider/resource_tfe_policy_set_parameter.go
+++ b/internal/provider/resource_tfe_policy_set_parameter.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -50,23 +52,25 @@ type modelTFEPolicySetParameter struct {
 	PolicySetID    types.String `tfsdk:"policy_set_id"`
 }
 
-func modelFromTFEPolicySetParameter(v *tfe.PolicySetParameter, lastValue types.String, valueWOVersion types.Int64) modelTFEPolicySetParameter {
+func modelFromV2PolicySetParameter(v models.VarsEnvelopeable, policySetID string, lastValue types.String, valueWOVersion types.Int64) modelTFEPolicySetParameter {
+	data := v.GetData()
+	attrs := data.GetAttributes()
+
+	sensitive := valueOrZero(attrs.GetSensitive())
+
 	p := modelTFEPolicySetParameter{
-		ID:             types.StringValue(v.ID),
-		Key:            types.StringValue(v.Key),
-		Value:          types.StringValue(v.Value),
+		ID:             types.StringValue(valueOrZero(data.GetId())),
+		Key:            types.StringValue(valueOrZero(attrs.GetKey())),
+		Value:          types.StringValue(valueOrZero(attrs.GetValue())),
 		ValueWOVersion: valueWOVersion,
-		Sensitive:      types.BoolValue(v.Sensitive),
-		PolicySetID:    types.StringValue(v.PolicySet.ID),
+		Sensitive:      types.BoolValue(sensitive),
+		PolicySetID:    types.StringValue(policySetID),
 	}
 
-	// If the variable is sensitive, carry forward the last known value
-	// instead, because the API never lets us read it again.
-	if v.Sensitive {
+	if sensitive {
 		p.Value = lastValue
 	}
 
-	// Don't retrieve values if write-only is being used. Unset the value field before updating the state.
 	isWriteOnlyValue := !valueWOVersion.IsNull()
 	if isWriteOnlyValue {
 		p.Value = types.StringValue("")
@@ -209,29 +213,34 @@ func (r *resourceTFEPolicySetParameter) Create(ctx context.Context, req resource
 		return
 	}
 
-	// Create an options struct
-	options := tfe.PolicySetParameterCreateOptions{
-		Key:       plan.Key.ValueStringPointer(),
-		Category:  tfe.Category(tfe.CategoryPolicySet),
-		Sensitive: plan.Sensitive.ValueBoolPointer(),
-	}
-
-	// Set Value from `value_wo` if set, otherwise use the normal value
+	var value *string
 	if !config.ValueWO.IsNull() {
-		options.Value = config.ValueWO.ValueStringPointer()
+		value = config.ValueWO.ValueStringPointer()
 	} else {
-		options.Value = plan.Value.ValueStringPointer()
+		value = plan.Value.ValueStringPointer()
 	}
 
-	// Create the policy set parameter
+	category := models.POLICYSET_VARS_ATTRIBUTES_CATEGORY
+	attrs := models.NewVars_attributes()
+	attrs.SetKey(plan.Key.ValueStringPointer())
+	attrs.SetCategory(&category)
+	attrs.SetSensitive(plan.Sensitive.ValueBoolPointer())
+	attrs.SetValue(value)
+
+	body := models.NewVars()
+	body.SetAttributes(attrs)
+	env := models.NewVarsEnvelope()
+	env.SetData(body)
+
 	tflog.Debug(ctx, fmt.Sprintf("Create %s parameter: %s", tfe.CategoryPolicySet, plan.Key.ValueString()))
-	p, err := r.config.Client.PolicySetParameters.Create(ctx, plan.PolicySetID.ValueString(), options)
+	policySetID := plan.PolicySetID.ValueString()
+	p, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Parameters().Post(ctx, env, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Error creating %s parameter %s", tfe.CategoryPolicySet, plan.Key), err.Error())
 		return
 	}
 
-	result := modelFromTFEPolicySetParameter(p, plan.Value, config.ValueWOVersion)
+	result := modelFromV2PolicySetParameter(p, policySetID, plan.Value, config.ValueWOVersion)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
@@ -243,18 +252,19 @@ func (r *resourceTFEPolicySetParameter) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	// Check that policy set exists before continuing
-	_, err := r.config.Client.PolicySets.Read(ctx, state.PolicySetID.ValueString())
+	policySetID := state.PolicySetID.ValueString()
+	parameterID := state.ID.ValueString()
+
+	_, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Error retrieving policy set %s", state.PolicySetID), err.Error())
 		return
 	}
 
-	// Read the policy set parameter
 	tflog.Debug(ctx, fmt.Sprintf("Read parameter: %s", state.ID))
-	p, err := r.config.Client.PolicySetParameters.Read(ctx, state.PolicySetID.ValueString(), state.ID.ValueString())
+	p, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Parameters().ById(parameterID).Get(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			tflog.Debug(ctx, fmt.Sprintf("Parameter %s no longer exists", state.ID))
 			resp.State.RemoveResource(ctx)
 		}
@@ -263,8 +273,7 @@ func (r *resourceTFEPolicySetParameter) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	// We got a parameter, so update state:
-	result := modelFromTFEPolicySetParameter(p, state.Value, state.ValueWOVersion)
+	result := modelFromV2PolicySetParameter(p, policySetID, state.Value, state.ValueWOVersion)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
@@ -279,29 +288,29 @@ func (r *resourceTFEPolicySetParameter) Update(ctx context.Context, req resource
 		return
 	}
 
-	// Create an options struct
-	options := tfe.PolicySetParameterUpdateOptions{
-		Key:       plan.Key.ValueStringPointer(),
-		Sensitive: plan.Sensitive.ValueBoolPointer(),
-	}
+	attrs := models.NewVars_attributes()
+	attrs.SetKey(plan.Key.ValueStringPointer())
+	attrs.SetSensitive(plan.Sensitive.ValueBoolPointer())
 
-	// determines value to update by considering any changes in value, value_wo, and version. Returns nil if no value update is needed.
 	valueToUpdate := r.determineValueForUpdate(plan, state, config)
 	if valueToUpdate != nil {
-		// unsetting value still works because the framework expects the zero value of a string to be "" not nil
-		options.Value = valueToUpdate
+		attrs.SetValue(valueToUpdate)
 	}
 
-	// Update the policy set parameter
+	body := models.NewVars()
+	body.SetAttributes(attrs)
+	env := models.NewVarsEnvelope()
+	env.SetData(body)
+
 	tflog.Debug(ctx, fmt.Sprintf("Update parameter: %s", plan.ID.ValueString()))
-	p, err := r.config.Client.PolicySetParameters.Update(ctx, plan.PolicySetID.ValueString(), plan.ID.ValueString(), options)
+	policySetID := plan.PolicySetID.ValueString()
+	p, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Parameters().ById(plan.ID.ValueString()).Patch(ctx, env, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Error updating parameter %s", plan.ID), err.Error())
 		return
 	}
 
-	// Update state
-	result := modelFromTFEPolicySetParameter(p, plan.Value, config.ValueWOVersion)
+	result := modelFromV2PolicySetParameter(p, policySetID, plan.Value, config.ValueWOVersion)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
@@ -314,21 +323,19 @@ func (r *resourceTFEPolicySetParameter) Delete(ctx context.Context, req resource
 		return
 	}
 
-	// Check that policy set exists before continuing
-	_, err := r.config.Client.PolicySets.Read(ctx, state.PolicySetID.ValueString())
+	policySetID := state.PolicySetID.ValueString()
+	_, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Error retrieving policy set %s", state.PolicySetID), err.Error())
 		return
 	}
 
-	// Delete the policy set parameter
 	tflog.Debug(ctx, fmt.Sprintf("Delete parameter: %s", state.ID))
-	err = r.config.Client.PolicySetParameters.Delete(ctx, state.PolicySetID.ValueString(), state.ID.ValueString())
-	if err != nil && !errors.Is(err, tfe.ErrResourceNotFound) {
+	err = r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Parameters().ById(state.ID.ValueString()).Delete(ctx, nil)
+	if err != nil && !errors.Is(err, tfeV2.ErrNotFound) {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error deleting parameter %s", state.ID), err.Error())
 	}
-	// Resource is implicitly deleted from resp.State if diagnostics have no errors.
 }
 
 func (r *resourceTFEPolicySetParameter) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/resource_tfe_project_oauth_client_.go
+++ b/internal/provider/resource_tfe_project_oauth_client_.go
@@ -10,7 +10,8 @@ import (
 	"log"
 	"strings"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -54,10 +55,8 @@ func resourceTFEProjectOauthClientCreate(d *schema.ResourceData, meta interface{
 	oauthClientID := d.Get("oauth_client_id").(string)
 	projectID := d.Get("project_id").(string)
 
-	oauthClientAddProjectsOptions := tfe.OAuthClientAddProjectsOptions{}
-	oauthClientAddProjectsOptions.Projects = append(oauthClientAddProjectsOptions.Projects, &tfe.Project{ID: projectID})
-
-	err := config.Client.OAuthClients.AddProjects(ctx, oauthClientID, oauthClientAddProjectsOptions)
+	body := makeProjectIdentifierArrayDocument([]interface{}{projectID})
+	err := config.ClientV2.API.OauthClients().ByOauth_client_id(oauthClientID).Relationships().Projects().Post(ctx, body, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"error attaching oauth client id %s to project %s: %w", oauthClientID, projectID, err)
@@ -75,11 +74,9 @@ func resourceTFEProjectOauthClientRead(d *schema.ResourceData, meta interface{})
 	projectID := d.Get("project_id").(string)
 
 	log.Printf("[DEBUG] Read configuration of project oauth client: %s", oauthClientID)
-	oauthClient, err := config.Client.OAuthClients.ReadWithOptions(ctx, oauthClientID, &tfe.OAuthClientReadOptions{
-		Include: []tfe.OAuthClientIncludeOpt{tfe.OauthClientProjects},
-	})
+	ocEnv, err := config.ClientV2.API.OauthClients().ByOauth_client_id(oauthClientID).Get(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			log.Printf("[DEBUG] Oauth client %s no longer exists", oauthClientID)
 			d.SetId("")
 			return nil
@@ -87,12 +84,17 @@ func resourceTFEProjectOauthClientRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("error reading configuration of oauth client %s: %w", oauthClientID, err)
 	}
 
+	oc := ocEnv.GetData()
+	rels := oc.GetRelationships()
+
 	isProjectAttached := false
-	for _, project := range oauthClient.Projects {
-		if project.ID == projectID {
-			isProjectAttached = true
-			d.Set("project_id", projectID)
-			break
+	if rels != nil && rels.GetProjects() != nil {
+		for _, proj := range rels.GetProjects().GetData() {
+			if valueOrZero(proj.GetId()) == projectID {
+				isProjectAttached = true
+				d.Set("project_id", projectID)
+				break
+			}
 		}
 	}
 
@@ -113,10 +115,8 @@ func resourceTFEProjectOauthClientDelete(d *schema.ResourceData, meta interface{
 	projectID := d.Get("project_id").(string)
 
 	log.Printf("[DEBUG] Detaching project (%s) from oauth client (%s)", projectID, oauthClientID)
-	oauthClientRemoveProjectsOptions := tfe.OAuthClientRemoveProjectsOptions{}
-	oauthClientRemoveProjectsOptions.Projects = append(oauthClientRemoveProjectsOptions.Projects, &tfe.Project{ID: projectID})
-
-	err := config.Client.OAuthClients.RemoveProjects(ctx, oauthClientID, oauthClientRemoveProjectsOptions)
+	body := makeProjectIdentifierArrayDocument([]interface{}{projectID})
+	err := config.ClientV2.API.OauthClients().ByOauth_client_id(oauthClientID).Relationships().Projects().Delete(ctx, body, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"error detaching project %s from oauth client %s: %w", projectID, oauthClientID, err)
@@ -145,37 +145,42 @@ func resourceTFEProjectOauthClientImporter(ctx context.Context, d *schema.Resour
 		return nil, fmt.Errorf("error reading configuration of project %s in organization %s: %w", projectID, organization, err)
 	}
 
-	options := &tfe.OAuthClientListOptions{Include: []tfe.OAuthClientIncludeOpt{tfe.OauthClientProjects}}
+	pageSize := int32(100)
+	queryParams := &organizations.ItemOauthClientsRequestBuilderGetQueryParameters{
+		Pagesize: &pageSize,
+	}
 	for {
-		list, err := config.Client.OAuthClients.List(ctx, organization, options)
+		list, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).OauthClients().Get(ctx, withQueryParams(queryParams))
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving organization's list of oauth clients: %w", err)
 		}
-		for _, oauthClient := range list.Items {
-			if *oauthClient.Name != oauthClientName {
+		for _, oauthClient := range list.GetData() {
+			ocAttrs := oauthClient.GetAttributes()
+			if ocAttrs == nil || valueOrZero(ocAttrs.GetName()) != oauthClientName {
 				continue
 			}
 
-			for _, project := range oauthClient.Projects {
-				if project.ID != projectID {
+			rels := oauthClient.GetRelationships()
+			if rels == nil || rels.GetProjects() == nil {
+				continue
+			}
+			for _, proj := range rels.GetProjects().GetData() {
+				if valueOrZero(proj.GetId()) != projectID {
 					continue
 				}
 
-				d.Set("project_id", project.ID)
-				d.Set("oauth_client_id", oauthClient.ID)
-				d.SetId(fmt.Sprintf("%s_%s", project.ID, oauthClient.ID))
-
+				d.Set("project_id", projectID)
+				d.Set("oauth_client_id", valueOrZero(oauthClient.GetId()))
+				d.SetId(fmt.Sprintf("%s_%s", projectID, valueOrZero(oauthClient.GetId())))
 				return []*schema.ResourceData{d}, nil
 			}
 		}
 
-		// Exit the loop when we've seen all pages.
-		if list.CurrentPage >= list.TotalPages {
+		nextPage := nextPageFromMeta(list.GetMeta())
+		if nextPage == nil {
 			break
 		}
-
-		// Update the page number to get the next page.
-		options.PageNumber = list.NextPage
+		queryParams.Pagenumber = nextPage
 	}
 
 	return nil, fmt.Errorf("project %s has not been assigned to oauth client %s", projectID, oauthClientName)

--- a/internal/provider/resource_tfe_project_oauth_client_.go
+++ b/internal/provider/resource_tfe_project_oauth_client_.go
@@ -140,7 +140,7 @@ func resourceTFEProjectOauthClientImporter(ctx context.Context, d *schema.Resour
 	config := meta.(ConfiguredClient)
 
 	// Ensure the named project exists before fetching all the oauth clients in the org
-	_, err := config.Client.Projects.Read(ctx, projectID)
+	_, err := config.ClientV2.API.Projects().ByProject_id(projectID).Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error reading configuration of project %s in organization %s: %w", projectID, organization, err)
 	}

--- a/internal/provider/resource_tfe_project_policy_set.go
+++ b/internal/provider/resource_tfe_project_policy_set.go
@@ -15,7 +15,8 @@ import (
 	"log"
 	"strings"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -63,10 +64,8 @@ func resourceTFEProjectPolicySetCreate(d *schema.ResourceData, meta interface{})
 	policySetID := d.Get("policy_set_id").(string)
 	projectID := d.Get("project_id").(string)
 
-	policySetAddProjectsOptions := tfe.PolicySetAddProjectsOptions{}
-	policySetAddProjectsOptions.Projects = append(policySetAddProjectsOptions.Projects, &tfe.Project{ID: projectID})
-
-	err := config.Client.PolicySets.AddProjects(ctx, policySetID, policySetAddProjectsOptions)
+	body := makeProjectIdentifierArrayDocument([]interface{}{projectID})
+	err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Relationships().Projects().Post(ctx, body, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"error attaching policy set id %s to project %s: %w", policySetID, projectID, err)
@@ -84,11 +83,9 @@ func resourceTFEProjectPolicySetRead(d *schema.ResourceData, meta interface{}) e
 	projectID := d.Get("project_id").(string)
 
 	log.Printf("[DEBUG] Read configuration of project policy set: %s", policySetID)
-	policySet, err := config.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
-		Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetProjects},
-	})
+	policySetEnv, err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			log.Printf("[DEBUG] Policy set %s no longer exists", policySetID)
 			d.SetId("")
 			return nil
@@ -96,12 +93,17 @@ func resourceTFEProjectPolicySetRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("error reading configuration of policy set %s: %w", policySetID, err)
 	}
 
+	policySet := policySetEnv.GetData()
+	rels := policySet.GetRelationships()
+
 	isProjectAttached := false
-	for _, project := range policySet.Projects {
-		if project.ID == projectID {
-			isProjectAttached = true
-			d.Set("project_id", projectID)
-			break
+	if rels != nil && rels.GetProjects() != nil {
+		for _, proj := range rels.GetProjects().GetData() {
+			if valueOrZero(proj.GetId()) == projectID {
+				isProjectAttached = true
+				d.Set("project_id", projectID)
+				break
+			}
 		}
 	}
 
@@ -122,10 +124,8 @@ func resourceTFEProjectPolicySetDelete(d *schema.ResourceData, meta interface{})
 	projectID := d.Get("project_id").(string)
 
 	log.Printf("[DEBUG] Detaching project (%s) from policy set (%s)", projectID, policySetID)
-	policySetRemoveProjectsOptions := tfe.PolicySetRemoveProjectsOptions{}
-	policySetRemoveProjectsOptions.Projects = append(policySetRemoveProjectsOptions.Projects, &tfe.Project{ID: projectID})
-
-	err := config.Client.PolicySets.RemoveProjects(ctx, policySetID, policySetRemoveProjectsOptions)
+	body := makeProjectIdentifierArrayDocument([]interface{}{projectID})
+	err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Relationships().Projects().Delete(ctx, body, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"error detaching project %s from policy set %s: %w", projectID, policySetID, err)
@@ -154,37 +154,43 @@ func resourceTFEProjectPolicySetImporter(ctx context.Context, d *schema.Resource
 		return nil, fmt.Errorf("error reading configuration of project %s in organization %s: %w", projectID, organization, err)
 	}
 
-	options := &tfe.PolicySetListOptions{Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetProjects}}
+	pageSize := int32(100)
+	queryParams := &organizations.ItemPolicySetsRequestBuilderGetQueryParameters{
+		Pagesize:   &pageSize,
+		Searchname: &policySetName,
+	}
 	for {
-		list, err := config.Client.PolicySets.List(ctx, organization, options)
+		list, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).PolicySets().Get(ctx, withQueryParams(queryParams))
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving organization's list of policy sets: %w", err)
 		}
-		for _, policySet := range list.Items {
-			if policySet.Name != policySetName {
+		for _, policySet := range list.GetData() {
+			psAttrs := policySet.GetAttributes()
+			if psAttrs == nil || valueOrZero(psAttrs.GetName()) != policySetName {
 				continue
 			}
 
-			for _, project := range policySet.Projects {
-				if project.ID != projectID {
+			rels := policySet.GetRelationships()
+			if rels == nil || rels.GetProjects() == nil {
+				continue
+			}
+			for _, proj := range rels.GetProjects().GetData() {
+				if valueOrZero(proj.GetId()) != projectID {
 					continue
 				}
 
-				d.Set("project_id", project.ID)
-				d.Set("policy_set_id", policySet.ID)
-				d.SetId(fmt.Sprintf("%s_%s", project.ID, policySet.ID))
-
+				d.Set("project_id", projectID)
+				d.Set("policy_set_id", valueOrZero(policySet.GetId()))
+				d.SetId(fmt.Sprintf("%s_%s", projectID, valueOrZero(policySet.GetId())))
 				return []*schema.ResourceData{d}, nil
 			}
 		}
 
-		// Exit the loop when we've seen all pages.
-		if list.CurrentPage >= list.TotalPages {
+		nextPage := nextPageFromMeta(list.GetMeta())
+		if nextPage == nil {
 			break
 		}
-
-		// Update the page number to get the next page.
-		options.PageNumber = list.NextPage
+		queryParams.Pagenumber = nextPage
 	}
 
 	return nil, fmt.Errorf("project %s has not been assigned to policy set %s", projectID, policySetName)

--- a/internal/provider/resource_tfe_project_policy_set.go
+++ b/internal/provider/resource_tfe_project_policy_set.go
@@ -149,7 +149,7 @@ func resourceTFEProjectPolicySetImporter(ctx context.Context, d *schema.Resource
 	config := meta.(ConfiguredClient)
 
 	// Ensure the named project exists before fetching all the policy sets in the org
-	_, err := config.Client.Projects.Read(ctx, projectID)
+	_, err := config.ClientV2.API.Projects().ByProject_id(projectID).Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error reading configuration of project %s in organization %s: %w", projectID, organization, err)
 	}

--- a/internal/provider/resource_tfe_project_policy_set_exclusion.go
+++ b/internal/provider/resource_tfe_project_policy_set_exclusion.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -111,7 +111,7 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) Create(ctx context.Conte
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Creating project exclusion for policy set %s", plan.PolicySetID.ValueString()))
-	if ok, err := r.checkProjectExists(ctx, r.config.Client, plan.ProjectID.ValueString()); err != nil {
+	if ok, err := r.checkProjectExists(ctx, plan.ProjectID.ValueString()); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Checking if Project Exists",
 			fmt.Sprintf("An error was encountered when checking if project %q exists: %s", plan.ProjectID.ValueString(), err),
@@ -125,14 +125,9 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) Create(ctx context.Conte
 		return
 	}
 
-	err := r.config.Client.PolicySets.AddProjectExclusions(ctx, plan.PolicySetID.ValueString(), tfe.PolicySetAddProjectExclusionsOptions{
-		ProjectExclusions: []*tfe.Project{
-			{
-				ID: plan.ProjectID.ValueString(),
-			},
-		},
-	})
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	body := makeProjectIdentifierArrayDocument([]interface{}{plan.ProjectID.ValueString()})
+	err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(plan.PolicySetID.ValueString()).Relationships().ProjectExclusions().Post(ctx, body, nil)
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", plan.PolicySetID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
@@ -173,23 +168,10 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) Read(ctx context.Context
 		return
 	}
 
-	policySet, err := r.config.Client.PolicySets.ReadWithOptions(ctx, state.PolicySetID.ValueString(), &tfe.PolicySetReadOptions{
-		Include: []tfe.PolicySetIncludeOpt{
-			tfe.PolicySetProjectExclusions,
-		},
-	})
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(state.PolicySetID.ValueString()).Get(ctx, nil)
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", state.PolicySetID.ValueString()))
 		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	if err != nil && errors.Is(err, tfe.ErrInvalidIncludeValue) {
-		tflog.Debug(ctx, "Policy set exclusion is not supported")
-		resp.Diagnostics.AddError(
-			"Policy Set Exclusion Not Supported",
-			"The API operation to manage project exclusions on policy sets is not supported in the current version of Terraform Enterprise. Please upgrade to a newer version of Terraform Enterprise that supports this feature.",
-		)
 		return
 	}
 	if err != nil {
@@ -200,10 +182,14 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) Read(ctx context.Context
 		return
 	}
 
-	for _, excludedProject := range policySet.ProjectExclusions {
-		if excludedProject.ID == state.ProjectID.ValueString() {
-			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-			return
+	policySet := policySetEnv.GetData()
+	rels := policySet.GetRelationships()
+	if rels != nil && rels.GetProjectExclusions() != nil {
+		for _, proj := range rels.GetProjectExclusions().GetData() {
+			if valueOrZero(proj.GetId()) == state.ProjectID.ValueString() {
+				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+				return
+			}
 		}
 	}
 
@@ -235,15 +221,10 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) Delete(ctx context.Conte
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Removing project (%s) from exclusion list of policy set (%s)", state.ProjectID.ValueString(), state.PolicySetID.ValueString()))
-	err := r.config.Client.PolicySets.RemoveProjectExclusions(ctx, state.PolicySetID.ValueString(), tfe.PolicySetRemoveProjectExclusionsOptions{
-		ProjectExclusions: []*tfe.Project{
-			{
-				ID: state.ProjectID.ValueString(),
-			},
-		},
-	})
+	body := makeProjectIdentifierArrayDocument([]interface{}{state.ProjectID.ValueString()})
+	err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(state.PolicySetID.ValueString()).Relationships().ProjectExclusions().Delete(ctx, body, nil)
 
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", state.PolicySetID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
@@ -273,7 +254,7 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) ImportState(ctx context.
 	projectID := parts[0]
 
 	tflog.Debug(ctx, fmt.Sprintf("Importing project exclusion for policy set with import ID %s", id))
-	if ok, err := r.checkProjectExists(ctx, r.config.Client, projectID); err != nil {
+	if ok, err := r.checkProjectExists(ctx, projectID); err != nil {
 		resp.Diagnostics.AddError(
 			"Error Checking if Project Exists",
 			fmt.Sprintf("An error was encountered when checking if project %q exists: %s", projectID, err),
@@ -287,36 +268,33 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) ImportState(ctx context.
 		return
 	}
 
-	ps, err := r.config.Client.PolicySets.ReadWithOptions(ctx, policySetID, &tfe.PolicySetReadOptions{
-		Include: []tfe.PolicySetIncludeOpt{
-			tfe.PolicySetProjectExclusions,
-		},
-	})
-
-	if err != nil && errors.Is(err, tfe.ErrInvalidIncludeValue) {
-		tflog.Debug(ctx, "Policy set exclusion is not supported")
-		resp.Diagnostics.AddError(
-			"Policy Set Exclusion Not Supported",
-			"The API operation to manage project exclusions on policy sets is not supported in the current version of Terraform Enterprise. Please upgrade to a newer version of Terraform Enterprise that supports this feature.",
-		)
-		return
-	}
-
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading Policy Set",
+			fmt.Sprintf("An error was encountered when reading policy set %q: %s", policySetID, err),
+		)
+		return
+	}
 
-	for _, excludedProject := range ps.ProjectExclusions {
-		if excludedProject.ID == projectID {
-			state := modelProjectPolicySetExclusionParameter{
-				ID:          types.StringValue(fmt.Sprintf("%s/%s", projectID, policySetID)),
-				PolicySetID: types.StringValue(policySetID),
-				ProjectID:   types.StringValue(projectID),
+	ps := policySetEnv.GetData()
+	rels := ps.GetRelationships()
+	if rels != nil && rels.GetProjectExclusions() != nil {
+		for _, proj := range rels.GetProjectExclusions().GetData() {
+			if valueOrZero(proj.GetId()) == projectID {
+				state := modelProjectPolicySetExclusionParameter{
+					ID:          types.StringValue(fmt.Sprintf("%s/%s", projectID, policySetID)),
+					PolicySetID: types.StringValue(policySetID),
+					ProjectID:   types.StringValue(projectID),
+				}
+				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+				return
 			}
-			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-			return
 		}
 	}
 
@@ -327,16 +305,11 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) ImportState(ctx context.
 	resp.State.RemoveResource(ctx)
 }
 
-func (r *resourceTFEProjectPolicySetExclusionParameter) checkProjectExists(ctx context.Context, client *tfe.Client, projectId string) (bool, error) {
+func (r *resourceTFEProjectPolicySetExclusionParameter) checkProjectExists(ctx context.Context, projectId string) (bool, error) {
 	tflog.Debug(ctx, fmt.Sprintf("Checking if project %s exists", projectId))
-	_, err := client.Projects.Read(ctx, projectId)
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
-		tflog.Debug(ctx, fmt.Sprintf("Project %s does not exist.", projectId))
-		return false, nil
-	}
+	_, err := r.config.Client.Projects.Read(ctx, projectId)
 	if err != nil {
 		return false, err
 	}
-
 	return true, nil
 }

--- a/internal/provider/resource_tfe_project_policy_set_exclusion.go
+++ b/internal/provider/resource_tfe_project_policy_set_exclusion.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	tfe "github.com/hashicorp/go-tfe"
 	tfeV2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/go-tfe/v2/api/policysets"
 	policysetitem "github.com/hashicorp/go-tfe/v2/api/policysets/item"
@@ -180,6 +179,14 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) Read(ctx context.Context
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	if isInvalidIncludeValueV2(err) {
+		tflog.Debug(ctx, "Policy set exclusion is not supported")
+		resp.Diagnostics.AddError(
+			"Policy Set Exclusion Not Supported",
+			"The API operation to manage project exclusions on policy sets is not supported in the current version of Terraform Enterprise. Please upgrade to a newer version of Terraform Enterprise that supports this feature.",
+		)
+		return
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Policy Set",
@@ -283,6 +290,14 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) ImportState(ctx context.
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	if isInvalidIncludeValueV2(err) {
+		tflog.Debug(ctx, "Policy set exclusion is not supported")
+		resp.Diagnostics.AddError(
+			"Policy Set Exclusion Not Supported",
+			"The API operation to manage project exclusions on policy sets is not supported in the current version of Terraform Enterprise. Please upgrade to a newer version of Terraform Enterprise that supports this feature.",
+		)
+		return
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Policy Set",
@@ -316,8 +331,8 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) ImportState(ctx context.
 
 func (r *resourceTFEProjectPolicySetExclusionParameter) checkProjectExists(ctx context.Context, projectId string) (bool, error) {
 	tflog.Debug(ctx, fmt.Sprintf("Checking if project %s exists", projectId))
-	_, err := r.config.Client.Projects.Read(ctx, projectId)
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	_, err := r.config.ClientV2.API.Projects().ByProject_id(projectId).Get(ctx, nil)
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Project %s does not exist.", projectId))
 		return false, nil
 	}
@@ -325,4 +340,17 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) checkProjectExists(ctx c
 		return false, err
 	}
 	return true, nil
+}
+
+func isInvalidIncludeValueV2(err error) bool {
+	var apiErr *tfeV2.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	for _, detail := range apiErr.Details {
+		if strings.Contains(detail, "Invalid include parameter") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/resource_tfe_project_policy_set_exclusion.go
+++ b/internal/provider/resource_tfe_project_policy_set_exclusion.go
@@ -10,7 +10,10 @@ import (
 	"regexp"
 	"strings"
 
+	tfe "github.com/hashicorp/go-tfe"
 	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/policysets"
+	policysetitem "github.com/hashicorp/go-tfe/v2/api/policysets/item"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -168,7 +171,10 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) Read(ctx context.Context
 		return
 	}
 
-	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(state.PolicySetID.ValueString()).Get(ctx, nil)
+	queryParams := &policysets.WithPolicy_set_ItemRequestBuilderGetQueryParameters{
+		Include: []policysetitem.GetIncludeQueryParameterType{policysetitem.PROJECT_EXCLUSIONS_GETINCLUDEQUERYPARAMETERTYPE},
+	}
+	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(state.PolicySetID.ValueString()).Get(ctx, withQueryParams(queryParams))
 	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", state.PolicySetID.ValueString()))
 		resp.State.RemoveResource(ctx)
@@ -268,7 +274,10 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) ImportState(ctx context.
 		return
 	}
 
-	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
+	queryParams := &policysets.WithPolicy_set_ItemRequestBuilderGetQueryParameters{
+		Include: []policysetitem.GetIncludeQueryParameterType{policysetitem.PROJECT_EXCLUSIONS_GETINCLUDEQUERYPARAMETERTYPE},
+	}
+	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, withQueryParams(queryParams))
 	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
 		resp.State.RemoveResource(ctx)
@@ -308,6 +317,10 @@ func (r *resourceTFEProjectPolicySetExclusionParameter) ImportState(ctx context.
 func (r *resourceTFEProjectPolicySetExclusionParameter) checkProjectExists(ctx context.Context, projectId string) (bool, error) {
 	tflog.Debug(ctx, fmt.Sprintf("Checking if project %s exists", projectId))
 	_, err := r.config.Client.Projects.Read(ctx, projectId)
+	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+		tflog.Debug(ctx, fmt.Sprintf("Project %s does not exist.", projectId))
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}

--- a/internal/provider/resource_tfe_sentinel_policy.go
+++ b/internal/provider/resource_tfe_sentinel_policy.go
@@ -118,6 +118,7 @@ func resourceTFESentinelPolicyCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	body := models.NewPolicies()
+	body.SetTypeEscaped(ptr(models.POLICIES_POLICIES_TYPE))
 	body.SetAttributes(attrs)
 	env := models.NewPoliciesEnvelope()
 	env.SetData(body)
@@ -163,9 +164,8 @@ func resourceTFESentinelPolicyRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("description", valueOrZero(attrs.GetDescription()))
 
 	//nolint:staticcheck // this is still used by TFE versions older than 202306-1
-	for _, e := range attrs.GetEnforce() {
-		d.Set("enforce_mode", valueOrZero(e.GetMode()))
-		break
+	if enforce := attrs.GetEnforce(); len(enforce) == 1 {
+		d.Set("enforce_mode", valueOrZero(enforce[0].GetMode()))
 	}
 
 	content, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Download().Get(ctx, nil)
@@ -198,6 +198,7 @@ func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 
 		body := models.NewPolicies()
+		body.SetTypeEscaped(ptr(models.POLICIES_POLICIES_TYPE))
 		body.SetAttributes(attrs)
 		env := models.NewPoliciesEnvelope()
 		env.SetData(body)

--- a/internal/provider/resource_tfe_sentinel_policy.go
+++ b/internal/provider/resource_tfe_sentinel_policy.go
@@ -10,11 +10,14 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -98,32 +101,39 @@ func resourceTFESentinelPolicyCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	// Create a new options struct.
-	options := tfe.PolicyCreateOptions{
-		Name: tfe.String(name),
-		Enforce: []*tfe.EnforcementOptions{
-			{
-				Path: tfe.String(name + ".sentinel"),
-				Mode: tfe.EnforcementMode(tfe.EnforcementLevel(d.Get("enforce_mode").(string))),
-			},
-		},
-	}
+	enforcePath := name + ".sentinel"
+	enforceMode := d.Get("enforce_mode").(string)
+	enforceEntry := models.NewPolicies_attributes_enforce()
+	enforceEntry.SetPath(ptr(enforcePath))
+	enforceEntry.SetMode(ptr(enforceMode))
+
+	attrs := models.NewPolicies_attributes()
+	attrs.SetName(ptr(name))
+	kind := models.SENTINEL_POLICIES_ATTRIBUTES_KIND
+	attrs.SetKind(&kind)
+	attrs.SetEnforce([]models.Policies_attributes_enforceable{enforceEntry})
 
 	if desc, ok := d.GetOk("description"); ok {
-		options.Description = tfe.String(desc.(string))
+		attrs.SetDescription(ptr(desc.(string)))
 	}
 
+	body := models.NewPolicies()
+	body.SetAttributes(attrs)
+	env := models.NewPoliciesEnvelope()
+	env.SetData(body)
+
 	log.Printf("[DEBUG] Create sentinel policy %s for organization: %s", name, organization)
-	policy, err := config.Client.Policies.Create(ctx, organization, options)
+	policyEnv, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).Policies().Post(ctx, env, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error creating sentinel policy %s for organization %s: %w", name, organization, err)
 	}
 
-	d.SetId(policy.ID)
+	policyID := valueOrZero(policyEnv.GetData().GetId())
+	d.SetId(policyID)
 
 	log.Printf("[DEBUG] Upload sentinel policy %s for organization: %s", name, organization)
-	err = config.Client.Policies.Upload(ctx, policy.ID, []byte(d.Get("policy").(string)))
+	_, err = config.ClientV2.API.Policies().ByPolicy_id(policyID).Upload().Put(ctx, []byte(d.Get("policy").(string)), nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error uploading sentinel policy %s for organization %s: %w", name, organization, err)
@@ -136,9 +146,9 @@ func resourceTFESentinelPolicyRead(d *schema.ResourceData, meta interface{}) err
 	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Read sentinel policy: %s", d.Id())
-	policy, err := config.Client.Policies.Read(ctx, d.Id())
+	policyEnv, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Get(ctx, nil)
 	if err != nil {
-		if err == tfe.ErrResourceNotFound {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			log.Printf("[DEBUG] Sentinel policy %s no longer exists", d.Id())
 			d.SetId("")
 			return nil
@@ -146,16 +156,19 @@ func resourceTFESentinelPolicyRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error reading sentinel policy %s: %w", d.Id(), err)
 	}
 
-	// Update the config.
-	d.Set("name", policy.Name)
-	d.Set("description", policy.Description)
+	policy := policyEnv.GetData()
+	attrs := policy.GetAttributes()
+
+	d.Set("name", valueOrZero(attrs.GetName()))
+	d.Set("description", valueOrZero(attrs.GetDescription()))
 
 	//nolint:staticcheck // this is still used by TFE versions older than 202306-1
-	if len(policy.Enforce) == 1 {
-		d.Set("enforce_mode", string(policy.Enforce[0].Mode))
+	for _, e := range attrs.GetEnforce() {
+		d.Set("enforce_mode", valueOrZero(e.GetMode()))
+		break
 	}
 
-	content, err := config.Client.Policies.Download(ctx, policy.ID)
+	content, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Download().Get(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("Error downloading sentinel policy %s: %w", d.Id(), err)
 	}
@@ -168,25 +181,29 @@ func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) e
 	config := meta.(ConfiguredClient)
 
 	if d.HasChange("description") || d.HasChange("enforce_mode") {
-		// Create a new options struct.
-		options := tfe.PolicyUpdateOptions{}
+		attrs := models.NewPolicies_attributes()
 
 		if desc, ok := d.GetOk("description"); ok {
-			options.Description = tfe.String(desc.(string))
+			attrs.SetDescription(ptr(desc.(string)))
 		}
 
 		if d.HasChange("enforce_mode") {
+			enforcePath := d.Get("name").(string) + ".sentinel"
+			enforceMode := d.Get("enforce_mode").(string)
+			enforceEntry := models.NewPolicies_attributes_enforce()
+			enforceEntry.SetPath(ptr(enforcePath))
+			enforceEntry.SetMode(ptr(enforceMode))
 			//nolint:staticcheck // this is still used by TFE versions older than 202306-1
-			options.Enforce = []*tfe.EnforcementOptions{
-				{
-					Path: tfe.String(d.Get("name").(string) + ".sentinel"),
-					Mode: tfe.EnforcementMode(tfe.EnforcementLevel(d.Get("enforce_mode").(string))),
-				},
-			}
+			attrs.SetEnforce([]models.Policies_attributes_enforceable{enforceEntry})
 		}
 
+		body := models.NewPolicies()
+		body.SetAttributes(attrs)
+		env := models.NewPoliciesEnvelope()
+		env.SetData(body)
+
 		log.Printf("[DEBUG] Update configuration for sentinel policy: %s", d.Id())
-		_, err := config.Client.Policies.Update(ctx, d.Id(), options)
+		_, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Patch(ctx, env, nil)
 		if err != nil {
 			return fmt.Errorf(
 				"Error updating configuration for sentinel policy %s: %w", d.Id(), err)
@@ -195,7 +212,7 @@ func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) e
 
 	if d.HasChange("policy") {
 		log.Printf("[DEBUG] Update sentinel policy: %s", d.Id())
-		err := config.Client.Policies.Upload(ctx, d.Id(), []byte(d.Get("policy").(string)))
+		_, err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Upload().Put(ctx, []byte(d.Get("policy").(string)), nil)
 		if err != nil {
 			return fmt.Errorf("Error updating sentinel policy %s: %w", d.Id(), err)
 		}
@@ -208,9 +225,9 @@ func resourceTFESentinelPolicyDelete(d *schema.ResourceData, meta interface{}) e
 	config := meta.(ConfiguredClient)
 
 	log.Printf("[DEBUG] Delete sentinel policy: %s", d.Id())
-	err := config.Client.Policies.Delete(ctx, d.Id())
+	err := config.ClientV2.API.Policies().ByPolicy_id(d.Id()).Delete(ctx, nil)
 	if err != nil {
-		if err == tfe.ErrResourceNotFound {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			return nil
 		}
 		return fmt.Errorf("Error deleting sentinel policy %s: %w", d.Id(), err)

--- a/internal/provider/resource_tfe_tag_policy_set.go
+++ b/internal/provider/resource_tfe_tag_policy_set.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -134,11 +134,8 @@ func (r *resourceTFETagPolicySet) Create(ctx context.Context, req resource.Creat
 	valuePtr := plan.Value.ValueStringPointer()
 
 	tflog.Debug(ctx, fmt.Sprintf("Adding tag inclusion (key=%s, value=%s) to policy set %s", key, ptrValueOrNil(valuePtr), policySetID))
-	err := r.config.Client.PolicySets.AddTagSelectors(ctx, policySetID, tfe.PolicySetAddTagSelectorsOptions{
-		TagSelectors: []*tfe.PolicySetTagSelector{
-			{Key: key, Value: valuePtr, IsExclude: false},
-		},
-	})
+	body := makeTagSelectorPostBody(key, valuePtr, false)
+	err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).TagSelectors().Post(ctx, body, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Adding Tag Inclusion to Policy Set",
@@ -171,8 +168,8 @@ func (r *resourceTFETagPolicySet) Read(ctx context.Context, req resource.ReadReq
 	valuePtr := state.Value.ValueStringPointer()
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading tag inclusion (key=%s, value=%s) from policy set %s", key, ptrValueOrNil(valuePtr), policySetID))
-	policySet, err := r.config.Client.PolicySets.Read(ctx, policySetID)
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
 		resp.State.RemoveResource(ctx)
 		return
@@ -185,10 +182,16 @@ func (r *resourceTFETagPolicySet) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	for _, ts := range policySet.TagSelectors {
-		if ts.Key == key && !ts.IsExclude && r.tagValueMatches(ts.Value, state.Value) {
-			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-			return
+	policySet := policySetEnv.GetData()
+	attrs := policySet.GetAttributes()
+	if attrs != nil {
+		for _, ts := range attrs.GetTagSelectors() {
+			tsKey := valueOrZero(ts.GetTagKey())
+			tsExclude := ts.GetIsExclude() != nil && *ts.GetIsExclude()
+			if tsKey == key && !tsExclude && r.tagValueMatchesV2(ts.GetTagValue(), state.Value) {
+				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+				return
+			}
 		}
 	}
 
@@ -220,13 +223,10 @@ func (r *resourceTFETagPolicySet) Delete(ctx context.Context, req resource.Delet
 	valuePtr := state.Value.ValueStringPointer()
 
 	tflog.Debug(ctx, fmt.Sprintf("Removing tag inclusion (key=%s, value=%s) from policy set (%s)", key, ptrValueOrNil(valuePtr), policySetID))
-	err := r.config.Client.PolicySets.RemoveTagSelectors(ctx, policySetID, tfe.PolicySetRemoveTagSelectorsOptions{
-		TagSelectors: []*tfe.PolicySetTagSelector{
-			{Key: key, Value: valuePtr, IsExclude: false},
-		},
-	})
+	body := makeTagSelectorDeleteBody(key, valuePtr, false)
+	err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).TagSelectors().Delete(ctx, body, nil)
 
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
 		return
 	}
@@ -270,7 +270,7 @@ func (r *resourceTFETagPolicySet) ImportState(ctx context.Context, req resource.
 
 	tflog.Debug(ctx, fmt.Sprintf("Importing tag inclusion (key=%s, value=%s) for policy set %s", tagKey, ptrValueOrNil(tagValue), policySetID))
 
-	policySet, err := r.config.Client.PolicySets.Read(ctx, policySetID)
+	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Policy Set",
@@ -279,29 +279,33 @@ func (r *resourceTFETagPolicySet) ImportState(ctx context.Context, req resource.
 		return
 	}
 
-	for _, ts := range policySet.TagSelectors {
-		if ts.Key != tagKey || ts.IsExclude {
-			continue
-		}
-		if !r.tagValueMatches(ts.Value, types.StringPointerValue(tagValue)) {
-			continue
-		}
+	policySet := policySetEnv.GetData()
+	attrs := policySet.GetAttributes()
+	if attrs != nil {
+		for _, ts := range attrs.GetTagSelectors() {
+			if valueOrZero(ts.GetTagKey()) != tagKey || (ts.GetIsExclude() != nil && *ts.GetIsExclude()) {
+				continue
+			}
+			if !r.tagValueMatchesV2(ts.GetTagValue(), types.StringPointerValue(tagValue)) {
+				continue
+			}
 
-		var id string
-		if ts.Value != nil {
-			id = fmt.Sprintf("%s/%s/%s", policySetID, tagKey, *ts.Value)
-		} else {
-			id = fmt.Sprintf("%s/%s", policySetID, tagKey)
-		}
+			var id string
+			if ts.GetTagValue() != nil {
+				id = fmt.Sprintf("%s/%s/%s", policySetID, tagKey, *ts.GetTagValue())
+			} else {
+				id = fmt.Sprintf("%s/%s", policySetID, tagKey)
+			}
 
-		state := modelTagPolicySet{
-			ID:          types.StringValue(id),
-			PolicySetID: types.StringValue(policySetID),
-			Key:         types.StringValue(tagKey),
-			Value:       types.StringPointerValue(ts.Value),
+			state := modelTagPolicySet{
+				ID:          types.StringValue(id),
+				PolicySetID: types.StringValue(policySetID),
+				Key:         types.StringValue(tagKey),
+				Value:       types.StringPointerValue(ts.GetTagValue()),
+			}
+			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+			return
 		}
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-		return
 	}
 
 	resp.Diagnostics.AddError(
@@ -310,10 +314,7 @@ func (r *resourceTFETagPolicySet) ImportState(ctx context.Context, req resource.
 	)
 }
 
-// tagValueMatches returns true when the tag value from the API
-// matches the value stored in state. A null stateValue means the tag has no
-// value (key-only), which corresponds to a nil API value.
-func (r *resourceTFETagPolicySet) tagValueMatches(tsValue *string, stateValue types.String) bool {
+func (r *resourceTFETagPolicySet) tagValueMatchesV2(tsValue *string, stateValue types.String) bool {
 	if stateValue.IsNull() {
 		return tsValue == nil
 	}

--- a/internal/provider/resource_tfe_tag_policy_set_exclusion.go
+++ b/internal/provider/resource_tfe_tag_policy_set_exclusion.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -126,11 +126,8 @@ func (r *resourceTFETagPolicySetExclusion) Create(ctx context.Context, req resou
 	valuePtr := plan.Value.ValueStringPointer()
 
 	tflog.Debug(ctx, fmt.Sprintf("Adding tag exclusion (key=%s, value=%s) to policy set %s", key, ptrValueOrNil(valuePtr), policySetID))
-	err := r.config.Client.PolicySets.AddTagSelectors(ctx, policySetID, tfe.PolicySetAddTagSelectorsOptions{
-		TagSelectors: []*tfe.PolicySetTagSelector{
-			{Key: key, Value: valuePtr, IsExclude: true},
-		},
-	})
+	body := makeTagSelectorPostBody(key, valuePtr, true)
+	err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).TagSelectors().Post(ctx, body, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Adding Tag Exclusion to Policy Set",
@@ -163,8 +160,8 @@ func (r *resourceTFETagPolicySetExclusion) Read(ctx context.Context, req resourc
 	valuePtr := state.Value.ValueStringPointer()
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading tag exclusion (key=%s, value=%s) from policy set %s", key, ptrValueOrNil(valuePtr), policySetID))
-	policySet, err := r.config.Client.PolicySets.Read(ctx, policySetID)
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
 		resp.State.RemoveResource(ctx)
 		return
@@ -177,10 +174,16 @@ func (r *resourceTFETagPolicySetExclusion) Read(ctx context.Context, req resourc
 		return
 	}
 
-	for _, ts := range policySet.TagSelectors {
-		if ts.Key == key && ts.IsExclude && r.tagValueMatches(ts.Value, state.Value) {
-			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-			return
+	policySet := policySetEnv.GetData()
+	attrs := policySet.GetAttributes()
+	if attrs != nil {
+		for _, ts := range attrs.GetTagSelectors() {
+			tsKey := valueOrZero(ts.GetTagKey())
+			tsExclude := ts.GetIsExclude() != nil && *ts.GetIsExclude()
+			if tsKey == key && tsExclude && r.tagValueMatchesV2(ts.GetTagValue(), state.Value) {
+				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+				return
+			}
 		}
 	}
 
@@ -212,13 +215,10 @@ func (r *resourceTFETagPolicySetExclusion) Delete(ctx context.Context, req resou
 	valuePtr := state.Value.ValueStringPointer()
 
 	tflog.Debug(ctx, fmt.Sprintf("Removing tag exclusion (key=%s, value=%s) from policy set (%s)", key, ptrValueOrNil(valuePtr), policySetID))
-	err := r.config.Client.PolicySets.RemoveTagSelectors(ctx, policySetID, tfe.PolicySetRemoveTagSelectorsOptions{
-		TagSelectors: []*tfe.PolicySetTagSelector{
-			{Key: key, Value: valuePtr, IsExclude: true},
-		},
-	})
+	body := makeTagSelectorDeleteBody(key, valuePtr, true)
+	err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).TagSelectors().Delete(ctx, body, nil)
 
-	if err != nil && errors.Is(err, tfe.ErrResourceNotFound) {
+	if err != nil && errors.Is(err, tfeV2.ErrNotFound) {
 		tflog.Debug(ctx, fmt.Sprintf("Policy set %s no longer exists.", policySetID))
 		return
 	}
@@ -262,7 +262,7 @@ func (r *resourceTFETagPolicySetExclusion) ImportState(ctx context.Context, req 
 
 	tflog.Debug(ctx, fmt.Sprintf("Importing tag exclusion (key=%s, value=%s) for policy set %s", tagKey, ptrValueOrNil(tagValue), policySetID))
 
-	policySet, err := r.config.Client.PolicySets.Read(ctx, policySetID)
+	policySetEnv, err := r.config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Policy Set",
@@ -271,29 +271,33 @@ func (r *resourceTFETagPolicySetExclusion) ImportState(ctx context.Context, req 
 		return
 	}
 
-	for _, ts := range policySet.TagSelectors {
-		if ts.Key != tagKey || !ts.IsExclude {
-			continue
-		}
-		if !r.tagValueMatches(ts.Value, types.StringPointerValue(tagValue)) {
-			continue
-		}
+	policySet := policySetEnv.GetData()
+	attrs := policySet.GetAttributes()
+	if attrs != nil {
+		for _, ts := range attrs.GetTagSelectors() {
+			if valueOrZero(ts.GetTagKey()) != tagKey || ts.GetIsExclude() == nil || !*ts.GetIsExclude() {
+				continue
+			}
+			if !r.tagValueMatchesV2(ts.GetTagValue(), types.StringPointerValue(tagValue)) {
+				continue
+			}
 
-		var id string
-		if ts.Value != nil {
-			id = fmt.Sprintf("%s/%s/%s", policySetID, tagKey, *ts.Value)
-		} else {
-			id = fmt.Sprintf("%s/%s", policySetID, tagKey)
-		}
+			var id string
+			if ts.GetTagValue() != nil {
+				id = fmt.Sprintf("%s/%s/%s", policySetID, tagKey, *ts.GetTagValue())
+			} else {
+				id = fmt.Sprintf("%s/%s", policySetID, tagKey)
+			}
 
-		state := modelTagPolicySetExclusion{
-			ID:          types.StringValue(id),
-			PolicySetID: types.StringValue(policySetID),
-			Key:         types.StringValue(tagKey),
-			Value:       types.StringPointerValue(ts.Value),
+			state := modelTagPolicySetExclusion{
+				ID:          types.StringValue(id),
+				PolicySetID: types.StringValue(policySetID),
+				Key:         types.StringValue(tagKey),
+				Value:       types.StringPointerValue(ts.GetTagValue()),
+			}
+			resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+			return
 		}
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-		return
 	}
 
 	resp.Diagnostics.AddError(
@@ -302,10 +306,7 @@ func (r *resourceTFETagPolicySetExclusion) ImportState(ctx context.Context, req 
 	)
 }
 
-// tagValueMatches returns true when the tag value from the API
-// matches the value stored in state. A null stateValue means the tag has no
-// value (key-only), which corresponds to a nil API value.
-func (r *resourceTFETagPolicySetExclusion) tagValueMatches(tsValue *string, stateValue types.String) bool {
+func (r *resourceTFETagPolicySetExclusion) tagValueMatchesV2(tsValue *string, stateValue types.String) bool {
 	if stateValue.IsNull() {
 		return tsValue == nil
 	}

--- a/internal/provider/resource_tfe_workspace_policy_set.go
+++ b/internal/provider/resource_tfe_workspace_policy_set.go
@@ -150,10 +150,11 @@ func resourceTFEWorkspacePolicySetImporter(ctx context.Context, d *schema.Resour
 	config := meta.(ConfiguredClient)
 
 	// Ensure the named workspace exists before fetching all the policy sets in the org
-	_, err := config.Client.Workspaces.Read(ctx, organization, wsName)
+	workspaceEnv, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).Workspaces().ByWorkspace_name(wsName).Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error reading configuration of workspace %s in organization %s: %w", wsName, organization, err)
 	}
+	workspaceID := valueOrZero(workspaceEnv.GetData().GetId())
 
 	pageSize := int32(100)
 	queryParams := &organizations.ItemPolicySetsRequestBuilderGetQueryParameters{
@@ -177,12 +178,7 @@ func resourceTFEWorkspacePolicySetImporter(ctx context.Context, d *schema.Resour
 			}
 			for _, ws := range rels.GetWorkspaces().GetData() {
 				wsID := valueOrZero(ws.GetId())
-				if wsID == "" {
-					continue
-				}
-				// We need the workspace name; fetch it via v1 to compare
-				wsObj, err := config.Client.Workspaces.ReadByID(ctx, wsID)
-				if err != nil || wsObj == nil || wsObj.Name != wsName {
+				if wsID != workspaceID {
 					continue
 				}
 

--- a/internal/provider/resource_tfe_workspace_policy_set.go
+++ b/internal/provider/resource_tfe_workspace_policy_set.go
@@ -15,7 +15,8 @@ import (
 	"log"
 	"strings"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -62,10 +63,9 @@ func resourceTFEWorkspacePolicySetCreate(d *schema.ResourceData, meta interface{
 	policySetID := d.Get("policy_set_id").(string)
 	workspaceID := d.Get("workspace_id").(string)
 
-	policySetAddWorkspacesOptions := tfe.PolicySetAddWorkspacesOptions{}
-	policySetAddWorkspacesOptions.Workspaces = append(policySetAddWorkspacesOptions.Workspaces, &tfe.Workspace{ID: workspaceID})
+	body := makeWorkspaceIdentifierArrayDocument([]interface{}{workspaceID})
 
-	err := config.Client.PolicySets.AddWorkspaces(ctx, policySetID, policySetAddWorkspacesOptions)
+	err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Relationships().Workspaces().Post(ctx, body, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error attaching policy set id %s to workspace %s: %w", policySetID, workspaceID, err)
@@ -83,9 +83,9 @@ func resourceTFEWorkspacePolicySetRead(d *schema.ResourceData, meta interface{})
 	workspaceID := d.Get("workspace_id").(string)
 
 	log.Printf("[DEBUG] Read configuration of workspace policy set: %s", policySetID)
-	policySet, err := config.Client.PolicySets.Read(ctx, policySetID)
+	policySetEnv, err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			log.Printf("[DEBUG] Policy set %s no longer exists", policySetID)
 			d.SetId("")
 			return nil
@@ -93,12 +93,17 @@ func resourceTFEWorkspacePolicySetRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error reading configuration of policy set %s: %w", policySetID, err)
 	}
 
+	policySet := policySetEnv.GetData()
+	rels := policySet.GetRelationships()
+
 	isWorkspaceAttached := false
-	for _, workspace := range policySet.Workspaces {
-		if workspace.ID == workspaceID {
-			isWorkspaceAttached = true
-			d.Set("workspace_id", workspaceID)
-			break
+	if rels != nil && rels.GetWorkspaces() != nil {
+		for _, ws := range rels.GetWorkspaces().GetData() {
+			if valueOrZero(ws.GetId()) == workspaceID {
+				isWorkspaceAttached = true
+				d.Set("workspace_id", workspaceID)
+				break
+			}
 		}
 	}
 
@@ -119,10 +124,9 @@ func resourceTFEWorkspacePolicySetDelete(d *schema.ResourceData, meta interface{
 	workspaceID := d.Get("workspace_id").(string)
 
 	log.Printf("[DEBUG] Detaching workspace (%s) from policy set (%s)", workspaceID, policySetID)
-	policySetRemoveWorkspacesOptions := tfe.PolicySetRemoveWorkspacesOptions{}
-	policySetRemoveWorkspacesOptions.Workspaces = append(policySetRemoveWorkspacesOptions.Workspaces, &tfe.Workspace{ID: workspaceID})
+	body := makeWorkspaceIdentifierArrayDocument([]interface{}{workspaceID})
 
-	err := config.Client.PolicySets.RemoveWorkspaces(ctx, policySetID, policySetRemoveWorkspacesOptions)
+	err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Relationships().Workspaces().Delete(ctx, body, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"Error detaching workspace %s from policy set %s: %w", workspaceID, policySetID, err)
@@ -151,37 +155,49 @@ func resourceTFEWorkspacePolicySetImporter(ctx context.Context, d *schema.Resour
 		return nil, fmt.Errorf("error reading configuration of workspace %s in organization %s: %w", wsName, organization, err)
 	}
 
-	options := &tfe.PolicySetListOptions{Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaces}}
+	pageSize := int32(100)
+	queryParams := &organizations.ItemPolicySetsRequestBuilderGetQueryParameters{
+		Pagesize:   &pageSize,
+		Searchname: &pSName,
+	}
 	for {
-		list, err := config.Client.PolicySets.List(ctx, organization, options)
+		list, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).PolicySets().Get(ctx, withQueryParams(queryParams))
 		if err != nil {
 			return nil, fmt.Errorf("Error retrieving policy sets: %w", err)
 		}
-		for _, policySet := range list.Items {
-			if policySet.Name != pSName {
+		for _, policySet := range list.GetData() {
+			psAttrs := policySet.GetAttributes()
+			if psAttrs == nil || valueOrZero(psAttrs.GetName()) != pSName {
 				continue
 			}
 
-			for _, ws := range policySet.Workspaces {
-				if ws.Name != wsName {
+			rels := policySet.GetRelationships()
+			if rels == nil || rels.GetWorkspaces() == nil {
+				continue
+			}
+			for _, ws := range rels.GetWorkspaces().GetData() {
+				wsID := valueOrZero(ws.GetId())
+				if wsID == "" {
+					continue
+				}
+				// We need the workspace name; fetch it via v1 to compare
+				wsObj, err := config.Client.Workspaces.ReadByID(ctx, wsID)
+				if err != nil || wsObj == nil || wsObj.Name != wsName {
 					continue
 				}
 
-				d.Set("workspace_id", ws.ID)
-				d.Set("policy_set_id", policySet.ID)
-				d.SetId(fmt.Sprintf("%s_%s", ws.ID, policySet.ID))
-
+				d.Set("workspace_id", wsID)
+				d.Set("policy_set_id", valueOrZero(policySet.GetId()))
+				d.SetId(fmt.Sprintf("%s_%s", wsID, valueOrZero(policySet.GetId())))
 				return []*schema.ResourceData{d}, nil
 			}
 		}
 
-		// Exit the loop when we've seen all pages.
-		if list.CurrentPage >= list.TotalPages {
+		nextPage := nextPageFromMeta(list.GetMeta())
+		if nextPage == nil {
 			break
 		}
-
-		// Update the page number to get the next page.
-		options.PageNumber = list.NextPage
+		queryParams.Pagenumber = nextPage
 	}
 
 	return nil, fmt.Errorf("workspace %s has not been assigned to policy set %s", wsName, pSName)

--- a/internal/provider/resource_tfe_workspace_policy_set_exclusion.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_exclusion.go
@@ -15,7 +15,8 @@ import (
 	"log"
 	"strings"
 
-	tfe "github.com/hashicorp/go-tfe"
+	tfeV2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/organizations"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -62,10 +63,8 @@ func resourceTFEWorkspacePolicySetExclusionCreate(d *schema.ResourceData, meta i
 	policySetID := d.Get("policy_set_id").(string)
 	workspaceExclusionID := d.Get("workspace_id").(string)
 
-	policySetAddWorkspaceExclusionsOptions := tfe.PolicySetAddWorkspaceExclusionsOptions{}
-	policySetAddWorkspaceExclusionsOptions.WorkspaceExclusions = append(policySetAddWorkspaceExclusionsOptions.WorkspaceExclusions, &tfe.Workspace{ID: workspaceExclusionID})
-
-	err := config.Client.PolicySets.AddWorkspaceExclusions(ctx, policySetID, policySetAddWorkspaceExclusionsOptions)
+	body := makeWorkspaceIdentifierArrayDocument([]interface{}{workspaceExclusionID})
+	err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Relationships().WorkspaceExclusions().Post(ctx, body, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"error adding workspace exclusion %s to policy set id %s: %w", workspaceExclusionID, policySetID, err)
@@ -83,9 +82,9 @@ func resourceTFEWorkspacePolicySetExclusionRead(d *schema.ResourceData, meta int
 	workspaceExclusionsID := d.Get("workspace_id").(string)
 
 	log.Printf("[DEBUG] Read configuration of excluded workspace policy set: %s", policySetID)
-	policySet, err := config.Client.PolicySets.Read(ctx, policySetID)
+	policySetEnv, err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Get(ctx, nil)
 	if err != nil {
-		if errors.Is(err, tfe.ErrResourceNotFound) {
+		if errors.Is(err, tfeV2.ErrNotFound) {
 			log.Printf("[DEBUG] Policy set %s no longer exists", policySetID)
 			d.SetId("")
 			return nil
@@ -93,12 +92,17 @@ func resourceTFEWorkspacePolicySetExclusionRead(d *schema.ResourceData, meta int
 		return fmt.Errorf("error reading configuration of policy set %s: %w", policySetID, err)
 	}
 
+	policySet := policySetEnv.GetData()
+	rels := policySet.GetRelationships()
+
 	isWorkspaceExclusionsAttached := false
-	for _, excludedWorkspace := range policySet.WorkspaceExclusions {
-		if excludedWorkspace.ID == workspaceExclusionsID {
-			isWorkspaceExclusionsAttached = true
-			d.Set("workspace_id", workspaceExclusionsID)
-			break
+	if rels != nil && rels.GetWorkspaceExclusions() != nil {
+		for _, ws := range rels.GetWorkspaceExclusions().GetData() {
+			if valueOrZero(ws.GetId()) == workspaceExclusionsID {
+				isWorkspaceExclusionsAttached = true
+				d.Set("workspace_id", workspaceExclusionsID)
+				break
+			}
 		}
 	}
 
@@ -119,10 +123,8 @@ func resourceTFEWorkspacePolicySetExclusionDelete(d *schema.ResourceData, meta i
 	workspaceExclusionsID := d.Get("workspace_id").(string)
 
 	log.Printf("[DEBUG] Removing excluded workspace (%s) from policy set (%s)", workspaceExclusionsID, policySetID)
-	policySetRemoveWorkspaceExclusionsOptions := tfe.PolicySetRemoveWorkspaceExclusionsOptions{}
-	policySetRemoveWorkspaceExclusionsOptions.WorkspaceExclusions = append(policySetRemoveWorkspaceExclusionsOptions.WorkspaceExclusions, &tfe.Workspace{ID: workspaceExclusionsID})
-
-	err := config.Client.PolicySets.RemoveWorkspaceExclusions(ctx, policySetID, policySetRemoveWorkspaceExclusionsOptions)
+	body := makeWorkspaceIdentifierArrayDocument([]interface{}{workspaceExclusionsID})
+	err := config.ClientV2.API.PolicySets().ByPolicy_set_id(policySetID).Relationships().WorkspaceExclusions().Delete(ctx, body, nil)
 	if err != nil {
 		return fmt.Errorf(
 			"error removing excluded workspace %s from policy set %s: %w", workspaceExclusionsID, policySetID, err)
@@ -151,37 +153,48 @@ func resourceTFEWorkspacePolicySetExclusionImporter(ctx context.Context, d *sche
 		return nil, fmt.Errorf("error reading configuration of the workspace to exclude %s in organization %s: %w", wsName, organization, err)
 	}
 
-	options := &tfe.PolicySetListOptions{Include: []tfe.PolicySetIncludeOpt{tfe.PolicySetWorkspaceExclusions}}
+	pageSize := int32(100)
+	queryParams := &organizations.ItemPolicySetsRequestBuilderGetQueryParameters{
+		Pagesize:   &pageSize,
+		Searchname: &pSName,
+	}
 	for {
-		list, err := config.Client.PolicySets.List(ctx, organization, options)
+		list, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).PolicySets().Get(ctx, withQueryParams(queryParams))
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving policy sets: %w", err)
 		}
-		for _, policySet := range list.Items {
-			if policySet.Name != pSName {
+		for _, policySet := range list.GetData() {
+			psAttrs := policySet.GetAttributes()
+			if psAttrs == nil || valueOrZero(psAttrs.GetName()) != pSName {
 				continue
 			}
 
-			for _, ws := range policySet.WorkspaceExclusions {
-				if ws.Name != wsName {
+			rels := policySet.GetRelationships()
+			if rels == nil || rels.GetWorkspaceExclusions() == nil {
+				continue
+			}
+			for _, ws := range rels.GetWorkspaceExclusions().GetData() {
+				wsID := valueOrZero(ws.GetId())
+				if wsID == "" {
+					continue
+				}
+				wsObj, err := config.Client.Workspaces.ReadByID(ctx, wsID)
+				if err != nil || wsObj == nil || wsObj.Name != wsName {
 					continue
 				}
 
-				d.Set("workspace_id", ws.ID)
-				d.Set("policy_set_id", policySet.ID)
-				d.SetId(fmt.Sprintf("%s_%s", ws.ID, policySet.ID))
-
+				d.Set("workspace_id", wsID)
+				d.Set("policy_set_id", valueOrZero(policySet.GetId()))
+				d.SetId(fmt.Sprintf("%s_%s", wsID, valueOrZero(policySet.GetId())))
 				return []*schema.ResourceData{d}, nil
 			}
 		}
 
-		// Exit the loop when we've seen all pages.
-		if list.CurrentPage >= list.TotalPages {
+		nextPage := nextPageFromMeta(list.GetMeta())
+		if nextPage == nil {
 			break
 		}
-
-		// Update the page number to get the next page.
-		options.PageNumber = list.NextPage
+		queryParams.Pagenumber = nextPage
 	}
 
 	return nil, fmt.Errorf("excluded workspace %s has not been added to policy set %s", wsName, pSName)

--- a/internal/provider/resource_tfe_workspace_policy_set_exclusion.go
+++ b/internal/provider/resource_tfe_workspace_policy_set_exclusion.go
@@ -148,10 +148,11 @@ func resourceTFEWorkspacePolicySetExclusionImporter(ctx context.Context, d *sche
 	config := meta.(ConfiguredClient)
 
 	// Ensure the named workspace exists before fetching all the policy sets in the org
-	_, err := config.Client.Workspaces.Read(ctx, organization, wsName)
+	workspaceEnv, err := config.ClientV2.API.Organizations().ByOrganization_name(organization).Workspaces().ByWorkspace_name(wsName).Get(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error reading configuration of the workspace to exclude %s in organization %s: %w", wsName, organization, err)
 	}
+	workspaceID := valueOrZero(workspaceEnv.GetData().GetId())
 
 	pageSize := int32(100)
 	queryParams := &organizations.ItemPolicySetsRequestBuilderGetQueryParameters{
@@ -175,11 +176,7 @@ func resourceTFEWorkspacePolicySetExclusionImporter(ctx context.Context, d *sche
 			}
 			for _, ws := range rels.GetWorkspaceExclusions().GetData() {
 				wsID := valueOrZero(ws.GetId())
-				if wsID == "" {
-					continue
-				}
-				wsObj, err := config.Client.Workspaces.ReadByID(ctx, wsID)
-				if err != nil || wsObj == nil || wsObj.Name != wsName {
+				if wsID != workspaceID {
 					continue
 				}
 


### PR DESCRIPTION
This PR continues the provider-wide migration from the hand-written go-tfe v1 client (config.Client) to the Kiota-generated go-tfe/v2 client (config.ClientV2.API). This batch covers the policy, registry-adjacent OAuth, and GitHub App installation surfaces.

Includes migrations for: 
- resource_tfe_sentinel_policy.go
- resource_tfe_policy.go
- resource_tfe_policy_set.go
- resource_tfe_policy_set_parameter.go
- resource_tfe_workspace_policy_set.go
- resource_tfe_workspace_policy_set_exclusion.go
- resource_tfe_project_policy_set.go
- resource_tfe_project_policy_set_exclusion.go
- resource_tfe_tag_policy_set.go
- resource_tfe_tag_policy_set_exclusion.go
- resource_tfe_oauth_client.go
- resource_tfe_project_oauth_client_.go
- data_source_policy_set.go
- data_source_oauth_client.go
- data_source_github_app_installation.go
- github_app_installation_helpers.go
- oauth_client_helpers.go
