### PR TITLE
TF-39824 fix: permissions adjustment for push docs action

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -5,6 +5,11 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   build:
     name: Deploy docs


### PR DESCRIPTION
## Description

The GitHub Actions mkdocs workflow requires write permissions. Due to changes in the defaults, the bot does not hold those write permissions unless explicit. This change was tested via the branch and this appears to be the minimal permissions granted for this workflow to work as-is.

Note that using `contents: read` does not seem to work at present.

## Testing plan

1.  May modify `mkdocs.yml` to active on push to a testing branch, then see that the workflow succeeds and the pages are pushed. (you can see the testing copy of that [here](https://github.com/hashicorp/terraform-provider-tfe/actions/runs/30938750756))

## External links

- [GitHub permissions info](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#modifying-the-permissions-for-the-github_token)
- [GitHub Pages permission info](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages) (note this is not sufficient)
- [the action target](https://github.com/mhausenblas/mkdocs-deploy-gh-pages)

Note also this relates to various HashiCorp security rollouts.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

Rollback and re-push of docs should be sufficient, but beware any writes inadvertently permitted by the bot's permission elevation.

## Changes to Security Controls

The GitHub Action for mkdocs has returned to having write permissions for `content`, `id-token`, and `pages`.
