### PR TITLE
[TF-38436] Cloudbox Deprecation: replace cloud box acceptance testing env with one generated in Github actions

### DIFF
--- a/.github/actions/create-tfe-acceptance-env/action.yml
+++ b/.github/actions/create-tfe-acceptance-env/action.yml
@@ -23,7 +23,7 @@ runs:
       with:
         workflow: setup-env-and-upload.yml
         repo: hashicorp/setup-tfe-acceptance-env
-        ref: christian-doucette/intial-version-with-just-creating-env
+        ref: e77ef1812e7108081d7fb0d5c3a2105dae7563c6 # main
         token: ${{ inputs.token }}
         inputs: '{ "terraform_enterprise": ${{ inputs.terraform_enterprise }}, "caller_repository": "${{ github.repository }}", "caller_run_id": "${{ github.run_id }}" }'
 

--- a/.github/actions/create-tfe-acceptance-env/action.yml
+++ b/.github/actions/create-tfe-acceptance-env/action.yml
@@ -23,7 +23,7 @@ runs:
       with:
         workflow: setup-env-and-upload.yml
         repo: hashicorp/setup-tfe-acceptance-env
-        ref: e77ef1812e7108081d7fb0d5c3a2105dae7563c6 # main
+        ref: v1.0.0
         token: ${{ inputs.token }}
         inputs: '{ "terraform_enterprise": ${{ inputs.terraform_enterprise }}, "caller_repository": "${{ github.repository }}", "caller_run_id": "${{ github.run_id }}" }'
 

--- a/.github/actions/create-tfe-acceptance-env/action.yml
+++ b/.github/actions/create-tfe-acceptance-env/action.yml
@@ -1,0 +1,68 @@
+# Copyright IBM Corp. 2018, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+name: Create TFE acceptance environment
+description: Dispatches the acceptance environment workflow and waits for its artifact
+inputs:
+  terraform_enterprise:
+    description: Whether to create a Terraform Enterprise environment
+    required: true
+  token:
+    description: Token used to access the setup-tfe-acceptance-env repository
+    required: true
+outputs:
+  setup_run_id:
+    description: Run ID of the dispatched setup workflow
+    value: ${{ steps.dispatch.outputs.runId }}
+runs:
+  using: composite
+  steps:
+    - name: Dispatch setup workflow
+      id: dispatch
+      uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
+      with:
+        workflow: setup-env-and-upload.yml
+        repo: hashicorp/setup-tfe-acceptance-env
+        ref: christian-doucette/intial-version-with-just-creating-env
+        token: ${{ inputs.token }}
+        inputs: '{ "terraform_enterprise": ${{ inputs.terraform_enterprise }}, "caller_repository": "${{ github.repository }}", "caller_run_id": "${{ github.run_id }}" }'
+
+    - name: Wait for environment artifact
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+        SETUP_RUN_ID: ${{ steps.dispatch.outputs.runId }}
+      run: |
+        artifact_id=""
+        for attempt in {1..30}; do
+          artifact_id="$({
+            gh api \
+              "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}/artifacts" \
+              --jq '.artifacts | map(select(.name == "tfe-acceptance-env")) | first | .id // ""'
+          })"
+
+          if [ -n "${artifact_id}" ]; then
+            echo "Found tfe-acceptance-env artifact: ${artifact_id}"
+            break
+          fi
+
+          run_state="$({
+            gh api \
+              "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}" \
+              --jq '.status + ":" + (.conclusion // "")'
+          })"
+
+          if [[ "${run_state}" == completed:* ]]; then
+            echo "Setup workflow completed before uploading tfe-acceptance-env artifact: ${run_state}"
+            exit 1
+          fi
+
+          echo "Waiting for tfe-acceptance-env artifact (${attempt}/30). Setup run state: ${run_state}"
+          sleep 60
+        done
+
+        if [ -z "${artifact_id}" ]; then
+          echo "Timed out waiting for tfe-acceptance-env artifact on setup run ${SETUP_RUN_ID}"
+          exit 1
+        fi

--- a/.github/actions/load-tfe-acceptance-env/action.yml
+++ b/.github/actions/load-tfe-acceptance-env/action.yml
@@ -1,0 +1,72 @@
+# Copyright IBM Corp. 2018, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+name: Load TFE acceptance environment
+description: Verifies and loads an environment created by setup-tfe-acceptance-env
+inputs:
+  setup_run_id:
+    description: Run ID of the setup workflow that owns the environment
+    required: true
+  token:
+    description: Token used to access the setup-tfe-acceptance-env repository
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Verify acceptance environment is still available
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+        SETUP_RUN_ID: ${{ inputs.setup_run_id }}
+      run: |
+        setup_status="$({
+          gh api \
+            "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}" \
+            --jq '.status'
+        })"
+
+        if [ "${setup_status}" != "in_progress" ]; then
+          echo "::error title=Stale TFE acceptance environment::The setup workflow is ${setup_status}, so its acceptance testing environment is no longer available. Re-run all jobs so the Setup TFE Acceptance Environment job regenerates it."
+          exit 1
+        fi
+
+    - name: Download acceptance environment artifact
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+        SETUP_RUN_ID: ${{ inputs.setup_run_id }}
+      run: |
+        gh run download "${SETUP_RUN_ID}" \
+          --repo "${SETUP_REPO}" \
+          --name tfe-acceptance-env \
+          --dir tfe-acceptance-env
+
+    - name: Load acceptance environment
+      shell: bash
+      run: |
+        export_value() {
+          local name="$1"
+          local query="$2"
+          local value
+
+          value="$(jq -er "${query}" tfe-acceptance-env/environment.json)"
+          if [ -z "${value}" ]; then
+            echo "Acceptance environment value ${name} is empty"
+            exit 1
+          fi
+
+          echo "::add-mask::${value}"
+          echo "${name}=${value}" >> "${GITHUB_ENV}"
+        }
+
+        export_value TFE_HOSTNAME '.ngrok_hostname'
+        export_value TFE_TOKEN '.tfe_token'
+        export_value TFE_ADMIN_CONFIGURATION_TOKEN '.admin_tokens.configuration'
+        export_value TFE_ADMIN_PROVISION_LICENSES_TOKEN '.admin_tokens.provision_licenses'
+        export_value TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN '.admin_tokens.security_maintenance'
+        export_value TFE_ADMIN_SITE_ADMIN_TOKEN '.admin_tokens.site_admin'
+        export_value TFE_ADMIN_SUBSCRIPTION_TOKEN '.admin_tokens.subscription'
+        export_value TFE_ADMIN_SUPPORT_TOKEN '.admin_tokens.support'
+        export_value TFE_ADMIN_VERSION_MAINTENANCE_TOKEN '.admin_tokens.version_maintenance'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,7 @@ jobs:
     if: "!startsWith(github.head_ref, 'changelog/')"
     runs-on: ubuntu-latest
     outputs:
-      hostname: ${{ steps.acceptance-env.outputs.hostname }}
-      token: ${{ steps.acceptance-env.outputs.token }}
-      admin_configuration_token: ${{ steps.acceptance-env.outputs.admin_configuration_token }}
-      admin_provision_licenses_token: ${{ steps.acceptance-env.outputs.admin_provision_licenses_token }}
-      admin_security_maintenance_token: ${{ steps.acceptance-env.outputs.admin_security_maintenance_token }}
-      admin_site_admin_token: ${{ steps.acceptance-env.outputs.admin_site_admin_token }}
-      admin_subscription_token: ${{ steps.acceptance-env.outputs.admin_subscription_token }}
-      admin_support_token: ${{ steps.acceptance-env.outputs.admin_support_token }}
-      admin_version_maintenance_token: ${{ steps.acceptance-env.outputs.admin_version_maintenance_token }}
+      setup_run_id: ${{ steps.dispatch.outputs.runId }}
     steps:
       - name: Dispatch setup workflow
         id: dispatch
@@ -95,24 +87,6 @@ jobs:
             exit 1
           fi
 
-          gh run download "${SETUP_RUN_ID}" \
-            --repo "${SETUP_REPO}" \
-            --name tfe-acceptance-env \
-            --dir tfe-acceptance-env
-
-      - name: Read environment artifact
-        id: acceptance-env
-        run: |
-          echo "hostname=$(jq -r '.ngrok_hostname' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-          echo "token=$(jq -r '.tfe_token' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-          echo "admin_configuration_token=$(jq -r '.admin_tokens.configuration' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-          echo "admin_provision_licenses_token=$(jq -r '.admin_tokens.provision_licenses' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-          echo "admin_security_maintenance_token=$(jq -r '.admin_tokens.security_maintenance' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-          echo "admin_site_admin_token=$(jq -r '.admin_tokens.site_admin' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-          echo "admin_subscription_token=$(jq -r '.admin_tokens.subscription' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-          echo "admin_support_token=$(jq -r '.admin_tokens.support' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-          echo "admin_version_maintenance_token=$(jq -r '.admin_tokens.version_maintenance' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
-
   tests:
     name: run
     if: "!startsWith(github.head_ref, 'changelog/')"
@@ -128,21 +102,59 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Download acceptance environment artifact
+        env:
+          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+          SETUP_RUN_ID: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
+        run: |
+          gh run download "${SETUP_RUN_ID}" \
+            --repo "${SETUP_REPO}" \
+            --name tfe-acceptance-env \
+            --dir tfe-acceptance-env
+
+      - name: Load acceptance environment
+        run: |
+          export_value() {
+            local name="$1"
+            local query="$2"
+            local value
+
+            value="$(jq -er "${query}" tfe-acceptance-env/environment.json)"
+            if [ -z "${value}" ]; then
+              echo "Acceptance environment value ${name} is empty"
+              exit 1
+            fi
+
+            echo "::add-mask::${value}"
+            echo "${name}=${value}" >> "${GITHUB_ENV}"
+          }
+
+          export_value TFE_HOSTNAME '.ngrok_hostname'
+          export_value TFE_TOKEN '.tfe_token'
+          export_value TFE_ADMIN_CONFIGURATION_TOKEN '.admin_tokens.configuration'
+          export_value TFE_ADMIN_PROVISION_LICENSES_TOKEN '.admin_tokens.provision_licenses'
+          export_value TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN '.admin_tokens.security_maintenance'
+          export_value TFE_ADMIN_SITE_ADMIN_TOKEN '.admin_tokens.site_admin'
+          export_value TFE_ADMIN_SUBSCRIPTION_TOKEN '.admin_tokens.subscription'
+          export_value TFE_ADMIN_SUPPORT_TOKEN '.admin_tokens.support'
+          export_value TFE_ADMIN_VERSION_MAINTENANCE_TOKEN '.admin_tokens.version_maintenance'
+
       - uses: ./.github/actions/test-provider-tfe
         with:
           matrix_index: ${{ matrix.index }}
           matrix_total: ${{ matrix.total }}
-          hostname: ${{ needs.setup-tfe-acceptance-env.outputs.hostname }}
-          token: ${{ needs.setup-tfe-acceptance-env.outputs.token }}
+          hostname: ${{ env.TFE_HOSTNAME }}
+          token: ${{ env.TFE_TOKEN }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
           testing-github-token-2: ${{ secrets.TESTING_GITHUB_TOKEN2 }}
-          admin_configuration_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_configuration_token }}
-          admin_provision_licenses_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_provision_licenses_token }}
-          admin_security_maintenance_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_security_maintenance_token }}
-          admin_site_admin_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_site_admin_token }}
-          admin_subscription_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_subscription_token }}
-          admin_support_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_support_token }}
-          admin_version_maintenance_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_version_maintenance_token }}
+          admin_configuration_token: ${{ env.TFE_ADMIN_CONFIGURATION_TOKEN }}
+          admin_provision_licenses_token: ${{ env.TFE_ADMIN_PROVISION_LICENSES_TOKEN }}
+          admin_security_maintenance_token: ${{ env.TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN }}
+          admin_site_admin_token: ${{ env.TFE_ADMIN_SITE_ADMIN_TOKEN }}
+          admin_subscription_token: ${{ env.TFE_ADMIN_SUBSCRIPTION_TOKEN }}
+          admin_support_token: ${{ env.TFE_ADMIN_SUPPORT_TOKEN }}
+          admin_version_maintenance_token: ${{ env.TFE_ADMIN_VERSION_MAINTENANCE_TOKEN }}
           # Run terminal cmd 'go help testflag' to learn more about -list and -skip flags
           # action.yml uses https://github.com/hashicorp-forge/go-test-split-action/blob/main/action.yml to split acceptance tests
           # which runs against all tests using the list arg.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,23 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Verify acceptance environment is still available
+        env:
+          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+          SETUP_RUN_ID: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
+        run: |
+          setup_status="$({
+            gh api \
+              "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}" \
+              --jq '.status'
+          })"
+
+          if [ "${setup_status}" != "in_progress" ]; then
+            echo "::error title=Stale TFE acceptance environment::The setup workflow is ${setup_status}, so its acceptance testing environment is no longer available. Re-run all jobs so the Setup TFE Acceptance Environment job regenerates it."
+            exit 1
+          fi
+
       - name: Download acceptance environment artifact
         env:
           GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         id: dispatch
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
-          workflow: setup-env-and-dispatch.yml
+          workflow: setup-env-and-upload.yml
           repo: hashicorp/setup-tfe-acceptance-env
           ref: christian-doucette/intial-version-with-just-creating-env
           token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/create-tfe-acceptance-env
         with:
           terraform_enterprise: "false"
-          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          token: ${{ secrets.SETUP_ENV_WORKFLOW_DISPATCH_PAT }}
 
   tests:
     name: run
@@ -65,7 +65,7 @@ jobs:
         uses: ./.github/actions/load-tfe-acceptance-env
         with:
           setup_run_id: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
-          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          token: ${{ secrets.SETUP_ENV_WORKFLOW_DISPATCH_PAT }}
 
       - uses: ./.github/actions/test-provider-tfe
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,56 +36,15 @@ jobs:
     if: "!startsWith(github.head_ref, 'changelog/')"
     runs-on: ubuntu-latest
     outputs:
-      setup_run_id: ${{ steps.dispatch.outputs.runId }}
+      setup_run_id: ${{ steps.setup.outputs.setup_run_id }}
     steps:
-      - name: Dispatch setup workflow
-        id: dispatch
-        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Create acceptance environment
+        id: setup
+        uses: ./.github/actions/create-tfe-acceptance-env
         with:
-          workflow: setup-env-and-upload.yml
-          repo: hashicorp/setup-tfe-acceptance-env
-          ref: christian-doucette/intial-version-with-just-creating-env
+          terraform_enterprise: "false"
           token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
-          inputs: '{ "terraform_enterprise": false, "request_id": "terraform-provider-tfe-${{ github.run_id }}-${{ github.run_attempt }}", "caller_repository": "${{ github.repository }}", "caller_run_id": "${{ github.run_id }}" }'
-
-      - name: Wait for environment artifact
-        env:
-          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
-          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
-          SETUP_RUN_ID: ${{ steps.dispatch.outputs.runId }}
-        run: |
-          artifact_id=""
-          for attempt in {1..30}; do
-            artifact_id="$({
-              gh api \
-                "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}/artifacts" \
-                --jq '.artifacts | map(select(.name == "tfe-acceptance-env")) | first | .id // ""'
-            })"
-
-            if [ -n "${artifact_id}" ]; then
-              echo "Found tfe-acceptance-env artifact: ${artifact_id}"
-              break
-            fi
-
-            run_state="$({
-              gh api \
-                "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}" \
-                --jq '.status + ":" + (.conclusion // "")'
-            })"
-
-            if [[ "${run_state}" == completed:* ]]; then
-              echo "Setup workflow completed before uploading tfe-acceptance-env artifact: ${run_state}"
-              exit 1
-            fi
-
-            echo "Waiting for tfe-acceptance-env artifact (${attempt}/30). Setup run state: ${run_state}"
-            sleep 60
-          done
-
-          if [ -z "${artifact_id}" ]; then
-            echo "Timed out waiting for tfe-acceptance-env artifact on setup run ${SETUP_RUN_ID}"
-            exit 1
-          fi
 
   tests:
     name: run
@@ -102,60 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Verify acceptance environment is still available
-        env:
-          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
-          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
-          SETUP_RUN_ID: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
-        run: |
-          setup_status="$({
-            gh api \
-              "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}" \
-              --jq '.status'
-          })"
-
-          if [ "${setup_status}" != "in_progress" ]; then
-            echo "::error title=Stale TFE acceptance environment::The setup workflow is ${setup_status}, so its acceptance testing environment is no longer available. Re-run all jobs so the Setup TFE Acceptance Environment job regenerates it."
-            exit 1
-          fi
-
-      - name: Download acceptance environment artifact
-        env:
-          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
-          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
-          SETUP_RUN_ID: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
-        run: |
-          gh run download "${SETUP_RUN_ID}" \
-            --repo "${SETUP_REPO}" \
-            --name tfe-acceptance-env \
-            --dir tfe-acceptance-env
-
       - name: Load acceptance environment
-        run: |
-          export_value() {
-            local name="$1"
-            local query="$2"
-            local value
-
-            value="$(jq -er "${query}" tfe-acceptance-env/environment.json)"
-            if [ -z "${value}" ]; then
-              echo "Acceptance environment value ${name} is empty"
-              exit 1
-            fi
-
-            echo "::add-mask::${value}"
-            echo "${name}=${value}" >> "${GITHUB_ENV}"
-          }
-
-          export_value TFE_HOSTNAME '.ngrok_hostname'
-          export_value TFE_TOKEN '.tfe_token'
-          export_value TFE_ADMIN_CONFIGURATION_TOKEN '.admin_tokens.configuration'
-          export_value TFE_ADMIN_PROVISION_LICENSES_TOKEN '.admin_tokens.provision_licenses'
-          export_value TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN '.admin_tokens.security_maintenance'
-          export_value TFE_ADMIN_SITE_ADMIN_TOKEN '.admin_tokens.site_admin'
-          export_value TFE_ADMIN_SUBSCRIPTION_TOKEN '.admin_tokens.subscription'
-          export_value TFE_ADMIN_SUPPORT_TOKEN '.admin_tokens.support'
-          export_value TFE_ADMIN_VERSION_MAINTENANCE_TOKEN '.admin_tokens.version_maintenance'
+        uses: ./.github/actions/load-tfe-acceptance-env
+        with:
+          setup_run_id: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
+          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
 
       - uses: ./.github/actions/test-provider-tfe
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,92 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/generate-docs-provider-tfe
 
+  setup-tfe-acceptance-env:
+    name: Setup TFE Acceptance Environment
+    if: "!startsWith(github.head_ref, 'changelog/')"
+    runs-on: ubuntu-latest
+    outputs:
+      hostname: ${{ steps.acceptance-env.outputs.hostname }}
+      token: ${{ steps.acceptance-env.outputs.token }}
+      admin_configuration_token: ${{ steps.acceptance-env.outputs.admin_configuration_token }}
+      admin_provision_licenses_token: ${{ steps.acceptance-env.outputs.admin_provision_licenses_token }}
+      admin_security_maintenance_token: ${{ steps.acceptance-env.outputs.admin_security_maintenance_token }}
+      admin_site_admin_token: ${{ steps.acceptance-env.outputs.admin_site_admin_token }}
+      admin_subscription_token: ${{ steps.acceptance-env.outputs.admin_subscription_token }}
+      admin_support_token: ${{ steps.acceptance-env.outputs.admin_support_token }}
+      admin_version_maintenance_token: ${{ steps.acceptance-env.outputs.admin_version_maintenance_token }}
+    steps:
+      - name: Dispatch setup workflow
+        id: dispatch
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
+        with:
+          workflow: setup-env-and-dispatch.yml
+          repo: hashicorp/setup-tfe-acceptance-env
+          ref: christian-doucette/intial-version-with-just-creating-env
+          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          inputs: '{ "terraform_enterprise": false, "request_id": "terraform-provider-tfe-${{ github.run_id }}-${{ github.run_attempt }}", "caller_repository": "${{ github.repository }}", "caller_run_id": "${{ github.run_id }}" }'
+
+      - name: Wait for environment artifact
+        env:
+          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+          SETUP_RUN_ID: ${{ steps.dispatch.outputs.runId }}
+        run: |
+          artifact_id=""
+          for attempt in {1..30}; do
+            artifact_id="$({
+              gh api \
+                "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}/artifacts" \
+                --jq '.artifacts | map(select(.name == "tfe-acceptance-env")) | first | .id // ""'
+            })"
+
+            if [ -n "${artifact_id}" ]; then
+              echo "Found tfe-acceptance-env artifact: ${artifact_id}"
+              break
+            fi
+
+            run_state="$({
+              gh api \
+                "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}" \
+                --jq '.status + ":" + (.conclusion // "")'
+            })"
+
+            if [[ "${run_state}" == completed:* ]]; then
+              echo "Setup workflow completed before uploading tfe-acceptance-env artifact: ${run_state}"
+              exit 1
+            fi
+
+            echo "Waiting for tfe-acceptance-env artifact (${attempt}/30). Setup run state: ${run_state}"
+            sleep 60
+          done
+
+          if [ -z "${artifact_id}" ]; then
+            echo "Timed out waiting for tfe-acceptance-env artifact on setup run ${SETUP_RUN_ID}"
+            exit 1
+          fi
+
+          gh run download "${SETUP_RUN_ID}" \
+            --repo "${SETUP_REPO}" \
+            --name tfe-acceptance-env \
+            --dir tfe-acceptance-env
+
+      - name: Read environment artifact
+        id: acceptance-env
+        run: |
+          echo "hostname=$(jq -r '.ngrok_hostname' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+          echo "token=$(jq -r '.tfe_token' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+          echo "admin_configuration_token=$(jq -r '.admin_tokens.configuration' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+          echo "admin_provision_licenses_token=$(jq -r '.admin_tokens.provision_licenses' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+          echo "admin_security_maintenance_token=$(jq -r '.admin_tokens.security_maintenance' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+          echo "admin_site_admin_token=$(jq -r '.admin_tokens.site_admin' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+          echo "admin_subscription_token=$(jq -r '.admin_tokens.subscription' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+          echo "admin_support_token=$(jq -r '.admin_tokens.support' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+          echo "admin_version_maintenance_token=$(jq -r '.admin_tokens.version_maintenance' tfe-acceptance-env/environment.json)" >> "${GITHUB_OUTPUT}"
+
   tests:
     name: run
     if: "!startsWith(github.head_ref, 'changelog/')"
+    needs: [ setup-tfe-acceptance-env ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -43,13 +126,21 @@ jobs:
         total: [ 8 ]
         index: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
     steps:
-      - name: Fetch Outputs
-        id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@63b5112558a7f2b1bf5ad05a5d4bbd3c5dfe7a82 # v1.1.2
-        with:
-          token: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
-          organization: hashicorp-v2
-          workspace: tflocal-terraform-provider-tfe
+      - name: Build ngrok basic auth hostname
+        id: ngrok-hostname
+        env:
+          NGROK_HTTP_BASIC_AUTH_USERNAME: ${{ secrets.NGROK_HTTP_BASIC_AUTH_USERNAME }}
+          NGROK_HTTP_BASIC_AUTH_PASSWORD: ${{ secrets.NGROK_HTTP_BASIC_AUTH_PASSWORD }}
+          NGROK_HOSTNAME: ${{ needs.setup-tfe-acceptance-env.outputs.hostname }}
+        run: |
+          if [ -z "${NGROK_HTTP_BASIC_AUTH_USERNAME}" ] || [ -z "${NGROK_HTTP_BASIC_AUTH_PASSWORD}" ]; then
+            echo "NGROK HTTP basic auth credentials are required"
+            exit 1
+          fi
+
+          ngrok_username="$(jq -rn --arg value "${NGROK_HTTP_BASIC_AUTH_USERNAME}" '$value | @uri')"
+          ngrok_password="$(jq -rn --arg value "${NGROK_HTTP_BASIC_AUTH_PASSWORD}" '$value | @uri')"
+          echo "hostname=${ngrok_username}:${ngrok_password}@${NGROK_HOSTNAME}" >> "${GITHUB_OUTPUT}"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -57,17 +148,17 @@ jobs:
         with:
           matrix_index: ${{ matrix.index }}
           matrix_total: ${{ matrix.total }}
-          hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
-          token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
+          hostname: ${{ needs.setup-tfe-acceptance-env.outputs.hostname }}
+          token: ${{ needs.setup-tfe-acceptance-env.outputs.token }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
           testing-github-token-2: ${{ secrets.TESTING_GITHUB_TOKEN2 }}
-          admin_configuration_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.configuration }}
-          admin_provision_licenses_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.provision-licenses }}
-          admin_security_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.security-maintenance }}
-          admin_site_admin_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.site-admin }}
-          admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
-          admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
-          admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version-maintenance }}
+          admin_configuration_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_configuration_token }}
+          admin_provision_licenses_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_provision_licenses_token }}
+          admin_security_maintenance_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_security_maintenance_token }}
+          admin_site_admin_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_site_admin_token }}
+          admin_subscription_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_subscription_token }}
+          admin_support_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_support_token }}
+          admin_version_maintenance_token: ${{ needs.setup-tfe-acceptance-env.outputs.admin_version_maintenance_token }}
           # Run terminal cmd 'go help testflag' to learn more about -list and -skip flags
           # action.yml uses https://github.com/hashicorp-forge/go-test-split-action/blob/main/action.yml to split acceptance tests
           # which runs against all tests using the list arg.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,22 +126,6 @@ jobs:
         total: [ 8 ]
         index: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
     steps:
-      - name: Build ngrok basic auth hostname
-        id: ngrok-hostname
-        env:
-          NGROK_HTTP_BASIC_AUTH_USERNAME: ${{ secrets.NGROK_HTTP_BASIC_AUTH_USERNAME }}
-          NGROK_HTTP_BASIC_AUTH_PASSWORD: ${{ secrets.NGROK_HTTP_BASIC_AUTH_PASSWORD }}
-          NGROK_HOSTNAME: ${{ needs.setup-tfe-acceptance-env.outputs.hostname }}
-        run: |
-          if [ -z "${NGROK_HTTP_BASIC_AUTH_USERNAME}" ] || [ -z "${NGROK_HTTP_BASIC_AUTH_PASSWORD}" ]; then
-            echo "NGROK HTTP basic auth credentials are required"
-            exit 1
-          fi
-
-          ngrok_username="$(jq -rn --arg value "${NGROK_HTTP_BASIC_AUTH_USERNAME}" '$value | @uri')"
-          ngrok_password="$(jq -rn --arg value "${NGROK_HTTP_BASIC_AUTH_PASSWORD}" '$value | @uri')"
-          echo "hostname=${ngrok_username}:${ngrok_password}@${NGROK_HOSTNAME}" >> "${GITHUB_OUTPUT}"
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/test-provider-tfe

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: ./.github/actions/create-tfe-acceptance-env
         with:
           terraform_enterprise: "true"
-          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          token: ${{ secrets.SETUP_ENV_WORKFLOW_DISPATCH_PAT }}
 
   tests:
     needs: setup-tfe-acceptance-env
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/load-tfe-acceptance-env
         with:
           setup_run_id: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
-          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          token: ${{ secrets.SETUP_ENV_WORKFLOW_DISPATCH_PAT }}
 
       - uses: ./.github/actions/test-provider-tfe
         with:
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/actions/load-tfe-acceptance-env
         with:
           setup_run_id: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
-          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          token: ${{ secrets.SETUP_ENV_WORKFLOW_DISPATCH_PAT }}
 
       - uses: ./.github/actions/test-provider-tfe
         with:

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -10,56 +10,15 @@ jobs:
     name: Setup TFE Acceptance Environment
     runs-on: ubuntu-latest
     outputs:
-      setup_run_id: ${{ steps.dispatch.outputs.runId }}
+      setup_run_id: ${{ steps.setup.outputs.setup_run_id }}
     steps:
-      - name: Dispatch setup workflow
-        id: dispatch
-        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Create acceptance environment
+        id: setup
+        uses: ./.github/actions/create-tfe-acceptance-env
         with:
-          workflow: setup-env-and-upload.yml
-          repo: hashicorp/setup-tfe-acceptance-env
-          ref: christian-doucette/intial-version-with-just-creating-env
+          terraform_enterprise: "true"
           token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
-          inputs: '{ "terraform_enterprise": true, "request_id": "terraform-provider-tfe-nightly-${{ github.run_id }}-${{ github.run_attempt }}", "caller_repository": "${{ github.repository }}", "caller_run_id": "${{ github.run_id }}" }'
-
-      - name: Wait for environment artifact
-        env:
-          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
-          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
-          SETUP_RUN_ID: ${{ steps.dispatch.outputs.runId }}
-        run: |
-          artifact_id=""
-          for attempt in {1..30}; do
-            artifact_id="$({
-              gh api \
-                "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}/artifacts" \
-                --jq '.artifacts | map(select(.name == "tfe-acceptance-env")) | first | .id // ""'
-            })"
-
-            if [ -n "${artifact_id}" ]; then
-              echo "Found tfe-acceptance-env artifact: ${artifact_id}"
-              break
-            fi
-
-            run_state="$({
-              gh api \
-                "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}" \
-                --jq '.status + ":" + (.conclusion // "")'
-            })"
-
-            if [[ "${run_state}" == completed:* ]]; then
-              echo "Setup workflow completed before uploading tfe-acceptance-env artifact: ${run_state}"
-              exit 1
-            fi
-
-            echo "Waiting for tfe-acceptance-env artifact (${attempt}/30). Setup run state: ${run_state}"
-            sleep 60
-          done
-
-          if [ -z "${artifact_id}" ]; then
-            echo "Timed out waiting for tfe-acceptance-env artifact on setup run ${SETUP_RUN_ID}"
-            exit 1
-          fi
 
   tests:
     needs: setup-tfe-acceptance-env
@@ -73,43 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Download acceptance environment artifact
-        env:
-          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
-          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
-          SETUP_RUN_ID: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
-        run: |
-          gh run download "${SETUP_RUN_ID}" \
-            --repo "${SETUP_REPO}" \
-            --name tfe-acceptance-env \
-            --dir tfe-acceptance-env
-
       - name: Load acceptance environment
-        run: |
-          export_value() {
-            local name="$1"
-            local query="$2"
-            local value
-
-            value="$(jq -er "${query}" tfe-acceptance-env/environment.json)"
-            if [ -z "${value}" ]; then
-              echo "Acceptance environment value ${name} is empty"
-              exit 1
-            fi
-
-            echo "::add-mask::${value}"
-            echo "${name}=${value}" >> "${GITHUB_ENV}"
-          }
-
-          export_value TFE_HOSTNAME '.ngrok_hostname'
-          export_value TFE_TOKEN '.tfe_token'
-          export_value TFE_ADMIN_CONFIGURATION_TOKEN '.admin_tokens.configuration'
-          export_value TFE_ADMIN_PROVISION_LICENSES_TOKEN '.admin_tokens.provision_licenses'
-          export_value TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN '.admin_tokens.security_maintenance'
-          export_value TFE_ADMIN_SITE_ADMIN_TOKEN '.admin_tokens.site_admin'
-          export_value TFE_ADMIN_SUBSCRIPTION_TOKEN '.admin_tokens.subscription'
-          export_value TFE_ADMIN_SUPPORT_TOKEN '.admin_tokens.support'
-          export_value TFE_ADMIN_VERSION_MAINTENANCE_TOKEN '.admin_tokens.version_maintenance'
+        uses: ./.github/actions/load-tfe-acceptance-env
+        with:
+          setup_run_id: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
+          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
 
       - uses: ./.github/actions/test-provider-tfe
         with:
@@ -145,43 +72,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Download acceptance environment artifact
-        env:
-          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
-          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
-          SETUP_RUN_ID: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
-        run: |
-          gh run download "${SETUP_RUN_ID}" \
-            --repo "${SETUP_REPO}" \
-            --name tfe-acceptance-env \
-            --dir tfe-acceptance-env
-
       - name: Load acceptance environment
-        run: |
-          export_value() {
-            local name="$1"
-            local query="$2"
-            local value
-
-            value="$(jq -er "${query}" tfe-acceptance-env/environment.json)"
-            if [ -z "${value}" ]; then
-              echo "Acceptance environment value ${name} is empty"
-              exit 1
-            fi
-
-            echo "::add-mask::${value}"
-            echo "${name}=${value}" >> "${GITHUB_ENV}"
-          }
-
-          export_value TFE_HOSTNAME '.ngrok_hostname'
-          export_value TFE_TOKEN '.tfe_token'
-          export_value TFE_ADMIN_CONFIGURATION_TOKEN '.admin_tokens.configuration'
-          export_value TFE_ADMIN_PROVISION_LICENSES_TOKEN '.admin_tokens.provision_licenses'
-          export_value TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN '.admin_tokens.security_maintenance'
-          export_value TFE_ADMIN_SITE_ADMIN_TOKEN '.admin_tokens.site_admin'
-          export_value TFE_ADMIN_SUBSCRIPTION_TOKEN '.admin_tokens.subscription'
-          export_value TFE_ADMIN_SUPPORT_TOKEN '.admin_tokens.support'
-          export_value TFE_ADMIN_VERSION_MAINTENANCE_TOKEN '.admin_tokens.version_maintenance'
+        uses: ./.github/actions/load-tfe-acceptance-env
+        with:
+          setup_run_id: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
+          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
 
       - uses: ./.github/actions/test-provider-tfe
         with:

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -1,25 +1,69 @@
 name: Nightly TFE Tests
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     # Monday-Friday at 7AM UTC (1 hour after infrastructure rebuild)
     - cron: '0 7 * * 1-5'
 
 jobs:
-  instance:
+  setup-tfe-acceptance-env:
+    name: Setup TFE Acceptance Environment
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    outputs:
+      setup_run_id: ${{ steps.dispatch.outputs.runId }}
     steps:
-      - name: Build nightly tflocal instance
-        uses: hashicorp-forge/terraform-cloud-action/apply@63b5112558a7f2b1bf5ad05a5d4bbd3c5dfe7a82 # v1.1.2
+      - name: Dispatch setup workflow
+        id: dispatch
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
-          token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
-          organization: "hashicorp-v2"
-          workspace: tflocal-terraform-provider-tfe-nightly
-          wait: true
+          workflow: setup-env-and-upload.yml
+          repo: hashicorp/setup-tfe-acceptance-env
+          ref: christian-doucette/intial-version-with-just-creating-env
+          token: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          inputs: '{ "terraform_enterprise": true, "request_id": "terraform-provider-tfe-nightly-${{ github.run_id }}-${{ github.run_attempt }}", "caller_repository": "${{ github.repository }}", "caller_run_id": "${{ github.run_id }}" }'
+
+      - name: Wait for environment artifact
+        env:
+          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+          SETUP_RUN_ID: ${{ steps.dispatch.outputs.runId }}
+        run: |
+          artifact_id=""
+          for attempt in {1..30}; do
+            artifact_id="$({
+              gh api \
+                "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}/artifacts" \
+                --jq '.artifacts | map(select(.name == "tfe-acceptance-env")) | first | .id // ""'
+            })"
+
+            if [ -n "${artifact_id}" ]; then
+              echo "Found tfe-acceptance-env artifact: ${artifact_id}"
+              break
+            fi
+
+            run_state="$({
+              gh api \
+                "repos/${SETUP_REPO}/actions/runs/${SETUP_RUN_ID}" \
+                --jq '.status + ":" + (.conclusion // "")'
+            })"
+
+            if [[ "${run_state}" == completed:* ]]; then
+              echo "Setup workflow completed before uploading tfe-acceptance-env artifact: ${run_state}"
+              exit 1
+            fi
+
+            echo "Waiting for tfe-acceptance-env artifact (${attempt}/30). Setup run state: ${run_state}"
+            sleep 60
+          done
+
+          if [ -z "${artifact_id}" ]; then
+            echo "Timed out waiting for tfe-acceptance-env artifact on setup run ${SETUP_RUN_ID}"
+            exit 1
+          fi
 
   tests:
-    needs: instance
+    needs: setup-tfe-acceptance-env
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -28,31 +72,68 @@ jobs:
         total: [ 5 ]
         index: [ 0, 1, 2, 3, 4 ]
     steps:
-      - name: Fetch Outputs
-        id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@63b5112558a7f2b1bf5ad05a5d4bbd3c5dfe7a82 # v1.1.2
-        with:
-          token: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
-          organization: hashicorp-v2
-          workspace: tflocal-terraform-provider-tfe-nightly
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download acceptance environment artifact
+        env:
+          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+          SETUP_RUN_ID: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
+        run: |
+          gh run download "${SETUP_RUN_ID}" \
+            --repo "${SETUP_REPO}" \
+            --name tfe-acceptance-env \
+            --dir tfe-acceptance-env
+
+      - name: Load acceptance environment
+        run: |
+          export_value() {
+            local name="$1"
+            local query="$2"
+            local value
+
+            value="$(jq -er "${query}" tfe-acceptance-env/environment.json)"
+            if [ -z "${value}" ]; then
+              echo "Acceptance environment value ${name} is empty"
+              exit 1
+            fi
+
+            echo "::add-mask::${value}"
+            echo "${name}=${value}" >> "${GITHUB_ENV}"
+          }
+
+          export_value TFE_HOSTNAME '.ngrok_hostname'
+          export_value TFE_TOKEN '.tfe_token'
+          export_value TFE_ADMIN_CONFIGURATION_TOKEN '.admin_tokens.configuration'
+          export_value TFE_ADMIN_PROVISION_LICENSES_TOKEN '.admin_tokens.provision_licenses'
+          export_value TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN '.admin_tokens.security_maintenance'
+          export_value TFE_ADMIN_SITE_ADMIN_TOKEN '.admin_tokens.site_admin'
+          export_value TFE_ADMIN_SUBSCRIPTION_TOKEN '.admin_tokens.subscription'
+          export_value TFE_ADMIN_SUPPORT_TOKEN '.admin_tokens.support'
+          export_value TFE_ADMIN_VERSION_MAINTENANCE_TOKEN '.admin_tokens.version_maintenance'
 
       - uses: ./.github/actions/test-provider-tfe
         with:
           matrix_index: ${{ matrix.index }}
           matrix_total: ${{ matrix.total }}
-          hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
-          token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
+          hostname: ${{ env.TFE_HOSTNAME }}
+          token: ${{ env.TFE_TOKEN }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
           testing-github-token-2: ${{ secrets.TESTING_GITHUB_TOKEN2 }}
+          admin_configuration_token: ${{ env.TFE_ADMIN_CONFIGURATION_TOKEN }}
+          admin_provision_licenses_token: ${{ env.TFE_ADMIN_PROVISION_LICENSES_TOKEN }}
+          admin_security_maintenance_token: ${{ env.TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN }}
+          admin_site_admin_token: ${{ env.TFE_ADMIN_SITE_ADMIN_TOKEN }}
+          admin_subscription_token: ${{ env.TFE_ADMIN_SUBSCRIPTION_TOKEN }}
+          admin_support_token: ${{ env.TFE_ADMIN_SUPPORT_TOKEN }}
+          admin_version_maintenance_token: ${{ env.TFE_ADMIN_VERSION_MAINTENANCE_TOKEN }}
           enterprise: "1"
           # Skip SAML/SCIM here; they run serially in the singleton-tests job.
           skip: "TestAccTFESAML|TestAccTFESCIM"
 
   singleton-tests:
     name: SAML and SCIM Tests
-    needs: instance
+    needs: setup-tfe-acceptance-env
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Runs SAML/SCIM tests serially on one runner; they share singleton TFE state.
@@ -63,24 +144,61 @@ jobs:
       matrix:
         index: [ singletons ]
     steps:
-      - name: Fetch Outputs
-        id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@63b5112558a7f2b1bf5ad05a5d4bbd3c5dfe7a82 # v1.1.2
-        with:
-          token: "${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}"
-          organization: hashicorp-v2
-          workspace: tflocal-terraform-provider-tfe-nightly
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download acceptance environment artifact
+        env:
+          GH_TOKEN: ${{ secrets.TF_ACCEPTANCE_ENV_SETUP_PAT }}
+          SETUP_REPO: hashicorp/setup-tfe-acceptance-env
+          SETUP_RUN_ID: ${{ needs.setup-tfe-acceptance-env.outputs.setup_run_id }}
+        run: |
+          gh run download "${SETUP_RUN_ID}" \
+            --repo "${SETUP_REPO}" \
+            --name tfe-acceptance-env \
+            --dir tfe-acceptance-env
+
+      - name: Load acceptance environment
+        run: |
+          export_value() {
+            local name="$1"
+            local query="$2"
+            local value
+
+            value="$(jq -er "${query}" tfe-acceptance-env/environment.json)"
+            if [ -z "${value}" ]; then
+              echo "Acceptance environment value ${name} is empty"
+              exit 1
+            fi
+
+            echo "::add-mask::${value}"
+            echo "${name}=${value}" >> "${GITHUB_ENV}"
+          }
+
+          export_value TFE_HOSTNAME '.ngrok_hostname'
+          export_value TFE_TOKEN '.tfe_token'
+          export_value TFE_ADMIN_CONFIGURATION_TOKEN '.admin_tokens.configuration'
+          export_value TFE_ADMIN_PROVISION_LICENSES_TOKEN '.admin_tokens.provision_licenses'
+          export_value TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN '.admin_tokens.security_maintenance'
+          export_value TFE_ADMIN_SITE_ADMIN_TOKEN '.admin_tokens.site_admin'
+          export_value TFE_ADMIN_SUBSCRIPTION_TOKEN '.admin_tokens.subscription'
+          export_value TFE_ADMIN_SUPPORT_TOKEN '.admin_tokens.support'
+          export_value TFE_ADMIN_VERSION_MAINTENANCE_TOKEN '.admin_tokens.version_maintenance'
 
       - uses: ./.github/actions/test-provider-tfe
         with:
           # Single slice: include every SAML/SCIM test in one serial run.
           matrix_index: 0
           matrix_total: 1
-          hostname: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).ngrok_domain }}
-          token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
+          hostname: ${{ env.TFE_HOSTNAME }}
+          token: ${{ env.TFE_TOKEN }}
           testing-github-token: ${{ secrets.TESTING_GITHUB_TOKEN }}
+          admin_configuration_token: ${{ env.TFE_ADMIN_CONFIGURATION_TOKEN }}
+          admin_provision_licenses_token: ${{ env.TFE_ADMIN_PROVISION_LICENSES_TOKEN }}
+          admin_security_maintenance_token: ${{ env.TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN }}
+          admin_site_admin_token: ${{ env.TFE_ADMIN_SITE_ADMIN_TOKEN }}
+          admin_subscription_token: ${{ env.TFE_ADMIN_SUBSCRIPTION_TOKEN }}
+          admin_support_token: ${{ env.TFE_ADMIN_SUPPORT_TOKEN }}
+          admin_version_maintenance_token: ${{ env.TFE_ADMIN_VERSION_MAINTENANCE_TOKEN }}
           enterprise: "1"
           list_tests: "TestAccTFESAML|TestAccTFESCIM"
 
@@ -127,25 +245,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-  cleanup:
-    runs-on: ubuntu-latest
-    needs: [tests-summarize]
-    if: "${{ always() }}"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
-          cache: true
-
-      - name: Destroy nightly tflocal instance
-        uses: hashicorp-forge/terraform-cloud-action/destroy@63b5112558a7f2b1bf5ad05a5d4bbd3c5dfe7a82 # v1.1.2
-        with:
-          token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
-          organization: "hashicorp-v2"
-          workspace: tflocal-terraform-provider-tfe-nightly
-          wait: true

--- a/.github/workflows/nightly-tfe-test.yml
+++ b/.github/workflows/nightly-tfe-test.yml
@@ -1,6 +1,5 @@
 name: Nightly TFE Tests
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     # Monday-Friday at 7AM UTC (1 hour after infrastructure rebuild)


### PR DESCRIPTION
## Description

Cloudboxes, which we previously used for CI acceptance tests, are going away. They have been replaced with an acceptance test environment created by the setup-tfe-acceptance-env action. 

## Testing plan

1.  Check that CI passes on this branch
2. Manually trigger a nightly workflow and ensure it passes on that branch as well

