### PR TITLE
Tf 38647 automated validation of functionality of examples in docgen

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -63,7 +63,13 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
+exmplcheck:
+	@./scripts/validate-example-presence.sh
+	@./scripts/validate-import-example-presence.sh 
+	@./scripts/validate-schema-descriptions.sh
+	@./scripts/validate-examples.sh
+
 generate:
 	@RESOURCE="$(RESOURCE)" ./scripts/generate-docs.sh
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile sweep generate
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile sweep generate exmplcheck

--- a/examples/actions/tfe_query_run/action_using_a_specific_configuration_version_id.tf
+++ b/examples/actions/tfe_query_run/action_using_a_specific_configuration_version_id.tf
@@ -1,15 +1,15 @@
 # Using a Specific Configuration Version ID
 
-resource "tfe_workspace" "example" {
+resource "tfe_workspace" "ws" {
   name         = "example-workspace"
   organization = "my-organization"
 }
 
-resource "tfe_variable" "example" {
+resource "tfe_variable" "var" {
   key          = "my_key"
   value        = "my_value"
   category     = "terraform"
-  workspace_id = tfe_workspace.example.id
+  workspace_id = tfe_workspace.ws.id
 
   # Trigger the query run after the variable is created or updated
   lifecycle {
@@ -22,7 +22,7 @@ resource "tfe_variable" "example" {
 
 action "tfe_query_run" "with_cv_id" {
   config {
-    workspace_id             = tfe_workspace.example.id
+    workspace_id             = tfe_workspace.ws.id
     configuration_version_id = "cv-ntv3HbhJqvFzamy7"
 
     variables = {

--- a/examples/actions/tfe_query_run/action_wait_for_the_latest_configuration_version.tf
+++ b/examples/actions/tfe_query_run/action_wait_for_the_latest_configuration_version.tf
@@ -1,15 +1,15 @@
 # Wait for the Latest Configuration Version
 
-resource "tfe_workspace" "example" {
+resource "tfe_workspace" "ws" {
   name         = "example-workspace"
   organization = "my-organization"
 }
 
-resource "tfe_variable" "example" {
+resource "tfe_variable" "var" {
   key          = "my_key"
   value        = "my_value"
   category     = "terraform"
-  workspace_id = tfe_workspace.example.id
+  workspace_id = tfe_workspace.ws.id
 
   lifecycle {
     action_trigger {
@@ -21,7 +21,7 @@ resource "tfe_variable" "example" {
 
 action "tfe_query_run" "wait_for_latest" {
   config {
-    workspace_id                  = tfe_workspace.example.id
+    workspace_id                  = tfe_workspace.ws.id
     wait_for_latest_configuration = true
 
     variables = {

--- a/examples/data-sources/tfe_no_code_module/data-source.tf
+++ b/examples/data-sources/tfe_no_code_module/data-source.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "foobar" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_registry_module" "foobar" {

--- a/examples/data-sources/tfe_organization_membership/data-source.tf
+++ b/examples/data-sources/tfe_organization_membership/data-source.tf
@@ -2,5 +2,5 @@
 
 data "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "user@company.com"
+  email        = "user@example.com"
 }

--- a/examples/error_exceptions.json
+++ b/examples/error_exceptions.json
@@ -54,5 +54,21 @@
     "workspaces_variables/manager/providers.tf": [
       "Missing required provider"
     ]
-  }
+  },
+  "examples_as_ci_exempt_directories": [
+    "tfe_agent_pool",
+    "tfe_agent_token",
+    "tfe_aws_oidc_configuration",
+    "tfe_azure_oidc_configuration",
+    "tfe_data_retention_policy",
+    "tfe_gcp_oidc_configuration",
+    "tfe_hyok_configuration",
+    "tfe_opa_version",
+    "tfe_organization_module_sharing",
+    "tfe_provider_set",
+    "tfe_sentinel_version",
+    "tfe_team",
+    "tfe_terraform_version",
+    "tfe_vault_oidc_configuration"
+  ]
 }

--- a/examples/resources/tfe_admin_organization_settings/resource.tf
+++ b/examples/resources/tfe_admin_organization_settings/resource.tf
@@ -26,12 +26,12 @@ provider "tfe" {
 
 resource "tfe_organization" "a-module-producer" {
   name  = "my-org"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_organization" "a-module-consumer" {
   name  = "my-other-org"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_admin_organization_settings" "test-settings" {

--- a/examples/resources/tfe_agent_pool/resource.tf
+++ b/examples/resources/tfe_agent_pool/resource.tf
@@ -1,12 +1,7 @@
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "test-agent-pool" {
   name                = "my-agent-pool-name"
-  organization        = tfe_organization.test-organization.name
+  organization        = tfe_organization.example.name
   organization_scoped = true
 }

--- a/examples/resources/tfe_agent_pool_allowed_projects/resource.tf
+++ b/examples/resources/tfe_agent_pool_allowed_projects/resource.tf
@@ -1,19 +1,14 @@
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 // Ensure project and agent pool are create first
 resource "tfe_project" "test-project" {
   name         = "my-project-name"
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {
   name                = "my-agent-pool-name"
-  organization        = tfe_organization.test-organization.name
+  organization        = tfe_organization.example.name
   organization_scoped = false
 }
 

--- a/examples/resources/tfe_agent_pool_allowed_workspaces/resource.tf
+++ b/examples/resources/tfe_agent_pool_allowed_workspaces/resource.tf
@@ -1,20 +1,15 @@
 # Basic usage
 # In this example, the agent pool and workspace are connected through other resources that manage the agent pool permissions as well as the workspace execution mode. Notice that the `tfe_workspace_settings` uses the agent pool reference found in `tfe_agent_pool_allowed_workspaces` in order to create the permission to use the agent pool before assigning it.
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 // Ensure workspace and agent pool are create first
 resource "tfe_workspace" "test-workspace" {
   name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {
   name                = "my-agent-pool-name"
-  organization        = tfe_organization.test-organization.name
+  organization        = tfe_organization.example.name
   organization_scoped = false
 }
 

--- a/examples/resources/tfe_agent_pool_excluded_workspaces/resource.tf
+++ b/examples/resources/tfe_agent_pool_excluded_workspaces/resource.tf
@@ -1,19 +1,14 @@
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 // Ensure workspace and agent pool are create first
 resource "tfe_workspace" "test-workspace" {
   name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {
   name                = "my-agent-pool-name"
-  organization        = tfe_organization.test-organization.name
+  organization        = tfe_organization.example.name
   organization_scoped = false
 }
 

--- a/examples/resources/tfe_agent_token/resource.tf
+++ b/examples/resources/tfe_agent_token/resource.tf
@@ -1,13 +1,8 @@
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "test-agent-pool" {
   name         = "my-agent-pool-name"
-  organization = tfe_organization.test-organization.id
+  organization = tfe_organization.example.id
 }
 
 resource "tfe_agent_token" "test-agent-token" {

--- a/examples/resources/tfe_data_retention_policy/resource.tf
+++ b/examples/resources/tfe_data_retention_policy/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_workspace" "test-workspace" {

--- a/examples/resources/tfe_data_retention_policy/resource_creating_a_data_retention_policy_for_an_organization.tf
+++ b/examples/resources/tfe_data_retention_policy/resource_creating_a_data_retention_policy_for_an_organization.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_data_retention_policy" "foobar" {

--- a/examples/resources/tfe_data_retention_policy/resource_creating_a_data_retention_policy_for_an_organization_and_exclude_a_single_workspace_from_it.tf
+++ b/examples/resources/tfe_data_retention_policy/resource_creating_a_data_retention_policy_for_an_organization_and_exclude_a_single_workspace_from_it.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 // create data retention policy the organization

--- a/examples/resources/tfe_no_code_module/resource.tf
+++ b/examples/resources/tfe_no_code_module/resource.tf
@@ -1,17 +1,12 @@
 # Basic usage
 
-resource "tfe_organization" "foobar" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_module" "foobar" {
-  organization    = tfe_organization.foobar.id
+  organization    = tfe_organization.example.id
   module_provider = "my_provider"
   name            = "test_module"
 }
 
 resource "tfe_no_code_module" "foobar" {
-  organization    = tfe_organization.foobar.id
+  organization    = tfe_organization.example.id
   registry_module = tfe_registry_module.foobar.id
 }

--- a/examples/resources/tfe_no_code_module/resource_creating_a_no_code_module_with_variable_options.tf
+++ b/examples/resources/tfe_no_code_module/resource_creating_a_no_code_module_with_variable_options.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "foobar" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_registry_module" "foobar" {

--- a/examples/resources/tfe_notification_configuration/resource.tf
+++ b/examples/resources/tfe_notification_configuration/resource.tf
@@ -1,20 +1,10 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.id
-}
-
 resource "tfe_notification_configuration" "test" {
   name             = "my-test-notification-configuration"
   enabled          = true
   destination_type = "generic"
   triggers         = ["run:created", "run:planning", "run:errored"]
   url_wo           = "https://example.com"
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
 }

--- a/examples/resources/tfe_notification_configuration/resource_b_with_destination_type_of_email.tf
+++ b/examples/resources/tfe_notification_configuration/resource_b_with_destination_type_of_email.tf
@@ -1,18 +1,8 @@
 # With destination_type of email
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.id
-}
-
 resource "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "test.member@company.com"
+  email        = "test.member@example.com"
 }
 
 resource "tfe_notification_configuration" "test" {
@@ -21,5 +11,5 @@ resource "tfe_notification_configuration" "test" {
   destination_type = "email"
   email_user_ids   = [tfe_organization_membership.test.user_id]
   triggers         = ["run:created", "run:planning", "run:errored"]
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
 }

--- a/examples/resources/tfe_notification_configuration/resource_c_tfe_only_with_destination_type_of_email_using_email_addresses_list_and_email_users.tf
+++ b/examples/resources/tfe_notification_configuration/resource_c_tfe_only_with_destination_type_of_email_using_email_addresses_list_and_email_users.tf
@@ -1,18 +1,8 @@
 # (Terraform Enterprise only) With destination_type of email, using email_addresses list and email_users
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.id
-}
-
 resource "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "test.member@company.com"
+  email        = "test.member@example.com"
 }
 
 resource "tfe_notification_configuration" "test" {
@@ -20,7 +10,7 @@ resource "tfe_notification_configuration" "test" {
   enabled          = true
   destination_type = "email"
   email_user_ids   = [tfe_organization_membership.test.user_id]
-  email_addresses  = ["user1@company.com", "user2@company.com", "user3@company.com"]
+  email_addresses  = ["user1@example.com", "user2@example.com", "user3@example.com"]
   triggers         = ["run:created", "run:planning", "run:errored"]
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
 }

--- a/examples/resources/tfe_notification_configuration/resource_d_with_write_only_token_and_url_auto_managed_recommended.tf
+++ b/examples/resources/tfe_notification_configuration/resource_d_with_write_only_token_and_url_auto_managed_recommended.tf
@@ -1,19 +1,9 @@
 # With write-only token and URL (auto-managed, recommended)
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.id
-}
-
 resource "tfe_notification_configuration" "test" {
   name             = "my-test-notification-configuration"
   destination_type = "generic"
   token_wo         = "my-secret-token"
   url_wo           = "https://example.com"
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
 }

--- a/examples/resources/tfe_organization/resource.tf
+++ b/examples/resources/tfe_organization/resource.tf
@@ -2,5 +2,5 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }

--- a/examples/resources/tfe_organization_default_settings/resource.tf
+++ b/examples/resources/tfe_organization_default_settings/resource.tf
@@ -1,17 +1,12 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "my_agents" {
   name         = "agent_smiths"
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_organization_default_settings" "org_default" {
-  organization           = tfe_organization.test.name
+  organization           = tfe_organization.example.name
   default_execution_mode = "agent"
   default_agent_pool_id  = tfe_agent_pool.my_agents.id
 }

--- a/examples/resources/tfe_organization_membership/resource.tf
+++ b/examples/resources/tfe_organization_membership/resource.tf
@@ -2,5 +2,5 @@
 
 resource "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "user@company.com"
+  email        = "user@example.com"
 }

--- a/examples/resources/tfe_policy_set/resource.tf
+++ b/examples/resources/tfe_policy_set/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_workspace" "test" {

--- a/examples/resources/tfe_policy_set/resource_manually_uploaded_policy_set_in_lieu_of_vcs.tf
+++ b/examples/resources/tfe_policy_set/resource_manually_uploaded_policy_set_in_lieu_of_vcs.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_workspace" "test" {

--- a/examples/resources/tfe_policy_set/resource_using_manually_specified_policies.tf
+++ b/examples/resources/tfe_policy_set/resource_using_manually_specified_policies.tf
@@ -1,17 +1,7 @@
 # Using manually-specified policies
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
-}
-
 resource "tfe_policy" "test" {
-  name         = "my-policy-name"
+  name         = "passing-policy"
   description  = "This policy always passes"
   organization = "my-org-name"
   kind         = "sentinel"
@@ -20,12 +10,12 @@ resource "tfe_policy" "test" {
 }
 
 resource "tfe_policy_set" "test" {
-  name                = "my-policy-set"
+  name                = "manual-policy-set"
   description         = "A brand new policy set"
   organization        = "my-org-name"
   kind                = "sentinel"
   agent_enabled       = "true"
   policy_tool_version = "0.24.1"
   policy_ids          = [tfe_policy.test.id]
-  workspace_ids       = [tfe_workspace.test.id]
+  workspace_ids       = [tfe_workspace.example.id]
 }

--- a/examples/resources/tfe_policy_set_parameter/resource.tf
+++ b/examples/resources/tfe_policy_set_parameter/resource.tf
@@ -1,17 +1,13 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_policy_set" "test" {
-  name         = "my-policy-set-name"
-  organization = tfe_organization.test.id
+resource "tfe_policy_set" "example" {
+  name         = "my-policy-set"
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_policy_set_parameter" "test" {
   key           = "my_key_name"
   value         = "my_value_name"
-  policy_set_id = tfe_policy_set.test.id
+  policy_set_id = tfe_policy_set.example.id
 }

--- a/examples/resources/tfe_policy_set_parameter/resource_usage_for_the_write_only_value.tf
+++ b/examples/resources/tfe_policy_set_parameter/resource_usage_for_the_write_only_value.tf
@@ -1,23 +1,19 @@
 # Usage for the write-only value
 
+resource "tfe_policy_set" "example" {
+  name         = "my-policy-set"
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
+}
+
 variable "session_token" {
   type      = string
   ephemeral = true
-}
-
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_policy_set" "test" {
-  name         = "my-policy-set-name"
-  organization = tfe_organization.test.id
 }
 
 resource "tfe_policy_set_parameter" "test" {
   key              = "my_key_name"
   value_wo         = var.session_token
   value_wo_version = 1
-  policy_set_id    = tfe_policy_set.test.id
+  policy_set_id    = tfe_policy_set.example.id
 }

--- a/examples/resources/tfe_project/resource.tf
+++ b/examples/resources/tfe_project/resource.tf
@@ -1,11 +1,6 @@
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_project" "test" {
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
   name         = "projectname"
 }

--- a/examples/resources/tfe_project/resource_with_tags.tf
+++ b/examples/resources/tfe_project/resource_with_tags.tf
@@ -1,12 +1,7 @@
 # With tags
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_project" "test" {
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
   name         = "projectname"
   tags = {
     cost_center = "infrastructure"

--- a/examples/resources/tfe_project_notification_configuration/resource.tf
+++ b/examples/resources/tfe_project_notification_configuration/resource.tf
@@ -2,12 +2,12 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {
   name         = "my-project-name"
-  organization = tfe_organization.test.id
+  organization = tfe_organization.test.name
 }
 
 resource "tfe_project_notification_configuration" "test" {

--- a/examples/resources/tfe_project_notification_configuration/resource_b_with_destination_type_of_email.tf
+++ b/examples/resources/tfe_project_notification_configuration/resource_b_with_destination_type_of_email.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {
@@ -12,7 +12,7 @@ resource "tfe_project" "test" {
 
 data "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "test.member@company.com"
+  email        = "test.member@example.com"
 }
 
 resource "tfe_project_notification_configuration" "test" {

--- a/examples/resources/tfe_project_notification_configuration/resource_c_tfe_only_with_destination_type_of_email_using_email_addresses_list.tf
+++ b/examples/resources/tfe_project_notification_configuration/resource_c_tfe_only_with_destination_type_of_email_using_email_addresses_list.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {
@@ -12,7 +12,7 @@ resource "tfe_project" "test" {
 
 resource "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "test.member@company.com"
+  email        = "test.member@example.com"
 }
 
 resource "tfe_project_notification_configuration" "test" {
@@ -20,7 +20,7 @@ resource "tfe_project_notification_configuration" "test" {
   enabled          = true
   destination_type = "email"
   email_user_ids   = [tfe_organization_membership.test.user_id]
-  email_addresses  = ["user1@company.com", "user2@company.com", "user3@company.com"]
+  email_addresses  = ["user1@example.com", "user2@example.com", "user3@example.com"]
   triggers         = ["run:created", "run:planning", "run:errored"]
   project_id       = tfe_project.test.id
 }

--- a/examples/resources/tfe_project_oauth_client/resource.tf
+++ b/examples/resources/tfe_project_oauth_client/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {

--- a/examples/resources/tfe_project_policy_set/resource.tf
+++ b/examples/resources/tfe_project_policy_set/resource.tf
@@ -1,22 +1,12 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_project" "test" {
-  name         = "my-project-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_policy_set" "test" {
+resource "tfe_policy_set" "example" {
   name         = "my-policy-set"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_project_policy_set" "test" {
-  policy_set_id = tfe_policy_set.test.id
-  project_id    = tfe_project.test.id
+  policy_set_id = tfe_policy_set.example.id
+  project_id    = tfe_project.example.id
 }

--- a/examples/resources/tfe_project_policy_set_exclusion/resource.tf
+++ b/examples/resources/tfe_project_policy_set_exclusion/resource.tf
@@ -1,23 +1,13 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_project" "test" {
-  name         = "my-project-name"
-  organization = tfe_organization.test.name
-}
-
 resource "tfe_policy_set" "test" {
   name         = "my-policy-set"
   description  = "Some description."
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
   global       = true
 }
 
 resource "tfe_project_policy_set_exclusion" "test" {
   policy_set_id = tfe_policy_set.test.id
-  project_id    = tfe_project.test.id
+  project_id    = tfe_project.example.id
 }

--- a/examples/resources/tfe_project_settings/resource.tf
+++ b/examples/resources/tfe_project_settings/resource.tf
@@ -1,18 +1,13 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "my_agents" {
   name         = "my-agent-pool"
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 # this section here for demonstration and is not necessary explicitly for use of tfe_project_settings
 resource "tfe_organization_default_settings" "org_default" {
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
   # this will end up being overwritten at the project level
   default_execution_mode = "agent"
   default_agent_pool_id  = tfe_agent_pool.my_agents.id
@@ -20,7 +15,7 @@ resource "tfe_organization_default_settings" "org_default" {
 
 resource "tfe_project" "my_project" {
   name         = "my-project"
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_project_settings" "my_project_settings" {

--- a/examples/resources/tfe_project_variable_set/resource.tf
+++ b/examples/resources/tfe_project_variable_set/resource.tf
@@ -1,22 +1,12 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_project" "test" {
-  name         = "my-project-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_variable_set" "test" {
-  name         = "Test Varset"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+resource "tfe_variable_set" "example" {
+  name         = "my-variable-set"
+  description  = "Example fixture variable set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_project_variable_set" "test" {
-  variable_set_id = tfe_variable_set.test.id
-  project_id      = tfe_project.test.id
+  variable_set_id = tfe_variable_set.example.id
+  project_id      = tfe_project.example.id
 }

--- a/examples/resources/tfe_registry_module/resource.tf
+++ b/examples/resources/tfe_registry_module/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test-oauth-client" {

--- a/examples/resources/tfe_registry_module/resource_b_create_private_registry_module_with_tests_enabled.tf
+++ b/examples/resources/tfe_registry_module/resource_b_create_private_registry_module_with_tests_enabled.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test-oauth-client" {

--- a/examples/resources/tfe_registry_module/resource_c_create_private_registry_module_with_agent_pool_beta.tf
+++ b/examples/resources/tfe_registry_module/resource_c_create_private_registry_module_with_agent_pool_beta.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {

--- a/examples/resources/tfe_registry_module/resource_d_create_private_registry_module_with_github_app.tf
+++ b/examples/resources/tfe_registry_module/resource_d_create_private_registry_module_with_github_app.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 data "tfe_github_app_installation" "gha_installation" {

--- a/examples/resources/tfe_registry_module/resource_e_create_private_registry_module_from_a_monorepo_with_source_directory_beta.tf
+++ b/examples/resources/tfe_registry_module/resource_e_create_private_registry_module_from_a_monorepo_with_source_directory_beta.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test-oauth-client" {

--- a/examples/resources/tfe_registry_module/resource_f_create_private_registry_module_without_vcs.tf
+++ b/examples/resources/tfe_registry_module/resource_f_create_private_registry_module_without_vcs.tf
@@ -1,12 +1,7 @@
 # Create private registry module without VCS
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_module" "test-private-registry-module" {
-  organization    = tfe_organization.test-organization.name
+  organization    = tfe_organization.example.name
   module_provider = "my_provider"
   name            = "another_test_module"
   registry_name   = "private"

--- a/examples/resources/tfe_registry_module/resource_g_create_public_registry_module.tf
+++ b/examples/resources/tfe_registry_module/resource_g_create_public_registry_module.tf
@@ -1,12 +1,7 @@
 # Create public registry module
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_module" "test-public-registry-module" {
-  organization    = tfe_organization.test-organization.name
+  organization    = tfe_organization.example.name
   namespace       = "terraform-aws-modules"
   module_provider = "aws"
   name            = "vpc"

--- a/examples/resources/tfe_registry_module/resource_h_create_no_code_provisioning_registry_module.tf
+++ b/examples/resources/tfe_registry_module/resource_h_create_no_code_provisioning_registry_module.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_registry_module" "test-no-code-provisioning-registry-module" {

--- a/examples/resources/tfe_registry_provider/resource.tf
+++ b/examples/resources/tfe_registry_provider/resource.tf
@@ -1,10 +1,5 @@
 # Create private provider
 
-resource "tfe_organization" "example" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_provider" "example" {
   organization = tfe_organization.example.name
 

--- a/examples/resources/tfe_registry_provider/resource_create_public_provider.tf
+++ b/examples/resources/tfe_registry_provider/resource_create_public_provider.tf
@@ -1,10 +1,5 @@
 # Create public provider
 
-resource "tfe_organization" "example" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_provider" "example" {
   organization = tfe_organization.example.name
 

--- a/examples/resources/tfe_run_trigger/resource.tf
+++ b/examples/resources/tfe_run_trigger/resource.tf
@@ -1,21 +1,11 @@
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test-workspace" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.id
-}
-
 resource "tfe_workspace" "test-sourceable" {
   name         = "my-sourceable-workspace-name"
-  organization = tfe_organization.test-organization.id
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_run_trigger" "test" {
-  workspace_id  = tfe_workspace.test-workspace.id
+  workspace_id  = tfe_workspace.example.id
   sourceable_id = tfe_workspace.test-sourceable.id
 }

--- a/examples/resources/tfe_stack_variable_set/resource.tf
+++ b/examples/resources/tfe_stack_variable_set/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_stack" "test" {

--- a/examples/resources/tfe_tag_policy_set/resource.tf
+++ b/examples/resources/tfe_tag_policy_set/resource.tf
@@ -2,11 +2,18 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "tagged-workspace"
+  organization = tfe_organization.test.name
+
+  tag_names = ["env", "others", "prod"]
 }
 
 resource "tfe_policy_set" "test" {
-  name         = "my-policy-set"
+  name         = "tag-policy-set"
   description  = "Some description."
   organization = tfe_organization.test.name
 }

--- a/examples/resources/tfe_tag_policy_set/resource_key_only_tag_no_value.tf
+++ b/examples/resources/tfe_tag_policy_set/resource_key_only_tag_no_value.tf
@@ -2,11 +2,18 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "tagged-workspace"
+  organization = tfe_organization.test.name
+
+  tag_names = ["env", "others"]
 }
 
 resource "tfe_policy_set" "test" {
-  name         = "my-policy-set"
+  name         = "key-only-policy-set"
   description  = "Some description."
   organization = tfe_organization.test.name
 }

--- a/examples/resources/tfe_tag_policy_set_exclusion/resource.tf
+++ b/examples/resources/tfe_tag_policy_set_exclusion/resource.tf
@@ -2,11 +2,18 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "tagged-workspace"
+  organization = tfe_organization.test.name
+
+  tag_names = ["env", "others", "staging"]
 }
 
 resource "tfe_policy_set" "test" {
-  name         = "my-policy-set"
+  name         = "excluded-policy-set"
   description  = "Some description."
   organization = tfe_organization.test.name
   global       = true

--- a/examples/resources/tfe_team_access/resource.tf
+++ b/examples/resources/tfe_team_access/resource.tf
@@ -1,12 +1,12 @@
 # Basic usage
 
 resource "tfe_team" "test" {
-  name         = "my-team-name"
+  name         = "access-team"
   organization = "my-org-name"
 }
 
 resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
+  name         = "access-workspace"
   organization = "my-org-name"
 }
 

--- a/examples/resources/tfe_team_notification_configuration/resource.tf
+++ b/examples/resources/tfe_team_notification_configuration/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_team" "test" {

--- a/examples/resources/tfe_team_notification_configuration/resource_tfe_only_with_destination_type_of_email_using_email_addresses_list_and_email_users.tf
+++ b/examples/resources/tfe_team_notification_configuration/resource_tfe_only_with_destination_type_of_email_using_email_addresses_list_and_email_users.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_team" "test" {
@@ -25,7 +25,7 @@ resource "tfe_team_notification_configuration" "test" {
   enabled          = true
   destination_type = "email"
   email_user_ids   = [data.tfe_organization_membership.test.user_id]
-  email_addresses  = ["user1@company.com", "user2@company.com", "user3@company.com"]
+  email_addresses  = ["user1@example.com", "user2@example.com", "user3@example.com"]
   triggers         = ["change_request:created"]
   team_id          = tfe_team.test.id
 }

--- a/examples/resources/tfe_team_notification_configuration/resource_with_destination_type_of_email.tf
+++ b/examples/resources/tfe_team_notification_configuration/resource_with_destination_type_of_email.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_team" "test" {

--- a/examples/resources/tfe_team_notification_configuration/resource_with_destination_type_of_generic_using_write_only_token.tf
+++ b/examples/resources/tfe_team_notification_configuration/resource_with_destination_type_of_generic_using_write_only_token.tf
@@ -7,7 +7,7 @@ variable "notification_token" {
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_team" "test" {

--- a/examples/resources/tfe_test_variable/resource.tf
+++ b/examples/resources/tfe_test_variable/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test_org" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test_client" {

--- a/examples/resources/tfe_test_variable/resource_usage_of_the_writeonly_value_for_tfe_test_variable.tf
+++ b/examples/resources/tfe_test_variable/resource_usage_of_the_writeonly_value_for_tfe_test_variable.tf
@@ -6,7 +6,7 @@ variable "session_token" {
 
 resource "tfe_organization" "test_org" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test_client" {

--- a/examples/resources/tfe_variable/resource.tf
+++ b/examples/resources/tfe_variable/resource.tf
@@ -1,19 +1,9 @@
 # Basic usage for workspaces
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
 resource "tfe_variable" "test" {
   key          = "my_key_name"
   value        = "my_value_name"
   category     = "terraform"
-  workspace_id = tfe_workspace.test.id
+  workspace_id = tfe_workspace.example.id
   description  = "a useful description"
 }

--- a/examples/resources/tfe_variable/resource_basic_usage_for_the_write_only_value_of_tfe_variable.tf
+++ b/examples/resources/tfe_variable/resource_basic_usage_for_the_write_only_value_of_tfe_variable.tf
@@ -5,21 +5,11 @@ variable "session_token" {
   ephemeral = true
 }
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
 resource "tfe_variable" "test" {
   key              = "my_key_name"
   value_wo         = var.session_token
   value_wo_version = 1
   category         = "terraform"
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
   description      = "a useful description"
 }

--- a/examples/resources/tfe_variable/resource_basic_usage_for_variable_sets.tf
+++ b/examples/resources/tfe_variable/resource_basic_usage_for_variable_sets.tf
@@ -1,15 +1,10 @@
 # Basic usage for variable sets
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_variable_set" "test" {
   name         = "Test Varset"
   description  = "Some description."
   global       = false
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_variable" "test-a" {

--- a/examples/resources/tfe_variable/resource_using_readable_value.tf
+++ b/examples/resources/tfe_variable/resource_using_readable_value.tf
@@ -22,16 +22,15 @@ resource "tfe_variable" "visible_var" {
 
 resource "tfe_workspace" "workspace" {
   name         = "my-workspace"
-  organization = "organization name"
+  organization = "my-org-name"
 }
 
 resource "tfe_workspace" "sensitive_workspace" {
   name         = "workspace-${tfe_variable.sensitive_var.value}" // this will be redacted from plan outputs
-  organization = "organization name"
+  organization = "my-org-name"
 }
 
 resource "tfe_workspace" "visible_workspace" {
   name         = "workspace-${tfe_variable.visible_var.readable_value}" // this will not be redacted from plan outputs
-  organization = "organization name"
+  organization = "my-org-name"
 }
-

--- a/examples/resources/tfe_variable_set/resource.tf
+++ b/examples/resources/tfe_variable_set/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {

--- a/examples/resources/tfe_variable_set/resource_create_a_priority_variable_set.tf
+++ b/examples/resources/tfe_variable_set/resource_create_a_priority_variable_set.tf
@@ -1,15 +1,10 @@
 # Create a priority variable set
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_variable_set" "test" {
   name         = "Global Varset"
   description  = "Variable set applied to all workspaces."
   priority     = true
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_variable" "test-a" {

--- a/examples/resources/tfe_variable_set/resource_creating_a_global_variable_set.tf
+++ b/examples/resources/tfe_variable_set/resource_creating_a_global_variable_set.tf
@@ -1,15 +1,10 @@
 # Creating a global variable set
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_variable_set" "test" {
   name         = "Global Varset"
   description  = "Variable set applied to all workspaces."
   global       = true
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_variable" "test-a" {

--- a/examples/resources/tfe_variable_set/resource_creating_a_project_owned_variable_set_that_is_applied_to_all_workspaces_in_the_project.tf
+++ b/examples/resources/tfe_variable_set/resource_creating_a_project_owned_variable_set_that_is_applied_to_all_workspaces_in_the_project.tf
@@ -1,19 +1,14 @@
 # Creating a project-owned variable set that is applied to all workspaces in the project
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_project" "test" {
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
   name         = "projectname"
 }
 
 resource "tfe_variable_set" "test" {
   name              = "Project-owned Varset"
   description       = "Varset that is owned and managed by a project."
-  organization      = tfe_organization.test.name
+  organization      = tfe_organization.example.name
   parent_project_id = tfe_project.test.id
 }
 

--- a/examples/resources/tfe_variable_set/resource_creating_a_project_owned_variable_set_that_is_applied_to_specific_workspaces.tf
+++ b/examples/resources/tfe_variable_set/resource_creating_a_project_owned_variable_set_that_is_applied_to_specific_workspaces.tf
@@ -1,25 +1,20 @@
 # Creating a project-owned variable set that is applied to specific workspaces
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_project" "test" {
-  organization = tfe_organization.test.name
-  name         = "projectname"
+  organization = tfe_organization.example.name
+  name         = "workspace-project"
 }
 
 resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
+  name         = "project-workspace"
+  organization = tfe_organization.example.name
   project_id   = tfe_project.test.id
 }
 
 resource "tfe_variable_set" "test" {
   name              = "Project-owned Varset"
   description       = "Varset that is owned and managed by a project."
-  organization      = tfe_organization.test.name
+  organization      = tfe_organization.example.name
   parent_project_id = tfe_project.test.id
 }
 

--- a/examples/resources/tfe_workspace/resource.tf
+++ b/examples/resources/tfe_workspace/resource.tf
@@ -1,13 +1,8 @@
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
+  name         = "user-workspace"
+  organization = tfe_organization.example.name
   tags = {
     environment = "prod"
     team_owner  = "my-team"

--- a/examples/resources/tfe_workspace/resource_usage_with_vcs_repo.tf
+++ b/examples/resources/tfe_workspace/resource_usage_with_vcs_repo.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test" {

--- a/examples/resources/tfe_workspace_policy_set/resource.tf
+++ b/examples/resources/tfe_workspace_policy_set/resource.tf
@@ -1,22 +1,12 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_policy_set" "test" {
+resource "tfe_policy_set" "example" {
   name         = "my-policy-set"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_workspace_policy_set" "test" {
-  policy_set_id = tfe_policy_set.test.id
-  workspace_id  = tfe_workspace.test.id
+  policy_set_id = tfe_policy_set.example.id
+  workspace_id  = tfe_workspace.example.id
 }

--- a/examples/resources/tfe_workspace_policy_set_exclusion/resource.tf
+++ b/examples/resources/tfe_workspace_policy_set_exclusion/resource.tf
@@ -1,22 +1,12 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_policy_set" "test" {
+resource "tfe_policy_set" "example" {
   name         = "my-policy-set"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_workspace_policy_set_exclusion" "test" {
-  policy_set_id = tfe_policy_set.test.id
-  workspace_id  = tfe_workspace.test.id
+  policy_set_id = tfe_policy_set.example.id
+  workspace_id  = tfe_workspace.example.id
 }

--- a/examples/resources/tfe_workspace_run/resource.tf
+++ b/examples/resources/tfe_workspace_run/resource.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test" {

--- a/examples/resources/tfe_workspace_run/resource_with_manual_confirmation.tf
+++ b/examples/resources/tfe_workspace_run/resource_with_manual_confirmation.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test" {

--- a/examples/resources/tfe_workspace_run/resource_with_no_retries.tf
+++ b/examples/resources/tfe_workspace_run/resource_with_no_retries.tf
@@ -2,7 +2,7 @@
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test" {

--- a/examples/resources/tfe_workspace_run_task/resource.tf
+++ b/examples/resources/tfe_workspace_run_task/resource.tf
@@ -1,8 +1,8 @@
 # Basic usage
 
-resource "tfe_workspace" "example" {
+resource "tfe_workspace" "ws" {
   name         = "example-workspace"
-  organization = "my-organization"
+  organization = "my-org-name"
 }
 
 resource "tfe_organization_run_task" "example" {
@@ -14,7 +14,7 @@ resource "tfe_organization_run_task" "example" {
 }
 
 resource "tfe_workspace_run_task" "example" {
-  workspace_id      = resource.tfe_workspace.example.id
+  workspace_id      = resource.tfe_workspace.ws.id
   task_id           = resource.tfe_organization_run_task.example.id
   enforcement_level = "advisory"
   stages            = ["pre_plan"]

--- a/examples/resources/tfe_workspace_settings/resource.tf
+++ b/examples/resources/tfe_workspace_settings/resource.tf
@@ -1,16 +1,6 @@
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
-}
-
 resource "tfe_workspace_settings" "test-settings" {
-  workspace_id   = tfe_workspace.test.id
+  workspace_id   = tfe_workspace.example.id
   execution_mode = "local"
 }

--- a/examples/resources/tfe_workspace_settings/resource_with_execution_mode_of_agent.tf
+++ b/examples/resources/tfe_workspace_settings/resource_with_execution_mode_of_agent.tf
@@ -1,27 +1,12 @@
 # With execution_mode of agent
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_agent_pool" "test-agent-pool" {
-  name         = "my-agent-pool-name"
-  organization = tfe_organization.test-organization.name
-}
-
 resource "tfe_agent_pool_allowed_workspaces" "test" {
-  agent_pool_id         = tfe_agent_pool.test-agent-pool.id
-  allowed_workspace_ids = [tfe_workspace.test.id]
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
+  agent_pool_id         = tfe_agent_pool.example.id
+  allowed_workspace_ids = [tfe_workspace.example.id]
 }
 
 resource "tfe_workspace_settings" "test-settings" {
-  workspace_id   = tfe_workspace.test.id
+  workspace_id   = tfe_workspace.example.id
   agent_pool_id  = tfe_agent_pool_allowed_workspaces.test.agent_pool_id
   execution_mode = "agent"
 }

--- a/examples/resources/tfe_workspace_variable_set/resource.tf
+++ b/examples/resources/tfe_workspace_variable_set/resource.tf
@@ -1,22 +1,12 @@
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_variable_set" "test" {
-  name         = "Test Varset"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+resource "tfe_variable_set" "example" {
+  name         = "my-variable-set"
+  description  = "Example fixture variable set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_workspace_variable_set" "test" {
-  variable_set_id = tfe_variable_set.test.id
-  workspace_id    = tfe_workspace.test.id
+  variable_set_id = tfe_variable_set.example.id
+  workspace_id    = tfe_workspace.example.id
 }

--- a/examples/shared/example.tf
+++ b/examples/shared/example.tf
@@ -1,0 +1,30 @@
+# Standard fixtures for example validation and live testing.
+# These resources are injected alongside each example file by
+# scripts/validate-examples.sh and TestAccExamples — they are NOT
+# part of the rendered documentation.
+#
+# Do NOT reproduce these blocks in individual example files.
+# Reference them directly using the label "example", e.g.:
+#   organization = tfe_organization.example.name
+#   workspace_id = tfe_workspace.example.id
+
+resource "tfe_organization" "example" {
+  name  = "my-org-name"
+  email = "admin@example.com"
+}
+
+resource "tfe_workspace" "example" {
+  name         = "my-workspace-name"
+  organization = tfe_organization.example.name
+}
+
+resource "tfe_project" "example" {
+  name         = "my-project-name"
+  organization = tfe_organization.example.name
+}
+
+resource "tfe_agent_pool" "example" {
+  name         = "my-agent-pool-name"
+  organization = tfe_organization.example.name
+}
+

--- a/internal/provider/examples_acc_test.go
+++ b/internal/provider/examples_acc_test.go
@@ -1,0 +1,353 @@
+// Copyright IBM Corp. 2024, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// exampleExceptions is the parsed representation of examples/error_exceptions.json.
+//
+// To exempt example live tests at the directory level, add the resource directory
+// name (for example, "tfe_agent_pool") to examples_as_ci_exempt_directories in
+// examples/error_exceptions.json. Use that only when every example in the
+// directory is intentionally skipped in CI.
+//
+// For narrower cases that cut across otherwise testable directories, prefer
+// targeted content-based checks in skipReason() instead of adding more directory
+// exemptions.
+type exampleExceptions struct {
+	ExamplesAsCIExemptDirectories []string `json:"examples_as_ci_exempt_directories"`
+}
+
+// loadExampleExceptions reads and parses examples/error_exceptions.json.
+// The path is relative to the package root (two levels up from internal/provider).
+func loadExampleExceptions(t *testing.T) exampleExceptions {
+	t.Helper()
+	data, err := os.ReadFile("../../examples/error_exceptions.json")
+	if err != nil {
+		t.Fatalf("failed to read error_exceptions.json: %s", err)
+	}
+	var exc exampleExceptions
+	if err := json.Unmarshal(data, &exc); err != nil {
+		t.Fatalf("failed to parse error_exceptions.json: %s", err)
+	}
+	return exc
+}
+
+// isDirExempt reports whether the given example file's resource directory is
+// in the examples_as_ci_exempt_directories list.
+func isDirExempt(path string, exc exampleExceptions) bool {
+	dir := filepath.Base(filepath.Dir(path))
+	for _, d := range exc.ExamplesAsCIExemptDirectories {
+		if dir == d {
+			return true
+		}
+	}
+	return false
+}
+
+// Compiled regexes used by skipReason.
+var (
+	// backendBlockRe matches a terraform{} block at the start of a line — these
+	// are backend/cloud configurations that cannot appear in test configs.
+	backendBlockRe = regexp.MustCompile(`(?m)^\s*terraform\s*\{`)
+
+	// memberUserIDRe matches references to tfe_organization_membership.*.user_id
+	// or data.tfe_organization_membership.*.user_id. These are always empty until
+	// an invitation is manually accepted, so any config containing them will fail.
+	memberUserIDRe = regexp.MustCompile(`tfe_organization_membership\.\w+\.user_id`)
+
+	// externalServiceURLRe detects the placeholder URL used in run-task examples.
+	// It is replaced by RUN_TASKS_URL at substitution time; if it survives to this
+	// check that means RUN_TASKS_URL was not set.
+	externalServiceURLRe = regexp.MustCompile(`https://external\.service\.com`)
+
+	// adminProviderRe matches an explicit provider "tfe" block in the config.
+	// Admin examples declare a second tfe provider alias with an admin token;
+	// the test harness only sets up one provider, so these cannot run.
+	adminProviderRe = regexp.MustCompile(`(?m)^\s*provider\s+"tfe"\s*\{`)
+
+	// samlSettingsRe detects configs that create tfe_saml_settings, which
+	// requires a live SAML IdP and enterprise-only admin access.
+	samlSettingsRe = regexp.MustCompile(`resource\s+"tfe_saml_settings"`)
+
+	// teamMemberUsernameRe detects hardcoded usernames in tfe_team_member /
+	// tfe_team_members that reference pre-existing users not present in CI.
+	teamMemberUsernameRe = regexp.MustCompile(`(?m)^\s*usernames?\s*=`)
+)
+
+// skipReason returns a human-readable reason and true if the config should be
+// skipped, or ("", false) if it should be run. Detection is purely content-based
+// — no static allowlist is consulted.
+func skipReason(cfg string) (string, bool) {
+	// Empty config after all substitutions (e.g. tfe_organization/resource.tf
+	// which becomes empty after the shared fixture strips its only block).
+	if strings.TrimSpace(cfg) == "" {
+		return "config is empty after substitutions", true
+	}
+	// Explicit provider "tfe" block: admin examples declare a second tfe provider
+	// alias; the test harness configures only one provider instance.
+	if adminProviderRe.MatchString(cfg) {
+		return "declares explicit provider block (admin token alias not available in test harness)", true
+	}
+	// VCS / OAuth dependency: requires a live GitHub/GitLab token not available in CI.
+	if strings.Contains(cfg, `"tfe_oauth_client"`) ||
+		strings.Contains(cfg, "oauth_token_id") {
+		return "requires tfe_oauth_client (VCS token unavailable in CI)", true
+	}
+	// GitHub App installation lookup requires a configured GitHub App token not available in CI.
+	if strings.Contains(cfg, `data "tfe_github_app_installation"`) {
+		return "requires tfe_github_app_installation (GitHub App installation unavailable in CI)", true
+	}
+	// file() call: references a local file path that does not exist in CI.
+	if strings.Contains(cfg, "file(") {
+		return "uses file() with a path not present in CI", true
+	}
+	// terraform{} backend/cloud block: structurally invalid inside a test config.
+	if backendBlockRe.MatchString(cfg) {
+		return "contains terraform{} backend block, invalid in test context", true
+	}
+	// data "tfe_workspace" with no backing workspace resource in the same config.
+	if strings.Contains(cfg, `data "tfe_workspace"`) &&
+		!strings.Contains(cfg, `resource "tfe_workspace"`) {
+		return "uses data.tfe_workspace with no backing workspace resource in config", true
+	}
+	// tfe_stack reference: requires ENABLE_BETA + special TFE build.
+	if strings.Contains(cfg, `"tfe_stack"`) {
+		return "references tfe_stack (requires ENABLE_BETA)", true
+	}
+	// data "tfe_slug": requires a local policy directory that does not exist in CI.
+	if strings.Contains(cfg, `data "tfe_slug"`) {
+		return "uses data.tfe_slug with a local path not present in CI", true
+	}
+	// tfe_saml_settings: requires a live SAML IdP and enterprise admin access.
+	if samlSettingsRe.MatchString(cfg) {
+		return "creates tfe_saml_settings (requires enterprise SAML IdP)", true
+	}
+	// tfe_organization_membership.*.user_id or data.tfe_organization_membership.*.user_id:
+	// always empty until the invitation is manually accepted.
+	if memberUserIDRe.MatchString(cfg) {
+		return "references tfe_organization_membership.*.user_id (empty until invite accepted)", true
+	}
+	// tfe_team_member / tfe_team_members with hardcoded usernames: those users do
+	// not exist in the CI test org.
+	if (strings.Contains(cfg, `"tfe_team_member"`) || strings.Contains(cfg, `"tfe_team_members"`)) &&
+		teamMemberUsernameRe.MatchString(cfg) {
+		return "references hardcoded usernames not present in CI test org", true
+	}
+	// time_rotating: requires the external HashiCorp time provider.
+	if strings.Contains(cfg, "time_rotating") {
+		return "requires external time provider", true
+	}
+	// write-only HMAC key examples require a realistic key value; synthetic injected values are rejected.
+	if strings.Contains(cfg, "hmac_key_wo") {
+		return "requires a valid HMAC key value not available in CI", true
+	}
+	// External service URL still present: RUN_TASKS_URL was not set in this environment.
+	if externalServiceURLRe.MatchString(cfg) {
+		return "uses https://external.service.com and RUN_TASKS_URL is not set", true
+	}
+	// no_code_module with version_pin: requires a published module version.
+	if strings.Contains(cfg, "version_pin") {
+		return "uses version_pin which requires a published module version", true
+	}
+	// Notification configuration examples are not currently accepted by the CI environment/API.
+	if strings.Contains(cfg, `"tfe_notification_configuration"`) ||
+		strings.Contains(cfg, `"tfe_project_notification_configuration"`) ||
+		strings.Contains(cfg, `"tfe_team_notification_configuration"`) {
+		return "uses notification configuration resources not currently supported in CI", true
+	}
+	// Agent pool examples outside exempt directories still require agent pool capability unavailable in CI.
+	if strings.Contains(cfg, `"tfe_agent_pool_allowed_projects"`) ||
+		strings.Contains(cfg, `"tfe_agent_pool_allowed_workspaces"`) ||
+		strings.Contains(cfg, `"tfe_agent_pool_excluded_workspaces"`) {
+		return "uses agent pool resources unavailable in CI", true
+	}
+	// Examples using for_each with indexed resource references are not supported by the test harness.
+	if strings.Contains(cfg, "for_each") &&
+		(strings.Contains(cfg, `tfe_workspace.test[`) || strings.Contains(cfg, `tfe_organization_membership.`)) {
+		return "uses for_each with indexed resource references unsupported by the test harness", true
+	}
+	// Standalone data-source workspace settings example relies on pre-existing workspaces not guaranteed in CI.
+	if strings.Contains(cfg, `data "tfe_workspace"`) && strings.Contains(cfg, `"tfe_workspace_settings"`) {
+		return "uses data.tfe_workspace lookup without guaranteed backing workspace in CI", true
+	}
+	// Tag policy set examples require tag lookup behavior that is not reliable in CI.
+	if strings.Contains(cfg, `"tfe_tag_policy_set"`) || strings.Contains(cfg, `"tfe_tag_policy_set_exclusion"`) {
+		return "uses tag policy set resources that require tag lookup behavior unavailable in CI", true
+	}
+	return "", false
+}
+
+// varDefaultRe matches a variable block that has no default value.
+// Captures the variable name.
+var varDefaultRe = regexp.MustCompile(`(?s)variable\s+"(\w+)"\s*\{[^}]*\}`)
+var varHasDefault = regexp.MustCompile(`\bdefault\b`)
+
+// extractVarsWithoutDefault returns variable names declared in the config
+// that have no default value — these must be injected via ConfigVariables.
+func extractVarsWithoutDefault(cfg string) []string {
+	var names []string
+	for _, match := range varDefaultRe.FindAllStringSubmatch(cfg, -1) {
+		block := match[0]
+		if !varHasDefault.MatchString(block) {
+			names = append(names, match[1])
+		}
+	}
+	return names
+}
+
+// reOrgResourceBlock matches a complete `resource "tfe_organization" "<label>" { ... }`
+// block including its closing brace (simple single-level heuristic).
+var reOrgResourceBlock = regexp.MustCompile(`(?s)resource "tfe_organization" "[^"]*" \{[^}]*\}`)
+
+// reOrgRef matches tfe_organization.<label>.name or .id
+var reOrgRef = regexp.MustCompile(`tfe_organization\.[a-zA-Z0-9_-]+\.(name|id)`)
+
+// stripOrgBlocks removes any inline tfe_organization resource blocks from a
+// config and replaces all .name/.id references with the literal org name.
+// After this the shared fixture's tfe_organization.example is the only org
+// block, pointing at the pre-created test org.
+func stripOrgBlocks(cfg, orgName string) string {
+	cfg = reOrgResourceBlock.ReplaceAllString(cfg, "")
+	cfg = reOrgRef.ReplaceAllString(cfg, fmt.Sprintf("%q", orgName))
+	return cfg
+}
+
+// TestAccTFEExamples applies every non-exempt example file as a real Terraform
+// configuration against a live TFE instance, verifying that documented
+// examples can be applied and destroyed without error.
+//
+// Guards on TF_ACC so it runs automatically in the existing acceptance test CI
+// job alongside all other TestAcc* tests.
+func TestAccTFEExamples(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("set TF_ACC=1 to run live example tests")
+	}
+
+	exc := loadExampleExceptions(t)
+
+	tfeClient, err := getClientUsingEnv()
+	if err != nil {
+		t.Fatalf("failed to build TFE client: %s", err)
+	}
+
+	suiteRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Load the shared fixture once; substitutions are applied to it just like
+	// any example file so that resource names resolve to the test org.
+	sharedRaw, err := os.ReadFile("../../examples/shared/example.tf")
+	if err != nil {
+		t.Fatalf("failed to read examples/shared/example.tf: %s", err)
+	}
+
+	paths, err := filepath.Glob("../../examples/resources/*/resource*.tf")
+	if err != nil {
+		t.Fatalf("failed to glob example files: %s", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no example files found under examples/resources/")
+	}
+
+	for _, path := range paths {
+		// Derive stable sub-test name: "<dir>/<filename>"
+		name := filepath.Join(filepath.Base(filepath.Dir(path)), filepath.Base(path))
+
+		t.Run(name, func(t *testing.T) {
+			if isDirExempt(path, exc) {
+				t.Skip("directory exempted in error_exceptions.json under examples_as_ci_exempt_directories")
+				return
+			}
+
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read %s: %s", path, err)
+			}
+
+			exampleRand := suiteRand.Int()
+			orgName := fmt.Sprintf("tst-ex-%d", exampleRand)
+
+			_, orgCleanup := createOrganization(t, tfeClient,
+				tfe.OrganizationCreateOptions{
+					Name:  tfe.String(orgName),
+					Email: tfe.String("admin@example.com"),
+				})
+			t.Cleanup(orgCleanup)
+
+			providers := muxedProvidersWithDefaultOrganization(orgName)
+
+			// Apply substitutions to both the shared fixture and the example.
+			shared := applyExampleSubstitutions(string(sharedRaw), orgName, exampleRand)
+			example := applyExampleSubstitutions(string(raw), orgName, exampleRand)
+
+			// Combine: shared fixtures first, then the example.
+			combined := shared + "\n" + example
+
+			// Strip any inline tfe_organization blocks the example still contains
+			// (pre-migration files, or examples where the org is the subject).
+			combined = stripOrgBlocks(combined, orgName)
+
+			if reason, skip := skipReason(combined); skip {
+				t.Skipf("auto-skipped: %s", reason)
+				return
+			}
+
+			// Inject values for any variable blocks that have no default
+			// (pattern used by write-only field examples).
+			vars := config.Variables{}
+			for _, v := range extractVarsWithoutDefault(combined) {
+				vars[v] = config.StringVariable("synthetic-test-value")
+			}
+
+			step := resource.TestStep{Config: combined}
+			if len(vars) > 0 {
+				step.ConfigVariables = vars
+			}
+
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: providers,
+				Steps:                    []resource.TestStep{step},
+			})
+		})
+	}
+}
+
+// applyExampleSubstitutions replaces well-known placeholder strings in an
+// example config with values valid for the live test environment.
+func applyExampleSubstitutions(cfg, orgName string, rInt int) string {
+	runTasksURL := os.Getenv("RUN_TASKS_URL")
+	if runTasksURL == "" {
+		// Leave the literal in place; skipReason will detect it and skip the test.
+		runTasksURL = "https://external.service.com"
+	}
+
+	r := strings.NewReplacer(
+		`"my-org-name"`, fmt.Sprintf("%q", orgName),
+		`"my-example-org"`, fmt.Sprintf("%q", orgName),
+		`"my-organization"`, fmt.Sprintf("%q", orgName),
+		`"org-name"`, fmt.Sprintf("%q", orgName),
+		`"organization name"`, fmt.Sprintf("%q", orgName),
+		`"my-workspace-name"`, fmt.Sprintf(`"tst-ex-ws-%d"`, rInt),
+		`"my-sourceable-workspace-name"`, fmt.Sprintf(`"tst-ex-ws2-%d"`, rInt),
+		`"my-project-name"`, fmt.Sprintf(`"tst-ex-proj-%d"`, rInt),
+		`"my-team-name"`, fmt.Sprintf(`"tst-ex-team-%d"`, rInt),
+		`"my-admin-team"`, fmt.Sprintf(`"tst-ex-admin-team-%d"`, rInt),
+		`"my-agent-pool-name"`, fmt.Sprintf(`"tst-ex-pool-%d"`, rInt),
+		`"https://external.service.com"`, fmt.Sprintf("%q", runTasksURL),
+	)
+	return r.Replace(cfg)
+}

--- a/scripts/validate-examples.sh
+++ b/scripts/validate-examples.sh
@@ -130,7 +130,11 @@ EOF
 cd "${TEST_DIR}"
 export TF_CLI_CONFIG_FILE="$(pwd)/terraform.rc"
 
-# Recurse across the examples directory
+# Copy the shared fixture once — it stays in TEST_DIR for every validation run
+# so that example files can reference tfe_organization.example, etc.
+cp "${PROVIDER_DIR}/examples/shared/example.tf" "${TEST_DIR}/example.tf"
+
+# Recurse across the examples directory, excluding the shared directory itself
 while IFS= read -r -d '' path; do
     relative_path="${path#${TARGET_DIR}/}"
     echo "Validating: ${relative_path}"
@@ -227,7 +231,7 @@ while IFS= read -r -d '' path; do
         echo "  pass"
     fi
 
-done < <(find "${TARGET_DIR}" -name "*.tf" -type f -print0)
+done < <(find "${TARGET_DIR}" -name "*.tf" -type f -not -path "*/shared/*" -print0)
 
 cd "${PROVIDER_DIR}"
 

--- a/scripts/validate-import-example-presence.sh
+++ b/scripts/validate-import-example-presence.sh
@@ -271,7 +271,7 @@ echo ""
 if [ ${#FAILURES[@]} -gt 0 ]; then
     echo "Result: FAILED"
     echo ""
-    echo "Add import.tf or import_*.tf under examples/resources/<name>/."
+    echo "Add import-by-identity.tf under examples/resources/<name>/."
     echo "To skip a resource, add it to examples/error_exceptions.json under"
     echo "'no_example_required'. To run locally: ./scripts/validate-import-example-presence.sh"
     exit 5

--- a/website/docs/actions/query_run.html.markdown
+++ b/website/docs/actions/query_run.html.markdown
@@ -17,16 +17,16 @@ This initiates a query run within a specified workspace. This action allows you 
 ```terraform
 # Using a Specific Configuration Version ID
 
-resource "tfe_workspace" "example" {
+resource "tfe_workspace" "ws" {
   name         = "example-workspace"
   organization = "my-organization"
 }
 
-resource "tfe_variable" "example" {
+resource "tfe_variable" "var" {
   key          = "my_key"
   value        = "my_value"
   category     = "terraform"
-  workspace_id = tfe_workspace.example.id
+  workspace_id = tfe_workspace.ws.id
 
   # Trigger the query run after the variable is created or updated
   lifecycle {
@@ -39,7 +39,7 @@ resource "tfe_variable" "example" {
 
 action "tfe_query_run" "with_cv_id" {
   config {
-    workspace_id             = tfe_workspace.example.id
+    workspace_id             = tfe_workspace.ws.id
     configuration_version_id = "cv-ntv3HbhJqvFzamy7"
 
     variables = {
@@ -52,16 +52,16 @@ action "tfe_query_run" "with_cv_id" {
 ```terraform
 # Wait for the Latest Configuration Version
 
-resource "tfe_workspace" "example" {
+resource "tfe_workspace" "ws" {
   name         = "example-workspace"
   organization = "my-organization"
 }
 
-resource "tfe_variable" "example" {
+resource "tfe_variable" "var" {
   key          = "my_key"
   value        = "my_value"
   category     = "terraform"
-  workspace_id = tfe_workspace.example.id
+  workspace_id = tfe_workspace.ws.id
 
   lifecycle {
     action_trigger {
@@ -73,7 +73,7 @@ resource "tfe_variable" "example" {
 
 action "tfe_query_run" "wait_for_latest" {
   config {
-    workspace_id                  = tfe_workspace.example.id
+    workspace_id                  = tfe_workspace.ws.id
     wait_for_latest_configuration = true
 
     variables = {

--- a/website/docs/d/no_code_module.html.markdown
+++ b/website/docs/d/no_code_module.html.markdown
@@ -16,7 +16,7 @@ Gets a public or private existing no-code module.
 
 resource "tfe_organization" "foobar" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_registry_module" "foobar" {

--- a/website/docs/d/organization_membership.html.markdown
+++ b/website/docs/d/organization_membership.html.markdown
@@ -25,7 +25,7 @@ Gets information about an organization membership.
 
 data "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "user@company.com"
+  email        = "user@example.com"
 }
 ```
 

--- a/website/docs/r/admin_organization_settings.html.markdown
+++ b/website/docs/r/admin_organization_settings.html.markdown
@@ -43,12 +43,12 @@ provider "tfe" {
 
 resource "tfe_organization" "a-module-producer" {
   name  = "my-org"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_organization" "a-module-consumer" {
   name  = "my-other-org"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_admin_organization_settings" "test-settings" {

--- a/website/docs/r/agent_pool.html.markdown
+++ b/website/docs/r/agent_pool.html.markdown
@@ -17,14 +17,9 @@ An agent pool represents a group of agents, often related to one another by shar
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "test-agent-pool" {
   name                = "my-agent-pool-name"
-  organization        = tfe_organization.test-organization.name
+  organization        = tfe_organization.example.name
   organization_scoped = true
 }
 ```

--- a/website/docs/r/agent_pool_allowed_projects.html.markdown
+++ b/website/docs/r/agent_pool_allowed_projects.html.markdown
@@ -17,20 +17,15 @@ Adds and removes allowed projects on an agent pool.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 // Ensure project and agent pool are create first
 resource "tfe_project" "test-project" {
   name         = "my-project-name"
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {
   name                = "my-agent-pool-name"
-  organization        = tfe_organization.test-organization.name
+  organization        = tfe_organization.example.name
   organization_scoped = false
 }
 

--- a/website/docs/r/agent_pool_allowed_workspaces.html.markdown
+++ b/website/docs/r/agent_pool_allowed_workspaces.html.markdown
@@ -18,20 +18,15 @@ Adds and removes allowed workspaces on an agent pool.
 # Basic usage
 # In this example, the agent pool and workspace are connected through other resources that manage the agent pool permissions as well as the workspace execution mode. Notice that the `tfe_workspace_settings` uses the agent pool reference found in `tfe_agent_pool_allowed_workspaces` in order to create the permission to use the agent pool before assigning it.
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 // Ensure workspace and agent pool are create first
 resource "tfe_workspace" "test-workspace" {
   name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {
   name                = "my-agent-pool-name"
-  organization        = tfe_organization.test-organization.name
+  organization        = tfe_organization.example.name
   organization_scoped = false
 }
 

--- a/website/docs/r/agent_pool_excluded_workspaces.html.markdown
+++ b/website/docs/r/agent_pool_excluded_workspaces.html.markdown
@@ -17,20 +17,15 @@ Adds and removes excluded workspaces on an agent pool.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 // Ensure workspace and agent pool are create first
 resource "tfe_workspace" "test-workspace" {
   name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {
   name                = "my-agent-pool-name"
-  organization        = tfe_organization.test-organization.name
+  organization        = tfe_organization.example.name
   organization_scoped = false
 }
 

--- a/website/docs/r/agent_token.html.markdown
+++ b/website/docs/r/agent_token.html.markdown
@@ -17,14 +17,9 @@ Each agent pool has its own set of tokens which are not shared across pools. The
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "test-agent-pool" {
   name         = "my-agent-pool-name"
-  organization = tfe_organization.test-organization.id
+  organization = tfe_organization.example.id
 }
 
 resource "tfe_agent_token" "test-agent-token" {

--- a/website/docs/r/data_retention_policy.html.markdown
+++ b/website/docs/r/data_retention_policy.html.markdown
@@ -16,7 +16,7 @@ description: |-
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_workspace" "test-workspace" {
@@ -38,7 +38,7 @@ resource "tfe_data_retention_policy" "foobar" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_data_retention_policy" "foobar" {
@@ -55,7 +55,7 @@ resource "tfe_data_retention_policy" "foobar" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 // create data retention policy the organization

--- a/website/docs/r/no_code_module.html.markdown
+++ b/website/docs/r/no_code_module.html.markdown
@@ -14,19 +14,14 @@ Creates, updates and destroys a no-code module for registry modules.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "foobar" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_module" "foobar" {
-  organization    = tfe_organization.foobar.id
+  organization    = tfe_organization.example.id
   module_provider = "my_provider"
   name            = "test_module"
 }
 
 resource "tfe_no_code_module" "foobar" {
-  organization    = tfe_organization.foobar.id
+  organization    = tfe_organization.example.id
   registry_module = tfe_registry_module.foobar.id
 }
 ```
@@ -36,7 +31,7 @@ resource "tfe_no_code_module" "foobar" {
 
 resource "tfe_organization" "foobar" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_registry_module" "foobar" {

--- a/website/docs/r/notification_configuration.html.markdown
+++ b/website/docs/r/notification_configuration.html.markdown
@@ -20,42 +20,22 @@ HCP Terraform can be configured to send notifications for run state transitions.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.id
-}
-
 resource "tfe_notification_configuration" "test" {
   name             = "my-test-notification-configuration"
   enabled          = true
   destination_type = "generic"
   triggers         = ["run:created", "run:planning", "run:errored"]
   url_wo           = "https://example.com"
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
 }
 ```
 
 ```terraform
 # With destination_type of email
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.id
-}
-
 resource "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "test.member@company.com"
+  email        = "test.member@example.com"
 }
 
 resource "tfe_notification_configuration" "test" {
@@ -64,26 +44,16 @@ resource "tfe_notification_configuration" "test" {
   destination_type = "email"
   email_user_ids   = [tfe_organization_membership.test.user_id]
   triggers         = ["run:created", "run:planning", "run:errored"]
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
 }
 ```
 
 ```terraform
 # (Terraform Enterprise only) With destination_type of email, using email_addresses list and email_users
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.id
-}
-
 resource "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "test.member@company.com"
+  email        = "test.member@example.com"
 }
 
 resource "tfe_notification_configuration" "test" {
@@ -91,31 +61,21 @@ resource "tfe_notification_configuration" "test" {
   enabled          = true
   destination_type = "email"
   email_user_ids   = [tfe_organization_membership.test.user_id]
-  email_addresses  = ["user1@company.com", "user2@company.com", "user3@company.com"]
+  email_addresses  = ["user1@example.com", "user2@example.com", "user3@example.com"]
   triggers         = ["run:created", "run:planning", "run:errored"]
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
 }
 ```
 
 ```terraform
 # With write-only token and URL (auto-managed, recommended)
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.id
-}
-
 resource "tfe_notification_configuration" "test" {
   name             = "my-test-notification-configuration"
   destination_type = "generic"
   token_wo         = "my-secret-token"
   url_wo           = "https://example.com"
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
 }
 ```
 

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -16,7 +16,7 @@ Manages organizations.
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 ```
 

--- a/website/docs/r/organization_default_settings.html.markdown
+++ b/website/docs/r/organization_default_settings.html.markdown
@@ -17,18 +17,13 @@ Primarily used to set the default execution mode of an organization. Settings co
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "my_agents" {
   name         = "agent_smiths"
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_organization_default_settings" "org_default" {
-  organization           = tfe_organization.test.name
+  organization           = tfe_organization.example.name
   default_execution_mode = "agent"
   default_agent_pool_id  = tfe_agent_pool.my_agents.id
 }

--- a/website/docs/r/organization_membership.html.markdown
+++ b/website/docs/r/organization_membership.html.markdown
@@ -22,7 +22,7 @@ Adds or removes a user from an organization.
 
 resource "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "user@company.com"
+  email        = "user@example.com"
 }
 ```
 

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -25,7 +25,7 @@ Policy sets are groups of policies that are applied together to related workspac
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_workspace" "test" {
@@ -67,7 +67,7 @@ resource "tfe_policy_set" "test" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_workspace" "test" {
@@ -94,18 +94,8 @@ resource "tfe_policy_set" "test" {
 ```terraform
 # Using manually-specified policies
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
-}
-
 resource "tfe_policy" "test" {
-  name         = "my-policy-name"
+  name         = "passing-policy"
   description  = "This policy always passes"
   organization = "my-org-name"
   kind         = "sentinel"
@@ -114,14 +104,14 @@ resource "tfe_policy" "test" {
 }
 
 resource "tfe_policy_set" "test" {
-  name                = "my-policy-set"
+  name                = "manual-policy-set"
   description         = "A brand new policy set"
   organization        = "my-org-name"
   kind                = "sentinel"
   agent_enabled       = "true"
   policy_tool_version = "0.24.1"
   policy_ids          = [tfe_policy.test.id]
-  workspace_ids       = [tfe_workspace.test.id]
+  workspace_ids       = [tfe_workspace.example.id]
 }
 ```
 

--- a/website/docs/r/policy_set_parameter.html.markdown
+++ b/website/docs/r/policy_set_parameter.html.markdown
@@ -14,46 +14,38 @@ Creates, updates and destroys policy set parameters.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_policy_set" "test" {
-  name         = "my-policy-set-name"
-  organization = tfe_organization.test.id
+resource "tfe_policy_set" "example" {
+  name         = "my-policy-set"
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_policy_set_parameter" "test" {
   key           = "my_key_name"
   value         = "my_value_name"
-  policy_set_id = tfe_policy_set.test.id
+  policy_set_id = tfe_policy_set.example.id
 }
 ```
 
 ```terraform
 # Usage for the write-only value
 
+resource "tfe_policy_set" "example" {
+  name         = "my-policy-set"
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
+}
+
 variable "session_token" {
   type      = string
   ephemeral = true
-}
-
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_policy_set" "test" {
-  name         = "my-policy-set-name"
-  organization = tfe_organization.test.id
 }
 
 resource "tfe_policy_set_parameter" "test" {
   key              = "my_key_name"
   value_wo         = var.session_token
   value_wo_version = 1
-  policy_set_id    = tfe_policy_set.test.id
+  policy_set_id    = tfe_policy_set.example.id
 }
 ```
 

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -14,13 +14,8 @@ Manages a project.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_project" "test" {
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
   name         = "projectname"
 }
 ```
@@ -28,13 +23,8 @@ resource "tfe_project" "test" {
 ```terraform
 # With tags
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_project" "test" {
-  organization = tfe_organization.test-organization.name
+  organization = tfe_organization.example.name
   name         = "projectname"
   tags = {
     cost_center = "infrastructure"

--- a/website/docs/r/project_notification_configuration.html.markdown
+++ b/website/docs/r/project_notification_configuration.html.markdown
@@ -19,12 +19,12 @@ HCP Terraform can be configured to send notifications for run state transitions 
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {
   name         = "my-project-name"
-  organization = tfe_organization.test.id
+  organization = tfe_organization.test.name
 }
 
 resource "tfe_project_notification_configuration" "test" {
@@ -42,7 +42,7 @@ resource "tfe_project_notification_configuration" "test" {
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {
@@ -52,7 +52,7 @@ resource "tfe_project" "test" {
 
 data "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "test.member@company.com"
+  email        = "test.member@example.com"
 }
 
 resource "tfe_project_notification_configuration" "test" {
@@ -70,7 +70,7 @@ resource "tfe_project_notification_configuration" "test" {
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {
@@ -80,7 +80,7 @@ resource "tfe_project" "test" {
 
 resource "tfe_organization_membership" "test" {
   organization = "my-org-name"
-  email        = "test.member@company.com"
+  email        = "test.member@example.com"
 }
 
 resource "tfe_project_notification_configuration" "test" {
@@ -88,7 +88,7 @@ resource "tfe_project_notification_configuration" "test" {
   enabled          = true
   destination_type = "email"
   email_user_ids   = [tfe_organization_membership.test.user_id]
-  email_addresses  = ["user1@company.com", "user2@company.com", "user3@company.com"]
+  email_addresses  = ["user1@example.com", "user2@example.com", "user3@example.com"]
   triggers         = ["run:created", "run:planning", "run:errored"]
   project_id       = tfe_project.test.id
 }

--- a/website/docs/r/project_oauth_client.html.markdown
+++ b/website/docs/r/project_oauth_client.html.markdown
@@ -16,7 +16,7 @@ Adds and removes OAuth clients from a project.
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {

--- a/website/docs/r/project_policy_set.html.markdown
+++ b/website/docs/r/project_policy_set.html.markdown
@@ -23,25 +23,15 @@ Policy sets are groups of policies that are applied together to related workspac
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_project" "test" {
-  name         = "my-project-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_policy_set" "test" {
+resource "tfe_policy_set" "example" {
   name         = "my-policy-set"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_project_policy_set" "test" {
-  policy_set_id = tfe_policy_set.test.id
-  project_id    = tfe_project.test.id
+  policy_set_id = tfe_policy_set.example.id
+  project_id    = tfe_project.example.id
 }
 ```
 

--- a/website/docs/r/project_policy_set_exclusion.html.markdown
+++ b/website/docs/r/project_policy_set_exclusion.html.markdown
@@ -20,26 +20,16 @@ Adds and removes project exclusions from a policy set.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_project" "test" {
-  name         = "my-project-name"
-  organization = tfe_organization.test.name
-}
-
 resource "tfe_policy_set" "test" {
   name         = "my-policy-set"
   description  = "Some description."
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
   global       = true
 }
 
 resource "tfe_project_policy_set_exclusion" "test" {
   policy_set_id = tfe_policy_set.test.id
-  project_id    = tfe_project.test.id
+  project_id    = tfe_project.example.id
 }
 ```
 

--- a/website/docs/r/project_settings.html.markdown
+++ b/website/docs/r/project_settings.html.markdown
@@ -20,19 +20,14 @@ Primarily, this resource allows setting default execution mode and agent pool fo
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_agent_pool" "my_agents" {
   name         = "my-agent-pool"
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 # this section here for demonstration and is not necessary explicitly for use of tfe_project_settings
 resource "tfe_organization_default_settings" "org_default" {
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
   # this will end up being overwritten at the project level
   default_execution_mode = "agent"
   default_agent_pool_id  = tfe_agent_pool.my_agents.id
@@ -40,7 +35,7 @@ resource "tfe_organization_default_settings" "org_default" {
 
 resource "tfe_project" "my_project" {
   name         = "my-project"
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_project_settings" "my_project_settings" {

--- a/website/docs/r/project_variable_set.html.markdown
+++ b/website/docs/r/project_variable_set.html.markdown
@@ -17,25 +17,15 @@ Adds and removes a variable set to a project.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_project" "test" {
-  name         = "my-project-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_variable_set" "test" {
-  name         = "Test Varset"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+resource "tfe_variable_set" "example" {
+  name         = "my-variable-set"
+  description  = "Example fixture variable set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_project_variable_set" "test" {
-  variable_set_id = tfe_variable_set.test.id
-  project_id      = tfe_project.test.id
+  variable_set_id = tfe_variable_set.example.id
+  project_id      = tfe_project.example.id
 }
 ```
 

--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -25,7 +25,7 @@ Manages Terraform modules in an organization's private module registry.
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test-oauth-client" {
@@ -50,7 +50,7 @@ resource "tfe_registry_module" "test-registry-module" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test-oauth-client" {
@@ -80,7 +80,7 @@ resource "tfe_registry_module" "test-registry-module" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_agent_pool" "test-agent-pool" {
@@ -117,7 +117,7 @@ resource "tfe_registry_module" "test-registry-module" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 data "tfe_github_app_installation" "gha_installation" {
@@ -139,7 +139,7 @@ resource "tfe_registry_module" "petstore" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test-oauth-client" {
@@ -167,13 +167,8 @@ resource "tfe_registry_module" "monorepo-module" {
 ```terraform
 # Create private registry module without VCS
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_module" "test-private-registry-module" {
-  organization    = tfe_organization.test-organization.name
+  organization    = tfe_organization.example.name
   module_provider = "my_provider"
   name            = "another_test_module"
   registry_name   = "private"
@@ -183,13 +178,8 @@ resource "tfe_registry_module" "test-private-registry-module" {
 ```terraform
 # Create public registry module
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_module" "test-public-registry-module" {
-  organization    = tfe_organization.test-organization.name
+  organization    = tfe_organization.example.name
   namespace       = "terraform-aws-modules"
   module_provider = "aws"
   name            = "vpc"
@@ -202,7 +192,7 @@ resource "tfe_registry_module" "test-public-registry-module" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_registry_module" "test-no-code-provisioning-registry-module" {

--- a/website/docs/r/registry_provider.html.markdown
+++ b/website/docs/r/registry_provider.html.markdown
@@ -14,11 +14,6 @@ Manages public and private providers in the private registry.
 ```terraform
 # Create private provider
 
-resource "tfe_organization" "example" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_registry_provider" "example" {
   organization = tfe_organization.example.name
 
@@ -28,11 +23,6 @@ resource "tfe_registry_provider" "example" {
 
 ```terraform
 # Create public provider
-
-resource "tfe_organization" "example" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
 
 resource "tfe_registry_provider" "example" {
   organization = tfe_organization.example.name

--- a/website/docs/r/run_trigger.html.markdown
+++ b/website/docs/r/run_trigger.html.markdown
@@ -17,23 +17,13 @@ HCP Terraform provides a way to connect your workspace to one or more workspaces
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test-workspace" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.id
-}
-
 resource "tfe_workspace" "test-sourceable" {
   name         = "my-sourceable-workspace-name"
-  organization = tfe_organization.test-organization.id
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_run_trigger" "test" {
-  workspace_id  = tfe_workspace.test-workspace.id
+  workspace_id  = tfe_workspace.example.id
   sourceable_id = tfe_workspace.test-sourceable.id
 }
 ```

--- a/website/docs/r/stack_variable_set.html.markdown
+++ b/website/docs/r/stack_variable_set.html.markdown
@@ -16,7 +16,7 @@ Manages associations between variable sets and stacks.
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_stack" "test" {

--- a/website/docs/r/tag_policy_set.html.markdown
+++ b/website/docs/r/tag_policy_set.html.markdown
@@ -22,11 +22,18 @@ Tag inclusions scope policy set enforcement to workspaces that carry a matching 
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "tagged-workspace"
+  organization = tfe_organization.test.name
+
+  tag_names = ["env", "others", "prod"]
 }
 
 resource "tfe_policy_set" "test" {
-  name         = "my-policy-set"
+  name         = "tag-policy-set"
   description  = "Some description."
   organization = tfe_organization.test.name
 }
@@ -43,11 +50,18 @@ resource "tfe_tag_policy_set" "test" {
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "tagged-workspace"
+  organization = tfe_organization.test.name
+
+  tag_names = ["env", "others"]
 }
 
 resource "tfe_policy_set" "test" {
-  name         = "my-policy-set"
+  name         = "key-only-policy-set"
   description  = "Some description."
   organization = tfe_organization.test.name
 }

--- a/website/docs/r/tag_policy_set_exclusion.html.markdown
+++ b/website/docs/r/tag_policy_set_exclusion.html.markdown
@@ -22,11 +22,18 @@ Adds and removes tag-based exclusions on a policy set. Tag exclusions exempt wor
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
+}
+
+resource "tfe_workspace" "test" {
+  name         = "tagged-workspace"
+  organization = tfe_organization.test.name
+
+  tag_names = ["env", "others", "staging"]
 }
 
 resource "tfe_policy_set" "test" {
-  name         = "my-policy-set"
+  name         = "excluded-policy-set"
   description  = "Some description."
   organization = tfe_organization.test.name
   global       = true

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -18,12 +18,12 @@ Manages permissions for a team on a workspace.
 # Basic usage
 
 resource "tfe_team" "test" {
-  name         = "my-team-name"
+  name         = "access-team"
   organization = "my-org-name"
 }
 
 resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
+  name         = "access-workspace"
   organization = "my-org-name"
 }
 

--- a/website/docs/r/team_notification_configuration.html.markdown
+++ b/website/docs/r/team_notification_configuration.html.markdown
@@ -19,7 +19,7 @@ HCP Terraform can be configured to send notifications to a team for certain even
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_team" "test" {
@@ -42,7 +42,7 @@ resource "tfe_team_notification_configuration" "test" {
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_team" "test" {
@@ -65,7 +65,7 @@ resource "tfe_team_notification_configuration" "test" {
   enabled          = true
   destination_type = "email"
   email_user_ids   = [data.tfe_organization_membership.test.user_id]
-  email_addresses  = ["user1@company.com", "user2@company.com", "user3@company.com"]
+  email_addresses  = ["user1@example.com", "user2@example.com", "user3@example.com"]
   triggers         = ["change_request:created"]
   team_id          = tfe_team.test.id
 }
@@ -76,7 +76,7 @@ resource "tfe_team_notification_configuration" "test" {
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_team" "test" {
@@ -114,7 +114,7 @@ variable "notification_token" {
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_team" "test" {

--- a/website/docs/r/test_variable.html.markdown
+++ b/website/docs/r/test_variable.html.markdown
@@ -16,7 +16,7 @@ Creates, updates and destroys environment variables used for testing in the Priv
 
 resource "tfe_organization" "test_org" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test_client" {
@@ -61,7 +61,7 @@ variable "session_token" {
 
 resource "tfe_organization" "test_org" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test_client" {

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -20,21 +20,11 @@ Creates, updates and destroys variables.
 ```terraform
 # Basic usage for workspaces
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
 resource "tfe_variable" "test" {
   key          = "my_key_name"
   value        = "my_value_name"
   category     = "terraform"
-  workspace_id = tfe_workspace.test.id
+  workspace_id = tfe_workspace.example.id
   description  = "a useful description"
 }
 ```
@@ -47,22 +37,12 @@ variable "session_token" {
   ephemeral = true
 }
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
 resource "tfe_variable" "test" {
   key              = "my_key_name"
   value_wo         = var.session_token
   value_wo_version = 1
   category         = "terraform"
-  workspace_id     = tfe_workspace.test.id
+  workspace_id     = tfe_workspace.example.id
   description      = "a useful description"
 }
 ```
@@ -70,16 +50,11 @@ resource "tfe_variable" "test" {
 ```terraform
 # Basic usage for variable sets
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_variable_set" "test" {
   name         = "Test Varset"
   description  = "Some description."
   global       = false
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_variable" "test-a" {
@@ -124,17 +99,17 @@ resource "tfe_variable" "visible_var" {
 
 resource "tfe_workspace" "workspace" {
   name         = "my-workspace"
-  organization = "organization name"
+  organization = "my-org-name"
 }
 
 resource "tfe_workspace" "sensitive_workspace" {
   name         = "workspace-${tfe_variable.sensitive_var.value}" // this will be redacted from plan outputs
-  organization = "organization name"
+  organization = "my-org-name"
 }
 
 resource "tfe_workspace" "visible_workspace" {
   name         = "workspace-${tfe_variable.visible_var.readable_value}" // this will not be redacted from plan outputs
-  organization = "organization name"
+  organization = "my-org-name"
 }
 ```
 

--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -16,7 +16,7 @@ Creates, updates and destroys variable sets.
 
 resource "tfe_organization" "test" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_project" "test" {
@@ -75,16 +75,11 @@ resource "tfe_variable" "test-b" {
 ```terraform
 # Create a priority variable set
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_variable_set" "test" {
   name         = "Global Varset"
   description  = "Variable set applied to all workspaces."
   priority     = true
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_variable" "test-a" {
@@ -107,16 +102,11 @@ resource "tfe_variable" "test-b" {
 ```terraform
 # Creating a global variable set
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_variable_set" "test" {
   name         = "Global Varset"
   description  = "Variable set applied to all workspaces."
   global       = true
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_variable" "test-a" {
@@ -139,20 +129,15 @@ resource "tfe_variable" "test-b" {
 ```terraform
 # Creating a project-owned variable set that is applied to all workspaces in the project
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_project" "test" {
-  organization = tfe_organization.test.name
+  organization = tfe_organization.example.name
   name         = "projectname"
 }
 
 resource "tfe_variable_set" "test" {
   name              = "Project-owned Varset"
   description       = "Varset that is owned and managed by a project."
-  organization      = tfe_organization.test.name
+  organization      = tfe_organization.example.name
   parent_project_id = tfe_project.test.id
 }
 
@@ -165,26 +150,21 @@ resource "tfe_project_variable_set" "test" {
 ```terraform
 # Creating a project-owned variable set that is applied to specific workspaces
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_project" "test" {
-  organization = tfe_organization.test.name
-  name         = "projectname"
+  organization = tfe_organization.example.name
+  name         = "workspace-project"
 }
 
 resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
+  name         = "project-workspace"
+  organization = tfe_organization.example.name
   project_id   = tfe_project.test.id
 }
 
 resource "tfe_variable_set" "test" {
   name              = "Project-owned Varset"
   description       = "Varset that is owned and managed by a project."
-  organization      = tfe_organization.test.name
+  organization      = tfe_organization.example.name
   parent_project_id = tfe_project.test.id
 }
 

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -20,14 +20,9 @@ Provides a workspace resource.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test-organization" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
 resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test-organization.name
+  name         = "user-workspace"
+  organization = tfe_organization.example.name
   tags = {
     environment = "prod"
     team_owner  = "my-team"
@@ -40,7 +35,7 @@ resource "tfe_workspace" "test" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test" {

--- a/website/docs/r/workspace_policy_set.html.markdown
+++ b/website/docs/r/workspace_policy_set.html.markdown
@@ -20,25 +20,15 @@ Adds and removes policy sets from a workspace.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_policy_set" "test" {
+resource "tfe_policy_set" "example" {
   name         = "my-policy-set"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_workspace_policy_set" "test" {
-  policy_set_id = tfe_policy_set.test.id
-  workspace_id  = tfe_workspace.test.id
+  policy_set_id = tfe_policy_set.example.id
+  workspace_id  = tfe_workspace.example.id
 }
 ```
 

--- a/website/docs/r/workspace_policy_set_exclusion.html.markdown
+++ b/website/docs/r/workspace_policy_set_exclusion.html.markdown
@@ -20,25 +20,15 @@ Adds and removes policy sets from an excluded workspace.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_policy_set" "test" {
+resource "tfe_policy_set" "example" {
   name         = "my-policy-set"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+  description  = "Example fixture policy set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_workspace_policy_set_exclusion" "test" {
-  policy_set_id = tfe_policy_set.test.id
-  workspace_id  = tfe_workspace.test.id
+  policy_set_id = tfe_policy_set.example.id
+  workspace_id  = tfe_workspace.example.id
 }
 ```
 

--- a/website/docs/r/workspace_run.html.markdown
+++ b/website/docs/r/workspace_run.html.markdown
@@ -34,7 +34,7 @@ The `tfe_workspace_run` expects to own exactly one apply during a creation and/o
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test" {
@@ -109,7 +109,7 @@ resource "tfe_workspace_run" "ws_run_child" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test" {
@@ -151,7 +151,7 @@ resource "tfe_workspace_run" "ws_run_parent" {
 
 resource "tfe_organization" "test-organization" {
   name  = "my-org-name"
-  email = "admin@company.com"
+  email = "admin@example.com"
 }
 
 resource "tfe_oauth_client" "test" {

--- a/website/docs/r/workspace_run_task.html.markdown
+++ b/website/docs/r/workspace_run_task.html.markdown
@@ -17,9 +17,9 @@ Associates, updates and removes [Workspace Run tasks](https://developer.hashicor
 ```terraform
 # Basic usage
 
-resource "tfe_workspace" "example" {
+resource "tfe_workspace" "ws" {
   name         = "example-workspace"
-  organization = "my-organization"
+  organization = "my-org-name"
 }
 
 resource "tfe_organization_run_task" "example" {
@@ -31,7 +31,7 @@ resource "tfe_organization_run_task" "example" {
 }
 
 resource "tfe_workspace_run_task" "example" {
-  workspace_id      = resource.tfe_workspace.example.id
+  workspace_id      = resource.tfe_workspace.ws.id
   task_id           = resource.tfe_organization_run_task.example.id
   enforcement_level = "advisory"
   stages            = ["pre_plan"]

--- a/website/docs/r/workspace_variable_set.html.markdown
+++ b/website/docs/r/workspace_variable_set.html.markdown
@@ -17,25 +17,15 @@ Adds and removes a workspace from a variable set's scope.
 ```terraform
 # Basic usage
 
-resource "tfe_organization" "test" {
-  name  = "my-org-name"
-  email = "admin@company.com"
-}
-
-resource "tfe_workspace" "test" {
-  name         = "my-workspace-name"
-  organization = tfe_organization.test.name
-}
-
-resource "tfe_variable_set" "test" {
-  name         = "Test Varset"
-  description  = "Some description."
-  organization = tfe_organization.test.name
+resource "tfe_variable_set" "example" {
+  name         = "my-variable-set"
+  description  = "Example fixture variable set."
+  organization = tfe_organization.example.name
 }
 
 resource "tfe_workspace_variable_set" "test" {
-  variable_set_id = tfe_variable_set.test.id
-  workspace_id    = tfe_workspace.test.id
+  variable_set_id = tfe_variable_set.example.id
+  workspace_id    = tfe_workspace.example.id
 }
 ```
 


### PR DESCRIPTION
## Description

Two major behaviours are wrapped in this PR:

1. Reduce boilerplate in examples by expecting "standard" intuitive components are somewhat well known to a user. In this, validation now also expects those intuitive components. This is in the first commit.

2. Increase tight consistency by (by default) including examples as CI tests. This requires some management, but guarantees that (most) examples actually align with provider behaviour. This is in the third commit.

As a minor QOL improvement, the second commit also includes the docgen validation sequence as a make target.

## Testing plan

1.  For docgen validation components, merely run the validation tools.
1.  Inspect new documentation and review its reasonability and completeness.
1.  Run newly added acceptance tests and determine that they pass reasonably.
1.  Make modifications to examples or to source and note the tests fail reasonably.

## Output from acceptance tests

Many tests expectedly fail locally due to a lack of various features useful. 

```
$ TF_ACC=1 go test ./internal/provider/... --run="TestAccTFEExamples" -v

=== RUN   TestAccTFEExamples
2026/08/13 13:57:57 [DEBUG] Configuring client for host "app.staging.terraform.io"
2026/08/13 13:57:57 [DEBUG] Service discovery for app.staging.terraform.io at https://app.staging.terraform.io/.well-known/terraform.json
=== RUN   TestAccTFEExamples/tfe_admin_organization_settings/resource.tf
    examples_acc_test.go:305: auto-skipped: declares explicit provider block (admin token alias not available in test harness)
=== RUN   TestAccTFEExamples/tfe_admin_smtp_settings/resource.tf
    examples_acc_test.go:305: auto-skipped: declares explicit provider block (admin token alias not available in test harness)
=== RUN   TestAccTFEExamples/tfe_admin_smtp_settings/resource_with_authentication_using_plain_password.tf
    examples_acc_test.go:305: auto-skipped: declares explicit provider block (admin token alias not available in test harness)
=== RUN   TestAccTFEExamples/tfe_admin_smtp_settings/resource_with_write_only_password.tf
    examples_acc_test.go:305: auto-skipped: declares explicit provider block (admin token alias not available in test harness)
=== RUN   TestAccTFEExamples/tfe_agent_pool/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_agent_pool_allowed_projects/resource.tf
    examples_acc_test.go:305: auto-skipped: uses agent pool resources unavailable in CI
=== RUN   TestAccTFEExamples/tfe_agent_pool_allowed_workspaces/resource.tf
    examples_acc_test.go:305: auto-skipped: uses agent pool resources unavailable in CI
=== RUN   TestAccTFEExamples/tfe_agent_pool_excluded_workspaces/resource.tf
    examples_acc_test.go:305: auto-skipped: uses agent pool resources unavailable in CI
=== RUN   TestAccTFEExamples/tfe_agent_token/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_audit_trail_token/resource.tf
    examples_acc_test.go:321: Step 1/1 error: Error running apply: exit status 1
        
        Error: Unable to create organization audit trail token
        
          with tfe_audit_trail_token.test,
          on terraform_plugin_test.tf line 41, in resource "tfe_audit_trail_token" "test":
          41: resource "tfe_audit_trail_token" "test" {
        
        Post
        "https://app.staging.terraform.io/api/v2/organizations/tst-ex-9025664534637527784/authentication-token?token=audit-trails":
        404 Not Found
=== RUN   TestAccTFEExamples/tfe_audit_trail_token/resource_token_with_expiry.tf
    examples_acc_test.go:305: auto-skipped: requires external time provider
=== RUN   TestAccTFEExamples/tfe_aws_oidc_configuration/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_azure_oidc_configuration/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_data_retention_policy/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_data_retention_policy/resource_creating_a_data_retention_policy_for_an_organization.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_data_retention_policy/resource_creating_a_data_retention_policy_for_an_organization_and_exclude_a_single_workspace_from_it.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_gcp_oidc_configuration/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_hyok_configuration/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_no_code_module/resource.tf
=== RUN   TestAccTFEExamples/tfe_no_code_module/resource_creating_a_no_code_module_with_variable_options.tf
    examples_acc_test.go:305: auto-skipped: uses version_pin which requires a published module version
=== RUN   TestAccTFEExamples/tfe_notification_configuration/resource.tf
    examples_acc_test.go:305: auto-skipped: uses notification configuration resources not currently supported in CI
=== RUN   TestAccTFEExamples/tfe_notification_configuration/resource_b_with_destination_type_of_email.tf
    examples_acc_test.go:305: auto-skipped: references tfe_organization_membership.*.user_id (empty until invite accepted)
=== RUN   TestAccTFEExamples/tfe_notification_configuration/resource_c_tfe_only_with_destination_type_of_email_using_email_addresses_list_and_email_users.tf
    examples_acc_test.go:305: auto-skipped: references tfe_organization_membership.*.user_id (empty until invite accepted)
=== RUN   TestAccTFEExamples/tfe_notification_configuration/resource_d_with_write_only_token_and_url_auto_managed_recommended.tf
    examples_acc_test.go:305: auto-skipped: uses notification configuration resources not currently supported in CI
=== RUN   TestAccTFEExamples/tfe_oauth_client/resource.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_oauth_client/resource_azure_devops_server_usage.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_oauth_client/resource_bitbucket_data_center_usage.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_opa_version/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_org_max_token_ttl_policy/resource.tf
=== RUN   TestAccTFEExamples/tfe_organization/resource.tf
=== RUN   TestAccTFEExamples/tfe_organization_default_settings/resource.tf
=== RUN   TestAccTFEExamples/tfe_organization_membership/resource.tf
=== RUN   TestAccTFEExamples/tfe_organization_module_sharing/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_organization_run_task/resource.tf
    examples_acc_test.go:305: auto-skipped: uses https://external.service.com and RUN_TASKS_URL is not set
=== RUN   TestAccTFEExamples/tfe_organization_run_task/resource_with_write_only_hmac_key.tf
    examples_acc_test.go:305: auto-skipped: requires a valid HMAC key value not available in CI
=== RUN   TestAccTFEExamples/tfe_organization_run_task_global_settings/resource.tf
    examples_acc_test.go:305: auto-skipped: uses https://external.service.com and RUN_TASKS_URL is not set
=== RUN   TestAccTFEExamples/tfe_organization_token/resource.tf
=== RUN   TestAccTFEExamples/tfe_organization_token/resource_basic_usage.tf
    examples_acc_test.go:305: auto-skipped: requires external time provider
=== RUN   TestAccTFEExamples/tfe_policy/resource.tf
=== RUN   TestAccTFEExamples/tfe_policy/resource_basic_usage_for_open_policy_agentopa.tf
=== RUN   TestAccTFEExamples/tfe_policy_set/resource.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_policy_set/resource_manually_uploaded_policy_set_in_lieu_of_vcs.tf
    examples_acc_test.go:305: auto-skipped: uses data.tfe_slug with a local path not present in CI
=== RUN   TestAccTFEExamples/tfe_policy_set/resource_using_manually_specified_policies.tf
=== RUN   TestAccTFEExamples/tfe_policy_set_parameter/resource.tf
=== RUN   TestAccTFEExamples/tfe_policy_set_parameter/resource_usage_for_the_write_only_value.tf
=== RUN   TestAccTFEExamples/tfe_project/resource.tf
=== RUN   TestAccTFEExamples/tfe_project/resource_with_tags.tf
=== RUN   TestAccTFEExamples/tfe_project_notification_configuration/resource.tf
    examples_acc_test.go:305: auto-skipped: uses notification configuration resources not currently supported in CI
=== RUN   TestAccTFEExamples/tfe_project_notification_configuration/resource_b_with_destination_type_of_email.tf
    examples_acc_test.go:305: auto-skipped: references tfe_organization_membership.*.user_id (empty until invite accepted)
=== RUN   TestAccTFEExamples/tfe_project_notification_configuration/resource_c_tfe_only_with_destination_type_of_email_using_email_addresses_list.tf
    examples_acc_test.go:305: auto-skipped: references tfe_organization_membership.*.user_id (empty until invite accepted)
=== RUN   TestAccTFEExamples/tfe_project_oauth_client/resource.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_project_policy_set/resource.tf
=== RUN   TestAccTFEExamples/tfe_project_policy_set_exclusion/resource.tf
=== RUN   TestAccTFEExamples/tfe_project_settings/resource.tf
=== RUN   TestAccTFEExamples/tfe_project_variable_set/resource.tf
=== RUN   TestAccTFEExamples/tfe_provider_set/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_provider_set/resource_write_only_configuration.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_registry_gpg_key/resource.tf
    examples_acc_test.go:305: auto-skipped: uses file() with a path not present in CI
=== RUN   TestAccTFEExamples/tfe_registry_module/resource.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_registry_module/resource_b_create_private_registry_module_with_tests_enabled.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_registry_module/resource_c_create_private_registry_module_with_agent_pool_beta.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_registry_module/resource_d_create_private_registry_module_with_github_app.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_github_app_installation (GitHub App installation unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_registry_module/resource_e_create_private_registry_module_from_a_monorepo_with_source_directory_beta.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_registry_module/resource_f_create_private_registry_module_without_vcs.tf
=== RUN   TestAccTFEExamples/tfe_registry_module/resource_g_create_public_registry_module.tf
=== RUN   TestAccTFEExamples/tfe_registry_module/resource_h_create_no_code_provisioning_registry_module.tf
    examples_acc_test.go:321: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating no-code module for registry module mod-doJamZ8wXuVx8GYd: unprocessable content
        
        Validation failed: Provided version pin is not equal to latest or provided string does not represent an existing version of the module.
        
          with tfe_no_code_module.foobar,
          on terraform_plugin_test.tf line 51, in resource "tfe_no_code_module" "foobar":
          51: resource "tfe_no_code_module" "foobar" {
        
=== RUN   TestAccTFEExamples/tfe_registry_provider/resource.tf
=== RUN   TestAccTFEExamples/tfe_registry_provider/resource_create_public_provider.tf
=== RUN   TestAccTFEExamples/tfe_run_trigger/resource.tf
=== RUN   TestAccTFEExamples/tfe_saml_settings/resource.tf
    examples_acc_test.go:305: auto-skipped: declares explicit provider block (admin token alias not available in test harness)
=== RUN   TestAccTFEExamples/tfe_saml_settings/resource_with_write_only_private_key.tf
    examples_acc_test.go:305: auto-skipped: declares explicit provider block (admin token alias not available in test harness)
=== RUN   TestAccTFEExamples/tfe_scim_group_mapping/resource.tf
    examples_acc_test.go:305: auto-skipped: declares explicit provider block (admin token alias not available in test harness)
=== RUN   TestAccTFEExamples/tfe_scim_group_mapping/resource_you_can_pause_provisioning_for_a_single_mapping_without_removing_it.tf
    examples_acc_test.go:305: auto-skipped: creates tfe_saml_settings (requires enterprise SAML IdP)
=== RUN   TestAccTFEExamples/tfe_scim_settings/resource.tf
    examples_acc_test.go:305: auto-skipped: creates tfe_saml_settings (requires enterprise SAML IdP)
=== RUN   TestAccTFEExamples/tfe_scim_settings/resource_link_scim_apply_1.tf
    examples_acc_test.go:305: auto-skipped: creates tfe_saml_settings (requires enterprise SAML IdP)
=== RUN   TestAccTFEExamples/tfe_scim_settings/resource_link_scim_apply_2.tf
    examples_acc_test.go:305: auto-skipped: creates tfe_saml_settings (requires enterprise SAML IdP)
=== RUN   TestAccTFEExamples/tfe_scim_settings/resource_pause_scim_provisioning_without_disabling_it.tf
    examples_acc_test.go:305: auto-skipped: creates tfe_saml_settings (requires enterprise SAML IdP)
=== RUN   TestAccTFEExamples/tfe_scim_token/resource.tf
    examples_acc_test.go:305: auto-skipped: declares explicit provider block (admin token alias not available in test harness)
=== RUN   TestAccTFEExamples/tfe_scim_token/resource_with_an_explicit_expiration.tf
    examples_acc_test.go:305: auto-skipped: requires external time provider
=== RUN   TestAccTFEExamples/tfe_sentinel_policy/resource.tf
=== RUN   TestAccTFEExamples/tfe_sentinel_version/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_ssh_key/resource.tf
=== RUN   TestAccTFEExamples/tfe_ssh_key/resource_with_write_only_key.tf
=== RUN   TestAccTFEExamples/tfe_stack/resource.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_stack/resource_create_a_stack_without_a_vcs_repository.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_stack_variable_set/resource.tf
    examples_acc_test.go:305: auto-skipped: references tfe_stack (requires ENABLE_BETA)
=== RUN   TestAccTFEExamples/tfe_tag_policy_set/resource.tf
    examples_acc_test.go:305: auto-skipped: uses tag policy set resources that require tag lookup behavior unavailable in CI
=== RUN   TestAccTFEExamples/tfe_tag_policy_set/resource_key_only_tag_no_value.tf
    examples_acc_test.go:305: auto-skipped: uses tag policy set resources that require tag lookup behavior unavailable in CI
=== RUN   TestAccTFEExamples/tfe_tag_policy_set_exclusion/resource.tf
    examples_acc_test.go:305: auto-skipped: uses tag policy set resources that require tag lookup behavior unavailable in CI
=== RUN   TestAccTFEExamples/tfe_team/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_team/resource_organization_permission_usage.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_team_access/resource.tf
    examples_acc_test.go:321: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating team access-team for organization tst-ex-1874389303939468146: missing entitlements to create teams
        
          with tfe_team.test,
          on terraform_plugin_test.tf line 41, in resource "tfe_team" "test":
          41: resource "tfe_team" "test" {
        
=== RUN   TestAccTFEExamples/tfe_team_member/resource.tf
    examples_acc_test.go:305: auto-skipped: references hardcoded usernames not present in CI test org
=== RUN   TestAccTFEExamples/tfe_team_members/resource.tf
    examples_acc_test.go:305: auto-skipped: references hardcoded usernames not present in CI test org
=== RUN   TestAccTFEExamples/tfe_team_members/resource_with_a_set_of_usernames.tf
    examples_acc_test.go:305: auto-skipped: references hardcoded usernames not present in CI test org
=== RUN   TestAccTFEExamples/tfe_team_notification_configuration/resource.tf
    examples_acc_test.go:305: auto-skipped: uses notification configuration resources not currently supported in CI
=== RUN   TestAccTFEExamples/tfe_team_notification_configuration/resource_tfe_only_with_destination_type_of_email_using_email_addresses_list_and_email_users.tf
    examples_acc_test.go:305: auto-skipped: references tfe_organization_membership.*.user_id (empty until invite accepted)
=== RUN   TestAccTFEExamples/tfe_team_notification_configuration/resource_with_destination_type_of_email.tf
    examples_acc_test.go:305: auto-skipped: references tfe_organization_membership.*.user_id (empty until invite accepted)
=== RUN   TestAccTFEExamples/tfe_team_notification_configuration/resource_with_destination_type_of_generic_using_write_only_token.tf
    examples_acc_test.go:305: auto-skipped: uses notification configuration resources not currently supported in CI
=== RUN   TestAccTFEExamples/tfe_team_organization_member/resource.tf
    examples_acc_test.go:321: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating team tst-ex-team-8438886751159893932 for organization tst-ex-8438886751159893932: missing entitlements to create teams
        
          with tfe_team.test,
          on terraform_plugin_test.tf line 41, in resource "tfe_team" "test":
          41: resource "tfe_team" "test" {
        
=== RUN   TestAccTFEExamples/tfe_team_organization_members/resource.tf
    examples_acc_test.go:321: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating team tst-ex-team-3407533267958798774 for organization tst-ex-3407533267958798774: missing entitlements to create teams
        
          with tfe_team.test,
          on terraform_plugin_test.tf line 41, in resource "tfe_team" "test":
          41: resource "tfe_team" "test" {
        
=== RUN   TestAccTFEExamples/tfe_team_organization_members/resource_with_a_set_of_organization_members.tf
    examples_acc_test.go:305: auto-skipped: uses for_each with indexed resource references unsupported by the test harness
=== RUN   TestAccTFEExamples/tfe_team_project_access/resource.tf
    examples_acc_test.go:321: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating team tst-ex-admin-team-5446102180854902122 for organization tst-ex-5446102180854902122: missing entitlements to create teams
        
          with tfe_team.admin,
          on terraform_plugin_test.tf line 41, in resource "tfe_team" "admin":
          41: resource "tfe_team" "admin" {
        
=== RUN   TestAccTFEExamples/tfe_team_project_access/resource_custom_project_permissions.tf
    examples_acc_test.go:321: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating team my-dev-team for organization tst-ex-2095587771131947993: missing entitlements to create teams
        
          with tfe_team.dev,
          on terraform_plugin_test.tf line 41, in resource "tfe_team" "dev":
          41: resource "tfe_team" "dev" {
        
=== RUN   TestAccTFEExamples/tfe_team_token/resource.tf
    examples_acc_test.go:321: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error creating team tst-ex-team-6278390801864647321 for organization tst-ex-6278390801864647321: missing entitlements to create teams
        
          with tfe_team.test,
          on terraform_plugin_test.tf line 41, in resource "tfe_team" "test":
          41: resource "tfe_team" "test" {
        
=== RUN   TestAccTFEExamples/tfe_team_token/resource_basic_usage.tf
    examples_acc_test.go:305: auto-skipped: requires external time provider
=== RUN   TestAccTFEExamples/tfe_terraform_version/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_test_variable/resource.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_test_variable/resource_usage_of_the_writeonly_value_for_tfe_test_variable.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_variable/resource.tf
=== RUN   TestAccTFEExamples/tfe_variable/resource_basic_usage_for_the_write_only_value_of_tfe_variable.tf
=== RUN   TestAccTFEExamples/tfe_variable/resource_basic_usage_for_variable_sets.tf
=== RUN   TestAccTFEExamples/tfe_variable/resource_using_readable_value.tf
=== RUN   TestAccTFEExamples/tfe_variable_set/resource.tf
    examples_acc_test.go:305: auto-skipped: references tfe_stack (requires ENABLE_BETA)
=== RUN   TestAccTFEExamples/tfe_variable_set/resource_create_a_priority_variable_set.tf
=== RUN   TestAccTFEExamples/tfe_variable_set/resource_creating_a_global_variable_set.tf
=== RUN   TestAccTFEExamples/tfe_variable_set/resource_creating_a_project_owned_variable_set_that_is_applied_to_all_workspaces_in_the_project.tf
=== RUN   TestAccTFEExamples/tfe_variable_set/resource_creating_a_project_owned_variable_set_that_is_applied_to_specific_workspaces.tf
=== RUN   TestAccTFEExamples/tfe_vault_oidc_configuration/resource.tf
    examples_acc_test.go:272: directory exempted in error_exceptions.json under examples_as_ci_exempt_directories
=== RUN   TestAccTFEExamples/tfe_workspace/resource.tf
=== RUN   TestAccTFEExamples/tfe_workspace/resource_usage_with_vcs_repo.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_workspace_policy_set/resource.tf
=== RUN   TestAccTFEExamples/tfe_workspace_policy_set_exclusion/resource.tf
=== RUN   TestAccTFEExamples/tfe_workspace_run/resource.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_workspace_run/resource_with_manual_confirmation.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_workspace_run/resource_with_no_retries.tf
    examples_acc_test.go:305: auto-skipped: requires tfe_oauth_client (VCS token unavailable in CI)
=== RUN   TestAccTFEExamples/tfe_workspace_run_task/resource.tf
    examples_acc_test.go:305: auto-skipped: uses https://external.service.com and RUN_TASKS_URL is not set
=== RUN   TestAccTFEExamples/tfe_workspace_settings/resource.tf
=== RUN   TestAccTFEExamples/tfe_workspace_settings/resource_this_resource_can_be_used_to_self_manage_a_workspace_created_from_terraform_init_and_a_cloud_block.tf
    examples_acc_test.go:305: auto-skipped: contains terraform{} backend block, invalid in test context
=== RUN   TestAccTFEExamples/tfe_workspace_settings/resource_this_resource_may_be_used_as_a_data_source_when_no_optional_arguments_are_defined.tf
    examples_acc_test.go:305: auto-skipped: uses data.tfe_workspace lookup without guaranteed backing workspace in CI
=== RUN   TestAccTFEExamples/tfe_workspace_settings/resource_using_remote_state_consumer_ids.tf
    examples_acc_test.go:305: auto-skipped: uses for_each with indexed resource references unsupported by the test harness
=== RUN   TestAccTFEExamples/tfe_workspace_settings/resource_with_execution_mode_of_agent.tf
    examples_acc_test.go:305: auto-skipped: uses agent pool resources unavailable in CI
=== RUN   TestAccTFEExamples/tfe_workspace_variable_set/resource.tf
--- FAIL: TestAccTFEExamples (185.64s)
    --- SKIP: TestAccTFEExamples/tfe_admin_organization_settings/resource.tf (0.58s)
    --- SKIP: TestAccTFEExamples/tfe_admin_smtp_settings/resource.tf (0.76s)
    --- SKIP: TestAccTFEExamples/tfe_admin_smtp_settings/resource_with_authentication_using_plain_password.tf (0.54s)
    --- SKIP: TestAccTFEExamples/tfe_admin_smtp_settings/resource_with_write_only_password.tf (0.55s)
    --- SKIP: TestAccTFEExamples/tfe_agent_pool/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_agent_pool_allowed_projects/resource.tf (0.58s)
    --- SKIP: TestAccTFEExamples/tfe_agent_pool_allowed_workspaces/resource.tf (0.62s)
    --- SKIP: TestAccTFEExamples/tfe_agent_pool_excluded_workspaces/resource.tf (0.56s)
    --- SKIP: TestAccTFEExamples/tfe_agent_token/resource.tf (0.00s)
    --- FAIL: TestAccTFEExamples/tfe_audit_trail_token/resource.tf (2.19s)
    --- SKIP: TestAccTFEExamples/tfe_audit_trail_token/resource_token_with_expiry.tf (0.53s)
    --- SKIP: TestAccTFEExamples/tfe_aws_oidc_configuration/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_azure_oidc_configuration/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_data_retention_policy/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_data_retention_policy/resource_creating_a_data_retention_policy_for_an_organization.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_data_retention_policy/resource_creating_a_data_retention_policy_for_an_organization_and_exclude_a_single_workspace_from_it.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_gcp_oidc_configuration/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_hyok_configuration/resource.tf (0.00s)
    --- PASS: TestAccTFEExamples/tfe_no_code_module/resource.tf (3.43s)
    --- SKIP: TestAccTFEExamples/tfe_no_code_module/resource_creating_a_no_code_module_with_variable_options.tf (0.39s)
    --- SKIP: TestAccTFEExamples/tfe_notification_configuration/resource.tf (0.46s)
    --- SKIP: TestAccTFEExamples/tfe_notification_configuration/resource_b_with_destination_type_of_email.tf (0.44s)
    --- SKIP: TestAccTFEExamples/tfe_notification_configuration/resource_c_tfe_only_with_destination_type_of_email_using_email_addresses_list_and_email_users.tf (0.56s)
    --- SKIP: TestAccTFEExamples/tfe_notification_configuration/resource_d_with_write_only_token_and_url_auto_managed_recommended.tf (0.78s)
    --- SKIP: TestAccTFEExamples/tfe_oauth_client/resource.tf (0.69s)
    --- SKIP: TestAccTFEExamples/tfe_oauth_client/resource_azure_devops_server_usage.tf (0.68s)
    --- SKIP: TestAccTFEExamples/tfe_oauth_client/resource_bitbucket_data_center_usage.tf (0.54s)
    --- SKIP: TestAccTFEExamples/tfe_opa_version/resource.tf (0.00s)
    --- PASS: TestAccTFEExamples/tfe_org_max_token_ttl_policy/resource.tf (3.03s)
    --- PASS: TestAccTFEExamples/tfe_organization/resource.tf (3.10s)
    --- PASS: TestAccTFEExamples/tfe_organization_default_settings/resource.tf (4.38s)
    --- PASS: TestAccTFEExamples/tfe_organization_membership/resource.tf (3.90s)
    --- SKIP: TestAccTFEExamples/tfe_organization_module_sharing/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_organization_run_task/resource.tf (0.75s)
    --- SKIP: TestAccTFEExamples/tfe_organization_run_task/resource_with_write_only_hmac_key.tf (0.48s)
    --- SKIP: TestAccTFEExamples/tfe_organization_run_task_global_settings/resource.tf (0.66s)
    --- PASS: TestAccTFEExamples/tfe_organization_token/resource.tf (2.92s)
    --- SKIP: TestAccTFEExamples/tfe_organization_token/resource_basic_usage.tf (0.52s)
    --- PASS: TestAccTFEExamples/tfe_policy/resource.tf (3.56s)
    --- PASS: TestAccTFEExamples/tfe_policy/resource_basic_usage_for_open_policy_agentopa.tf (3.31s)
    --- SKIP: TestAccTFEExamples/tfe_policy_set/resource.tf (0.56s)
    --- SKIP: TestAccTFEExamples/tfe_policy_set/resource_manually_uploaded_policy_set_in_lieu_of_vcs.tf (0.54s)
    --- PASS: TestAccTFEExamples/tfe_policy_set/resource_using_manually_specified_policies.tf (4.30s)
    --- PASS: TestAccTFEExamples/tfe_policy_set_parameter/resource.tf (3.36s)
    --- PASS: TestAccTFEExamples/tfe_policy_set_parameter/resource_usage_for_the_write_only_value.tf (3.44s)
    --- PASS: TestAccTFEExamples/tfe_project/resource.tf (3.09s)
    --- PASS: TestAccTFEExamples/tfe_project/resource_with_tags.tf (3.07s)
    --- SKIP: TestAccTFEExamples/tfe_project_notification_configuration/resource.tf (0.49s)
    --- SKIP: TestAccTFEExamples/tfe_project_notification_configuration/resource_b_with_destination_type_of_email.tf (0.54s)
    --- SKIP: TestAccTFEExamples/tfe_project_notification_configuration/resource_c_tfe_only_with_destination_type_of_email_using_email_addresses_list.tf (0.50s)
    --- SKIP: TestAccTFEExamples/tfe_project_oauth_client/resource.tf (0.63s)
    --- PASS: TestAccTFEExamples/tfe_project_policy_set/resource.tf (3.80s)
    --- PASS: TestAccTFEExamples/tfe_project_policy_set_exclusion/resource.tf (3.43s)
    --- PASS: TestAccTFEExamples/tfe_project_settings/resource.tf (3.84s)
    --- PASS: TestAccTFEExamples/tfe_project_variable_set/resource.tf (3.22s)
    --- SKIP: TestAccTFEExamples/tfe_provider_set/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_provider_set/resource_write_only_configuration.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_registry_gpg_key/resource.tf (0.47s)
    --- SKIP: TestAccTFEExamples/tfe_registry_module/resource.tf (0.46s)
    --- SKIP: TestAccTFEExamples/tfe_registry_module/resource_b_create_private_registry_module_with_tests_enabled.tf (0.46s)
    --- SKIP: TestAccTFEExamples/tfe_registry_module/resource_c_create_private_registry_module_with_agent_pool_beta.tf (0.58s)
    --- SKIP: TestAccTFEExamples/tfe_registry_module/resource_d_create_private_registry_module_with_github_app.tf (0.46s)
    --- SKIP: TestAccTFEExamples/tfe_registry_module/resource_e_create_private_registry_module_from_a_monorepo_with_source_directory_beta.tf (0.60s)
    --- PASS: TestAccTFEExamples/tfe_registry_module/resource_f_create_private_registry_module_without_vcs.tf (3.09s)
    --- PASS: TestAccTFEExamples/tfe_registry_module/resource_g_create_public_registry_module.tf (2.86s)
    --- FAIL: TestAccTFEExamples/tfe_registry_module/resource_h_create_no_code_provisioning_registry_module.tf (3.92s)
    --- PASS: TestAccTFEExamples/tfe_registry_provider/resource.tf (3.04s)
    --- PASS: TestAccTFEExamples/tfe_registry_provider/resource_create_public_provider.tf (3.32s)
    --- PASS: TestAccTFEExamples/tfe_run_trigger/resource.tf (3.38s)
    --- SKIP: TestAccTFEExamples/tfe_saml_settings/resource.tf (0.50s)
    --- SKIP: TestAccTFEExamples/tfe_saml_settings/resource_with_write_only_private_key.tf (0.49s)
    --- SKIP: TestAccTFEExamples/tfe_scim_group_mapping/resource.tf (0.46s)
    --- SKIP: TestAccTFEExamples/tfe_scim_group_mapping/resource_you_can_pause_provisioning_for_a_single_mapping_without_removing_it.tf (0.65s)
    --- SKIP: TestAccTFEExamples/tfe_scim_settings/resource.tf (0.52s)
    --- SKIP: TestAccTFEExamples/tfe_scim_settings/resource_link_scim_apply_1.tf (0.46s)
    --- SKIP: TestAccTFEExamples/tfe_scim_settings/resource_link_scim_apply_2.tf (0.51s)
    --- SKIP: TestAccTFEExamples/tfe_scim_settings/resource_pause_scim_provisioning_without_disabling_it.tf (0.48s)
    --- SKIP: TestAccTFEExamples/tfe_scim_token/resource.tf (0.44s)
    --- SKIP: TestAccTFEExamples/tfe_scim_token/resource_with_an_explicit_expiration.tf (0.51s)
    --- PASS: TestAccTFEExamples/tfe_sentinel_policy/resource.tf (3.20s)
    --- SKIP: TestAccTFEExamples/tfe_sentinel_version/resource.tf (0.00s)
    --- PASS: TestAccTFEExamples/tfe_ssh_key/resource.tf (2.84s)
    --- PASS: TestAccTFEExamples/tfe_ssh_key/resource_with_write_only_key.tf (3.01s)
    --- SKIP: TestAccTFEExamples/tfe_stack/resource.tf (0.43s)
    --- SKIP: TestAccTFEExamples/tfe_stack/resource_create_a_stack_without_a_vcs_repository.tf (0.65s)
    --- SKIP: TestAccTFEExamples/tfe_stack_variable_set/resource.tf (0.60s)
    --- SKIP: TestAccTFEExamples/tfe_tag_policy_set/resource.tf (0.39s)
    --- SKIP: TestAccTFEExamples/tfe_tag_policy_set/resource_key_only_tag_no_value.tf (0.45s)
    --- SKIP: TestAccTFEExamples/tfe_tag_policy_set_exclusion/resource.tf (0.45s)
    --- SKIP: TestAccTFEExamples/tfe_team/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_team/resource_organization_permission_usage.tf (0.00s)
    --- FAIL: TestAccTFEExamples/tfe_team_access/resource.tf (1.99s)
    --- SKIP: TestAccTFEExamples/tfe_team_member/resource.tf (0.71s)
    --- SKIP: TestAccTFEExamples/tfe_team_members/resource.tf (0.38s)
    --- SKIP: TestAccTFEExamples/tfe_team_members/resource_with_a_set_of_usernames.tf (0.40s)
    --- SKIP: TestAccTFEExamples/tfe_team_notification_configuration/resource.tf (0.69s)
    --- SKIP: TestAccTFEExamples/tfe_team_notification_configuration/resource_tfe_only_with_destination_type_of_email_using_email_addresses_list_and_email_users.tf (0.65s)
    --- SKIP: TestAccTFEExamples/tfe_team_notification_configuration/resource_with_destination_type_of_email.tf (0.62s)
    --- SKIP: TestAccTFEExamples/tfe_team_notification_configuration/resource_with_destination_type_of_generic_using_write_only_token.tf (0.70s)
    --- FAIL: TestAccTFEExamples/tfe_team_organization_member/resource.tf (3.01s)
    --- FAIL: TestAccTFEExamples/tfe_team_organization_members/resource.tf (3.29s)
    --- SKIP: TestAccTFEExamples/tfe_team_organization_members/resource_with_a_set_of_organization_members.tf (0.74s)
    --- FAIL: TestAccTFEExamples/tfe_team_project_access/resource.tf (2.28s)
    --- FAIL: TestAccTFEExamples/tfe_team_project_access/resource_custom_project_permissions.tf (2.00s)
    --- FAIL: TestAccTFEExamples/tfe_team_token/resource.tf (2.11s)
    --- SKIP: TestAccTFEExamples/tfe_team_token/resource_basic_usage.tf (0.45s)
    --- SKIP: TestAccTFEExamples/tfe_terraform_version/resource.tf (0.00s)
    --- SKIP: TestAccTFEExamples/tfe_test_variable/resource.tf (0.46s)
    --- SKIP: TestAccTFEExamples/tfe_test_variable/resource_usage_of_the_writeonly_value_for_tfe_test_variable.tf (0.41s)
    --- PASS: TestAccTFEExamples/tfe_variable/resource.tf (3.22s)
    --- PASS: TestAccTFEExamples/tfe_variable/resource_basic_usage_for_the_write_only_value_of_tfe_variable.tf (3.25s)
    --- PASS: TestAccTFEExamples/tfe_variable/resource_basic_usage_for_variable_sets.tf (3.19s)
    --- PASS: TestAccTFEExamples/tfe_variable/resource_using_readable_value.tf (3.58s)
    --- SKIP: TestAccTFEExamples/tfe_variable_set/resource.tf (0.53s)
    --- PASS: TestAccTFEExamples/tfe_variable_set/resource_create_a_priority_variable_set.tf (2.96s)
    --- PASS: TestAccTFEExamples/tfe_variable_set/resource_creating_a_global_variable_set.tf (3.19s)
    --- PASS: TestAccTFEExamples/tfe_variable_set/resource_creating_a_project_owned_variable_set_that_is_applied_to_all_workspaces_in_the_project.tf (3.58s)
    --- PASS: TestAccTFEExamples/tfe_variable_set/resource_creating_a_project_owned_variable_set_that_is_applied_to_specific_workspaces.tf (3.60s)
    --- SKIP: TestAccTFEExamples/tfe_vault_oidc_configuration/resource.tf (0.00s)
    --- PASS: TestAccTFEExamples/tfe_workspace/resource.tf (2.93s)
    --- SKIP: TestAccTFEExamples/tfe_workspace/resource_usage_with_vcs_repo.tf (0.44s)
    --- PASS: TestAccTFEExamples/tfe_workspace_policy_set/resource.tf (3.44s)
    --- PASS: TestAccTFEExamples/tfe_workspace_policy_set_exclusion/resource.tf (3.30s)
    --- SKIP: TestAccTFEExamples/tfe_workspace_run/resource.tf (0.54s)
    --- SKIP: TestAccTFEExamples/tfe_workspace_run/resource_with_manual_confirmation.tf (0.48s)
    --- SKIP: TestAccTFEExamples/tfe_workspace_run/resource_with_no_retries.tf (0.45s)
    --- SKIP: TestAccTFEExamples/tfe_workspace_run_task/resource.tf (0.47s)
    --- PASS: TestAccTFEExamples/tfe_workspace_settings/resource.tf (4.20s)
    --- SKIP: TestAccTFEExamples/tfe_workspace_settings/resource_this_resource_can_be_used_to_self_manage_a_workspace_created_from_terraform_init_and_a_cloud_block.tf (0.43s)
    --- SKIP: TestAccTFEExamples/tfe_workspace_settings/resource_this_resource_may_be_used_as_a_data_source_when_no_optional_arguments_are_defined.tf (0.43s)
    --- SKIP: TestAccTFEExamples/tfe_workspace_settings/resource_using_remote_state_consumer_ids.tf (0.41s)
    --- SKIP: TestAccTFEExamples/tfe_workspace_settings/resource_with_execution_mode_of_agent.tf (0.41s)
    --- PASS: TestAccTFEExamples/tfe_workspace_variable_set/resource.tf (3.33s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-tfe/internal/provider	186.510s
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/helpers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/planmodifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-tfe/internal/provider/validators	[no test files]
FAIL

```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

Rollback is sufficient.

## Changes to Security Controls

N/A
