### PR TITLE
fix: keep listing tfe_projects after a full 100-item page

### DIFF
--- a/internal/provider/client_v2_helpers.go
+++ b/internal/provider/client_v2_helpers.go
@@ -64,6 +64,20 @@ func nextPageNumber(p models.Paginationable) *int32 {
 	return p.GetNextPage()
 }
 
+// advanceListPage returns the next page to request. Prefer the API's
+// next-page pointer. When that pointer is missing — the projects list
+// types `meta` as Paginationable while HCP Terraform nests pagination
+// under `meta.pagination` — keep walking while the current page was full.
+func advanceListPage(current, pageSize int32, itemCount int, next *int32) (int32, bool) {
+	if next != nil {
+		return *next, true
+	}
+	if int32(itemCount) >= pageSize {
+		return current + 1, true
+	}
+	return current, false
+}
+
 // paginationMetaGetter is satisfied by every go-tfe v2 generated list
 // response's `meta` type (e.g. ItemSshKeysGetResponse_meta,
 // ItemTeamsGetResponse_meta): each is a distinct generated type, but all of

--- a/internal/provider/client_v2_helpers_test.go
+++ b/internal/provider/client_v2_helpers_test.go
@@ -1,0 +1,25 @@
+package provider
+
+import "testing"
+
+func TestAdvanceListPage(t *testing.T) {
+	two := int32(2)
+	t.Run("follows next-page when present", func(t *testing.T) {
+		got, more := advanceListPage(1, 100, 100, &two)
+		if !more || got != 2 {
+			t.Fatalf("got (%d, %v), want (2, true)", got, more)
+		}
+	})
+	t.Run("walks a full page when next-page is missing", func(t *testing.T) {
+		got, more := advanceListPage(1, 100, 100, nil)
+		if !more || got != 2 {
+			t.Fatalf("got (%d, %v), want (2, true)", got, more)
+		}
+	})
+	t.Run("stops on a short page when next-page is missing", func(t *testing.T) {
+		_, more := advanceListPage(2, 100, 5, nil)
+		if more {
+			t.Fatal("expected no further page")
+		}
+	})
+}

--- a/internal/provider/data_source_project.go
+++ b/internal/provider/data_source_project.go
@@ -247,11 +247,11 @@ func (d *dataSourceTFEProject) Read(ctx context.Context, req datasource.ReadRequ
 			return
 		}
 
-		nextPage := nextPageNumber(projectList.GetMeta())
-		if nextPage == nil {
+		next, more := advanceListPage(pageNumber, pageSize, len(projectList.GetData()), nextPageNumber(projectList.GetMeta()))
+		if !more {
 			break
 		}
-		pageNumber = *nextPage
+		pageNumber = next
 	}
 
 	resp.Diagnostics.AddError("Could not find project", fmt.Sprintf("Project %s/%s not found", organization, name))

--- a/internal/provider/data_source_projects.go
+++ b/internal/provider/data_source_projects.go
@@ -184,11 +184,11 @@ func (d *dataSourceTFEProjects) Read(ctx context.Context, req datasource.ReadReq
 			model.Projects = append(model.Projects, modelFromTFEProjectsProject(project))
 		}
 
-		nextPage := nextPageNumber(projectList.GetMeta())
-		if nextPage == nil {
+		next, more := advanceListPage(pageNumber, pageSize, len(projectList.GetData()), nextPageNumber(projectList.GetMeta()))
+		if !more {
 			break
 		}
-		pageNumber = *nextPage
+		pageNumber = next
 	}
 
 	// Save model into Terraform state


### PR DESCRIPTION
## Problem

`data.tfe_projects` returned only the first 100 projects. The list response types `meta` as `Paginationable`, but HCP Terraform nests pagination under `meta.pagination`, so `GetNextPage()` was always nil and the loop stopped after page 1.

Fixes #2196.

## Change

If `next-page` is missing, keep fetching while the current page was full (`advanceListPage`).

## Test

```
go test ./internal/provider -count=1 -run TestAdvanceListPage
# ok
```
