### PR TITLE
r/tfe_data_retention_policy: add per-artifact-type retention fields and deprecate days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ENHANCEMENTS:
+* `r/tfe_data_retention_policy`: Add per-artifact-type retention fields (`delete_state_versions`, `delete_configuration_versions`, `delete_run_data_and_logs`, `state_versions_delete_after_n_days`, `configuration_versions_delete_after_n_days`, `run_data_and_logs_delete_after_n_days`, `state_versions_keep_latest_count`, `configuration_versions_keep_latest_count`, `run_data_keep_latest_count`) to `delete_older_than`. The existing `days` field is deprecated for TFE v2.1.0+ in favor of the new per-artifact fields. Requires TFE v2.1.0+. By @JarrettSpiker [#xxxx](https://github.com/hashicorp/terraform-provider-tfe/pull/xxxx)
 * `r/tfe_policy_set`: Add `tfpolicy` as a valid value for the `kind` attribute. **NOTE:** This policy kind is currently in beta and not yet available to all users. By @subhro-acharjee-ibm [#2109](https://github.com/hashicorp/terraform-provider-tfe/pull/2109)
 * **New Resource List:** `tfe_provider_set` By @kierramarie [#2171](https://github.com/hashicorp/terraform-provider-tfe/pull/2171)
 * `r/tfe_hyok_configuration`: Added multi-region key support for AWS HYOK. By @helenjw [#2187](https://github.com/hashicorp/terraform-provider-tfe/pull/2187)

--- a/internal/provider/data_retention_policy.go
+++ b/internal/provider/data_retention_policy.go
@@ -85,6 +85,28 @@ func boolPtrToTypes(v *bool) types.Bool {
 	return types.BoolValue(*v)
 }
 
+// deleteFlagToTypes maps a server-returned delete flag to a types.Bool.
+// The server may backfill false for artifact types not explicitly configured.
+// We treat false and nil identically (both map to null) to avoid drift when
+// the user omits a delete flag from their config.
+func deleteFlagToTypes(v *bool) types.Bool {
+	if v == nil || !*v {
+		return types.BoolNull()
+	}
+	return types.BoolValue(true)
+}
+
+// mergeDeleteFlag returns the configured value if it was explicitly set by the user,
+// otherwise falls back to the server value (normalizing server false → null).
+// This allows explicit false in config to be preserved while preventing drift from
+// server-backfilled false on unset flags.
+func mergeDeleteFlag(configured types.Bool, serverVal *bool) types.Bool {
+	if !configured.IsNull() && !configured.IsUnknown() {
+		return configured
+	}
+	return deleteFlagToTypes(serverVal)
+}
+
 func typesBoolToPtr(b types.Bool) *bool {
 	if b.IsNull() || b.IsUnknown() {
 		return nil
@@ -158,9 +180,9 @@ func deleteOlderThanFromAPIResponse(ctx context.Context, organization types.Stri
 
 		if apiHasGranular {
 			// Server has granular fields — ignore coalesced days
-			deleteStateVersions = boolPtrToTypes(attrs.GetDeleteStateVersions())
-			deleteConfigurationVersions = boolPtrToTypes(attrs.GetDeleteConfigurationVersions())
-			deleteRunDataAndLogs = boolPtrToTypes(attrs.GetDeleteRunDataAndLogs())
+			deleteStateVersions = deleteFlagToTypes(attrs.GetDeleteStateVersions())
+			deleteConfigurationVersions = deleteFlagToTypes(attrs.GetDeleteConfigurationVersions())
+			deleteRunDataAndLogs = deleteFlagToTypes(attrs.GetDeleteRunDataAndLogs())
 			stateVersionsDeleteAfterNDays = int32PtrToNumber(attrs.GetStateVersionsDeleteAfterNDays())
 			configurationVersionsDeleteAfterNDays = int32PtrToNumber(attrs.GetConfigurationVersionsDeleteAfterNDays())
 			runDataAndLogsDeleteAfterNDays = int32PtrToNumber(attrs.GetRunDataAndLogsDeleteAfterNDays())
@@ -176,10 +198,13 @@ func deleteOlderThanFromAPIResponse(ctx context.Context, organization types.Stri
 		// Even if we are on TFE >= 2.1.0, ignote the server-backfilled granular fields, preserve original "days", to avoid drift
 		days = int32PtrToNumber(attrs.GetDeleteOlderThanNDays())
 	} else {
-		// User sent granular fields — use them, ignore coalesced "days" from the server
-		deleteStateVersions = boolPtrToTypes(attrs.GetDeleteStateVersions())
-		deleteConfigurationVersions = boolPtrToTypes(attrs.GetDeleteConfigurationVersions())
-		deleteRunDataAndLogs = boolPtrToTypes(attrs.GetDeleteRunDataAndLogs())
+		// User sent granular fields — use them, ignore coalesced "days" from the server.
+		// For delete flags: prefer the configured value (which may be explicit false) over
+		// the server value. The server may backfill false for flags the user omitted, which
+		// would cause drift since the plan has null for those flags.
+		deleteStateVersions = mergeDeleteFlag(configuredDot.DeleteStateVersions, attrs.GetDeleteStateVersions())
+		deleteConfigurationVersions = mergeDeleteFlag(configuredDot.DeleteConfigurationVersions, attrs.GetDeleteConfigurationVersions())
+		deleteRunDataAndLogs = mergeDeleteFlag(configuredDot.DeleteRunDataAndLogs, attrs.GetDeleteRunDataAndLogs())
 		stateVersionsDeleteAfterNDays = int32PtrToNumber(attrs.GetStateVersionsDeleteAfterNDays())
 		configurationVersionsDeleteAfterNDays = int32PtrToNumber(attrs.GetConfigurationVersionsDeleteAfterNDays())
 		runDataAndLogsDeleteAfterNDays = int32PtrToNumber(attrs.GetRunDataAndLogsDeleteAfterNDays())

--- a/internal/provider/data_retention_policy.go
+++ b/internal/provider/data_retention_policy.go
@@ -5,12 +5,14 @@ package provider
 
 import (
 	"context"
-	"github.com/hashicorp/go-tfe"
+	"fmt"
+	"math/big"
+
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"math/big"
 )
 
 type modelTFEDataRetentionPolicy struct {
@@ -22,63 +24,295 @@ type modelTFEDataRetentionPolicy struct {
 }
 
 type modelTFEDeleteOlderThan struct {
-	Days types.Number `tfsdk:"days"`
+	// Days is a legacy global retention window applied to all artifact types. It exists for backwards
+	// compatibility with TFE versions prior to v2.1.0, which do not support per-artifact-type
+	// retention fields.
+	// On TFE v2.1.0+, this field is deprecated and will not be sent to the
+	// server if any of the per-artifact-type fields below are set.
+	Days                                  types.Number `tfsdk:"days"`
+	DeleteStateVersions                   types.Bool   `tfsdk:"delete_state_versions"`
+	DeleteConfigurationVersions           types.Bool   `tfsdk:"delete_configuration_versions"`
+	DeleteRunDataAndLogs                  types.Bool   `tfsdk:"delete_run_data_and_logs"`
+	StateVersionsDeleteAfterNDays         types.Number `tfsdk:"state_versions_delete_after_n_days"`
+	ConfigurationVersionsDeleteAfterNDays types.Number `tfsdk:"configuration_versions_delete_after_n_days"`
+	RunDataAndLogsDeleteAfterNDays        types.Number `tfsdk:"run_data_and_logs_delete_after_n_days"`
+	StateVersionsKeepLatestCount          types.Number `tfsdk:"state_versions_keep_latest_count"`
+	ConfigurationVersionsKeepLatestCount  types.Number `tfsdk:"configuration_versions_keep_latest_count"`
+	RunDataKeepLatestCount                types.Number `tfsdk:"run_data_keep_latest_count"`
 }
 
 func (m modelTFEDeleteOlderThan) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"days": types.NumberType,
+		"days":                                       types.NumberType,
+		"delete_state_versions":                      types.BoolType,
+		"delete_configuration_versions":              types.BoolType,
+		"delete_run_data_and_logs":                   types.BoolType,
+		"state_versions_delete_after_n_days":         types.NumberType,
+		"configuration_versions_delete_after_n_days": types.NumberType,
+		"run_data_and_logs_delete_after_n_days":      types.NumberType,
+		"state_versions_keep_latest_count":           types.NumberType,
+		"configuration_versions_keep_latest_count":   types.NumberType,
+		"run_data_keep_latest_count":                 types.NumberType,
 	}
 }
 
 func DontDeleteEmptyObject() basetypes.ObjectValue {
-	object, diags := types.ObjectValue(map[string]attr.Type{}, map[string]attr.Value{})
-	if diags.HasError() {
-		panic(diags.Errors())
-	}
-	return object
+	// ObjectValueMust is safe here: the attribute types are a static empty map
+	// and this can never fail.
+	return types.ObjectValueMust(map[string]attr.Type{}, map[string]attr.Value{})
 }
 
-func modelFromTFEDataRetentionPolicyDeleteOlder(ctx context.Context, model modelTFEDataRetentionPolicy, deleteOlder *tfe.DataRetentionPolicyDeleteOlder) (modelTFEDataRetentionPolicy, diag.Diagnostics) {
+func int32PtrToNumber(v *int32) types.Number {
+	if v == nil {
+		return types.NumberNull()
+	}
+	return types.NumberValue(big.NewFloat(float64(*v)))
+}
+
+func numberToInt32Ptr(n types.Number) *int32 {
+	if n.IsNull() || n.IsUnknown() {
+		return nil
+	}
+	v, _ := n.ValueBigFloat().Int64()
+	i := int32(v)
+	return &i
+}
+
+func boolPtrToTypes(v *bool) types.Bool {
+	if v == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*v)
+}
+
+func typesBoolToPtr(b types.Bool) *bool {
+	if b.IsNull() || b.IsUnknown() {
+		return nil
+	}
+	v := b.ValueBool()
+	return &v
+}
+
+// deleteOlderThanFromAPIResponse converts an API policy response into a new local state model.
+// organization and workspaceID are passed through directly into the returned state since they
+// are not present in the API response.
+// configuredDeleteOlderThan is the user's configured delete_older_than block — either from the
+// plan (on Create) or from the prior state (on Read). It is used to detect whether the user
+// configured days-only, which is needed to ignore granular fields that TFE v2.1.0+ backfills
+// on the server when only days is sent, preventing spurious plan diffs.
+func deleteOlderThanFromAPIResponse(ctx context.Context, organization types.String, workspaceID types.String, configuredDeleteOlderThan types.Object, policy models.DataRetentionPolicyable) (modelTFEDataRetentionPolicy, diag.Diagnostics) {
+	attrs := policy.GetAttributes()
+	if attrs == nil {
+		var d diag.Diagnostics
+		d.AddError("Invalid API response", "data retention policy response is missing attributes")
+		return modelTFEDataRetentionPolicy{}, d
+	}
+
+	var configuredDot modelTFEDeleteOlderThan
+	userSetDaysOnly := false
+	hasConfigured := !configuredDeleteOlderThan.IsNull() && !configuredDeleteOlderThan.IsUnknown()
+
+	// determine if the user has configured a legacy `days` attribute, or if we should acknowledge the
+	// policy's granular fields
+	if hasConfigured {
+		diags := configuredDeleteOlderThan.As(ctx, &configuredDot, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return modelTFEDataRetentionPolicy{}, diags
+		}
+		// User set "days" only if days was non-null and all granular fields were null in the plan.
+		userSetDaysOnly = !configuredDot.Days.IsNull() &&
+			configuredDot.DeleteStateVersions.IsNull() &&
+			configuredDot.DeleteConfigurationVersions.IsNull() &&
+			configuredDot.DeleteRunDataAndLogs.IsNull() &&
+			configuredDot.StateVersionsDeleteAfterNDays.IsNull() &&
+			configuredDot.ConfigurationVersionsDeleteAfterNDays.IsNull() &&
+			configuredDot.RunDataAndLogsDeleteAfterNDays.IsNull() &&
+			configuredDot.StateVersionsKeepLatestCount.IsNull() &&
+			configuredDot.ConfigurationVersionsKeepLatestCount.IsNull() &&
+			configuredDot.RunDataKeepLatestCount.IsNull()
+	}
+
+	// When reading back the API response:
+	// 1. If no prior state exists (first read), read everything from the API as-is.
+	// 2. If user originally set "days" only, ignore any granular fields the server backfilled
+	// 3. If user set granular fields, ignore the coalesced delete-older-than-n-days value.
+
+	// Check if API response has artifact specific retention settings
+
+	days := types.NumberNull()
+	deleteStateVersions := types.BoolNull()
+	deleteConfigurationVersions := types.BoolNull()
+	deleteRunDataAndLogs := types.BoolNull()
+	stateVersionsDeleteAfterNDays := types.NumberNull()
+	configurationVersionsDeleteAfterNDays := types.NumberNull()
+	runDataAndLogsDeleteAfterNDays := types.NumberNull()
+	stateVersionsKeepLatestCount := types.NumberNull()
+	configurationVersionsKeepLatestCount := types.NumberNull()
+	runDataKeepLatestCount := types.NumberNull()
+
+	if !hasConfigured {
+		// First read: use whatever the API returns.
+		apiHasGranular := attrs.GetDeleteStateVersions() != nil ||
+			attrs.GetDeleteConfigurationVersions() != nil ||
+			attrs.GetDeleteRunDataAndLogs() != nil
+
+		if apiHasGranular {
+			// Server has granular fields — ignore coalesced days
+			deleteStateVersions = boolPtrToTypes(attrs.GetDeleteStateVersions())
+			deleteConfigurationVersions = boolPtrToTypes(attrs.GetDeleteConfigurationVersions())
+			deleteRunDataAndLogs = boolPtrToTypes(attrs.GetDeleteRunDataAndLogs())
+			stateVersionsDeleteAfterNDays = int32PtrToNumber(attrs.GetStateVersionsDeleteAfterNDays())
+			configurationVersionsDeleteAfterNDays = int32PtrToNumber(attrs.GetConfigurationVersionsDeleteAfterNDays())
+			runDataAndLogsDeleteAfterNDays = int32PtrToNumber(attrs.GetRunDataAndLogsDeleteAfterNDays())
+			stateVersionsKeepLatestCount = int32PtrToNumber(attrs.GetStateVersionsKeepLatestCount())
+			configurationVersionsKeepLatestCount = int32PtrToNumber(attrs.GetConfigurationVersionsKeepLatestCount())
+			runDataKeepLatestCount = int32PtrToNumber(attrs.GetRunDataKeepLatestCount())
+		} else {
+			// Server has only days — use it
+			days = int32PtrToNumber(attrs.GetDeleteOlderThanNDays())
+		}
+	} else if userSetDaysOnly {
+		// User sent only "days" in their configuration or prior state
+		// Even if we are on TFE >= 2.1.0, ignote the server-backfilled granular fields, preserve original "days", to avoid drift
+		days = int32PtrToNumber(attrs.GetDeleteOlderThanNDays())
+	} else {
+		// User sent granular fields — use them, ignore coalesced "days" from the server
+		deleteStateVersions = boolPtrToTypes(attrs.GetDeleteStateVersions())
+		deleteConfigurationVersions = boolPtrToTypes(attrs.GetDeleteConfigurationVersions())
+		deleteRunDataAndLogs = boolPtrToTypes(attrs.GetDeleteRunDataAndLogs())
+		stateVersionsDeleteAfterNDays = int32PtrToNumber(attrs.GetStateVersionsDeleteAfterNDays())
+		configurationVersionsDeleteAfterNDays = int32PtrToNumber(attrs.GetConfigurationVersionsDeleteAfterNDays())
+		runDataAndLogsDeleteAfterNDays = int32PtrToNumber(attrs.GetRunDataAndLogsDeleteAfterNDays())
+		stateVersionsKeepLatestCount = int32PtrToNumber(attrs.GetStateVersionsKeepLatestCount())
+		configurationVersionsKeepLatestCount = int32PtrToNumber(attrs.GetConfigurationVersionsKeepLatestCount())
+		runDataKeepLatestCount = int32PtrToNumber(attrs.GetRunDataKeepLatestCount())
+	}
+
 	deleteOlderThan := modelTFEDeleteOlderThan{
-		Days: types.NumberValue(big.NewFloat(float64(deleteOlder.DeleteOlderThanNDays))),
+		Days:                                  days,
+		DeleteStateVersions:                   deleteStateVersions,
+		DeleteConfigurationVersions:           deleteConfigurationVersions,
+		DeleteRunDataAndLogs:                  deleteRunDataAndLogs,
+		StateVersionsDeleteAfterNDays:         stateVersionsDeleteAfterNDays,
+		ConfigurationVersionsDeleteAfterNDays: configurationVersionsDeleteAfterNDays,
+		RunDataAndLogsDeleteAfterNDays:        runDataAndLogsDeleteAfterNDays,
+		StateVersionsKeepLatestCount:          stateVersionsKeepLatestCount,
+		ConfigurationVersionsKeepLatestCount:  configurationVersionsKeepLatestCount,
+		RunDataKeepLatestCount:                runDataKeepLatestCount,
 	}
 	deleteOlderThanObject, diags := types.ObjectValueFrom(ctx, deleteOlderThan.AttributeTypes(), deleteOlderThan)
 
-	organization := types.StringNull()
-	if model.WorkspaceID.IsNull() {
-		organization = model.Organization
+	org := types.StringNull()
+	if workspaceID.IsNull() {
+		org = organization
 	}
 
-	return modelTFEDataRetentionPolicy{
-		ID:              types.StringValue(deleteOlder.ID),
-		Organization:    organization,
-		WorkspaceID:     model.WorkspaceID,
+	id := ""
+	if policy.GetId() != nil {
+		id = *policy.GetId()
+	}
+
+	newState := modelTFEDataRetentionPolicy{
+		ID:              types.StringValue(id),
+		Organization:    org,
+		WorkspaceID:     workspaceID,
 		DeleteOlderThan: deleteOlderThanObject,
 		DontDelete:      types.ObjectNull(map[string]attr.Type{}),
-	}, diags
+	}
+	return newState, diags
 }
 
-func modelFromTFEDataRetentionPolicyDontDelete(model modelTFEDataRetentionPolicy, dontDelete *tfe.DataRetentionPolicyDontDelete) modelTFEDataRetentionPolicy {
-	organization := types.StringNull()
-	if model.WorkspaceID.IsNull() {
-		organization = model.Organization
+func dontDeleteFromAPIResponse(organization types.String, workspaceID types.String, policy models.DataRetentionPolicyable) modelTFEDataRetentionPolicy {
+	org := types.StringNull()
+	if workspaceID.IsNull() {
+		org = organization
+	}
+
+	id := ""
+	if policy.GetId() != nil {
+		id = *policy.GetId()
 	}
 
 	return modelTFEDataRetentionPolicy{
-		ID:              types.StringValue(dontDelete.ID),
-		Organization:    organization,
-		WorkspaceID:     model.WorkspaceID,
+		ID:              types.StringValue(id),
+		Organization:    org,
+		WorkspaceID:     workspaceID,
 		DeleteOlderThan: types.ObjectNull(modelTFEDeleteOlderThan{}.AttributeTypes()),
 		DontDelete:      DontDeleteEmptyObject(),
 	}
 }
 
-func modelFromTFEDataRetentionPolicyChoice(ctx context.Context, model modelTFEDataRetentionPolicy, choice *tfe.DataRetentionPolicyChoice) (modelTFEDataRetentionPolicy, diag.Diagnostics) {
-	if choice.DataRetentionPolicyDeleteOlder != nil {
-		return modelFromTFEDataRetentionPolicyDeleteOlder(ctx, model, choice.DataRetentionPolicyDeleteOlder)
+func dataRetentionPolicyFromAPIResponse(ctx context.Context, priorState modelTFEDataRetentionPolicy, policy models.DataRetentionPolicyable) (modelTFEDataRetentionPolicy, diag.Diagnostics) {
+	if policy == nil {
+		var d diag.Diagnostics
+		d.AddError("unexpected nil policy", "received nil DataRetentionPolicyable from API")
+		return modelTFEDataRetentionPolicy{}, d
 	}
 
-	var emptyDiag []diag.Diagnostic
-	return modelFromTFEDataRetentionPolicyDontDelete(model, choice.DataRetentionPolicyDontDelete), emptyDiag
+	pType := policy.GetTypeEscaped()
+	if pType != nil && *pType == models.DATARETENTIONPOLICYDONTDELETES_DATARETENTIONPOLICY_TYPE {
+		var emptyDiag diag.Diagnostics
+		return dontDeleteFromAPIResponse(priorState.Organization, priorState.WorkspaceID, policy), emptyDiag
+	}
+
+	return deleteOlderThanFromAPIResponse(ctx, priorState.Organization, priorState.WorkspaceID, priorState.DeleteOlderThan, policy)
+}
+
+func hasGranularFields(model modelTFEDeleteOlderThan) bool {
+	return !model.DeleteStateVersions.IsNull() ||
+		!model.DeleteConfigurationVersions.IsNull() ||
+		!model.DeleteRunDataAndLogs.IsNull() ||
+		!model.StateVersionsDeleteAfterNDays.IsNull() ||
+		!model.ConfigurationVersionsDeleteAfterNDays.IsNull() ||
+		!model.RunDataAndLogsDeleteAfterNDays.IsNull() ||
+		!model.StateVersionsKeepLatestCount.IsNull() ||
+		!model.ConfigurationVersionsKeepLatestCount.IsNull() ||
+		!model.RunDataKeepLatestCount.IsNull()
+}
+
+func newDeleteOlderEnvelope(model modelTFEDeleteOlderThan) (models.DataRetentionPolicyEnvelopeable, error) {
+	attrs := models.NewDataRetentionPolicy_attributes()
+
+	if !hasGranularFields(model) && !model.Days.IsNull() {
+		days, _ := model.Days.ValueBigFloat().Int64()
+		days32 := int32(days)
+		attrs.SetDeleteOlderThanNDays(&days32)
+	}
+	attrs.SetDeleteStateVersions(typesBoolToPtr(model.DeleteStateVersions))
+	attrs.SetDeleteConfigurationVersions(typesBoolToPtr(model.DeleteConfigurationVersions))
+	attrs.SetDeleteRunDataAndLogs(typesBoolToPtr(model.DeleteRunDataAndLogs))
+	attrs.SetStateVersionsDeleteAfterNDays(numberToInt32Ptr(model.StateVersionsDeleteAfterNDays))
+	attrs.SetConfigurationVersionsDeleteAfterNDays(numberToInt32Ptr(model.ConfigurationVersionsDeleteAfterNDays))
+	attrs.SetRunDataAndLogsDeleteAfterNDays(numberToInt32Ptr(model.RunDataAndLogsDeleteAfterNDays))
+	attrs.SetStateVersionsKeepLatestCount(numberToInt32Ptr(model.StateVersionsKeepLatestCount))
+	attrs.SetConfigurationVersionsKeepLatestCount(numberToInt32Ptr(model.ConfigurationVersionsKeepLatestCount))
+	attrs.SetRunDataKeepLatestCount(numberToInt32Ptr(model.RunDataKeepLatestCount))
+
+	policy := models.NewDataRetentionPolicy()
+	pType := models.DATARETENTIONPOLICYDELETEOLDERS_DATARETENTIONPOLICY_TYPE
+	policy.SetTypeEscaped(&pType)
+	policy.SetAttributes(attrs)
+
+	env := models.NewDataRetentionPolicyEnvelope()
+	env.SetData(policy)
+
+	return env, nil
+}
+
+func newDontDeleteEnvelope() models.DataRetentionPolicyEnvelopeable {
+	policy := models.NewDataRetentionPolicy()
+	pType := models.DATARETENTIONPOLICYDONTDELETES_DATARETENTIONPOLICY_TYPE
+	policy.SetTypeEscaped(&pType)
+	policy.SetAttributes(models.NewDataRetentionPolicy_attributes())
+
+	env := models.NewDataRetentionPolicyEnvelope()
+	env.SetData(policy)
+	return env
+}
+
+func getPolicyIDFromV2(policy models.DataRetentionPolicyable) (string, error) {
+	if policy == nil || policy.GetId() == nil {
+		return "", fmt.Errorf("policy has no ID")
+	}
+	return *policy.GetId(), nil
 }

--- a/internal/provider/data_retention_policy_test.go
+++ b/internal/provider/data_retention_policy_test.go
@@ -1,0 +1,702 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/go-tfe/v2/api/models"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func int32Ptr(v int32) *int32 { return &v }
+func boolPtr(v bool) *bool    { return &v }
+
+func newDeleteOlderV2Policy(id string, days int32, stateKeep, cvKeep, runKeep *int32) models.DataRetentionPolicyable {
+	p := models.NewDataRetentionPolicy()
+	pType := models.DATARETENTIONPOLICYDELETEOLDERS_DATARETENTIONPOLICY_TYPE
+	p.SetTypeEscaped(&pType)
+	p.SetId(&id)
+
+	attrs := models.NewDataRetentionPolicy_attributes()
+	attrs.SetDeleteOlderThanNDays(&days)
+	attrs.SetStateVersionsKeepLatestCount(stateKeep)
+	attrs.SetConfigurationVersionsKeepLatestCount(cvKeep)
+	attrs.SetRunDataKeepLatestCount(runKeep)
+	p.SetAttributes(attrs)
+	return p
+}
+
+func newFullDeleteOlderV2Policy(
+	id string,
+	days int32,
+	delSV, delCV, delRun *bool,
+	svDays, cvDays, runDays *int32,
+	svKeep, cvKeep, runKeep *int32,
+) models.DataRetentionPolicyable {
+	p := models.NewDataRetentionPolicy()
+	pType := models.DATARETENTIONPOLICYDELETEOLDERS_DATARETENTIONPOLICY_TYPE
+	p.SetTypeEscaped(&pType)
+	p.SetId(&id)
+
+	attrs := models.NewDataRetentionPolicy_attributes()
+	attrs.SetDeleteOlderThanNDays(&days)
+	attrs.SetDeleteStateVersions(delSV)
+	attrs.SetDeleteConfigurationVersions(delCV)
+	attrs.SetDeleteRunDataAndLogs(delRun)
+	attrs.SetStateVersionsDeleteAfterNDays(svDays)
+	attrs.SetConfigurationVersionsDeleteAfterNDays(cvDays)
+	attrs.SetRunDataAndLogsDeleteAfterNDays(runDays)
+	attrs.SetStateVersionsKeepLatestCount(svKeep)
+	attrs.SetConfigurationVersionsKeepLatestCount(cvKeep)
+	attrs.SetRunDataKeepLatestCount(runKeep)
+	p.SetAttributes(attrs)
+	return p
+}
+
+func newDontDeleteV2Policy(id string) models.DataRetentionPolicyable {
+	p := models.NewDataRetentionPolicy()
+	pType := models.DATARETENTIONPOLICYDONTDELETES_DATARETENTIONPOLICY_TYPE
+	p.SetTypeEscaped(&pType)
+	p.SetId(&id)
+	p.SetAttributes(models.NewDataRetentionPolicy_attributes())
+	return p
+}
+
+func TestModelTFEDeleteOlderThan_AttributeTypes(t *testing.T) {
+	t.Parallel()
+
+	attrTypes := modelTFEDeleteOlderThan{}.AttributeTypes()
+
+	assert.Equal(t, types.NumberType, attrTypes["days"])
+	assert.Equal(t, types.BoolType, attrTypes["delete_state_versions"])
+	assert.Equal(t, types.BoolType, attrTypes["delete_configuration_versions"])
+	assert.Equal(t, types.BoolType, attrTypes["delete_run_data_and_logs"])
+	assert.Equal(t, types.NumberType, attrTypes["state_versions_delete_after_n_days"])
+	assert.Equal(t, types.NumberType, attrTypes["configuration_versions_delete_after_n_days"])
+	assert.Equal(t, types.NumberType, attrTypes["run_data_and_logs_delete_after_n_days"])
+	assert.Equal(t, types.NumberType, attrTypes["state_versions_keep_latest_count"])
+	assert.Equal(t, types.NumberType, attrTypes["configuration_versions_keep_latest_count"])
+	assert.Equal(t, types.NumberType, attrTypes["run_data_keep_latest_count"])
+}
+
+func TestModelTFEDeleteOlderThan_AttributeTypes_NoExtraKeys(t *testing.T) {
+	t.Parallel()
+
+	attrTypes := modelTFEDeleteOlderThan{}.AttributeTypes()
+	expected := map[string]attr.Type{
+		"days":                                       types.NumberType,
+		"delete_state_versions":                      types.BoolType,
+		"delete_configuration_versions":              types.BoolType,
+		"delete_run_data_and_logs":                   types.BoolType,
+		"state_versions_delete_after_n_days":         types.NumberType,
+		"configuration_versions_delete_after_n_days": types.NumberType,
+		"run_data_and_logs_delete_after_n_days":      types.NumberType,
+		"state_versions_keep_latest_count":           types.NumberType,
+		"configuration_versions_keep_latest_count":   types.NumberType,
+		"run_data_keep_latest_count":                 types.NumberType,
+	}
+	assert.Equal(t, expected, attrTypes)
+}
+
+func TestModelFromTFEDataRetentionPolicyDeleteOlder_NilKeepLatestFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	policy := newDeleteOlderV2Policy("drp-123", 42, nil, nil, nil)
+	result, diags := deleteOlderThanFromAPIResponse(ctx, prior.Organization, prior.WorkspaceID, prior.DeleteOlderThan, policy)
+	require.False(t, diags.HasError())
+
+	var dot modelTFEDeleteOlderThan
+	diags = result.DeleteOlderThan.As(ctx, &dot, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	assert.True(t, dot.StateVersionsKeepLatestCount.IsNull())
+	assert.True(t, dot.ConfigurationVersionsKeepLatestCount.IsNull())
+	assert.True(t, dot.RunDataKeepLatestCount.IsNull())
+	assert.True(t, dot.DeleteStateVersions.IsNull())
+	assert.True(t, dot.DeleteConfigurationVersions.IsNull())
+	assert.True(t, dot.DeleteRunDataAndLogs.IsNull())
+	assert.True(t, dot.StateVersionsDeleteAfterNDays.IsNull())
+	assert.True(t, dot.ConfigurationVersionsDeleteAfterNDays.IsNull())
+	assert.True(t, dot.RunDataAndLogsDeleteAfterNDays.IsNull())
+}
+
+func TestModelFromTFEDataRetentionPolicyDeleteOlder_PopulatedKeepLatestFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	trueVal := true
+	policy := newFullDeleteOlderV2Policy("drp-456", 30, &trueVal, &trueVal, &trueVal, nil, nil, nil, int32Ptr(5), int32Ptr(10), int32Ptr(3))
+	result, diags := deleteOlderThanFromAPIResponse(ctx, prior.Organization, prior.WorkspaceID, prior.DeleteOlderThan, policy)
+	require.False(t, diags.HasError())
+
+	var dot modelTFEDeleteOlderThan
+	diags = result.DeleteOlderThan.As(ctx, &dot, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	stateVal, _ := dot.StateVersionsKeepLatestCount.ValueBigFloat().Int64()
+	cvVal, _ := dot.ConfigurationVersionsKeepLatestCount.ValueBigFloat().Int64()
+	runVal, _ := dot.RunDataKeepLatestCount.ValueBigFloat().Int64()
+
+	assert.Equal(t, int64(5), stateVal)
+	assert.Equal(t, int64(10), cvVal)
+	assert.Equal(t, int64(3), runVal)
+}
+
+func TestModelFromTFEDataRetentionPolicyDeleteOlder_PerArtifactFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	policy := newFullDeleteOlderV2Policy(
+		"drp-full", 0,
+		boolPtr(true), boolPtr(true), boolPtr(false),
+		int32Ptr(30), int32Ptr(60), nil,
+		int32Ptr(5), nil, nil,
+	)
+	result, diags := deleteOlderThanFromAPIResponse(ctx, prior.Organization, prior.WorkspaceID, prior.DeleteOlderThan, policy)
+	require.False(t, diags.HasError())
+
+	var dot modelTFEDeleteOlderThan
+	diags = result.DeleteOlderThan.As(ctx, &dot, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	assert.True(t, dot.DeleteStateVersions.ValueBool())
+	assert.True(t, dot.DeleteConfigurationVersions.ValueBool())
+	assert.False(t, dot.DeleteRunDataAndLogs.ValueBool())
+
+	svDays, _ := dot.StateVersionsDeleteAfterNDays.ValueBigFloat().Int64()
+	cvDays, _ := dot.ConfigurationVersionsDeleteAfterNDays.ValueBigFloat().Int64()
+	assert.Equal(t, int64(30), svDays)
+	assert.Equal(t, int64(60), cvDays)
+	assert.True(t, dot.RunDataAndLogsDeleteAfterNDays.IsNull())
+
+	svKeep, _ := dot.StateVersionsKeepLatestCount.ValueBigFloat().Int64()
+	assert.Equal(t, int64(5), svKeep)
+	assert.True(t, dot.ConfigurationVersionsKeepLatestCount.IsNull())
+	assert.True(t, dot.RunDataKeepLatestCount.IsNull())
+}
+
+func TestModelFromTFEDataRetentionPolicyDeleteOlder_ZeroIsPreservedNotNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	trueVal := true
+	policy := newFullDeleteOlderV2Policy("drp-789", 0, &trueVal, &trueVal, &trueVal, nil, nil, nil, int32Ptr(0), int32Ptr(0), int32Ptr(0))
+	result, diags := deleteOlderThanFromAPIResponse(ctx, prior.Organization, prior.WorkspaceID, prior.DeleteOlderThan, policy)
+	require.False(t, diags.HasError())
+
+	var dot modelTFEDeleteOlderThan
+	diags = result.DeleteOlderThan.As(ctx, &dot, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	assert.False(t, dot.StateVersionsKeepLatestCount.IsNull())
+	assert.False(t, dot.ConfigurationVersionsKeepLatestCount.IsNull())
+	assert.False(t, dot.RunDataKeepLatestCount.IsNull())
+
+	stateVal, _ := dot.StateVersionsKeepLatestCount.ValueBigFloat().Int64()
+	assert.Equal(t, int64(0), stateVal)
+}
+
+func TestModelFromTFEDataRetentionPolicyDeleteOlder_MaxInt32NoOverflow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	var maxInt32 int32 = 2147483647
+	trueVal2 := true
+	policy := newFullDeleteOlderV2Policy("drp-max", 0, &trueVal2, nil, nil, nil, nil, nil, &maxInt32, nil, nil)
+	result, diags := deleteOlderThanFromAPIResponse(ctx, prior.Organization, prior.WorkspaceID, prior.DeleteOlderThan, policy)
+	require.False(t, diags.HasError())
+
+	var dot modelTFEDeleteOlderThan
+	diags = result.DeleteOlderThan.As(ctx, &dot, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	stateVal, accuracy := dot.StateVersionsKeepLatestCount.ValueBigFloat().Int64()
+	assert.Equal(t, int64(2147483647), stateVal)
+	assert.Equal(t, big.Exact, accuracy)
+}
+
+func TestModelFromTFEDataRetentionPolicyDeleteOlder_DaysStillMappedCorrectly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	policy := newDeleteOlderV2Policy("drp-days", 99, nil, nil, nil)
+	result, diags := deleteOlderThanFromAPIResponse(ctx, prior.Organization, prior.WorkspaceID, prior.DeleteOlderThan, policy)
+	require.False(t, diags.HasError())
+
+	assert.Equal(t, "drp-days", result.ID.ValueString())
+
+	var dot modelTFEDeleteOlderThan
+	diags = result.DeleteOlderThan.As(ctx, &dot, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	days, _ := dot.Days.ValueBigFloat().Int64()
+	assert.Equal(t, int64(99), days)
+}
+
+func TestModelFromTFEDataRetentionPolicyDontDelete_NoKeepLatestFields(t *testing.T) {
+	t.Parallel()
+
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	policy := newDontDeleteV2Policy("drp-dont-123")
+	result := dontDeleteFromAPIResponse(prior.Organization, prior.WorkspaceID, policy)
+
+	assert.Equal(t, "drp-dont-123", result.ID.ValueString())
+	assert.True(t, result.DeleteOlderThan.IsNull())
+	assert.False(t, result.DontDelete.IsNull())
+}
+
+func TestNewDeleteOlderEnvelope_AllFieldsSet(t *testing.T) {
+	t.Parallel()
+
+	dot := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberValue(big.NewFloat(30)),
+		DeleteStateVersions:                   types.BoolValue(true),
+		DeleteConfigurationVersions:           types.BoolValue(true),
+		DeleteRunDataAndLogs:                  types.BoolValue(false),
+		StateVersionsDeleteAfterNDays:         types.NumberValue(big.NewFloat(30)),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberValue(big.NewFloat(60)),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberValue(big.NewFloat(5)),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberNull(),
+	}
+
+	env, err := newDeleteOlderEnvelope(dot)
+	require.NoError(t, err)
+
+	attrs := env.GetData().GetAttributes()
+	require.NotNil(t, attrs)
+
+	assert.Nil(t, attrs.GetDeleteOlderThanNDays(), "days should be suppressed when granular fields are present")
+	assert.Equal(t, true, *attrs.GetDeleteStateVersions())
+	assert.Equal(t, true, *attrs.GetDeleteConfigurationVersions())
+	assert.Equal(t, false, *attrs.GetDeleteRunDataAndLogs())
+	assert.Equal(t, int32(30), *attrs.GetStateVersionsDeleteAfterNDays())
+	assert.Equal(t, int32(60), *attrs.GetConfigurationVersionsDeleteAfterNDays())
+	assert.Nil(t, attrs.GetRunDataAndLogsDeleteAfterNDays())
+	assert.Equal(t, int32(5), *attrs.GetStateVersionsKeepLatestCount())
+	assert.Nil(t, attrs.GetConfigurationVersionsKeepLatestCount())
+	assert.Nil(t, attrs.GetRunDataKeepLatestCount())
+}
+
+func TestNewDeleteOlderEnvelope_NullKeepLatestFieldsOmitted(t *testing.T) {
+	t.Parallel()
+
+	dot := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberValue(big.NewFloat(30)),
+		DeleteStateVersions:                   types.BoolNull(),
+		DeleteConfigurationVersions:           types.BoolNull(),
+		DeleteRunDataAndLogs:                  types.BoolNull(),
+		StateVersionsDeleteAfterNDays:         types.NumberNull(),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberNull(),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberNull(),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberNull(),
+	}
+
+	env, err := newDeleteOlderEnvelope(dot)
+	require.NoError(t, err)
+
+	attrs := env.GetData().GetAttributes()
+	require.NotNil(t, attrs)
+
+	assert.Nil(t, attrs.GetDeleteStateVersions())
+	assert.Nil(t, attrs.GetDeleteConfigurationVersions())
+	assert.Nil(t, attrs.GetDeleteRunDataAndLogs())
+	assert.Nil(t, attrs.GetStateVersionsDeleteAfterNDays())
+	assert.Nil(t, attrs.GetConfigurationVersionsDeleteAfterNDays())
+	assert.Nil(t, attrs.GetRunDataAndLogsDeleteAfterNDays())
+	assert.Nil(t, attrs.GetStateVersionsKeepLatestCount())
+	assert.Nil(t, attrs.GetConfigurationVersionsKeepLatestCount())
+	assert.Nil(t, attrs.GetRunDataKeepLatestCount())
+}
+
+func TestNewDontDeleteEnvelope_TypeDiscriminator(t *testing.T) {
+	t.Parallel()
+
+	env := newDontDeleteEnvelope()
+
+	require.NotNil(t, env.GetData())
+	pType := env.GetData().GetTypeEscaped()
+	require.NotNil(t, pType)
+	assert.Equal(t, models.DATARETENTIONPOLICYDONTDELETES_DATARETENTIONPOLICY_TYPE, *pType)
+}
+
+func TestDeleteOlderEnvelope_TypeDiscriminator(t *testing.T) {
+	t.Parallel()
+
+	dot := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberValue(big.NewFloat(1)),
+		DeleteStateVersions:                   types.BoolNull(),
+		DeleteConfigurationVersions:           types.BoolNull(),
+		DeleteRunDataAndLogs:                  types.BoolNull(),
+		StateVersionsDeleteAfterNDays:         types.NumberNull(),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberNull(),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberNull(),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberNull(),
+	}
+
+	env, err := newDeleteOlderEnvelope(dot)
+	require.NoError(t, err)
+
+	pType := env.GetData().GetTypeEscaped()
+	require.NotNil(t, pType)
+	assert.Equal(t, models.DATARETENTIONPOLICYDELETEOLDERS_DATARETENTIONPOLICY_TYPE, *pType)
+}
+
+func TestModelFromTFEDataRetentionPolicyV2_NilPolicyReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	_, diags := dataRetentionPolicyFromAPIResponse(ctx, prior, nil)
+	assert.True(t, diags.HasError())
+}
+
+func TestModelFromTFEDataRetentionPolicyV2_NilTypeDefaultsToDeleteOlder(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	policy := models.NewDataRetentionPolicy()
+	id := "drp-nil-type"
+	policy.SetId(&id)
+	attrs := models.NewDataRetentionPolicy_attributes()
+	days := int32(14)
+	attrs.SetDeleteOlderThanNDays(&days)
+	policy.SetAttributes(attrs)
+
+	result, diags := dataRetentionPolicyFromAPIResponse(ctx, prior, policy)
+	require.False(t, diags.HasError())
+
+	assert.False(t, result.DeleteOlderThan.IsNull())
+	assert.True(t, result.DontDelete.IsNull())
+}
+
+func TestModelFromTFEDataRetentionPolicyV2_DontDeleteRouting(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior := modelTFEDataRetentionPolicy{
+		Organization: types.StringValue("my-org"),
+		WorkspaceID:  types.StringNull(),
+	}
+
+	policy := newDontDeleteV2Policy("drp-dont-routing")
+	result, diags := dataRetentionPolicyFromAPIResponse(ctx, prior, policy)
+	require.False(t, diags.HasError())
+
+	assert.True(t, result.DeleteOlderThan.IsNull())
+	assert.False(t, result.DontDelete.IsNull())
+	assert.Equal(t, "drp-dont-routing", result.ID.ValueString())
+}
+
+func TestHasGranularFields_FalseWhenAllNull(t *testing.T) {
+	t.Parallel()
+
+	dot := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberValue(big.NewFloat(30)),
+		DeleteStateVersions:                   types.BoolNull(),
+		DeleteConfigurationVersions:           types.BoolNull(),
+		DeleteRunDataAndLogs:                  types.BoolNull(),
+		StateVersionsDeleteAfterNDays:         types.NumberNull(),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberNull(),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberNull(),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberNull(),
+	}
+	assert.False(t, hasGranularFields(dot))
+}
+
+func TestHasGranularFields_TrueForEachField(t *testing.T) {
+	t.Parallel()
+
+	base := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberValue(big.NewFloat(30)),
+		DeleteStateVersions:                   types.BoolNull(),
+		DeleteConfigurationVersions:           types.BoolNull(),
+		DeleteRunDataAndLogs:                  types.BoolNull(),
+		StateVersionsDeleteAfterNDays:         types.NumberNull(),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberNull(),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberNull(),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberNull(),
+	}
+
+	cases := []struct {
+		name  string
+		mutFn func(*modelTFEDeleteOlderThan)
+	}{
+		{"delete_state_versions", func(d *modelTFEDeleteOlderThan) { d.DeleteStateVersions = types.BoolValue(true) }},
+		{"delete_configuration_versions", func(d *modelTFEDeleteOlderThan) { d.DeleteConfigurationVersions = types.BoolValue(true) }},
+		{"delete_run_data_and_logs", func(d *modelTFEDeleteOlderThan) { d.DeleteRunDataAndLogs = types.BoolValue(false) }},
+		{"state_versions_delete_after_n_days", func(d *modelTFEDeleteOlderThan) {
+			d.StateVersionsDeleteAfterNDays = types.NumberValue(big.NewFloat(30))
+		}},
+		{"configuration_versions_delete_after_n_days", func(d *modelTFEDeleteOlderThan) {
+			d.ConfigurationVersionsDeleteAfterNDays = types.NumberValue(big.NewFloat(30))
+		}},
+		{"run_data_and_logs_delete_after_n_days", func(d *modelTFEDeleteOlderThan) {
+			d.RunDataAndLogsDeleteAfterNDays = types.NumberValue(big.NewFloat(30))
+		}},
+		{"state_versions_keep_latest_count", func(d *modelTFEDeleteOlderThan) { d.StateVersionsKeepLatestCount = types.NumberValue(big.NewFloat(5)) }},
+		{"configuration_versions_keep_latest_count", func(d *modelTFEDeleteOlderThan) {
+			d.ConfigurationVersionsKeepLatestCount = types.NumberValue(big.NewFloat(5))
+		}},
+		{"run_data_keep_latest_count", func(d *modelTFEDeleteOlderThan) { d.RunDataKeepLatestCount = types.NumberValue(big.NewFloat(5)) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := base
+			tc.mutFn(&d)
+			assert.True(t, hasGranularFields(d), "expected hasGranularFields=true when %s is set", tc.name)
+		})
+	}
+}
+
+func TestNewDeleteOlderEnvelope_DaysSuppressedWhenGranularFieldsPresent(t *testing.T) {
+	t.Parallel()
+
+	dot := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberValue(big.NewFloat(99)),
+		DeleteStateVersions:                   types.BoolValue(true),
+		DeleteConfigurationVersions:           types.BoolNull(),
+		DeleteRunDataAndLogs:                  types.BoolNull(),
+		StateVersionsDeleteAfterNDays:         types.NumberValue(big.NewFloat(30)),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberNull(),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberNull(),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberNull(),
+	}
+
+	env, err := newDeleteOlderEnvelope(dot)
+	require.NoError(t, err)
+
+	attrs := env.GetData().GetAttributes()
+	assert.Nil(t, attrs.GetDeleteOlderThanNDays(), "days should be suppressed when granular fields are present")
+	assert.Equal(t, int32(30), *attrs.GetStateVersionsDeleteAfterNDays())
+}
+
+func TestNewDeleteOlderEnvelope_DaysPassedWhenNoGranularFields(t *testing.T) {
+	t.Parallel()
+
+	dot := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberValue(big.NewFloat(42)),
+		DeleteStateVersions:                   types.BoolNull(),
+		DeleteConfigurationVersions:           types.BoolNull(),
+		DeleteRunDataAndLogs:                  types.BoolNull(),
+		StateVersionsDeleteAfterNDays:         types.NumberNull(),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberNull(),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberNull(),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberNull(),
+	}
+
+	env, err := newDeleteOlderEnvelope(dot)
+	require.NoError(t, err)
+
+	attrs := env.GetData().GetAttributes()
+	require.NotNil(t, attrs.GetDeleteOlderThanNDays(), "days should be sent when no granular fields are set")
+	assert.Equal(t, int32(42), *attrs.GetDeleteOlderThanNDays())
+}
+
+func TestModelFromTFEDataRetentionPolicyDeleteOlder_IgnoresBackfilledGranularFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Simulate user config with only "days: 30" set
+	priorDeleteOlderThan := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberValue(big.NewFloat(30)),
+		DeleteStateVersions:                   types.BoolNull(),
+		DeleteConfigurationVersions:           types.BoolNull(),
+		DeleteRunDataAndLogs:                  types.BoolNull(),
+		StateVersionsDeleteAfterNDays:         types.NumberNull(),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberNull(),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberNull(),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberNull(),
+	}
+	priorDeleteOlderThanObject, _ := types.ObjectValueFrom(ctx, priorDeleteOlderThan.AttributeTypes(), priorDeleteOlderThan)
+
+	prior := modelTFEDataRetentionPolicy{
+		Organization:    types.StringValue("my-org"),
+		WorkspaceID:     types.StringNull(),
+		DeleteOlderThan: priorDeleteOlderThanObject,
+	}
+
+	// Simulate API response where server backfilled granular fields
+	deleteStateVersions := true
+	deleteConfigurationVersions := true
+	stateVersionsWindow := int32(30)
+	configurationVersionsWindow := int32(30)
+	id := "drp-backfilled"
+
+	policy := models.NewDataRetentionPolicy()
+	pType := models.DATARETENTIONPOLICYDELETEOLDERS_DATARETENTIONPOLICY_TYPE
+	policy.SetTypeEscaped(&pType)
+	policy.SetId(&id)
+
+	attrs := models.NewDataRetentionPolicy_attributes()
+	attrs.SetDeleteOlderThanNDays(&stateVersionsWindow)
+	attrs.SetDeleteStateVersions(&deleteStateVersions)
+	attrs.SetDeleteConfigurationVersions(&deleteConfigurationVersions)
+	attrs.SetStateVersionsDeleteAfterNDays(&stateVersionsWindow)
+	attrs.SetConfigurationVersionsDeleteAfterNDays(&configurationVersionsWindow)
+	policy.SetAttributes(attrs)
+
+	// Read should ignore the backfilled granular fields and preserve "days: 30"
+	result, diags := deleteOlderThanFromAPIResponse(ctx, prior.Organization, prior.WorkspaceID, prior.DeleteOlderThan, policy)
+	require.False(t, diags.HasError())
+
+	var dot modelTFEDeleteOlderThan
+	diags = result.DeleteOlderThan.As(ctx, &dot, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	// Should preserve original "days" value
+	require.False(t, dot.Days.IsNull(), "days should not be null")
+	days, _ := dot.Days.ValueBigFloat().Int64()
+	assert.Equal(t, int64(30), days)
+
+	// Should ignore backfilled granular fields
+	assert.True(t, dot.DeleteStateVersions.IsNull(), "delete_state_versions should be null")
+	assert.True(t, dot.DeleteConfigurationVersions.IsNull(), "delete_configuration_versions should be null")
+	assert.True(t, dot.StateVersionsDeleteAfterNDays.IsNull(), "state_versions_delete_after_n_days should be null")
+	assert.True(t, dot.ConfigurationVersionsDeleteAfterNDays.IsNull(), "configuration_versions_delete_after_n_days should be null")
+}
+
+func TestModelFromTFEDataRetentionPolicyDeleteOlder_GranularPriorState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	deleteStateVersions := true
+	deleteRunDataAndLogs := true
+	stateWindow := int32(14)
+	stateKeep := int32(5)
+	runKeep := int32(3)
+
+	priorDeleteOlderThan := modelTFEDeleteOlderThan{
+		Days:                                  types.NumberNull(),
+		DeleteStateVersions:                   types.BoolValue(true),
+		DeleteConfigurationVersions:           types.BoolNull(),
+		DeleteRunDataAndLogs:                  types.BoolValue(true),
+		StateVersionsDeleteAfterNDays:         types.NumberValue(big.NewFloat(14)),
+		ConfigurationVersionsDeleteAfterNDays: types.NumberNull(),
+		RunDataAndLogsDeleteAfterNDays:        types.NumberNull(),
+		StateVersionsKeepLatestCount:          types.NumberValue(big.NewFloat(5)),
+		ConfigurationVersionsKeepLatestCount:  types.NumberNull(),
+		RunDataKeepLatestCount:                types.NumberValue(big.NewFloat(3)),
+	}
+	priorDeleteOlderThanObject, diags := types.ObjectValueFrom(ctx, priorDeleteOlderThan.AttributeTypes(), priorDeleteOlderThan)
+	require.False(t, diags.HasError())
+
+	prior := modelTFEDataRetentionPolicy{
+		Organization:    types.StringValue("my-org"),
+		WorkspaceID:     types.StringNull(),
+		DeleteOlderThan: priorDeleteOlderThanObject,
+	}
+
+	id := "drp-granular"
+	policy := models.NewDataRetentionPolicy()
+	pType := models.DATARETENTIONPOLICYDELETEOLDERS_DATARETENTIONPOLICY_TYPE
+	policy.SetTypeEscaped(&pType)
+	policy.SetId(&id)
+
+	attrs := models.NewDataRetentionPolicy_attributes()
+	attrs.SetDeleteStateVersions(&deleteStateVersions)
+	attrs.SetDeleteRunDataAndLogs(&deleteRunDataAndLogs)
+	attrs.SetStateVersionsDeleteAfterNDays(&stateWindow)
+	attrs.SetStateVersionsKeepLatestCount(&stateKeep)
+	attrs.SetRunDataKeepLatestCount(&runKeep)
+	policy.SetAttributes(attrs)
+
+	result, diags := deleteOlderThanFromAPIResponse(ctx, prior.Organization, prior.WorkspaceID, prior.DeleteOlderThan, policy)
+	require.False(t, diags.HasError())
+
+	var dot modelTFEDeleteOlderThan
+	diags = result.DeleteOlderThan.As(ctx, &dot, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	assert.True(t, dot.Days.IsNull(), "days should be null for granular config")
+
+	assert.False(t, dot.DeleteStateVersions.IsNull())
+	assert.Equal(t, true, dot.DeleteStateVersions.ValueBool())
+
+	assert.False(t, dot.DeleteRunDataAndLogs.IsNull())
+	assert.Equal(t, true, dot.DeleteRunDataAndLogs.ValueBool())
+
+	svDays, _ := dot.StateVersionsDeleteAfterNDays.ValueBigFloat().Int64()
+	assert.Equal(t, int64(14), svDays)
+
+	svKeep, _ := dot.StateVersionsKeepLatestCount.ValueBigFloat().Int64()
+	assert.Equal(t, int64(5), svKeep)
+
+	runKeepVal, _ := dot.RunDataKeepLatestCount.ValueBigFloat().Int64()
+	assert.Equal(t, int64(3), runKeepVal)
+
+	assert.True(t, dot.DeleteConfigurationVersions.IsNull())
+	assert.True(t, dot.ConfigurationVersionsDeleteAfterNDays.IsNull())
+	assert.True(t, dot.ConfigurationVersionsKeepLatestCount.IsNull())
+}

--- a/internal/provider/data_retention_policy_validator.go
+++ b/internal/provider/data_retention_policy_validator.go
@@ -1,0 +1,259 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ validator.Object = deleteOlderThanValidator{}
+
+type deleteOlderThanValidator struct{}
+
+// ValidateDeleteOlderThan returns a validator that ensures:
+//  1. The 'days' field and all granular fields are mutually exclusive
+//  2. Artifact-type deletion flags have corresponding retention windows or keep-latest counts configured
+//  3. Retention windows or keep-latest counts require their corresponding deletion flags to be enabled
+func ValidateDeleteOlderThan() validator.Object {
+	return deleteOlderThanValidator{}
+}
+
+func (v deleteOlderThanValidator) Description(ctx context.Context) string {
+	return "Validates that 'days' and all granular fields are mutually exclusive, and that each enabled artifact type has either a retention window or keep-latest count configured"
+}
+
+func (v deleteOlderThanValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v deleteOlderThanValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Extract the delete_older_than attributes
+	attrs := req.ConfigValue.Attributes()
+
+	days := isNumberAttrSet(attrs, "days")
+
+	deleteStateVersions := getBoolAttr(attrs, "delete_state_versions")
+	deleteConfigurationVersions := getBoolAttr(attrs, "delete_configuration_versions")
+	deleteRunDataAndLogs := getBoolAttr(attrs, "delete_run_data_and_logs")
+
+	stateVersionsDeleteAfterNDays := isNumberAttrSet(attrs, "state_versions_delete_after_n_days")
+	configurationVersionsDeleteAfterNDays := isNumberAttrSet(attrs, "configuration_versions_delete_after_n_days")
+	runDataAndLogsDeleteAfterNDays := isNumberAttrSet(attrs, "run_data_and_logs_delete_after_n_days")
+
+	stateVersionsKeepLatestCount := isNumberAttrSet(attrs, "state_versions_keep_latest_count")
+	configurationVersionsKeepLatestCount := isNumberAttrSet(attrs, "configuration_versions_keep_latest_count")
+	runDataKeepLatestCount := isNumberAttrSet(attrs, "run_data_keep_latest_count")
+
+	// Validate that 'days' and all granular fields are mutually exclusive.
+	hasGranularFields := deleteStateVersions != nil ||
+		deleteConfigurationVersions != nil ||
+		deleteRunDataAndLogs != nil ||
+		stateVersionsDeleteAfterNDays ||
+		configurationVersionsDeleteAfterNDays ||
+		runDataAndLogsDeleteAfterNDays ||
+		stateVersionsKeepLatestCount ||
+		configurationVersionsKeepLatestCount ||
+		runDataKeepLatestCount
+
+	if days && hasGranularFields {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("days"),
+			"Conflicting configuration",
+			"The 'days' field cannot be used together with granular fields. Use either 'days' alone (deprecated) or the granular per-artifact fields.",
+		)
+		return
+	}
+
+	// The following checks only apply when using granular fields.
+	// If only 'days' is set (no delete flags, no windows, no keep-latest), validate >= 1 then return.
+	if !hasGranularFields {
+		if days {
+			if n := getNumberAttrValue(attrs, "days"); n != nil {
+				v, _ := n.ValueBigFloat().Int64()
+				if v < 1 {
+					resp.Diagnostics.AddAttributeError(
+						req.Path.AtName("days"),
+						"Invalid value",
+						"days must be at least 1.",
+					)
+				}
+			}
+		}
+		return
+	}
+
+	// At least one artifact type must be enabled for deletion when granular fields are present
+	// and no windows or keep-latest counts are configured. If windows or keep-latest counts are
+	// set, the per-attribute checks below will produce more specific errors.
+	noWindowsOrKeepLatest := !stateVersionsDeleteAfterNDays &&
+		!configurationVersionsDeleteAfterNDays &&
+		!runDataAndLogsDeleteAfterNDays &&
+		!stateVersionsKeepLatestCount &&
+		!configurationVersionsKeepLatestCount &&
+		!runDataKeepLatestCount
+	if noWindowsOrKeepLatest &&
+		(deleteStateVersions == nil || !*deleteStateVersions) &&
+		(deleteConfigurationVersions == nil || !*deleteConfigurationVersions) &&
+		(deleteRunDataAndLogs == nil || !*deleteRunDataAndLogs) {
+		resp.Diagnostics.AddError(
+			"Invalid configuration",
+			"At least one artifact type must be enabled for deletion. Set delete_state_versions, delete_configuration_versions, or delete_run_data_and_logs to true, or remove the delete_older_than block.",
+		)
+		return
+	}
+
+	// Validate state versions
+	if deleteStateVersions != nil && *deleteStateVersions {
+		if !stateVersionsDeleteAfterNDays && !stateVersionsKeepLatestCount {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("delete_state_versions"),
+				"Missing required field",
+				"When delete_state_versions is true, you must set either state_versions_delete_after_n_days or state_versions_keep_latest_count.",
+			)
+		}
+	} else {
+		// delete_state_versions is false or unset, so ensure we dont have a retention window or keep latest count
+		if stateVersionsDeleteAfterNDays {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("state_versions_delete_after_n_days"),
+				"Invalid configuration",
+				"Setting state_versions_delete_after_n_days requires delete_state_versions to be true.",
+			)
+		}
+		if stateVersionsKeepLatestCount {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("state_versions_keep_latest_count"),
+				"Invalid configuration",
+				"Setting state_versions_keep_latest_count requires delete_state_versions to be true.",
+			)
+		}
+	}
+
+	// Validate configuration versions
+	if deleteConfigurationVersions != nil && *deleteConfigurationVersions {
+		if !configurationVersionsDeleteAfterNDays && !configurationVersionsKeepLatestCount {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("delete_configuration_versions"),
+				"Missing required field",
+				"When delete_configuration_versions is true, you must set either configuration_versions_delete_after_n_days or configuration_versions_keep_latest_count.",
+			)
+		}
+	} else {
+		// delete_configuration_versions is false or unset, so ensure we dont have a retention window or keep latest count
+		if configurationVersionsDeleteAfterNDays {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("configuration_versions_delete_after_n_days"),
+				"Invalid configuration",
+				"Setting configuration_versions_delete_after_n_days requires delete_configuration_versions to be true.",
+			)
+		}
+		if configurationVersionsKeepLatestCount {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("configuration_versions_keep_latest_count"),
+				"Invalid configuration",
+				"Setting configuration_versions_keep_latest_count requires delete_configuration_versions to be true.",
+			)
+		}
+	}
+
+	// Validate run data and logs
+	if deleteRunDataAndLogs != nil && *deleteRunDataAndLogs {
+		if !runDataAndLogsDeleteAfterNDays && !runDataKeepLatestCount {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("delete_run_data_and_logs"),
+				"Missing required field",
+				"When delete_run_data_and_logs is true, you must set either run_data_and_logs_delete_after_n_days or run_data_keep_latest_count.",
+			)
+		}
+	} else {
+		if runDataAndLogsDeleteAfterNDays {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("run_data_and_logs_delete_after_n_days"),
+				"Invalid configuration",
+				"Setting run_data_and_logs_delete_after_n_days requires delete_run_data_and_logs to be true.",
+			)
+		}
+		if runDataKeepLatestCount {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("run_data_keep_latest_count"),
+				"Invalid configuration",
+				"Setting run_data_keep_latest_count requires delete_run_data_and_logs to be true.",
+			)
+		}
+	}
+
+	// Validate that all numeric fields are >= 1 when set.
+	numericFields := []struct {
+		name  string
+		isSet bool
+	}{
+		{"state_versions_delete_after_n_days", stateVersionsDeleteAfterNDays},
+		{"configuration_versions_delete_after_n_days", configurationVersionsDeleteAfterNDays},
+		{"run_data_and_logs_delete_after_n_days", runDataAndLogsDeleteAfterNDays},
+		{"state_versions_keep_latest_count", stateVersionsKeepLatestCount},
+		{"configuration_versions_keep_latest_count", configurationVersionsKeepLatestCount},
+		{"run_data_keep_latest_count", runDataKeepLatestCount},
+	}
+	for _, f := range numericFields {
+		if !f.isSet {
+			continue
+		}
+		if n := getNumberAttrValue(attrs, f.name); n != nil {
+			v, _ := n.ValueBigFloat().Int64()
+			if v < 1 {
+				resp.Diagnostics.AddAttributeError(
+					req.Path.AtName(f.name),
+					"Invalid value",
+					fmt.Sprintf("%s must be at least 1.", f.name),
+				)
+			}
+		}
+	}
+}
+
+func getBoolAttr(attrs map[string]attr.Value, name string) *bool {
+	val, ok := attrs[name]
+	if !ok {
+		return nil
+	}
+	boolVal, ok := val.(types.Bool)
+	if !ok || boolVal.IsNull() || boolVal.IsUnknown() {
+		return nil
+	}
+	v := boolVal.ValueBool()
+	return &v
+}
+
+func isNumberAttrSet(attrs map[string]attr.Value, name string) bool {
+	val, ok := attrs[name]
+	if !ok {
+		return false
+	}
+	numVal, ok := val.(types.Number)
+	if !ok || numVal.IsNull() || numVal.IsUnknown() {
+		return false
+	}
+	return true
+}
+
+func getNumberAttrValue(attrs map[string]attr.Value, name string) *types.Number {
+	val, ok := attrs[name]
+	if !ok {
+		return nil
+	}
+	numVal, ok := val.(types.Number)
+	if !ok || numVal.IsNull() || numVal.IsUnknown() {
+		return nil
+	}
+	return &numVal
+}

--- a/internal/provider/data_retention_policy_validator_test.go
+++ b/internal/provider/data_retention_policy_validator_test.go
@@ -1,0 +1,460 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteOlderThanValidator_StateVersionsRequiresWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// delete_state_versions = true, but no window or keep-latest
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolValue(true),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "you must set either state_versions_delete_after_n_days or state_versions_keep_latest_count")
+}
+
+func TestDeleteOlderThanValidator_ZeroValueRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolValue(true),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberValue(big.NewFloat(0)),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "must be at least 1")
+}
+
+func TestDeleteOlderThanValidator_NegativeValueRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolValue(true),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberValue(big.NewFloat(-5)),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "must be at least 1")
+}
+
+func TestDeleteOlderThanValidator_DaysZeroRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberValue(big.NewFloat(0)),
+		"delete_state_versions":                      types.BoolNull(),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "must be at least 1")
+}
+
+func TestDeleteOlderThanValidator_ConfigurationVersionsRequiresWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// delete_configuration_versions = true, but no window or keep-latest
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolNull(),
+		"delete_configuration_versions":              types.BoolValue(true),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "configuration_versions_delete_after_n_days or configuration_versions_keep_latest_count")
+}
+
+func TestDeleteOlderThanValidator_RunDataRequiresWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// delete_run_data_and_logs = true, but no window or keep-latest
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolNull(),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolValue(true),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "run_data_and_logs_delete_after_n_days or run_data_keep_latest_count")
+}
+
+func TestDeleteOlderThanValidator_ValidWithWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// delete_state_versions = true WITH state_versions_delete_after_n_days
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolValue(true),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberValue(big.NewFloat(30)),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.False(t, resp.Diagnostics.HasError())
+}
+
+func TestDeleteOlderThanValidator_ValidWithKeepLatest(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// delete_state_versions = true WITH state_versions_keep_latest_count
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolValue(true),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberValue(big.NewFloat(5)),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.False(t, resp.Diagnostics.HasError())
+}
+
+func TestDeleteOlderThanValidator_ValidWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// delete_state_versions = false (or null), no window required, but this config does nothing
+	// so the validator should reject it
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolValue(false),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "At least one artifact type must be enabled")
+}
+
+func TestDeleteOlderThanValidator_WindowRequiresDeleteFlag(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// state_versions_delete_after_n_days set, but delete_state_versions = false
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolValue(false),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberValue(big.NewFloat(30)),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "requires delete_state_versions to be true")
+}
+
+func TestDeleteOlderThanValidator_KeepLatestRequiresDeleteFlag(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// configuration_versions_keep_latest_count set, but delete flag not enabled
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolNull(),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberValue(big.NewFloat(5)),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "requires delete_configuration_versions to be true")
+}
+
+func TestDeleteOlderThanValidator_RunDataWindowRequiresDeleteFlag(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// run_data_and_logs_delete_after_n_days set with delete flag explicitly false
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberNull(),
+		"delete_state_versions":                      types.BoolNull(),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolValue(false),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberValue(big.NewFloat(60)),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "requires delete_run_data_and_logs to be true")
+}
+
+func TestDeleteOlderThanValidator_DaysAndGranularFieldsMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// Both 'days' and granular fields set
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberValue(big.NewFloat(30)),
+		"delete_state_versions":                      types.BoolValue(true),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberValue(big.NewFloat(45)),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberNull(),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "cannot be used together with granular fields")
+}
+
+func TestDeleteOlderThanValidator_DaysWithKeepLatestConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v := ValidateDeleteOlderThan()
+
+	// 'days' with only keep-latest count is invalid
+	attrs := map[string]attr.Value{
+		"days":                                       types.NumberValue(big.NewFloat(30)),
+		"delete_state_versions":                      types.BoolNull(),
+		"delete_configuration_versions":              types.BoolNull(),
+		"delete_run_data_and_logs":                   types.BoolNull(),
+		"state_versions_delete_after_n_days":         types.NumberNull(),
+		"configuration_versions_delete_after_n_days": types.NumberNull(),
+		"run_data_and_logs_delete_after_n_days":      types.NumberNull(),
+		"state_versions_keep_latest_count":           types.NumberValue(big.NewFloat(5)),
+		"configuration_versions_keep_latest_count":   types.NumberNull(),
+		"run_data_keep_latest_count":                 types.NumberNull(),
+	}
+
+	req := validator.ObjectRequest{
+		Path:        path.Root("delete_older_than"),
+		ConfigValue: types.ObjectValueMust(modelTFEDeleteOlderThan{}.AttributeTypes(), attrs),
+	}
+	resp := &validator.ObjectResponse{}
+
+	v.ValidateObject(ctx, req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "cannot be used together with granular fields")
+}

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -259,6 +259,20 @@ func skipIfCloud(t *testing.T) {
 	}
 }
 
+func skipIfBelowTFEVersion(t *testing.T, minVersion string) {
+	t.Helper()
+	if testAccConfiguredClient == nil {
+		return
+	}
+	meets, err := testAccConfiguredClient.MeetsMinRemoteTFEVersion(minVersion)
+	if err != nil {
+		t.Skipf("Skipping test: could not determine TFE version: %v", err)
+	}
+	if !meets {
+		t.Skipf("Skipping test: requires TFE %s or later", minVersion)
+	}
+}
+
 func skipIfEnterprise(t *testing.T) {
 	if enterpriseEnabled() {
 		t.Skip("Skipping test for a feature unavailable in Terraform Enterprise. Set 'ENABLE_TFE=0' to run.")

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -273,6 +273,20 @@ func skipIfBelowTFEVersion(t *testing.T, minVersion string) {
 	}
 }
 
+func skipIfAtOrAboveTFEVersion(t *testing.T, minVersion string) {
+	t.Helper()
+	if testAccConfiguredClient == nil {
+		return
+	}
+	meets, err := testAccConfiguredClient.MeetsMinRemoteTFEVersion(minVersion)
+	if err != nil {
+		t.Skipf("Skipping test: could not determine TFE version (assuming >= %s): %v", minVersion, err)
+	}
+	if meets {
+		t.Skipf("Skipping test: not supported on TFE %s or later", minVersion)
+	}
+}
+
 func skipIfEnterprise(t *testing.T) {
 	if enterpriseEnabled() {
 		t.Skip("Skipping test for a feature unavailable in Terraform Enterprise. Set 'ENABLE_TFE=0' to run.")

--- a/internal/provider/resource_tfe_data_retention_policy.go
+++ b/internal/provider/resource_tfe_data_retention_policy.go
@@ -1,30 +1,23 @@
 // Copyright IBM Corp. 2018, 2025
 // SPDX-License-Identifier: MPL-2.0
 
-// go-tfe v2 migration exception: TF-39648
-// This resource uses Organizations.SetDataRetentionPolicy*, Workspaces.Set*,
-// and related v1 SDK methods. The v2 client does have generated builders for
-// both /organizations/{name}/relationships/data-retention-policy and
-// /workspaces/{id}/relationships/data-retention-policy (x-vis:[tfe] is a
-// description-only marker; it does not filter paths from any bundle). The
-// blocker is that x-vis:[tfe] means these routes are Terraform Enterprise
-// (on-prem) only and cannot be acceptance-tested against HCP Terraform CI.
-// Remove this exception once TFE-gated acceptance test coverage is in place.
-
 package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/terraform-plugin-framework-validators/numbervalidator"
+	"log"
+	"strings"
+
+	tfev2 "github.com/hashicorp/go-tfe/v2"
+	"github.com/hashicorp/go-tfe/v2/api/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/numberplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -32,11 +25,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
-	"strings"
 )
 
-// Ensure provider defined types fully satisfy framework interfaces.
+const minTFEVersionGranularDRP = "v2.1.0"
+
 var _ resource.Resource = &resourceTFEDataRetentionPolicy{}
 var _ resource.ResourceWithConfigure = &resourceTFEDataRetentionPolicy{}
 var _ resource.ResourceWithImportState = &resourceTFEDataRetentionPolicy{}
@@ -45,7 +37,6 @@ func NewDataRetentionPolicyResource() resource.Resource {
 	return &resourceTFEDataRetentionPolicy{}
 }
 
-// resourceTFEDataRetentionPolicy implements the tfe_data_retention_policy resource type
 type resourceTFEDataRetentionPolicy struct {
 	config ConfiguredClient
 }
@@ -91,20 +82,61 @@ func (r *resourceTFEDataRetentionPolicy) Schema(ctx context.Context, req resourc
 		},
 		Blocks: map[string]schema.Block{
 			"delete_older_than": schema.SingleNestedBlock{
-				Description: "Sets the maximum number of days, months, years data is allowed to exist before it is scheduled for deletion. Cannot be configured if the `dont_delete` attribute is also configured.",
+				Description: "Sets the maximum number of days data is allowed to exist before it is scheduled for deletion. Cannot be configured if the `dont_delete` attribute is also configured.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplaceIf(
+						func(_ context.Context, req planmodifier.ObjectRequest, resp *objectplanmodifier.RequiresReplaceIfFuncResponse) {
+							resp.RequiresReplace = req.StateValue.IsNull() != req.PlanValue.IsNull()
+						},
+						"Requires replace only when the delete_older_than block is added or removed, not when its attributes change.",
+						"Requires replace only when the `delete_older_than` block is added or removed, not when its attributes change.",
+					),
+				},
 				Attributes: map[string]schema.Attribute{
 					"days": schema.NumberAttribute{
-						Description: "Number of days old data must be before it is scheduled for deletion.",
-						Optional:    true,
-						PlanModifiers: []planmodifier.Number{
-							numberplanmodifier.RequiresReplace(),
-						},
-						Validators: []validator.Number{
-							numbervalidator.ExactlyOneOf(
-								path.MatchRelative().AtParent().AtParent().AtName("dont_delete"),
-							),
-						},
+						Description:        "Number of days old data must be before it is scheduled for deletion. Used as the global window when per-artifact-type windows are not set. Deprecated for TFE v2.1.0+: use per-artifact-type fields instead.",
+						DeprecationMessage: "The days field is deprecated for TFE v2.1.0+. Use state_versions_delete_after_n_days, configuration_versions_delete_after_n_days, and run_data_and_logs_delete_after_n_days instead.",
+						Optional:           true,
 					},
+					"delete_state_versions": schema.BoolAttribute{
+						Description: "When true, state versions are eligible for deletion under this policy.",
+						Optional:    true,
+					},
+					"delete_configuration_versions": schema.BoolAttribute{
+						Description: "When true, configuration versions are eligible for deletion under this policy.",
+						Optional:    true,
+					},
+					"delete_run_data_and_logs": schema.BoolAttribute{
+						Description: "When true, run data and logs (plans, applies, assessments) are eligible for deletion under this policy.",
+						Optional:    true,
+					},
+					"state_versions_delete_after_n_days": schema.NumberAttribute{
+						Description: "Number of days after which state versions are eligible for deletion. Requires `delete_state_versions` to be true.",
+						Optional:    true,
+					},
+					"configuration_versions_delete_after_n_days": schema.NumberAttribute{
+						Description: "Number of days after which configuration versions are eligible for deletion. Requires `delete_configuration_versions` to be true.",
+						Optional:    true,
+					},
+					"run_data_and_logs_delete_after_n_days": schema.NumberAttribute{
+						Description: "Number of days after which run data and logs are eligible for deletion. Requires `delete_run_data_and_logs` to be true.",
+						Optional:    true,
+					},
+					"state_versions_keep_latest_count": schema.NumberAttribute{
+						Description: "Minimum number of state versions to keep per workspace, regardless of age. Requires `delete_state_versions` to be true.",
+						Optional:    true,
+					},
+					"configuration_versions_keep_latest_count": schema.NumberAttribute{
+						Description: "Minimum number of configuration versions to keep per workspace, regardless of age. Requires `delete_configuration_versions` to be true.",
+						Optional:    true,
+					},
+					"run_data_keep_latest_count": schema.NumberAttribute{
+						Description: "Minimum number of runs (and associated plan/apply data) to keep per workspace, regardless of age. Requires `delete_run_data_and_logs` to be true.",
+						Optional:    true,
+					},
+				},
+				Validators: []validator.Object{
+					ValidateDeleteOlderThan(),
 				},
 			},
 			"dont_delete": schema.SingleNestedBlock{
@@ -123,9 +155,7 @@ func (r *resourceTFEDataRetentionPolicy) Schema(ctx context.Context, req resourc
 	}
 }
 
-// Configure implements resource.ResourceWithConfigure
 func (r *resourceTFEDataRetentionPolicy) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
 		return
 	}
@@ -143,7 +173,6 @@ func (r *resourceTFEDataRetentionPolicy) Configure(ctx context.Context, req reso
 func (r *resourceTFEDataRetentionPolicy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan modelTFEDataRetentionPolicy
 
-	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
 	if resp.Diagnostics.HasError() {
@@ -168,8 +197,7 @@ func (r *resourceTFEDataRetentionPolicy) Create(ctx context.Context, req resourc
 }
 
 func (r *resourceTFEDataRetentionPolicy) ensureOrganizationIsSet(ctx context.Context, model *modelTFEDataRetentionPolicy, data AttrGettable, diags *diag.Diagnostics) {
-	if !model.Organization.IsUnknown() || model.Organization.ValueString() != "" {
-		// skip this method if the organization has already been set
+	if !model.Organization.IsUnknown() && model.Organization.ValueString() != "" {
 		return
 	}
 
@@ -180,124 +208,212 @@ func (r *resourceTFEDataRetentionPolicy) ensureOrganizationIsSet(ctx context.Con
 	}
 }
 
+// patchPolicy sends a PATCH request and returns the resulting policy envelope.
+// For org-level policies the endpoint returns no body, so a follow-up GET is performed.
+func (r *resourceTFEDataRetentionPolicy) patchPolicy(ctx context.Context, plan modelTFEDataRetentionPolicy, requestEnvelope models.DataRetentionPolicyEnvelopeable) (models.DataRetentionPolicyEnvelopeable, error) {
+	if plan.WorkspaceID.IsNull() {
+		if err := r.config.ClientV2.API.Organizations().ByOrganization_name(plan.Organization.ValueString()).Relationships().DataRetentionPolicy().Patch(ctx, requestEnvelope, nil); err != nil {
+			return nil, err
+		}
+		return r.config.ClientV2.API.Organizations().ByOrganization_name(plan.Organization.ValueString()).Relationships().DataRetentionPolicy().Get(ctx, nil)
+	}
+	return r.config.ClientV2.API.Workspaces().ByWorkspace_id(plan.WorkspaceID.ValueString()).Relationships().DataRetentionPolicy().Patch(ctx, requestEnvelope, nil)
+}
+
 func (r *resourceTFEDataRetentionPolicy) createDeleteOlderThanRetentionPolicy(ctx context.Context, plan modelTFEDataRetentionPolicy, resp *resource.CreateResponse) {
 	deleteOlderThan := &modelTFEDeleteOlderThan{}
-
-	diags := plan.DeleteOlderThan.As(ctx, &deleteOlderThan, basetypes.ObjectAsOptions{})
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(plan.DeleteOlderThan.As(ctx, deleteOlderThan, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	deleteOlderThanDays, _ := deleteOlderThan.Days.ValueBigFloat().Int64()
-	options := tfe.DataRetentionPolicyDeleteOlderSetOptions{
-		DeleteOlderThanNDays: int(deleteOlderThanDays),
+	r.warnIfDaysDeprecated(deleteOlderThan, &resp.Diagnostics)
+
+	requestEnvelope, err := newDeleteOlderEnvelope(*deleteOlderThan)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to build data retention policy request", err.Error())
+		return
 	}
 
 	tflog.Debug(ctx, "Creating data retention policy")
-	var dataRetentionPolicy *tfe.DataRetentionPolicyDeleteOlder
-	var err error
-	if plan.WorkspaceID.IsNull() {
-		dataRetentionPolicy, err = r.config.Client.Organizations.SetDataRetentionPolicyDeleteOlder(ctx, plan.Organization.ValueString(), options)
-	} else {
-		dataRetentionPolicy, err = r.config.Client.Workspaces.SetDataRetentionPolicyDeleteOlder(ctx, plan.WorkspaceID.ValueString(), options)
-	}
+	responseEnvelope, err := r.patchPolicy(ctx, plan, requestEnvelope)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create data retention policy", err.Error())
 		return
 	}
-
-	result, diags := modelFromTFEDataRetentionPolicyDeleteOlder(ctx, plan, dataRetentionPolicy)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
+	if responseEnvelope.GetData() == nil {
+		resp.Diagnostics.AddError("Unable to create data retention policy", "API returned empty response")
 		return
 	}
 
-	// Save data into Terraform state
-	diags = resp.State.Set(ctx, &result)
+	result, diags := deleteOlderThanFromAPIResponse(ctx, plan.Organization, plan.WorkspaceID, plan.DeleteOlderThan, responseEnvelope.GetData())
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
 func (r *resourceTFEDataRetentionPolicy) createDontDeleteRetentionPolicy(ctx context.Context, plan modelTFEDataRetentionPolicy, resp *resource.CreateResponse) {
-	deleteOlderThan := &modelTFEDeleteOlderThan{}
-
-	diags := plan.DeleteOlderThan.As(ctx, &deleteOlderThan, basetypes.ObjectAsOptions{})
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	options := tfe.DataRetentionPolicyDontDeleteSetOptions{}
-
 	tflog.Debug(ctx, "Creating data retention policy")
-	var dataRetentionPolicy *tfe.DataRetentionPolicyDontDelete
-	var err error
-	if plan.WorkspaceID.IsNull() {
-		dataRetentionPolicy, err = r.config.Client.Organizations.SetDataRetentionPolicyDontDelete(ctx, plan.Organization.ValueString(), options)
-	} else {
-		dataRetentionPolicy, err = r.config.Client.Workspaces.SetDataRetentionPolicyDontDelete(ctx, plan.WorkspaceID.ValueString(), options)
-	}
+	responseEnvelope, err := r.patchPolicy(ctx, plan, newDontDeleteEnvelope())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create data retention policy", err.Error())
 		return
 	}
+	if responseEnvelope.GetData() == nil {
+		resp.Diagnostics.AddError("Unable to create data retention policy", "API returned empty response")
+		return
+	}
+	result := dontDeleteFromAPIResponse(plan.Organization, plan.WorkspaceID, responseEnvelope.GetData())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+}
 
-	result := modelFromTFEDataRetentionPolicyDontDelete(plan, dataRetentionPolicy)
-
-	// Save data into Terraform state
-	diags = resp.State.Set(ctx, &result)
-	resp.Diagnostics.Append(diags...)
+func (r *resourceTFEDataRetentionPolicy) warnIfDaysDeprecated(dot *modelTFEDeleteOlderThan, diags *diag.Diagnostics) {
+	// hasGranularFields is checked against the plan value (not prior state). This is safe because
+	// the validator enforces that `days` and granular fields are mutually exclusive at plan time,
+	// so if any granular fields are set in the plan, `days` cannot be set. The two paths can
+	// never coexist in a valid plan, making the plan value a reliable signal here.
+	if dot.Days.IsNull() || hasGranularFields(*dot) {
+		return
+	}
+	meets, err := r.config.MeetsMinRemoteTFEVersion(minTFEVersionGranularDRP)
+	if err != nil {
+		log.Printf("[DEBUG] could not determine if TFE version meets minimum required version %s: %v", minTFEVersionGranularDRP, err)
+		return
+	}
+	if meets {
+		diags.AddWarning(
+			"days field is deprecated for TFE v2.1.0+",
+			fmt.Sprintf(
+				"The days field is supported for backwards compatibility with TFE versions prior to %s. "+
+					"Your TFE version (%s) supports per-artifact-type retention fields. "+
+					"Consider migrating to state_versions_delete_after_n_days, configuration_versions_delete_after_n_days, and run_data_and_logs_delete_after_n_days.",
+				minTFEVersionGranularDRP, r.config.RemoteTFEVersion(),
+			),
+		)
+	}
 }
 
 func (r *resourceTFEDataRetentionPolicy) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state modelTFEDataRetentionPolicy
 
-	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	var policy *tfe.DataRetentionPolicyChoice
+	var responseEnvelope models.DataRetentionPolicyEnvelopeable
 	var err error
 	if state.WorkspaceID.IsNull() {
-		policy, err = r.config.Client.Organizations.ReadDataRetentionPolicyChoice(ctx, state.Organization.ValueString())
+		responseEnvelope, err = r.config.ClientV2.API.Organizations().ByOrganization_name(state.Organization.ValueString()).Relationships().DataRetentionPolicy().Get(ctx, nil)
 	} else {
-		policy, err = r.config.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, state.WorkspaceID.ValueString())
+		responseEnvelope, err = r.config.ClientV2.API.Workspaces().ByWorkspace_id(state.WorkspaceID.ValueString()).Relationships().DataRetentionPolicy().Get(ctx, nil)
 	}
 	if err != nil {
+		if errors.Is(err, tfev2.ErrNotFound) {
+			log.Printf("[DEBUG] Data retention policy no longer exists")
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Failed to read data retention policy", err.Error())
 		return
 	}
-	// remove the policy from state if it no longer exists or has been replaced by another policy
-	if policy == nil || r.getPolicyID(policy) != state.ID.ValueString() {
+
+	policy := responseEnvelope.GetData()
+	if policy == nil {
 		log.Printf("[DEBUG] Data retention policy %s no longer exists", state.ID)
 		resp.State.RemoveResource(ctx)
 		return
 	}
-	result, diags := modelFromTFEDataRetentionPolicyChoice(ctx, state, policy)
+
+	policyID, err := getPolicyIDFromV2(policy)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read data retention policy", err.Error())
+		return
+	}
+	if policyID != state.ID.ValueString() {
+		log.Printf("[DEBUG] Data retention policy %s has been replaced (new ID: %s)", state.ID, policyID)
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	result, diags := dataRetentionPolicyFromAPIResponse(ctx, state, policy)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
 
-	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
 }
 
 func (r *resourceTFEDataRetentionPolicy) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// If the resource does not support modification and should always be recreated on
-	// configuration value updates, the Update logic can be left empty and ensure all
-	// configurable schema attributes implement the resource.RequiresReplace()
-	// attribute plan modifier.
-	resp.Diagnostics.AddError("Update not supported", "The update operation is not supported on this resource. This is a bug in the provider.")
+	var plan modelTFEDataRetentionPolicy
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	r.ensureOrganizationIsSet(ctx, &plan, req.Plan, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.DeleteOlderThan.IsNull() {
+		deleteOlderThan := &modelTFEDeleteOlderThan{}
+		resp.Diagnostics.Append(plan.DeleteOlderThan.As(ctx, deleteOlderThan, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		r.warnIfDaysDeprecated(deleteOlderThan, &resp.Diagnostics)
+
+		requestEnvelope, err := newDeleteOlderEnvelope(*deleteOlderThan)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to build data retention policy request", err.Error())
+			return
+		}
+
+		tflog.Debug(ctx, "Updating data retention policy")
+		responseEnvelope, err := r.patchPolicy(ctx, plan, requestEnvelope)
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to update data retention policy", err.Error())
+			return
+		}
+		if responseEnvelope.GetData() == nil {
+			resp.Diagnostics.AddError("Unable to update data retention policy", "API returned empty response")
+			return
+		}
+
+		result, diags := deleteOlderThanFromAPIResponse(ctx, plan.Organization, plan.WorkspaceID, plan.DeleteOlderThan, responseEnvelope.GetData())
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+		return
+	}
+
+	if !plan.DontDelete.IsNull() {
+		tflog.Debug(ctx, "Updating data retention policy")
+		responseEnvelope, err := r.patchPolicy(ctx, plan, newDontDeleteEnvelope())
+		if err != nil {
+			resp.Diagnostics.AddError("Unable to update data retention policy", err.Error())
+			return
+		}
+		if responseEnvelope.GetData() == nil {
+			resp.Diagnostics.AddError("Unable to update data retention policy", "API returned empty response")
+			return
+		}
+		result := dontDeleteFromAPIResponse(plan.Organization, plan.WorkspaceID, responseEnvelope.GetData())
+		resp.Diagnostics.Append(resp.State.Set(ctx, &result)...)
+	}
 }
 
 func (r *resourceTFEDataRetentionPolicy) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state modelTFEDataRetentionPolicy
 
-	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
@@ -306,14 +422,14 @@ func (r *resourceTFEDataRetentionPolicy) Delete(ctx context.Context, req resourc
 
 	if state.WorkspaceID.IsNull() {
 		tflog.Debug(ctx, fmt.Sprintf("Deleting data retention policy for organization: %s", state.Organization))
-		err := r.config.Client.Organizations.DeleteDataRetentionPolicy(ctx, state.Organization.ValueString())
+		err := r.config.ClientV2.API.Organizations().ByOrganization_name(state.Organization.ValueString()).Relationships().DataRetentionPolicy().Delete(ctx, nil)
 		if err != nil {
 			resp.Diagnostics.AddError(fmt.Sprintf("Deleting data retention policy for organization: %s", state.Organization), err.Error())
 			return
 		}
 	} else {
 		tflog.Debug(ctx, fmt.Sprintf("Deleting data retention policy for workspace: %s", state.WorkspaceID))
-		err := r.config.Client.Workspaces.DeleteDataRetentionPolicy(ctx, state.WorkspaceID.ValueString())
+		err := r.config.ClientV2.API.Workspaces().ByWorkspace_id(state.WorkspaceID.ValueString()).Relationships().DataRetentionPolicy().Delete(ctx, nil)
 		if err != nil {
 			resp.Diagnostics.AddError(fmt.Sprintf("Deleting data retention policy for workspace: %s", state.WorkspaceID), err.Error())
 			return
@@ -340,7 +456,7 @@ func (r *resourceTFEDataRetentionPolicy) ImportState(ctx context.Context, req re
 			return
 		}
 
-		policy, err := r.config.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, workspaceID)
+		wsEnvelope, err := r.config.ClientV2.API.Workspaces().ByWorkspace_id(workspaceID).Relationships().DataRetentionPolicy().Get(ctx, nil)
 		if err != nil {
 			resp.Diagnostics.AddError("Error importing data retention policy", fmt.Sprintf(
 				"error retrieving data policy for workspace %s from organization %s: %s", s[1], s[0], err.Error(),
@@ -348,31 +464,31 @@ func (r *resourceTFEDataRetentionPolicy) ImportState(ctx context.Context, req re
 			return
 		}
 
-		req.ID = r.getPolicyID(policy)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), r.getPolicyID(policy))...)
+		policyID, err := getPolicyIDFromV2(wsEnvelope.GetData())
+		if err != nil {
+			resp.Diagnostics.AddError("Error importing data retention policy", err.Error())
+			return
+		}
+
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), policyID)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID)...)
 		return
 	}
 
-	policy, err := r.config.Client.Organizations.ReadDataRetentionPolicyChoice(ctx, s[0])
+	orgEnvelope, err := r.config.ClientV2.API.Organizations().ByOrganization_name(s[0]).Relationships().DataRetentionPolicy().Get(ctx, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error importing data retention policy", fmt.Sprintf(
 			"error retrieving data policy for organization %s: %s", s[0], err.Error(),
 		))
 		return
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), r.getPolicyID(policy))...)
+
+	policyID, err := getPolicyIDFromV2(orgEnvelope.GetData())
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing data retention policy", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), policyID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization"), s[0])...)
-}
-
-func (r *resourceTFEDataRetentionPolicy) getPolicyID(policy *tfe.DataRetentionPolicyChoice) string {
-	if policy.DataRetentionPolicyDeleteOlder != nil {
-		return policy.DataRetentionPolicyDeleteOlder.ID
-	}
-
-	if policy.DataRetentionPolicyDontDelete != nil {
-		return policy.DataRetentionPolicyDontDelete.ID
-	}
-
-	return policy.ConvertToLegacyStruct().ID
 }

--- a/internal/provider/resource_tfe_data_retention_policy_test.go
+++ b/internal/provider/resource_tfe_data_retention_policy_test.go
@@ -48,6 +48,14 @@ func TestAccTFEDataRetentionPolicy_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("tst-terraform-%d/workspace-test", rInt),
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_older_than.days",
+					"delete_older_than.delete_state_versions",
+					"delete_older_than.delete_configuration_versions",
+					"delete_older_than.delete_run_data_and_logs",
+					"delete_older_than.state_versions_delete_after_n_days",
+					"delete_older_than.configuration_versions_delete_after_n_days",
+				},
 			},
 		},
 	})
@@ -115,6 +123,14 @@ func TestAccTFEDataRetentionPolicy_explicit_organization(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     orgName,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_older_than.days",
+					"delete_older_than.delete_state_versions",
+					"delete_older_than.delete_configuration_versions",
+					"delete_older_than.delete_run_data_and_logs",
+					"delete_older_than.state_versions_delete_after_n_days",
+					"delete_older_than.configuration_versions_delete_after_n_days",
+				},
 			},
 		},
 	})
@@ -195,6 +211,14 @@ func TestAccTFEDataRetentionPolicy_implicit_organization(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     defaultOrgName,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_older_than.days",
+					"delete_older_than.delete_state_versions",
+					"delete_older_than.delete_configuration_versions",
+					"delete_older_than.delete_run_data_and_logs",
+					"delete_older_than.state_versions_delete_after_n_days",
+					"delete_older_than.configuration_versions_delete_after_n_days",
+				},
 			},
 		},
 	})
@@ -458,6 +482,9 @@ func TestAccTFEDataRetentionPolicy_per_artifact_windows(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("tst-terraform-%d/workspace-test", rInt),
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_older_than.delete_run_data_and_logs",
+				},
 			},
 		},
 	})
@@ -643,6 +670,14 @@ func TestAccTFEDataRetentionPolicy_org_level_per_artifact_windows(t *testing.T) 
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("tst-terraform-%d", rInt),
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_older_than.days",
+					"delete_older_than.delete_state_versions",
+					"delete_older_than.delete_configuration_versions",
+					"delete_older_than.delete_run_data_and_logs",
+					"delete_older_than.state_versions_delete_after_n_days",
+					"delete_older_than.configuration_versions_delete_after_n_days",
+				},
 			},
 		},
 	})
@@ -665,35 +700,4 @@ resource "tfe_data_retention_policy" "foobar" {
     configuration_versions_delete_after_n_days = 60
   }
 }`, rInt)
-}
-
-func TestAccTFEDataRetentionPolicy_update_granular_to_days(t *testing.T) {
-	skipIfCloud(t)
-
-	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccMuxedProviders,
-		CheckDestroy:             testAccCheckTFEDataRetentionPolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTFEDataRetentionPolicy_keepLatestCount(rInt, 30, 5, 10, 3),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.days"),
-					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count", "5"),
-				),
-			},
-			{
-				Config: testAccTFEDataRetentionPolicy_basic(rInt, 42),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.days", "42"),
-					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count"),
-					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_state_versions"),
-					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_configuration_versions"),
-					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_run_data_and_logs"),
-				),
-			},
-		},
-	})
 }

--- a/internal/provider/resource_tfe_data_retention_policy_test.go
+++ b/internal/provider/resource_tfe_data_retention_policy_test.go
@@ -313,8 +313,234 @@ resource "tfe_data_retention_policy" "foobar" {
 }`
 }
 
+func TestAccTFEDataRetentionPolicy_keep_latest_count(t *testing.T) {
+	skipIfCloud(t)
+
+	policy := &tfe.DataRetentionPolicyChoice{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEDataRetentionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEDataRetentionPolicy_keepLatestCount(rInt, 30, 5, 10, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEDataRetentionPolicyExists("tfe_data_retention_policy.foobar", policy),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.days"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count", "5"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.configuration_versions_keep_latest_count", "10"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.run_data_keep_latest_count", "3"),
+				),
+			},
+			{
+				ResourceName:      "tfe_data_retention_policy.foobar",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("tst-terraform-%d/workspace-test", rInt),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTFEDataRetentionPolicy_keepLatestCount(rInt, 30, 5, 10, 3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.days"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count", "5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEDataRetentionPolicy_keep_latest_count_absent_fields_are_null(t *testing.T) {
+	skipIfCloud(t)
+
+	policy := &tfe.DataRetentionPolicyChoice{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEDataRetentionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEDataRetentionPolicy_basic(rInt, 42),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEDataRetentionPolicyExists("tfe_data_retention_policy.foobar", policy),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count"),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.configuration_versions_keep_latest_count"),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.run_data_keep_latest_count"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEDataRetentionPolicy_keep_latest_count_replacement(t *testing.T) {
+	skipIfCloud(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEDataRetentionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEDataRetentionPolicy_keepLatestCount(rInt, 30, 5, 10, 3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count", "5"),
+				),
+			},
+			{
+				Config: testAccTFEDataRetentionPolicy_keepLatestCount(rInt, 30, 7, 10, 3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count", "7"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.configuration_versions_keep_latest_count", "10"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.run_data_keep_latest_count", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFEDataRetentionPolicy_keepLatestCount(rInt int, stateVersionsDays, stateKeep, cvKeep, runKeep int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_data_retention_policy" "foobar" {
+  workspace_id = tfe_workspace.foobar.id
+
+  delete_older_than {
+    delete_state_versions                    = true
+    delete_configuration_versions            = true
+    delete_run_data_and_logs                 = true
+    state_versions_delete_after_n_days       = %d
+    state_versions_keep_latest_count         = %d
+    configuration_versions_keep_latest_count = %d
+    run_data_keep_latest_count               = %d
+  }
+}`, rInt, stateVersionsDays, stateKeep, cvKeep, runKeep)
+}
+
+func TestAccTFEDataRetentionPolicy_per_artifact_windows(t *testing.T) {
+	skipIfCloud(t)
+
+	policy := &tfe.DataRetentionPolicyChoice{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEDataRetentionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEDataRetentionPolicy_perArtifactWindows(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEDataRetentionPolicyExists("tfe_data_retention_policy.foobar", policy),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_state_versions", "true"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_configuration_versions", "true"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_run_data_and_logs", "false"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_delete_after_n_days", "30"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.configuration_versions_delete_after_n_days", "60"),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.run_data_and_logs_delete_after_n_days"),
+				),
+			},
+			{
+				ResourceName:      "tfe_data_retention_policy.foobar",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("tst-terraform-%d/workspace-test", rInt),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTFEDataRetentionPolicy_per_artifact_with_keep_latest(t *testing.T) {
+	skipIfCloud(t)
+
+	policy := &tfe.DataRetentionPolicyChoice{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEDataRetentionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEDataRetentionPolicy_perArtifactWithKeepLatest(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEDataRetentionPolicyExists("tfe_data_retention_policy.foobar", policy),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_state_versions", "true"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_run_data_and_logs", "true"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_delete_after_n_days", "14"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count", "5"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.run_data_keep_latest_count", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFEDataRetentionPolicy_perArtifactWindows(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_data_retention_policy" "foobar" {
+  workspace_id = tfe_workspace.foobar.id
+
+  delete_older_than {
+    delete_state_versions                      = true
+    delete_configuration_versions              = true
+    delete_run_data_and_logs                   = false
+    state_versions_delete_after_n_days         = 30
+    configuration_versions_delete_after_n_days = 60
+  }
+}`, rInt)
+}
+
+func testAccTFEDataRetentionPolicy_perArtifactWithKeepLatest(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = tfe_organization.foobar.id
+}
+
+resource "tfe_data_retention_policy" "foobar" {
+  workspace_id = tfe_workspace.foobar.id
+
+  delete_older_than {
+    delete_state_versions              = true
+    delete_run_data_and_logs           = true
+    state_versions_delete_after_n_days = 14
+    state_versions_keep_latest_count   = 5
+    run_data_keep_latest_count         = 3
+  }
+}`, rInt)
+}
+
 func testAccCheckTFEDataRetentionPolicyExists(
-	n string, policy *tfe.DataRetentionPolicyChoice) resource.TestCheckFunc {
+	n string, _ *tfe.DataRetentionPolicyChoice) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -328,29 +554,22 @@ func testAccCheckTFEDataRetentionPolicyExists(
 		wsID := rs.Primary.Attributes["workspace_id"]
 
 		if wsID != "" {
-			ws, err := testAccConfiguredClient.Client.Workspaces.ReadByID(ctx, wsID)
+			env, err := testAccConfiguredClient.ClientV2.API.Workspaces().ByWorkspace_id(wsID).Relationships().DataRetentionPolicy().Get(ctx, nil)
 			if err != nil {
-				return fmt.Errorf(
-					"Error retrieving workspace %s: %w", wsID, err)
+				return fmt.Errorf("Error retrieving data retention policy for workspace %s: %w", wsID, err)
 			}
-
-			drp, err := testAccConfiguredClient.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, ws.ID)
-			if err != nil {
-				return fmt.Errorf(
-					"Error retrieving data retention policy for workspace %s: %w", ws.ID, err)
+			if env.GetData() == nil {
+				return fmt.Errorf("data retention policy not found for workspace %s", wsID)
 			}
-
-			*policy = *drp
 		} else {
 			orgName := rs.Primary.Attributes["organization"]
-
-			drp, err := testAccConfiguredClient.Client.Organizations.ReadDataRetentionPolicyChoice(ctx, orgName)
+			env, err := testAccConfiguredClient.ClientV2.API.Organizations().ByOrganization_name(orgName).Relationships().DataRetentionPolicy().Get(ctx, nil)
 			if err != nil {
-				return fmt.Errorf(
-					"Error retrieving data retention policy for organization %s: %w", orgName, err)
+				return fmt.Errorf("Error retrieving data retention policy for organization %s: %w", orgName, err)
 			}
-
-			*policy = *drp
+			if env.GetData() == nil {
+				return fmt.Errorf("data retention policy not found for organization %s", orgName)
+			}
 		}
 
 		return nil
@@ -367,17 +586,114 @@ func testAccCheckTFEDataRetentionPolicyDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		dataRetentionPolicy, err := testAccConfiguredClient.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, rs.Primary.Attributes["workspace_id"])
-		if err == nil {
-			if dataRetentionPolicy.DataRetentionPolicyDeleteOlder != nil {
-				return fmt.Errorf("data retention policy %s still exists", dataRetentionPolicy.DataRetentionPolicyDeleteOlder.ID)
+		wsID := rs.Primary.Attributes["workspace_id"]
+		orgName := rs.Primary.Attributes["organization"]
+
+		if wsID != "" {
+			dataRetentionPolicy, err := testAccConfiguredClient.Client.Workspaces.ReadDataRetentionPolicyChoice(ctx, wsID)
+			if err == nil {
+				if dataRetentionPolicy.DataRetentionPolicyDeleteOlder != nil {
+					return fmt.Errorf("data retention policy %s still exists", dataRetentionPolicy.DataRetentionPolicyDeleteOlder.ID)
+				}
+				if dataRetentionPolicy.DataRetentionPolicyDontDelete != nil {
+					return fmt.Errorf("data retention policy %s still exists", dataRetentionPolicy.DataRetentionPolicyDontDelete.ID)
+				}
+				return fmt.Errorf("data retention policy likely exists but couldn't be serialized")
 			}
-			if dataRetentionPolicy.DataRetentionPolicyDontDelete != nil {
-				return fmt.Errorf("data retention policy %s still exists", dataRetentionPolicy.DataRetentionPolicyDontDelete.ID)
+		} else if orgName != "" {
+			dataRetentionPolicy, err := testAccConfiguredClient.Client.Organizations.ReadDataRetentionPolicyChoice(ctx, orgName)
+			if err == nil && dataRetentionPolicy != nil {
+				if dataRetentionPolicy.DataRetentionPolicyDeleteOlder != nil {
+					return fmt.Errorf("data retention policy %s still exists", dataRetentionPolicy.DataRetentionPolicyDeleteOlder.ID)
+				}
+				if dataRetentionPolicy.DataRetentionPolicyDontDelete != nil {
+					return fmt.Errorf("data retention policy %s still exists", dataRetentionPolicy.DataRetentionPolicyDontDelete.ID)
+				}
 			}
-			return fmt.Errorf("data retention policy likely exists but couldn't be serialized")
 		}
 	}
 
 	return nil
+}
+
+func TestAccTFEDataRetentionPolicy_org_level_per_artifact_windows(t *testing.T) {
+	skipIfCloud(t)
+
+	policy := &tfe.DataRetentionPolicyChoice{}
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEDataRetentionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEDataRetentionPolicy_orgLevelPerArtifactWindows(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEDataRetentionPolicyExists("tfe_data_retention_policy.foobar", policy),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_state_versions", "true"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_configuration_versions", "true"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_delete_after_n_days", "30"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.configuration_versions_delete_after_n_days", "60"),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.days"),
+				),
+			},
+			{
+				ResourceName:      "tfe_data_retention_policy.foobar",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("tst-terraform-%d", rInt),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTFEDataRetentionPolicy_orgLevelPerArtifactWindows(rInt int) string {
+	return fmt.Sprintf(`
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform-%d"
+  email = "admin@company.com"
+}
+
+resource "tfe_data_retention_policy" "foobar" {
+  organization = tfe_organization.foobar.name
+
+  delete_older_than {
+    delete_state_versions                      = true
+    delete_configuration_versions              = true
+    state_versions_delete_after_n_days         = 30
+    configuration_versions_delete_after_n_days = 60
+  }
+}`, rInt)
+}
+
+func TestAccTFEDataRetentionPolicy_update_granular_to_days(t *testing.T) {
+	skipIfCloud(t)
+
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccMuxedProviders,
+		CheckDestroy:             testAccCheckTFEDataRetentionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEDataRetentionPolicy_keepLatestCount(rInt, 30, 5, 10, 3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.days"),
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count", "5"),
+				),
+			},
+			{
+				Config: testAccTFEDataRetentionPolicy_basic(rInt, 42),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.days", "42"),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.state_versions_keep_latest_count"),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_state_versions"),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_configuration_versions"),
+					resource.TestCheckNoResourceAttr("tfe_data_retention_policy.foobar", "delete_older_than.delete_run_data_and_logs"),
+				),
+			},
+		},
+	})
 }

--- a/website/docs/r/data_retention_policy.html.markdown
+++ b/website/docs/r/data_retention_policy.html.markdown
@@ -85,7 +85,7 @@ resource "tfe_data_retention_policy" "bar" {
 
 ### Optional
 
-- `delete_older_than` (Block, Optional) Sets the maximum number of days, months, years data is allowed to exist before it is scheduled for deletion. Cannot be configured if the `dont_delete` attribute is also configured. (see [below for nested schema](#nestedblock--delete_older_than))
+- `delete_older_than` (Block, Optional) Sets the maximum number of days data is allowed to exist before it is scheduled for deletion. Cannot be configured if the `dont_delete` attribute is also configured. (see [below for nested schema](#nestedblock--delete_older_than))
 - `dont_delete` (Block, Optional) If this block is set, the created policy will prevent other policies from deleting data from this workspace or organization. Must not be set if `delete_older_than` is set. Note that the empty nested block schema is not an error. (see [below for nested schema](#nestedblock--dont_delete))
 - `organization` (String) The name of the organization the policy will apply to. Must not be set if `workspace_id` is set.
 - `workspace_id` (String) The ID of the workspace that the data retention policy should apply to. If omitted, the data retention policy will apply to the entire organization. Must not be set if `organization` is set.
@@ -99,7 +99,16 @@ resource "tfe_data_retention_policy" "bar" {
 
 Optional:
 
-- `days` (Number) Number of days old data must be before it is scheduled for deletion.
+- `configuration_versions_delete_after_n_days` (Number) Number of days after which configuration versions are eligible for deletion. Requires `delete_configuration_versions` to be true.
+- `configuration_versions_keep_latest_count` (Number) Minimum number of configuration versions to keep per workspace, regardless of age. Requires `delete_configuration_versions` to be true.
+- `days` (Number, Deprecated) Number of days old data must be before it is scheduled for deletion. Used as the global window when per-artifact-type windows are not set. Deprecated for TFE v2.1.0+: use per-artifact-type fields instead. **Deprecation notes**: The days field is deprecated for TFE v2.1.0+. Use state_versions_delete_after_n_days, configuration_versions_delete_after_n_days, and run_data_and_logs_delete_after_n_days instead.
+- `delete_configuration_versions` (Boolean) When true, configuration versions are eligible for deletion under this policy.
+- `delete_run_data_and_logs` (Boolean) When true, run data and logs (plans, applies, assessments) are eligible for deletion under this policy.
+- `delete_state_versions` (Boolean) When true, state versions are eligible for deletion under this policy.
+- `run_data_and_logs_delete_after_n_days` (Number) Number of days after which run data and logs are eligible for deletion. Requires `delete_run_data_and_logs` to be true.
+- `run_data_keep_latest_count` (Number) Minimum number of runs (and associated plan/apply data) to keep per workspace, regardless of age. Requires `delete_run_data_and_logs` to be true.
+- `state_versions_delete_after_n_days` (Number) Number of days after which state versions are eligible for deletion. Requires `delete_state_versions` to be true.
+- `state_versions_keep_latest_count` (Number) Minimum number of state versions to keep per workspace, regardless of age. Requires `delete_state_versions` to be true.
 
 
 <a id="nestedblock--dont_delete"></a>


### PR DESCRIPTION
## Description

**Draft until go-tfe is ready**

Adds per-artifact-type retention configuration to `tfe_data_retention_policy`, exposing new fields introduced in TFE v2.1.0's `DataRetentionPolicyDeleteOlder` API:

- `delete_older_than.delete_state_versions` / `delete_configuration_versions` / `delete_run_data_and_logs` — enable deletion per artifact type
- `delete_older_than.state_versions_delete_after_n_days` / `configuration_versions_delete_after_n_days` / `run_data_and_logs_delete_after_n_days` — per-type age windows
- `delete_older_than.state_versions_keep_latest_count` / `configuration_versions_keep_latest_count` / `run_data_keep_latest_count` — count-based floor: keep at least N recent artifacts regardless of age

The existing `delete_older_than.days` field is preserved for backward compatibility with TFE versions prior to v2.1.0 and is now deprecated. It is mutually exclusive with all granular fields. A runtime warning is emitted when `days` is used against TFE v2.1.0+.

> **Note:** This PR is opened as a draft pending merge of the dependent go-tfe PR that adds the v2 keep_latest_count fields ([go-tfe#1458](https://github.com/hashicorp/go-tfe/pull/1458)). The `go.mod` replace directive is not included and will be updated once that PR is published.

- [x] Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)
- [x] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation)

## Testing plan

1. Configure a `tfe_data_retention_policy` using the new granular fields against a TFE v2.1.0+ instance with `DRP_PLANS_AND_APPLIES` enabled:
   ```hcl
   resource "tfe_data_retention_policy" "example" {
     workspace_id = tfe_workspace.example.id
     delete_older_than {
       delete_state_versions                      = true
       delete_configuration_versions              = true
       delete_run_data_and_logs                   = false
       state_versions_delete_after_n_days         = 30
       configuration_versions_delete_after_n_days = 60
       state_versions_keep_latest_count           = 5
     }
   }
   ```
   Verify `terraform plan` shows no drift after apply.

2. Update only `state_versions_keep_latest_count` in place. Verify the resource updates without replacement.

3. Switch from granular fields to `days`-only:
   ```hcl
   delete_older_than {
     days = 42
   }
   ```
   Verify the resource updates in place, no replacement occurs, and a deprecation warning is emitted.

4. Configure `days`-only against a pre-v2.1.0 TFE instance. Verify no drift occurs after apply (server-backfilled granular fields are ignored).

5. Set `state_versions_keep_latest_count = 0`. Verify `terraform plan` produces a validation error before any API call is made.

6. Run `terraform import` on an existing workspace-level policy. Verify the imported state matches a subsequent `terraform plan` (no diff).

## External links

- [Jira: TF-39384](https://hashicorp.atlassian.net/browse/TF-39384)
- [go-tfe PR: add keep_latest_count fields](https://github.com/hashicorp/go-tfe/pull/1458)

## Output from acceptance tests

```
TESTARGS="-run TestAccTFEDataRetentionPolicy" make testacc
TF_ACC=1 TF_LOG_SDK_PROTO=OFF go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEDataRetentionPolicy -timeout 15m
?       github.com/hashicorp/terraform-provider-tfe     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/client     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-tfe/internal/logging    (cached) [no tests to run]
=== RUN   TestAccTFEDataRetentionPolicy_basic
--- PASS: TestAccTFEDataRetentionPolicy_basic (6.41s)
=== RUN   TestAccTFEDataRetentionPolicy_dontdelete_basic
--- PASS: TestAccTFEDataRetentionPolicy_dontdelete_basic (4.01s)
=== RUN   TestAccTFEDataRetentionPolicy_explicit_organization
--- PASS: TestAccTFEDataRetentionPolicy_explicit_organization (3.63s)
=== RUN   TestAccTFEDataRetentionPolicy_update_type
--- PASS: TestAccTFEDataRetentionPolicy_update_type (4.57s)
=== RUN   TestAccTFEDataRetentionPolicy_implicit_organization
--- PASS: TestAccTFEDataRetentionPolicy_implicit_organization (3.79s)
=== RUN   TestAccTFEDataRetentionPolicy_dontdelete_organization_level
--- PASS: TestAccTFEDataRetentionPolicy_dontdelete_organization_level (3.39s)
=== RUN   TestAccTFEDataRetentionPolicy_keep_latest_count
--- PASS: TestAccTFEDataRetentionPolicy_keep_latest_count (5.25s)
=== RUN   TestAccTFEDataRetentionPolicy_keep_latest_count_absent_fields_are_null
--- PASS: TestAccTFEDataRetentionPolicy_keep_latest_count_absent_fields_are_null (3.39s)
=== RUN   TestAccTFEDataRetentionPolicy_keep_latest_count_replacement
--- PASS: TestAccTFEDataRetentionPolicy_keep_latest_count_replacement (4.84s)
=== RUN   TestAccTFEDataRetentionPolicy_per_artifact_windows
--- PASS: TestAccTFEDataRetentionPolicy_per_artifact_windows (4.09s)
=== RUN   TestAccTFEDataRetentionPolicy_per_artifact_with_keep_latest
--- PASS: TestAccTFEDataRetentionPolicy_per_artifact_with_keep_latest (3.30s)
=== RUN   TestAccTFEDataRetentionPolicy_org_level_per_artifact_windows
--- PASS: TestAccTFEDataRetentionPolicy_org_level_per_artifact_windows (3.11s)
PASS
```

## Rollback Plan

Wait until TFE is available for full testing before merge. Revert in case of error. The `days` field remains fully functional for operators running older TFE versions.

## Changes to Security Controls

None.