### PR TITLE
Add Site Auditor SCIM group mapping and migrate tfe_scim_settings to go-tfe/v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ ENHANCEMENTS:
 * `r/tfe_policy_set`: Add `tfpolicy` as a valid value for the `kind` attribute. **NOTE:** This policy kind is currently in beta and not yet available to all users. By @subhro-acharjee-ibm [#2109](https://github.com/hashicorp/terraform-provider-tfe/pull/2109)
 * **New Resource List:** `tfe_provider_set` By @kierramarie [#2171](https://github.com/hashicorp/terraform-provider-tfe/pull/2171)
 * `r/tfe_hyok_configuration`: Added multi-region key support for AWS HYOK. By @helenjw [#2187](https://github.com/hashicorp/terraform-provider-tfe/pull/2187)
-* `r/tfe_saml_settings`, `d/tfe_saml_settings`: Add `attr_site_auditor` and `site_auditor_role` attributes for provisioning the Site Auditor role through SAML. Requires Terraform Enterprise v2.1.0 or later; on earlier releases the attributes are ignored unless set explicitly, in which case a minimum-version error is returned. By @tanushreegorai
-* `r/tfe_scim_settings`, `d/tfe_scim_settings`: Add `site_auditor_group_scim_id` and `site_auditor_group_display_name` attributes for granting the Site Auditor role to the members of a SCIM group, mirroring the existing site admin group mapping. Setting `site_auditor_group_scim_id` to `""` (or omitting it) unlinks the group. Requires Terraform Enterprise v2.1.0 or later; on earlier releases a minimum-version error is returned when `site_auditor_group_scim_id` is set. By @tanushreegorai
+* `r/tfe_saml_settings`, `d/tfe_saml_settings`: Add `attr_site_auditor` and `site_auditor_role` attributes for provisioning the Site Auditor role through SAML. Requires Terraform Enterprise v2.1.0 or later; on earlier releases the attributes are ignored unless set explicitly, in which case a minimum-version error is returned. By @tanushreegorai [#2201](https://github.com/hashicorp/terraform-provider-tfe/pull/2201)
+* `r/tfe_scim_settings`, `d/tfe_scim_settings`: Add `site_auditor_group_scim_id` and `site_auditor_group_display_name` attributes for granting the Site Auditor role to the members of a SCIM group, mirroring the existing site admin group mapping. Setting `site_auditor_group_scim_id` to `""` (or omitting it) unlinks the group. Requires Terraform Enterprise v2.1.0 or later; on earlier releases a minimum-version error is returned when `site_auditor_group_scim_id` is set. By @tanushreegorai [#2209](https://github.com/hashicorp/terraform-provider-tfe/pull/2209)
 
 BUG FIXES:
-* `r/tfe_saml_settings`: Fix `Provider produced inconsistent result after apply` error on the sensitive `private_key` attribute when updating any other attribute without changing the private key. By @tanushreegorai
+* `r/tfe_saml_settings`: Fix `Provider produced inconsistent result after apply` error on the sensitive `private_key` attribute when updating any other attribute without changing the private key. By @tanushreegorai [#2201](https://github.com/hashicorp/terraform-provider-tfe/pull/2201)
 
 ## v0.80.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 * **New Resource List:** `tfe_provider_set` By @kierramarie [#2171](https://github.com/hashicorp/terraform-provider-tfe/pull/2171)
 * `r/tfe_hyok_configuration`: Added multi-region key support for AWS HYOK. By @helenjw [#2187](https://github.com/hashicorp/terraform-provider-tfe/pull/2187)
 * `r/tfe_saml_settings`, `d/tfe_saml_settings`: Add `attr_site_auditor` and `site_auditor_role` attributes for provisioning the Site Auditor role through SAML. Requires Terraform Enterprise v2.1.0 or later; on earlier releases the attributes are ignored unless set explicitly, in which case a minimum-version error is returned. By @tanushreegorai
+* `r/tfe_scim_settings`, `d/tfe_scim_settings`: Add `site_auditor_group_scim_id` and `site_auditor_group_display_name` attributes for granting the Site Auditor role to the members of a SCIM group, mirroring the existing site admin group mapping. Setting `site_auditor_group_scim_id` to `""` (or omitting it) unlinks the group. Requires Terraform Enterprise v2.1.0 or later; on earlier releases a minimum-version error is returned when `site_auditor_group_scim_id` is set. By @tanushreegorai
 
 BUG FIXES:
 * `r/tfe_saml_settings`: Fix `Provider produced inconsistent result after apply` error on the sensitive `private_key` attribute when updating any other attribute without changing the private key. By @tanushreegorai

--- a/internal/provider/data_source_scim_settings.go
+++ b/internal/provider/data_source_scim_settings.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -21,7 +20,7 @@ var (
 
 // dataSourceTFESCIMSettings is the data source implementation.
 type dataSourceTFESCIMSettings struct {
-	client *tfe.Client
+	config ConfiguredClient
 }
 
 // NewSCIMSettingsDataSource is a helper function to simplify the provider implementation.
@@ -31,11 +30,13 @@ func NewSCIMSettingsDataSource() datasource.DataSource {
 
 // modelDataTFESCIMSettings maps the data source schema data.
 type modelDataTFESCIMSettings struct {
-	ID                        types.String `tfsdk:"id"`
-	Enabled                   types.Bool   `tfsdk:"enabled"`
-	Paused                    types.Bool   `tfsdk:"paused"`
-	SiteAdminGroupSCIMID      types.String `tfsdk:"site_admin_group_scim_id"`
-	SiteAdminGroupDisplayName types.String `tfsdk:"site_admin_group_display_name"`
+	ID                          types.String `tfsdk:"id"`
+	Enabled                     types.Bool   `tfsdk:"enabled"`
+	Paused                      types.Bool   `tfsdk:"paused"`
+	SiteAdminGroupSCIMID        types.String `tfsdk:"site_admin_group_scim_id"`
+	SiteAdminGroupDisplayName   types.String `tfsdk:"site_admin_group_display_name"`
+	SiteAuditorGroupSCIMID      types.String `tfsdk:"site_auditor_group_scim_id"`
+	SiteAuditorGroupDisplayName types.String `tfsdk:"site_auditor_group_display_name"`
 }
 
 // Metadata returns the data source type name.
@@ -69,6 +70,14 @@ func (d *dataSourceTFESCIMSettings) Schema(_ context.Context, _ datasource.Schem
 				Computed:    true,
 				Description: "The display name of the SCIM group whose members are granted site admin privileges.",
 			},
+			"site_auditor_group_scim_id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: fmt.Sprintf("The SCIM ID of the SCIM group whose members are granted site auditor privileges. Empty when no group is linked, and on Terraform Enterprise releases older than %s.", minTFEVersionSiteAuditor),
+			},
+			"site_auditor_group_display_name": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: fmt.Sprintf("The display name of the SCIM group whose members are granted site auditor privileges. Empty when no group is linked, and on Terraform Enterprise releases older than %s.", minTFEVersionSiteAuditor),
+			},
 		},
 	}
 }
@@ -88,24 +97,31 @@ func (d *dataSourceTFESCIMSettings) Configure(_ context.Context, req datasource.
 
 		return
 	}
-	d.client = client.Client
+	d.config = client
 }
 
 // Read refreshes the Terraform state with the latest data.
 func (d *dataSourceTFESCIMSettings) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
-	s, err := d.client.Admin.Settings.SCIM.Read(ctx)
+	env, err := d.config.ClientV2.API.Admin().ScimSettings().Get(ctx, nil)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to read SCIM settings", err.Error())
+		resp.Diagnostics.AddError("Unable to read SCIM settings", apiErrorDetail(err))
 		return
 	}
+	if env == nil || env.GetData() == nil || env.GetData().GetAttributes() == nil {
+		resp.Diagnostics.AddError("Unable to read SCIM settings", "SCIM settings response did not contain any data")
+		return
+	}
+	s := env.GetData().GetAttributes()
 
 	// Set state
 	diags := resp.State.Set(ctx, &modelDataTFESCIMSettings{
-		ID:                        types.StringValue(s.ID),
-		Enabled:                   types.BoolValue(s.Enabled),
-		Paused:                    types.BoolValue(s.Paused),
-		SiteAdminGroupSCIMID:      types.StringValue(s.SiteAdminGroupSCIMID),
-		SiteAdminGroupDisplayName: types.StringValue(s.SiteAdminGroupDisplayName),
+		ID:                          types.StringValue(valueOrZero(env.GetData().GetId())),
+		Enabled:                     types.BoolValue(valueOrZero(s.GetEnabled())),
+		Paused:                      types.BoolValue(valueOrZero(s.GetPaused())),
+		SiteAdminGroupSCIMID:        types.StringValue(valueOrZero(s.GetSiteAdminGroupScimId())),
+		SiteAdminGroupDisplayName:   types.StringValue(valueOrZero(s.GetSiteAdminGroupDisplayName())),
+		SiteAuditorGroupSCIMID:      types.StringValue(valueOrZero(s.GetSiteAuditorGroupScimId())),
+		SiteAuditorGroupDisplayName: types.StringValue(valueOrZero(s.GetSiteAuditorGroupDisplayName())),
 	})
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/data_source_scim_settings_test.go
+++ b/internal/provider/data_source_scim_settings_test.go
@@ -23,6 +23,14 @@ func TestAccTFESCIMSettingsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceAddress, "id"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "enabled"),
 					resource.TestCheckResourceAttrSet(resourceAddress, "paused"),
+					// site_auditor_group_scim_id and site_auditor_group_display_name
+					// are deliberately not asserted here: TestCheckResourceAttrSet
+					// fails on an empty value, and both are empty whenever no group
+					// is linked — which is the case on a bare instance, and always
+					// on Terraform Enterprise releases older than
+					// minTFEVersionSiteAuditor. They are covered with real values by
+					// the "SCIM settings site auditor group" subtest in
+					// resource_tfe_scim_settings_test.go.
 				),
 			},
 		},

--- a/internal/provider/resource_tfe_scim_settings.go
+++ b/internal/provider/resource_tfe_scim_settings.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	tfe "github.com/hashicorp/go-tfe"
-	"github.com/hashicorp/jsonapi"
+	"github.com/hashicorp/go-tfe/v2/api/models"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -17,29 +17,65 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+// scimSettingsID is the ID of the SCIM settings singleton resource.
+const scimSettingsID string = "scim"
+
 type modelTFESCIMSettings struct {
-	ID                        types.String `tfsdk:"id"`
-	Enabled                   types.Bool   `tfsdk:"enabled"`
-	Paused                    types.Bool   `tfsdk:"paused"`
-	SiteAdminGroupSCIMID      types.String `tfsdk:"site_admin_group_scim_id"`
-	SiteAdminGroupDisplayName types.String `tfsdk:"site_admin_group_display_name"`
+	ID                          types.String `tfsdk:"id"`
+	Enabled                     types.Bool   `tfsdk:"enabled"`
+	Paused                      types.Bool   `tfsdk:"paused"`
+	SiteAdminGroupSCIMID        types.String `tfsdk:"site_admin_group_scim_id"`
+	SiteAdminGroupDisplayName   types.String `tfsdk:"site_admin_group_display_name"`
+	SiteAuditorGroupSCIMID      types.String `tfsdk:"site_auditor_group_scim_id"`
+	SiteAuditorGroupDisplayName types.String `tfsdk:"site_auditor_group_display_name"`
 }
 
 // resourceTFESCIMSettings implements the tfe_scim_settings resource type
 type resourceTFESCIMSettings struct {
-	client *tfe.Client
+	config ConfiguredClient
 }
 
-// modelFromTFEAdminSCIMSettings builds a modelTFESCIMSettings struct from a tfe.AdminSCIMSetting value
-func modelFromTFEAdminSCIMSettings(v tfe.AdminSCIMSetting) modelTFESCIMSettings {
-	m := modelTFESCIMSettings{
-		ID:                        types.StringValue(v.ID),
-		Enabled:                   types.BoolValue(v.Enabled),
-		Paused:                    types.BoolValue(v.Paused),
-		SiteAdminGroupSCIMID:      types.StringValue(v.SiteAdminGroupSCIMID),
-		SiteAdminGroupDisplayName: types.StringValue(v.SiteAdminGroupDisplayName),
+// scimSettingsEnvelope wraps a set of SCIM settings attributes in the JSON:API
+// document shape the admin SCIM settings endpoint expects.
+func scimSettingsEnvelope(attrs models.AdminScimSettings_attributesable) models.AdminScimSettingsEnvelopeable {
+	data := models.NewAdminScimSettings()
+	data.SetId(ptr(scimSettingsID))
+	data.SetTypeEscaped(ptr(models.SCIMSETTINGS_ADMINSCIMSETTINGS_TYPE))
+	data.SetAttributes(attrs)
+
+	envelope := models.NewAdminScimSettingsEnvelope()
+	envelope.SetData(data)
+	return envelope
+}
+
+// modelFromV2SCIMSettings builds a modelTFESCIMSettings from an admin SCIM
+// settings response.
+//
+// Every group attribute is read with valueOrZero, so a missing pointer becomes
+// "". That is deliberately the same result for both cases that produce one: an
+// unlinked group (Terraform Enterprise serializes those as JSON null, because
+// AdminSettings::Scim delegates to the group with allow_nil) and a release
+// older than minTFEVersionSiteAuditor that does not know the attribute at all.
+// Both mean "no group is linked", which is also the schema default, so plan and
+// state agree either way. Note this is the opposite of the SAML resource, whose
+// Site Auditor attributes have non-empty defaults and therefore need
+// stringOrPrior to tell "absent" apart from "empty".
+func modelFromV2SCIMSettings(env models.AdminScimSettingsEnvelopeable) (modelTFESCIMSettings, error) {
+	if env == nil || env.GetData() == nil || env.GetData().GetAttributes() == nil {
+		return modelTFESCIMSettings{}, fmt.Errorf("SCIM settings response did not contain any data")
 	}
-	return m
+	data := env.GetData()
+	attrs := data.GetAttributes()
+
+	return modelTFESCIMSettings{
+		ID:                          types.StringValue(valueOrZero(data.GetId())),
+		Enabled:                     types.BoolValue(valueOrZero(attrs.GetEnabled())),
+		Paused:                      types.BoolValue(valueOrZero(attrs.GetPaused())),
+		SiteAdminGroupSCIMID:        types.StringValue(valueOrZero(attrs.GetSiteAdminGroupScimId())),
+		SiteAdminGroupDisplayName:   types.StringValue(valueOrZero(attrs.GetSiteAdminGroupDisplayName())),
+		SiteAuditorGroupSCIMID:      types.StringValue(valueOrZero(attrs.GetSiteAuditorGroupScimId())),
+		SiteAuditorGroupDisplayName: types.StringValue(valueOrZero(attrs.GetSiteAuditorGroupDisplayName())),
+	}, nil
 }
 
 var (
@@ -73,7 +109,40 @@ func (r *resourceTFESCIMSettings) Configure(_ context.Context, req resource.Conf
 		)
 		return
 	}
-	r.client = client.Client
+	r.config = client
+}
+
+// supportsSiteAuditor reports whether the connected Terraform Enterprise
+// supports linking a SCIM group to the Site Auditor role. When the practitioner
+// has set site_auditor_group_scim_id in configuration against an older release,
+// this records an error rather than letting the request silently drop the
+// attribute — older releases do not permit it, so the link would never happen
+// and Terraform would report no problem at all.
+func (r *resourceTFESCIMSettings) supportsSiteAuditor(config modelTFESCIMSettings, d *diag.Diagnostics) bool {
+	meets, err := r.config.MeetsMinRemoteTFEVersion(minTFEVersionSiteAuditor)
+	if err != nil {
+		d.AddError(
+			"Error checking minimum Terraform Enterprise version",
+			fmt.Sprintf("Could not determine whether Terraform Enterprise version %s meets the minimum required version %s: %v",
+				r.config.RemoteTFEVersion(), minTFEVersionSiteAuditor, err),
+		)
+		return false
+	}
+	if meets {
+		return true
+	}
+
+	// Only fail when the practitioner actually asked for a Site Auditor group.
+	// The schema default alone must not break existing configurations on older
+	// releases.
+	if !config.SiteAuditorGroupSCIMID.IsNull() {
+		d.AddError(
+			"Terraform Enterprise version does not support Site Auditor",
+			fmt.Sprintf("The attribute site_auditor_group_scim_id requires Terraform Enterprise %s or later. This instance reports %s. Remove that attribute from your configuration or upgrade Terraform Enterprise.",
+				minTFEVersionSiteAuditor, r.config.RemoteTFEVersion()),
+		)
+	}
+	return false
 }
 
 // Schema implements resource.Resource
@@ -82,7 +151,7 @@ func (r *resourceTFESCIMSettings) Schema(_ context.Context, _ resource.SchemaReq
 		Description: "(Only for Terraform Enterprise) Manages SCIM provisioning settings for the Terraform Enterprise instance." +
 			"\n\nRequires admin token configuration. See example usage for incorporating an admin token in your provider config." +
 			"\n\n-> **Note:** SCIM requires SAML to be configured first, so the examples below depend on a `tfe_saml_settings` resource. While this resource exists, SCIM is always `enabled = true`; running `terraform destroy` disables SCIM." +
-			"\n\n-> **Note:** `paused` and `site_admin_group_scim_id` are the only mutable arguments. To fully disable SCIM you must run `terraform destroy` on this resource; there is no argument to disable it in-place.",
+			"\n\n-> **Note:** `paused`, `site_admin_group_scim_id` and `site_auditor_group_scim_id` are the only mutable arguments. To fully disable SCIM you must run `terraform destroy` on this resource; there is no argument to disable it in-place.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the SCIM settings. Always `scim`.",
@@ -108,6 +177,16 @@ func (r *resourceTFESCIMSettings) Schema(_ context.Context, _ resource.SchemaReq
 				Description: "Display name of the group whose members are granted site admin privileges. Empty when no group is linked.",
 				Computed:    true,
 			},
+			"site_auditor_group_scim_id": schema.StringAttribute{
+				MarkdownDescription: fmt.Sprintf("SCIM ID of the group whose members are granted site auditor privileges. Defaults to `\"\"` (unlinked). Requires Terraform Enterprise %s or later.", minTFEVersionSiteAuditor),
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
+			},
+			"site_auditor_group_display_name": schema.StringAttribute{
+				MarkdownDescription: fmt.Sprintf("Display name of the group whose members are granted site auditor privileges. Empty when no group is linked, and on Terraform Enterprise releases older than %s.", minTFEVersionSiteAuditor),
+				Computed:            true,
+			},
 		},
 	}
 }
@@ -116,9 +195,15 @@ func (r *resourceTFESCIMSettings) Schema(_ context.Context, _ resource.SchemaReq
 func (r *resourceTFESCIMSettings) Read(ctx context.Context, _ resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Debug(ctx, "Reading SCIM Settings")
 
-	scimSettings, err := r.client.Admin.Settings.SCIM.Read(ctx)
+	scimSettings, err := r.config.ClientV2.API.Admin().ScimSettings().Get(ctx, nil)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading SCIM Settings", "Could not read SCIM Settings, unexpected error: "+err.Error())
+		resp.Diagnostics.AddError("Error reading SCIM Settings", "Could not read SCIM Settings, unexpected error: "+apiErrorDetail(err))
+		return
+	}
+
+	result, err := modelFromV2SCIMSettings(scimSettings)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading SCIM Settings", err.Error())
 		return
 	}
 
@@ -127,13 +212,12 @@ func (r *resourceTFESCIMSettings) Read(ctx context.Context, _ resource.ReadReque
 	// API contract: when Enabled=false the remaining fields (Paused,
 	// SiteAdminGroupSCIMID, etc.) are always zero-valued, so no valid settings
 	// are lost by removing state here.
-	if !scimSettings.Enabled {
+	if !result.Enabled.ValueBool() {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
 	// update state with refreshed data
-	result := modelFromTFEAdminSCIMSettings(*scimSettings)
 	diags := resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
@@ -147,14 +231,30 @@ func (r *resourceTFESCIMSettings) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	tflog.Debug(ctx, "Updating SCIM Settings")
-	scimSettings, err := r.updateSCIMSettings(ctx, m)
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating SCIM Settings", "Could not set SCIM Settings, unexpected error: "+err.Error())
+	var config modelTFESCIMSettings
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	result := modelFromTFEAdminSCIMSettings(*scimSettings)
+	withSiteAuditor := r.supportsSiteAuditor(config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Updating SCIM Settings")
+	scimSettings, err := r.updateSCIMSettings(ctx, m, withSiteAuditor)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating SCIM Settings", "Could not set SCIM Settings, unexpected error: "+apiErrorDetail(err))
+		return
+	}
+
+	result, err := modelFromV2SCIMSettings(scimSettings)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating SCIM Settings", err.Error())
+		return
+	}
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
@@ -167,34 +267,59 @@ func (r *resourceTFESCIMSettings) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	tflog.Debug(ctx, "Update SCIM Settings")
-	scimSettings, err := r.updateSCIMSettings(ctx, m)
-	if err != nil {
-		resp.Diagnostics.AddError("Error updating SCIM Settings", "Could not set SCIM Settings, unexpected error: "+err.Error())
+	var config modelTFESCIMSettings
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-	result := modelFromTFEAdminSCIMSettings(*scimSettings)
+
+	withSiteAuditor := r.supportsSiteAuditor(config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Update SCIM Settings")
+	scimSettings, err := r.updateSCIMSettings(ctx, m, withSiteAuditor)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating SCIM Settings", "Could not set SCIM Settings, unexpected error: "+apiErrorDetail(err))
+		return
+	}
+
+	result, err := modelFromV2SCIMSettings(scimSettings)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating SCIM Settings", err.Error())
+		return
+	}
 	diags = resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
 
 func (r *resourceTFESCIMSettings) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
 	tflog.Debug(ctx, "Delete SCIM Settings")
-	err := r.client.Admin.Settings.SCIM.Delete(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError("Error deleting SCIM Settings", "Could not disable SCIM Settings, unexpected error: "+err.Error())
+
+	// Deleting resets every SCIM setting server-side, including both group
+	// links, so there is nothing version-specific to send here.
+	if _, err := r.config.ClientV2.API.Admin().ScimSettings().Delete(ctx, nil); err != nil {
+		resp.Diagnostics.AddError("Error deleting SCIM Settings", "Could not disable SCIM Settings, unexpected error: "+apiErrorDetail(err))
 		return
 	}
 }
 
 func (r *resourceTFESCIMSettings) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	scimSettings, err := r.client.Admin.Settings.SCIM.Read(ctx)
+	scimSettings, err := r.config.ClientV2.API.Admin().ScimSettings().Get(ctx, nil)
 	if err != nil {
-		resp.Diagnostics.AddError("Error importing SCIM Settings", "Could not retrieve SCIM Settings, unexpected error: "+err.Error())
+		resp.Diagnostics.AddError("Error importing SCIM Settings", "Could not retrieve SCIM Settings, unexpected error: "+apiErrorDetail(err))
 		return
 	}
 
-	if !scimSettings.Enabled {
+	result, err := modelFromV2SCIMSettings(scimSettings)
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing SCIM Settings", err.Error())
+		return
+	}
+
+	if !result.Enabled.ValueBool() {
 		resp.Diagnostics.AddError(
 			"Cannot import disabled SCIM Settings",
 			"SCIM provisioning is currently disabled. Enable SCIM before importing, or use 'terraform apply' to enable it via this resource.",
@@ -202,36 +327,56 @@ func (r *resourceTFESCIMSettings) ImportState(ctx context.Context, _ resource.Im
 		return
 	}
 
-	result := modelFromTFEAdminSCIMSettings(*scimSettings)
 	diags := resp.State.Set(ctx, &result)
 	resp.Diagnostics.Append(diags...)
 }
 
 // updateSCIMSettings applies the SCIM settings for Create and Update. The plan
 // is the source of truth: every field is sent on every call (schema defaults
-// populate fields the user omits). site_admin_group_scim_id sends JSON null
-// when empty (unlinks the group) and the raw value otherwise (links it).
-func (r *resourceTFESCIMSettings) updateSCIMSettings(ctx context.Context, m modelTFESCIMSettings) (*tfe.AdminSCIMSetting, error) {
-	var siteAdminGroupSCIMID jsonapi.NullableAttr[string]
-	switch {
-	case m.SiteAdminGroupSCIMID.IsUnknown():
-		// Can't distinguish "not yet resolved" from an intentional unlink; fail loudly.
-		return nil, fmt.Errorf("site_admin_group_scim_id is not yet known; ensure the value is resolved before applying")
-	case m.SiteAdminGroupSCIMID.IsNull() || m.SiteAdminGroupSCIMID.ValueString() == "":
-		// Empty/null → unlink the site admin group.
-		siteAdminGroupSCIMID = tfe.NullString()
-	default:
-		siteAdminGroupSCIMID = tfe.NullableString(m.SiteAdminGroupSCIMID.ValueString())
+// populate fields the user omits). A group ID is sent as the raw value to link
+// a group and as "" to unlink one — Terraform Enterprise branches on Ruby's
+// .present?, and the generated client omits a nil pointer from the request
+// body entirely, which the server reads as "leave this link unchanged".
+//
+// withSiteAuditor controls whether the Site Auditor group is sent at all:
+// releases older than minTFEVersionSiteAuditor drop the attribute from their
+// permitted parameters, so sending it there is silently ignored.
+func (r *resourceTFESCIMSettings) updateSCIMSettings(ctx context.Context, m modelTFESCIMSettings, withSiteAuditor bool) (models.AdminScimSettingsEnvelopeable, error) {
+	siteAdminGroupSCIMID, err := groupSCIMIDForRequest(m.SiteAdminGroupSCIMID, "site_admin_group_scim_id")
+	if err != nil {
+		return nil, err
 	}
 
-	s, err := r.client.Admin.Settings.SCIM.Update(ctx, tfe.AdminSCIMSettingUpdateOptions{
-		Enabled:              tfe.Bool(true),
-		Paused:               m.Paused.ValueBoolPointer(),
-		SiteAdminGroupSCIMID: siteAdminGroupSCIMID,
-	})
+	attrs := models.NewAdminScimSettings_attributes()
+	attrs.SetEnabled(ptr(true))
+	attrs.SetPaused(m.Paused.ValueBoolPointer())
+	attrs.SetSiteAdminGroupScimId(siteAdminGroupSCIMID)
 
+	if withSiteAuditor {
+		siteAuditorGroupSCIMID, err := groupSCIMIDForRequest(m.SiteAuditorGroupSCIMID, "site_auditor_group_scim_id")
+		if err != nil {
+			return nil, err
+		}
+		attrs.SetSiteAuditorGroupScimId(siteAuditorGroupSCIMID)
+	}
+
+	s, err := r.config.ClientV2.API.Admin().ScimSettings().Patch(ctx, scimSettingsEnvelope(attrs), nil)
 	if err != nil {
 		return s, fmt.Errorf("failed to set SCIM Settings: %w", err)
 	}
 	return s, nil
+}
+
+// groupSCIMIDForRequest converts a planned group SCIM ID into the value to send
+// on the wire. Null and "" both mean "unlink", and both are sent as "" rather
+// than omitted, because an omitted attribute leaves the existing link in place.
+func groupSCIMIDForRequest(v types.String, attribute string) (*string, error) {
+	if v.IsUnknown() {
+		// Can't distinguish "not yet resolved" from an intentional unlink; fail loudly.
+		return nil, fmt.Errorf("%s is not yet known; ensure the value is resolved before applying", attribute)
+	}
+	if v.IsNull() {
+		return ptr(""), nil
+	}
+	return ptr(v.ValueString()), nil
 }

--- a/internal/provider/resource_tfe_scim_settings_test.go
+++ b/internal/provider/resource_tfe_scim_settings_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/go-tfe/v2/api/models"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
@@ -200,6 +202,121 @@ func TestAccTFESCIMSettings_omnibus(t *testing.T) {
 		})
 	})
 
+	// Linking a SCIM group to the Site Auditor role requires TFE
+	// minTFEVersionSiteAuditor or later. Against an older release the provider
+	// fails this subtest with an explicit minimum-version error rather than
+	// silently doing nothing, which is the behaviour we want to surface.
+	t.Run("SCIM settings site auditor group", func(t *testing.T) {
+		var siteAuditorGroupID string
+		var siteAuditorGroupName string
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccMuxedProviders,
+			CheckDestroy:             testAccTFESCIMSettingsDestroy,
+			Steps: []resource.TestStep{
+				// Enable SCIM with no site auditor group linked.
+				{
+					Config: testAccTFESCIMSettings_enable(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "enabled", "true"),
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "site_auditor_group_scim_id", ""),
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "site_auditor_group_display_name", ""),
+					),
+				},
+				// Create a SCIM group out-of-band and link it via TF_VAR.
+				{
+					PreConfig: func() {
+						tokenName := "tf-acc-test-scim-token-auditor-" + randomString(t)
+						token, err := testAccConfiguredClient.Client.Admin.Settings.SCIM.Tokens.Create(
+							context.Background(), tokenName,
+						)
+						if err != nil {
+							t.Fatalf("create SCIM token for the site auditor group: %v", err)
+						}
+						t.Cleanup(func() {
+							_ = testAccConfiguredClient.Client.Admin.Settings.SCIM.Tokens.Delete(context.Background(), token.ID)
+						})
+
+						// No explicit group cleanup: disabling SCIM (CheckDestroy) removes all groups from the backend.
+						siteAuditorGroupName = "tf-acc-site-auditors-" + randomString(t)
+						siteAuditorGroupID = createSCIMGroup(t, siteAuditorGroupName, token.Token)
+						t.Setenv("TF_VAR_site_auditor_group_scim_id", siteAuditorGroupID)
+					},
+					Config: testAccTFESCIMSettings_withSiteAuditorGroup(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "enabled", "true"),
+						resource.TestCheckResourceAttrPtr(
+							"tfe_scim_settings.enable_scim",
+							"site_auditor_group_scim_id",
+							&siteAuditorGroupID,
+						),
+						resource.TestCheckResourceAttrPtr(
+							"tfe_scim_settings.enable_scim",
+							"site_auditor_group_display_name",
+							&siteAuditorGroupName,
+						),
+						// Linking the auditor group must not disturb the admin group.
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "site_admin_group_scim_id", ""),
+						// The data source reports the same values.
+						resource.TestCheckResourceAttrPtr(
+							"data.tfe_scim_settings.foobar",
+							"site_auditor_group_scim_id",
+							&siteAuditorGroupID,
+						),
+						resource.TestCheckResourceAttrPtr(
+							"data.tfe_scim_settings.foobar",
+							"site_auditor_group_display_name",
+							&siteAuditorGroupName,
+						),
+					),
+				},
+				// Re-apply same config: should be a no-op (no perpetual diff).
+				{
+					Config:   testAccTFESCIMSettings_withSiteAuditorGroup(),
+					PlanOnly: true,
+				},
+				// Import round-trips the linked group through state.
+				{
+					ResourceName:      "tfe_scim_settings.enable_scim",
+					ImportState:       true,
+					ImportStateId:     "scim",
+					ImportStateVerify: true,
+				},
+				// Clear the site auditor group by setting it to "".
+				{
+					Config: testAccTFESCIMSettings_clearSiteAuditorGroup(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "enabled", "true"),
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "site_auditor_group_scim_id", ""),
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "site_auditor_group_display_name", ""),
+					),
+				},
+				// Re-link the same group, so the next step can prove that
+				// omitting the argument (not just emptying it) unlinks.
+				{
+					Config: testAccTFESCIMSettings_withSiteAuditorGroup(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrPtr(
+							"tfe_scim_settings.enable_scim",
+							"site_auditor_group_scim_id",
+							&siteAuditorGroupID,
+						),
+					),
+				},
+				// Omitting site_auditor_group_scim_id reverts to the default (""), unlinking the group.
+				{
+					Config: testAccTFESCIMSettings_enable(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "enabled", "true"),
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "site_auditor_group_scim_id", ""),
+						resource.TestCheckResourceAttr("tfe_scim_settings.enable_scim", "site_auditor_group_display_name", ""),
+					),
+				},
+			},
+		})
+	})
+
 	t.Run("SCIM settings import", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -294,6 +411,22 @@ func testAccTFESCIMSettingsDestroy(_ *terraform.State) error {
 	if s.SiteAdminGroupSCIMID != "" {
 		return errors.New("SCIM Settings still have site admin group linked")
 	}
+
+	// The go-tfe v1 struct read above predates the Site Auditor attributes, so
+	// the auditor group needs a second read through the v2 client. On releases
+	// older than minTFEVersionSiteAuditor the attribute is simply absent, which
+	// valueOrZero reports as "" — the same as unlinked, so this check is safe
+	// to run unconditionally.
+	env, err := testAccConfiguredClient.ClientV2.API.Admin().ScimSettings().Get(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to read SCIM Settings via go-tfe v2: %s", apiErrorDetail(err))
+	}
+	if env == nil || env.GetData() == nil || env.GetData().GetAttributes() == nil {
+		return errors.New("SCIM settings response did not contain any data")
+	}
+	if valueOrZero(env.GetData().GetAttributes().GetSiteAuditorGroupScimId()) != "" {
+		return errors.New("SCIM Settings still have site auditor group linked")
+	}
 	return nil
 }
 
@@ -370,4 +503,139 @@ resource "tfe_scim_settings" "enable_scim" {
     depends_on               = [tfe_saml_settings.enable_saml]
 }
 `, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting))
+}
+
+func testAccTFESCIMSettings_withSiteAuditorGroup() string {
+	return fmt.Sprintf(`
+%s
+
+variable "site_auditor_group_scim_id" {
+	type = string
+}
+resource "tfe_scim_settings" "enable_scim" {
+	site_auditor_group_scim_id = var.site_auditor_group_scim_id
+	depends_on                 = [tfe_saml_settings.enable_saml]
+}
+
+data "tfe_scim_settings" "foobar" {
+	depends_on = [tfe_scim_settings.enable_scim]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting))
+}
+
+func testAccTFESCIMSettings_clearSiteAuditorGroup() string {
+	return fmt.Sprintf(`
+%s
+
+resource "tfe_scim_settings" "enable_scim" {
+	site_auditor_group_scim_id = ""
+	depends_on                 = [tfe_saml_settings.enable_saml]
+}
+`, testAccTFESCIMSettings_enableSAMLWithProviderType(scimTestSAMLSetting))
+}
+
+// scimSettingsEnvelopeForTest builds a minimal admin SCIM settings response.
+// Attributes left unset return nil from their getters, which is how both an
+// unlinked group and a Terraform Enterprise release predating the attribute
+// arrive at the provider.
+func scimSettingsEnvelopeForTest(mutate func(*models.AdminScimSettings_attributes)) models.AdminScimSettingsEnvelopeable {
+	attrs := models.NewAdminScimSettings_attributes()
+	if mutate != nil {
+		mutate(attrs)
+	}
+	return scimSettingsEnvelope(attrs)
+}
+
+// TestSCIMSettingsSiteAuditorAbsentAttributes pins what the provider records
+// when the server sends no Site Auditor attributes. Two different situations
+// produce that response and both must land on "" rather than null: an unlinked
+// group (Terraform Enterprise delegates the attribute to the group with
+// allow_nil, so it serializes as JSON null) and a release older than
+// minTFEVersionSiteAuditor (the attribute does not exist at all). "" is the
+// schema default, so plan and state agree; null would show up as a spurious
+// diff on an untouched resource.
+func TestSCIMSettingsSiteAuditorAbsentAttributes(t *testing.T) {
+	result, err := modelFromV2SCIMSettings(scimSettingsEnvelopeForTest(nil))
+	if err != nil {
+		t.Fatalf("modelFromV2SCIMSettings: %v", err)
+	}
+	if result.SiteAuditorGroupSCIMID.IsNull() || result.SiteAuditorGroupDisplayName.IsNull() {
+		t.Fatal("Site Auditor attributes recorded as null; this produces a spurious diff against the \"\" schema default")
+	}
+	if got := result.SiteAuditorGroupSCIMID.ValueString(); got != "" {
+		t.Errorf("site_auditor_group_scim_id = %q, want \"\"", got)
+	}
+	if got := result.SiteAuditorGroupDisplayName.ValueString(); got != "" {
+		t.Errorf("site_auditor_group_display_name = %q, want \"\"", got)
+	}
+}
+
+// TestSCIMSettingsSiteAuditorServerValues covers the supported-release path,
+// where both attributes come back populated.
+func TestSCIMSettingsSiteAuditorServerValues(t *testing.T) {
+	env := scimSettingsEnvelopeForTest(func(a *models.AdminScimSettings_attributes) {
+		a.SetEnabled(ptr(true))
+		a.SetSiteAuditorGroupScimId(ptr("scim-group-auditors"))
+		a.SetSiteAuditorGroupDisplayName(ptr("Site Auditors"))
+	})
+	result, err := modelFromV2SCIMSettings(env)
+	if err != nil {
+		t.Fatalf("modelFromV2SCIMSettings: %v", err)
+	}
+	if !result.Enabled.ValueBool() {
+		t.Error("enabled = false, want true")
+	}
+	if got := result.SiteAuditorGroupSCIMID.ValueString(); got != "scim-group-auditors" {
+		t.Errorf("site_auditor_group_scim_id = %q, want scim-group-auditors", got)
+	}
+	if got := result.SiteAuditorGroupDisplayName.ValueString(); got != "Site Auditors" {
+		t.Errorf("site_auditor_group_display_name = %q, want \"Site Auditors\"", got)
+	}
+}
+
+// TestSCIMSettingsGroupSCIMIDForRequest pins the wire value for each planned
+// state of a group ID. The empty string matters: the generated client omits a
+// nil pointer from the request body entirely, and Terraform Enterprise reads an
+// absent key as "leave this link alone" rather than "unlink". Sending "" is
+// what actually unlinks a group.
+func TestSCIMSettingsGroupSCIMIDForRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		planned types.String
+		want    string
+		wantErr bool
+	}{
+		{name: "a linked group is sent as its ID", planned: types.StringValue("scim-group-1"), want: "scim-group-1"},
+		{name: "an empty value unlinks", planned: types.StringValue(""), want: ""},
+		{name: "a null value unlinks rather than being omitted", planned: types.StringNull(), want: ""},
+		{name: "an unresolved value is rejected", planned: types.StringUnknown(), wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := groupSCIMIDForRequest(tc.planned, "site_auditor_group_scim_id")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error for an unknown value, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("groupSCIMIDForRequest: %v", err)
+			}
+			if got == nil {
+				t.Fatal("group ID sent as a nil pointer; the generated client omits it from the request body, which leaves the existing link in place")
+			}
+			if *got != tc.want {
+				t.Errorf("group ID on the wire = %q, want %q", *got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSCIMSettingsEmptyResponse checks that a response carrying no data is
+// reported as an error instead of being silently written to state as a set of
+// zero values, which would look like SCIM had been disabled.
+func TestSCIMSettingsEmptyResponse(t *testing.T) {
+	if _, err := modelFromV2SCIMSettings(models.NewAdminScimSettingsEnvelope()); err == nil {
+		t.Fatal("expected an error for a response with no data, got none")
+	}
 }

--- a/website/docs/d/scim_settings.html.markdown
+++ b/website/docs/d/scim_settings.html.markdown
@@ -56,5 +56,7 @@ data "tfe_scim_settings" "foo" {
 - `paused` (Boolean) Whether SCIM provisioning is paused.
 - `site_admin_group_display_name` (String) The display name of the SCIM group whose members are granted site admin privileges.
 - `site_admin_group_scim_id` (String) The SCIM ID of the SCIM group whose members are granted site admin privileges. Empty when no group is linked.
+- `site_auditor_group_display_name` (String) The display name of the SCIM group whose members are granted site auditor privileges. Empty when no group is linked, and on Terraform Enterprise releases older than 2.1.0.
+- `site_auditor_group_scim_id` (String) The SCIM ID of the SCIM group whose members are granted site auditor privileges. Empty when no group is linked, and on Terraform Enterprise releases older than 2.1.0.
 
 

--- a/website/docs/r/scim_settings.html.markdown
+++ b/website/docs/r/scim_settings.html.markdown
@@ -5,7 +5,7 @@ description: |-
   (Only for Terraform Enterprise) Manages SCIM provisioning settings for the Terraform Enterprise instance.
   Requires admin token configuration. See example usage for incorporating an admin token in your provider config.
   -> Note: SCIM requires SAML to be configured first, so the examples below depend on a tfe_saml_settings resource. While this resource exists, SCIM is always enabled = true; running terraform destroy disables SCIM.
-  -> Note: paused and site_admin_group_scim_id are the only mutable arguments. To fully disable SCIM you must run terraform destroy on this resource; there is no argument to disable it in-place.
+  -> Note: paused, site_admin_group_scim_id and site_auditor_group_scim_id are the only mutable arguments. To fully disable SCIM you must run terraform destroy on this resource; there is no argument to disable it in-place.
 ---
 
 # Resource: tfe_scim_settings
@@ -16,7 +16,7 @@ Requires admin token configuration. See example usage for incorporating an admin
 
 -> **Note:** SCIM requires SAML to be configured first, so the examples below depend on a `tfe_saml_settings` resource. While this resource exists, SCIM is always `enabled = true`; running `terraform destroy` disables SCIM.
 
--> **Note:** `paused` and `site_admin_group_scim_id` are the only mutable arguments. To fully disable SCIM you must run `terraform destroy` on this resource; there is no argument to disable it in-place.
+-> **Note:** `paused`, `site_admin_group_scim_id` and `site_auditor_group_scim_id` are the only mutable arguments. To fully disable SCIM you must run `terraform destroy` on this resource; there is no argument to disable it in-place.
 
 ## Example Usage
 
@@ -97,12 +97,14 @@ resource "tfe_scim_settings" "this" {
 
 - `paused` (Boolean) Whether SCIM provisioning is paused. Defaults to `false`.
 - `site_admin_group_scim_id` (String) SCIM ID of the group whose members are granted site admin privileges. Defaults to `""` (unlinked).
+- `site_auditor_group_scim_id` (String) SCIM ID of the group whose members are granted site auditor privileges. Defaults to `""` (unlinked). Requires Terraform Enterprise 2.1.0 or later.
 
 ### Read-Only
 
 - `enabled` (Boolean) Whether SCIM provisioning is enabled. Always `true` while this resource exists; use `terraform destroy` to disable. If SCIM is disabled outside of Terraform, the next `terraform plan` will propose re-creating this resource.
 - `id` (String) The ID of the SCIM settings. Always `scim`.
 - `site_admin_group_display_name` (String) Display name of the group whose members are granted site admin privileges. Empty when no group is linked.
+- `site_auditor_group_display_name` (String) Display name of the group whose members are granted site auditor privileges. Empty when no group is linked, and on Terraform Enterprise releases older than 2.1.0.
 
 
 


### PR DESCRIPTION
## Description

Migrates `tfe_scim_settings` (resource and data source) from the frozen go-tfe v1 client to go-tfe/v2 (v2.8.0), and adds the Site Auditor group mapping shipped in Terraform Enterprise 2.1.0:

- `site_auditor_group_scim_id` — Optional + Computed, default `""`. Links a SCIM group to the Site Auditor role; `""` or omitting it unlinks.
- `site_auditor_group_display_name` — Computed. The linked group's display name.

Both mirror the existing `site_admin_group_*` pair exactly, per the RFC review decision. This is the SCIM half of the Site Auditor provider work; the SAML half was #2201.

Two things worth knowing while reviewing:

- **The empty string is what unlinks, not null.** The generated client omits a JSON key when its pointer is nil, and TFE reads an absent key as "leave this link unchanged". So `groupSCIMIDForRequest` maps both null and empty to `""` and never sends a nil pointer.
- **These attributes use `valueOrZero`, not the `stringOrPrior` helper #2201 added for SAML.** An unlinked group serializes as JSON `null`, indistinguishable from a pre-2.1.0 release omitting the attribute — falling back to the prior value would hide a genuine out-of-band unlink.

Gating reuses the `minTFEVersionSiteAuditor` constant from #2201 and errors only when the attribute is set in config, so existing configurations keep working on older releases. Also corrects the resource description, which said `paused` and `site_admin_group_scim_id` were "the only mutable arguments" — true until this change added a third.

- [x] Update the [Change Log](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md)
- [x] Update the [Documentation](https://github.com/hashicorp/terraform-provider-tfe/blob/main/docs/changelog-process.md#updating-the-documentation) — `make generate` run; doc content is a separate follow-up story

## Testing plan

Requires a licensed TFE running 2.1.0 or later, with SAML enabled and a recognized provider type.

1. Apply `tfe_scim_settings` with no group linked; confirm both auditor attributes are `""`.
2. Create a SCIM group out-of-band, set `site_auditor_group_scim_id` to its ID, and confirm the display name populates and the data source agrees.
3. Re-apply the same config; confirm an empty plan.
4. Confirm members of the linked group gain `is_site_auditor` via the admin users API.
5. Set the attribute to `""`, then re-link and remove it entirely — confirm both unlink and revoke the role.
6. Against a pre-2.1.0 instance, confirm setting the attribute fails with `requires Terraform Enterprise 2.1.0 or later`, and that a config without it still applies cleanly.

## External links

- [SCIM configuration docs](https://developer.hashicorp.com/terraform/enterprise/saml/login#scim)
- [SAML half of this work](https://github.com/hashicorp/terraform-provider-tfe/pull/2201)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-40128)

## Output from acceptance tests

The acceptance subtests for this resource are excluded from PR CI and run in the nightly TFE job (`ci.yml` skips `TestAccTFESCIM`), and need a licensed 2.1.0 instance. **They have not been run yet** — the live verification above is still outstanding.

Green locally: the four new unit tests (no `TF_ACC` needed), plus `go build`, `go vet`, `gofmt`, `make lint` (0 issues), `make exmplcheck`, `make generate`.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

If this change needs to be reverted, we will roll out an update to the code within 7 days. The change is additive, so reverting removes the two attributes and returns the resource to the v1 client. Any Site Auditor group already linked would need to be unlinked through the TFE admin UI, since a provider rollback does not undo the server-side link.

## Changes to Security Controls

This adds a Terraform-managed path for granting the Site Auditor role (a read-only administrative role) to members of a SCIM group. It is the counterpart of the existing `site_admin_group_scim_id` control and uses the same server-side mechanism; the provider only sets the group link, and all grant/revoke logic stays in Terraform Enterprise. Requires an admin token, as this resource already did. No changes to encryption or logging.